### PR TITLE
Update access resources to use account_id over zone_id

### DIFF
--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -24,11 +24,13 @@ func resourceCloudflareAccessApplication() *schema.Resource {
 			"account_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"zone_id": {
 				Deprecated: "This field will be removed in version 3 and replaced with the account_id field.",
 				Type:       schema.TypeString,
 				Optional:   true,
+				Computed:   true,
 			},
 			"aud": {
 				Type:     schema.TypeString,
@@ -120,6 +122,7 @@ func resourceCloudflareAccessApplicationCreate(d *schema.ResourceData, meta inte
 	if err != nil {
 		return err
 	}
+
 	allowedIDPList := expandInterfaceToStringList(d.Get("allowed_idps"))
 
 	newAccessApplication := cloudflare.AccessApplication{
@@ -146,6 +149,7 @@ func resourceCloudflareAccessApplicationCreate(d *schema.ResourceData, meta inte
 	}
 
 	d.SetId(accessApplication.ID)
+	d.Set("account_id", accountID)
 
 	return resourceCloudflareAccessApplicationRead(d, meta)
 }

--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -21,9 +21,14 @@ func resourceCloudflareAccessApplication() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"zone_id": {
+			"account_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+			},
+			"zone_id": {
+				Deprecated: "This field will be removed in version 3 and replaced with the account_id field.",
+				Type:       schema.TypeString,
+				Optional:   true,
 			},
 			"aud": {
 				Type:     schema.TypeString,
@@ -111,7 +116,10 @@ func resourceCloudflareAccessApplication() *schema.Resource {
 
 func resourceCloudflareAccessApplicationCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
-	zoneID := d.Get("zone_id").(string)
+	accountID, err := getAccountIDFromZoneID(d, client)
+	if err != nil {
+		return err
+	}
 	allowedIDPList := expandInterfaceToStringList(d.Get("allowed_idps"))
 
 	newAccessApplication := cloudflare.AccessApplication{
@@ -132,9 +140,9 @@ func resourceCloudflareAccessApplicationCreate(d *schema.ResourceData, meta inte
 
 	log.Printf("[DEBUG] Creating Cloudflare Access Application from struct: %+v", newAccessApplication)
 
-	accessApplication, err := client.CreateAccessApplication(zoneID, newAccessApplication)
+	accessApplication, err := client.CreateAccessApplication(accountID, newAccessApplication)
 	if err != nil {
-		return fmt.Errorf("error creating Access Application for zone %q: %s", zoneID, err)
+		return fmt.Errorf("error creating Access Application for account %q: %s", accountID, err)
 	}
 
 	d.SetId(accessApplication.ID)
@@ -144,9 +152,12 @@ func resourceCloudflareAccessApplicationCreate(d *schema.ResourceData, meta inte
 
 func resourceCloudflareAccessApplicationRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
-	zoneID := d.Get("zone_id").(string)
+	accountID, err := getAccountIDFromZoneID(d, client)
+	if err != nil {
+		return err
+	}
 
-	accessApplication, err := client.AccessApplication(zoneID, d.Id())
+	accessApplication, err := client.AccessApplication(accountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[INFO] Access Application %s no longer exists", d.Id())
@@ -172,7 +183,10 @@ func resourceCloudflareAccessApplicationRead(d *schema.ResourceData, meta interf
 
 func resourceCloudflareAccessApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
-	zoneID := d.Get("zone_id").(string)
+	accountID, err := getAccountIDFromZoneID(d, client)
+	if err != nil {
+		return err
+	}
 	allowedIDPList := expandInterfaceToStringList(d.Get("allowed_idps"))
 
 	updatedAccessApplication := cloudflare.AccessApplication{
@@ -194,9 +208,9 @@ func resourceCloudflareAccessApplicationUpdate(d *schema.ResourceData, meta inte
 
 	log.Printf("[DEBUG] Updating Cloudflare Access Application from struct: %+v", updatedAccessApplication)
 
-	accessApplication, err := client.UpdateAccessApplication(zoneID, updatedAccessApplication)
+	accessApplication, err := client.UpdateAccessApplication(accountID, updatedAccessApplication)
 	if err != nil {
-		return fmt.Errorf("error updating Access Application for zone %q: %s", zoneID, err)
+		return fmt.Errorf("error updating Access Application for account %q: %s", accountID, err)
 	}
 
 	if accessApplication.ID == "" {
@@ -208,14 +222,17 @@ func resourceCloudflareAccessApplicationUpdate(d *schema.ResourceData, meta inte
 
 func resourceCloudflareAccessApplicationDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
-	zoneID := d.Get("zone_id").(string)
+	accountID, err := getAccountIDFromZoneID(d, client)
+	if err != nil {
+		return err
+	}
 	appID := d.Id()
 
 	log.Printf("[DEBUG] Deleting Cloudflare Access Application using ID: %s", appID)
 
-	err := client.DeleteAccessApplication(zoneID, appID)
+	err = client.DeleteAccessApplication(accountID, appID)
 	if err != nil {
-		return fmt.Errorf("error deleting Access Application for zone %q: %s", zoneID, err)
+		return fmt.Errorf("error deleting Access Application for account %q: %s", accountID, err)
 	}
 
 	resourceCloudflareAccessApplicationRead(d, meta)
@@ -227,14 +244,14 @@ func resourceCloudflareAccessApplicationImport(d *schema.ResourceData, meta inte
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
-		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneID/accessApplicationID\"", d.Id())
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"accountID/accessApplicationID\"", d.Id())
 	}
 
-	zoneID, accessApplicationID := attributes[0], attributes[1]
+	accountID, accessApplicationID := attributes[0], attributes[1]
 
-	log.Printf("[DEBUG] Importing Cloudflare Access Application: id %s for zone %s", accessApplicationID, zoneID)
+	log.Printf("[DEBUG] Importing Cloudflare Access Application: id %s for account %s", accessApplicationID, accountID)
 
-	d.Set("zone_id", zoneID)
+	d.Set("account_id", accountID)
 	d.SetId(accessApplicationID)
 
 	resourceCloudflareAccessApplicationRead(d, meta)

--- a/cloudflare/resource_cloudflare_access_application_test.go
+++ b/cloudflare/resource_cloudflare_access_application_test.go
@@ -211,7 +211,7 @@ func TestAccCloudflareAccessApplicationWithZoneID(t *testing.T) {
 	}
 
 	rnd := generateRandomResourceName()
-	name := "cloudflare_access_application" + rnd
+	name := "cloudflare_access_application." + rnd
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")

--- a/cloudflare/resource_cloudflare_access_application_test.go
+++ b/cloudflare/resource_cloudflare_access_application_test.go
@@ -255,7 +255,7 @@ func testAccessApplicationWithZoneID(resourceID, zone, zoneID string) string {
 func testAccessApplicationWithZoneIDUpdated(resourceID, zone, zoneID string) string {
 	return fmt.Sprintf(`
 		resource "cloudflare_access_application" "%[1]s" {
-			name    = "%[1]s"
+			name    = "%[1]s-updated"
 			zone_id = "%[3]s"
 			domain  = "%[1]s.%[2]s"
 		}

--- a/cloudflare/resource_cloudflare_access_application_test.go
+++ b/cloudflare/resource_cloudflare_access_application_test.go
@@ -198,3 +198,66 @@ func testAccCheckCloudflareAccessApplicationDestroy(s *terraform.State) error {
 
 	return nil
 }
+
+func TestAccCloudflareAccessApplicationWithZoneID(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := generateRandomResourceName()
+	name := "cloudflare_access_application" + rnd
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	updatedName := fmt.Sprintf("%s-updated", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccessApplicationWithZoneID(rnd, zone, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+				),
+			},
+			{
+				Config: testAccessApplicationWithZoneIDUpdated(rnd, zone, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", updatedName),
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+				),
+			},
+		},
+	})
+}
+
+func testAccessApplicationWithZoneID(resourceID, zone, zoneID string) string {
+	return fmt.Sprintf(`
+		resource "cloudflare_access_application" "%[1]s" {
+			name    = "%[1]s"
+			zone_id = "%[3]s"
+			domain  = "%[1]s.%[2]s"
+		}
+	`, resourceID, zone, zoneID)
+}
+
+func testAccessApplicationWithZoneIDUpdated(resourceID, zone, zoneID string) string {
+	return fmt.Sprintf(`
+		resource "cloudflare_access_application" "%[1]s" {
+			name    = "%[1]s"
+			zone_id = "%[3]s"
+			domain  = "%[1]s.%[2]s"
+		}
+	`, resourceID, zone, zoneID)
+}

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -28,10 +28,12 @@ func resourceCloudflareAccessPolicy() *schema.Resource {
 			"account_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"zone_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -25,9 +25,13 @@ func resourceCloudflareAccessPolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"account_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"zone_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -63,10 +67,13 @@ func resourceCloudflareAccessPolicy() *schema.Resource {
 
 func resourceCloudflareAccessPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
-	zoneID := d.Get("zone_id").(string)
+	accountID, err := getAccountIDFromZoneID(d, client)
+	if err != nil {
+		return err
+	}
 	appID := d.Get("application_id").(string)
 
-	accessPolicy, err := client.AccessPolicy(zoneID, appID, d.Id())
+	accessPolicy, err := client.AccessPolicy(accountID, appID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[INFO] Access Policy %s no longer exists", d.Id())
@@ -89,7 +96,10 @@ func resourceCloudflareAccessPolicyRead(d *schema.ResourceData, meta interface{}
 func resourceCloudflareAccessPolicyCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 	appID := d.Get("application_id").(string)
-	zoneID := d.Get("zone_id").(string)
+	accountID, err := getAccountIDFromZoneID(d, client)
+	if err != nil {
+		return err
+	}
 	newAccessPolicy := cloudflare.AccessPolicy{
 		Name:       d.Get("name").(string),
 		Precedence: d.Get("precedence").(int),
@@ -100,7 +110,7 @@ func resourceCloudflareAccessPolicyCreate(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Creating Cloudflare Access Policy from struct: %+v", newAccessPolicy)
 
-	accessPolicy, err := client.CreateAccessPolicy(zoneID, appID, newAccessPolicy)
+	accessPolicy, err := client.CreateAccessPolicy(accountID, appID, newAccessPolicy)
 	if err != nil {
 		return fmt.Errorf("error creating Access Policy for ID %q: %s", accessPolicy.ID, err)
 	}
@@ -112,7 +122,10 @@ func resourceCloudflareAccessPolicyCreate(d *schema.ResourceData, meta interface
 
 func resourceCloudflareAccessPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
-	zoneID := d.Get("zone_id").(string)
+	accountID, err := getAccountIDFromZoneID(d, client)
+	if err != nil {
+		return err
+	}
 	appID := d.Get("application_id").(string)
 	updatedAccessPolicy := cloudflare.AccessPolicy{
 		Name:       d.Get("name").(string),
@@ -125,7 +138,7 @@ func resourceCloudflareAccessPolicyUpdate(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Updating Cloudflare Access Policy from struct: %+v", updatedAccessPolicy)
 
-	accessPolicy, err := client.UpdateAccessPolicy(zoneID, appID, updatedAccessPolicy)
+	accessPolicy, err := client.UpdateAccessPolicy(accountID, appID, updatedAccessPolicy)
 	if err != nil {
 		return fmt.Errorf("error updating Access Policy for ID %q: %s", d.Id(), err)
 	}
@@ -139,12 +152,15 @@ func resourceCloudflareAccessPolicyUpdate(d *schema.ResourceData, meta interface
 
 func resourceCloudflareAccessPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
-	zoneID := d.Get("zone_id").(string)
+	accountID, err := getAccountIDFromZoneID(d, client)
+	if err != nil {
+		return err
+	}
 	appID := d.Get("application_id").(string)
 
 	log.Printf("[DEBUG] Deleting Cloudflare Access Policy using ID: %s", d.Id())
 
-	err := client.DeleteAccessPolicy(zoneID, appID, d.Id())
+	err = client.DeleteAccessPolicy(accountID, appID, d.Id())
 	if err != nil {
 		return fmt.Errorf("error deleting Access Policy for ID %q: %s", d.Id(), err)
 	}
@@ -158,14 +174,14 @@ func resourceCloudflareAccessPolicyImport(d *schema.ResourceData, meta interface
 	attributes := strings.SplitN(d.Id(), "/", 3)
 
 	if len(attributes) != 3 {
-		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneID/accessApplicationID/accessPolicyID\"", d.Id())
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"accountID/accessApplicationID/accessPolicyID\"", d.Id())
 	}
 
-	zoneID, accessAppID, accessPolicyID := attributes[0], attributes[1], attributes[2]
+	accountID, accessAppID, accessPolicyID := attributes[0], attributes[1], attributes[2]
 
-	log.Printf("[DEBUG] Importing Cloudflare Access Policy: zoneID %q, appID %q, accessPolicyID %q", zoneID, accessAppID, accessPolicyID)
+	log.Printf("[DEBUG] Importing Cloudflare Access Policy: accountID %q, appID %q, accessPolicyID %q", accountID, accessAppID, accessPolicyID)
 
-	d.Set("zone_id", zoneID)
+	d.Set("account_id", accountID)
 	d.Set("application_id", accessAppID)
 	d.SetId(accessPolicyID)
 

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	errors "github.com/pkg/errors"
 )
@@ -136,4 +137,17 @@ func stringFromBool(status bool) string {
 		return "on"
 	}
 	return "off"
+}
+
+func getAccountIDFromZoneID(d *schema.ResourceData, client *cloudflare.API) (string, error) {
+	accountID := d.Get("account_id").(string)
+	if accountID == "" {
+		zoneID := d.Get("zone_id").(string)
+		zone, err := client.ZoneDetails(zoneID)
+		if err != nil {
+			return "", fmt.Errorf("error retrieving zone for zone_id %q: %s", zoneID, err)
+		}
+		accountID = zone.Account.ID
+	}
+	return accountID, nil
 }

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -149,5 +149,7 @@ func getAccountIDFromZoneID(d *schema.ResourceData, client *cloudflare.API) (str
 		}
 		accountID = zone.Account.ID
 	}
+
+	d.Set("account_id", accountID)
 	return accountID, nil
 }


### PR DESCRIPTION
This PR changes Access resources to use `account_id` over `zone_id` since the `/zones` routes have been deprecated in favor of `/accounts`. I'll update the `cloudflare-go` version once https://github.com/cloudflare/cloudflare-go/pull/486 is merged. 