### PR TITLE
Remove partial setup on Enterprise subscriptions

### DIFF
--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -73,28 +73,6 @@ func TestAccCloudflareZonePartialSetup(t *testing.T) {
 	})
 }
 
-func TestAccCloudflareZonePartialSetupEnterprise(t *testing.T) {
-	name := "cloudflare_zone.tf-acc-partial-setup-zone"
-	resourceName := strings.Split(name, ".")[1]
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testZoneConfigWithPartialSetup(resourceName, "tf-acc-partial-enterprise.cfapi.net", "false", "false", "enterprise"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "zone", "tf-acc-partial-enterprise.cfapi.net"),
-					resource.TestCheckResourceAttr(name, "paused", "false"),
-					resource.TestCheckResourceAttr(name, "plan", planIDEnterprise),
-					resource.TestCheckResourceAttr(name, "type", "partial"),
-					resource.TestCheckResourceAttrSet(name, "verification_key"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccCloudflareZoneFullSetup(t *testing.T) {
 	name := "cloudflare_zone.tf-acc-full-setup-zone"
 	resourceName := strings.Split(name, ".")[1]


### PR DESCRIPTION
The ability to setup a partial zone on a partial parent zone is no
longer supported so this test is now redundant.

https://github.com/cloudflare/terraform-provider-cloudflare/runs/916379863?check_suite_focus=true#step:6:337