### PR TITLE
Compare firewall descriptions after converting unicode + HTML entities

### DIFF
--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"fmt"
+	"html"
 	"log"
 	"strings"
 
@@ -41,6 +42,12 @@ func resourceCloudflareFilter() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(0, 500),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if html.UnescapeString(old) == html.UnescapeString(new) {
+						return true
+					}
+					return false
+				},
 			},
 			"ref": {
 				Type:         schema.TypeString,

--- a/cloudflare/resource_cloudflare_firewall_rule.go
+++ b/cloudflare/resource_cloudflare_firewall_rule.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"fmt"
+	"html"
 	"log"
 	"strings"
 
@@ -44,6 +45,12 @@ func resourceCloudflareFirewallRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(0, 500),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if html.UnescapeString(old) == html.UnescapeString(new) {
+						return true
+					}
+					return false
+				},
 			},
 			"paused": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
For a while now, I've noticed that we have an occasional flapping test
in our internal test suite where "example 'string'" is attempting to
trigger an update despite not actually doing anything. Diving further
into this, I found that the Cloudflare API returns unicode + HTML
entities for the descriptions.

```
{
  "result": {
    "id": "e97a2db142ae4ff09499bb6a458981fd",
    "paused": true,
    "description": "this is a \u0026#39;test\u0026#39;",
    "expression": "(http.host eq \"example.com\")"
  },
  "success": true,
  "errors": [],
  "messages": []
}
```

However most people (ok, no one) is actually wanting to write the
description that way. Instead, they are using the single characters such
as an apostrophe (`'`).

```
resource "cloudflare_filter" "%[1]s" {
  description = "this is a 'test'"
  expression = "(http.host eq \"example.com\")"
}
```

This means that Terraform constantly thinks that it needs to update the
value when it doesn't really.

To combat this, I've added a `DiffSuppressFunc` to the descriptions
which ensure the string values are compared after being processed by
`html.UnescapeString`. This accounts for the differences in the strings
and will still ensure we aren't missing updates -- even if someone
decides to actually use entities in their descriptions.