### PR TITLE
ForceNew if zone changes on CustomHostname resource

### DIFF
--- a/cloudflare/provider_test.go
+++ b/cloudflare/provider_test.go
@@ -53,7 +53,9 @@ func testAccPreCheckAltDomain(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_ALT_DOMAIN"); v == "" {
 		t.Fatal("CLOUDFLARE_ALT_DOMAIN must be set for this acceptance test")
 	}
+}
 
+func testAccPreCheckAltZoneID(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_ALT_ZONE_ID"); v == "" {
 		t.Fatal("CLOUDFLARE_ALT_ZONE_ID must be set for this acceptance test")
 	}

--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -26,6 +26,7 @@ func resourceCloudflareCustomHostname() *schema.Resource {
 			"zone_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"hostname": {
 				Type:         schema.TypeString,

--- a/cloudflare/resource_cloudflare_custom_hostname_test.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_test.go
@@ -267,10 +267,10 @@ func TestAccCloudflareCustomHostname_UpdatingZoneForcesNewResource(t *testing.T)
 					resource.TestCheckResourceAttr(resourceName, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("%s.%s", rnd, domain)),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccCheckCloudflareCustomHostnameBasic(altZoneID, rnd, altDomain),
+				ExpectNonEmptyPlan: true,
+				Config:             testAccCheckCloudflareCustomHostnameBasic(altZoneID, rnd, altDomain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareCustomHostnameExists(resourceName, &after),
 					testAccCheckCloudflareCustomHostnameRecreated(&before, &after),

--- a/cloudflare/resource_cloudflare_custom_hostname_test.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_test.go
@@ -257,7 +257,10 @@ func TestAccCloudflareCustomHostname_UpdatingZoneForcesNewResource(t *testing.T)
 	resourceName := "cloudflare_custom_hostname." + rnd
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAltZoneID(t)
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/cloudflare/resource_cloudflare_custom_hostname_test.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"testing"
 
+	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccCloudflareCustomHostnameBasic(t *testing.T) {
@@ -241,4 +243,77 @@ resource "cloudflare_custom_hostname" "%[2]s" {
   }
 }
 `, zoneID, rnd, domain)
+}
+
+func TestAccCloudflareCustomHostname_UpdatingZoneForcesNewResource(t *testing.T) {
+	t.Parallel()
+
+	var before, after cloudflare.CustomHostname
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	altZoneID := os.Getenv("CLOUDFLARE_ALT_ZONE_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	altDomain := os.Getenv("CLOUDFLARE_ALT_DOMAIN")
+	rnd := generateRandomResourceName()
+	resourceName := "cloudflare_custom_hostname." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareCustomHostnameBasic(zoneID, rnd, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareCustomHostnameExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "zone_id", zoneID),
+					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("%s.%s", rnd, domain)),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccCheckCloudflareCustomHostnameBasic(altZoneID, rnd, altDomain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareCustomHostnameExists(resourceName, &after),
+					testAccCheckCloudflareCustomHostnameRecreated(&before, &after),
+					resource.TestCheckResourceAttr(resourceName, "zone_id", altZoneID),
+					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("%s.%s", rnd, altDomain)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareCustomHostnameRecreated(before, after *cloudflare.CustomHostname) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before.ID == after.ID {
+			return fmt.Errorf("Expected change of CustomHostname Ids, but both were %v", before.ID)
+		}
+		return nil
+	}
+}
+
+func testAccCheckCloudflareCustomHostnameExists(n string, customHostname *cloudflare.CustomHostname) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No CustomHostname ID is set")
+		}
+
+		client := testAccProvider.Meta().(*cloudflare.API)
+		foundCustomHostname, err := client.CustomHostname(rs.Primary.Attributes["zone_id"], rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if foundCustomHostname.ID != rs.Primary.ID {
+			return fmt.Errorf("CustomHostname not found")
+		}
+
+		*customHostname = foundCustomHostname
+
+		return nil
+	}
 }

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -205,6 +205,7 @@ func TestAccCloudflarePageRule_UpdatingZoneForcesNewResource(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAltDomain(t)
+			testAccPreCheckAltZoneID(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
Custom Hostnames cannot be moved across zones. ForceNew if the zone changes.