### PR TITLE
Restore custom_hostname resource accidentally removed in #749

### DIFF
--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -113,6 +113,7 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_authenticated_origin_pulls":             resourceCloudflareAuthenticatedOriginPulls(),
 			"cloudflare_authenticated_origin_pulls_certificate": resourceCloudflareAuthenticatedOriginPullsCertificate(),
 			"cloudflare_byo_ip_prefix":                          resourceCloudflareBYOIPPrefix(),
+			"cloudflare_custom_hostname":                        resourceCloudflareCustomHostname(),
 			"cloudflare_custom_pages":                           resourceCloudflareCustomPages(),
 			"cloudflare_custom_ssl":                             resourceCloudflareCustomSsl(),
 			"cloudflare_filter":                                 resourceCloudflareFilter(),


### PR DESCRIPTION
As per title. During a reformatting of provider.go the custom_hostname resource was accidentally removed during merge #749 