### PR TITLE
Adding undocumented CF access session_duration values 0s and 15m

### DIFF
--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -41,7 +41,7 @@ func resourceCloudflareAccessApplication() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "24h",
-				ValidateFunc: validation.StringInSlice([]string{"30m", "6h", "12h", "24h", "168h", "730h"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"0s", "15m", "30m", "6h", "12h", "24h", "168h", "730h"}, false),
 			},
 			"cors_headers": {
 				Type:     schema.TypeList,

--- a/website/docs/r/access_application.html.markdown
+++ b/website/docs/r/access_application.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 * `domain` - (Required) The complete URL of the asset you wish to put
   Cloudflare Access in front of. Can include subdomains or paths. Or both.
 * `session_duration` - (Optional) How often a user will be forced to
-  re-authorise. Must be one of `30m`, `6h`, `12h`, `24h`, `168h`, `730h`.
+  re-authorise. Must be one of `0s`, `15m`, `30m`, `6h`, `12h`, `24h`, `168h`, `730h`.
 * `cors_headers` - (Optional) CORS configuration for the Access Application. See
   below for reference structure.
 * `allowed_idps` - (Optional) The identity providers selected for the application.


### PR DESCRIPTION
This PR adds additional valid values to Access's session_durations to match what is accessible via the Web UI.

New values: 
- 0s (No Duration - Expires Immediately)
- 15m
