### PR TITLE
Remove AOP API Tokens gate as it's now supported in production

### DIFF
--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate_test.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate_test.go
@@ -11,15 +11,6 @@ import (
 )
 
 func TestAccCloudflareAuthenticatedOriginPullsCertificatePerZone(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the AOP API
-	// does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		defer func(apiToken string) {
-			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
-		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
-		os.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 	var perZoneAOP cloudflare.PerZoneAuthenticatedOriginPullsCertificateDetails
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	rnd := generateRandomResourceName()
@@ -46,15 +37,6 @@ func TestAccCloudflareAuthenticatedOriginPullsCertificatePerZone(t *testing.T) {
 }
 
 func TestAccCloudflareAuthenticatedOriginPullsCertificatePerHostname(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the AOP API
-	// does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		defer func(apiToken string) {
-			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
-		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
-		os.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 	var perZoneAOP cloudflare.PerHostnameAuthenticatedOriginPullsCertificateDetails
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	rnd := generateRandomResourceName()

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls_test.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls_test.go
@@ -10,15 +10,6 @@ import (
 
 func TestAccCloudflareAuthenticatedOriginPullsGlobal(t *testing.T) {
 	t.Parallel()
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the AOP API
-	// does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		defer func(apiToken string) {
-			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
-		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
-		os.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_authenticated_origin_pulls.%s", rnd)
@@ -41,15 +32,6 @@ func TestAccCloudflareAuthenticatedOriginPullsGlobal(t *testing.T) {
 
 func TestAccCloudflareAuthenticatedOriginPullsPerZone(t *testing.T) {
 	t.Parallel()
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the AOP API
-	// does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		defer func(apiToken string) {
-			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
-		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
-		os.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_authenticated_origin_pulls.%s", rnd)
@@ -70,15 +52,6 @@ func TestAccCloudflareAuthenticatedOriginPullsPerZone(t *testing.T) {
 
 func TestAccCloudflareAuthenticatedOriginPullsPerHostname(t *testing.T) {
 	t.Parallel()
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the AOP API
-	// does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		defer func(apiToken string) {
-			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
-		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
-		os.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	hostname := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := generateRandomResourceName()


### PR DESCRIPTION
Essentially reverts https://github.com/cloudflare/terraform-provider-cloudflare/pull/772