### PR TITLE
resource/healthcheck: Handle deletion outside of Terraform

### DIFF
--- a/cloudflare/resource_cloudflare_healthcheck.go
+++ b/cloudflare/resource_cloudflare_healthcheck.go
@@ -171,6 +171,11 @@ func resourceCloudflareHealthcheckRead(d *schema.ResourceData, meta interface{})
 
 	healthcheck, err := client.Healthcheck(zoneID, d.Id())
 	if err != nil {
+		if strings.Contains(err.Error(), "object does not exist") {
+			log.Printf("[INFO] Healthcheck %s no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return errors.Wrap(err, fmt.Sprintf("error reading healthcheck information for %q", d.Id()))
 	}
 


### PR DESCRIPTION
When a resource is managed by Terraform, any changes outside of the
configuration, should be synced to keep the state in sync. This
previously wasn't the case with healthchecks as the 404 error (here,
resource has been deleted outside of Terraform) was returning a generic
error for any non-success statuses. To fix this, we inspect the returned
error and check for a string which denotes the resource not longer
exists and then sets `d.Id()` to an empty string and Terraform handles
the lifecycle correctly.

Fixes #785