### PR TITLE
resource/custom_hostname: Ensure `Import` stores hostname

### DIFF
--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -174,6 +174,7 @@ func resourceCloudflareCustomHostnameRead(d *schema.ResourceData, meta interface
 		return errors.Wrap(err, fmt.Sprintf("error reading custom hostname %q", hostnameID))
 	}
 
+	d.Set("hostname", customHostname.Hostname)
 	d.Set("ssl.custom_origin_server", customHostname.CustomOriginServer)
 
 	d.Set("ssl.0.type", customHostname.SSL.Type)

--- a/cloudflare/resource_cloudflare_custom_hostname_test.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_test.go
@@ -285,6 +285,32 @@ func TestAccCloudflareCustomHostname_UpdatingZoneForcesNewResource(t *testing.T)
 	})
 }
 
+func TestAccCloudflareCustomHostnameImport(t *testing.T) {
+	t.Parallel()
+
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := generateRandomResourceName()
+	resourceName := "cloudflare_custom_hostname." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareCustomHostnameBasic(zoneID, rnd, domain),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", zoneID),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ssl.#", "ssl.0.certificate_authority", "ssl.0.cname_name", "ssl.0.cname_target", "ssl.0.custom_certificate", "ssl.0.custom_key", "ssl.0.method", "ssl.0.status", "ssl.0.type", "ssl.0.wildcard"},
+			},
+		},
+	})
+}
+
 func testAccCheckCloudflareCustomHostnameRecreated(before, after *cloudflare.CustomHostname) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if before.ID == after.ID {


### PR DESCRIPTION
Within the `Read` function, we weren't setting the hostname to the
imported value (assuming it was always provided) which has left it
missing in state and subsequently causing replacements unnecessarily.

Fixes #783