### PR TITLE
resource/ip_list: handle missing remote IP List and recreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Fixes**
 
 * `resource/cloudflare_healthcheck`: Handle resource deletion outside of Terraform ([#787](https://github.com/cloudflare/terraform-provider-cloudflare/issues/787)) 
+* `resource/cloudflare_custom_hostname`: Ensure `Import` sets hostname to prevent recreation ([#788](https://github.com/cloudflare/terraform-provider-cloudflare/issues/788)) 
 
 ## 2.10.1 (August 24th, 2020)
 

--- a/cloudflare/resource_cloudflare_ip_list.go
+++ b/cloudflare/resource_cloudflare_ip_list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/pkg/errors"
+	"log"
 	"regexp"
 	"strings"
 )
@@ -112,6 +113,11 @@ func resourceCloudflareIPListRead(d *schema.ResourceData, meta interface{}) erro
 
 	list, err := client.GetIPList(context.Background(), d.Id())
 	if err != nil {
+		if strings.Contains(err.Error(), "could not find list") {
+			log.Printf("[INFO] IP List %s no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return errors.Wrap(err, fmt.Sprintf("error reading IP List with ID %q", d.Id()))
 	}
 


### PR DESCRIPTION
This is fixing pretty much the same issue as with #785 but for IP Lists