### PR TITLE
resouce/ip_list: Remove `item.id` from schema

### DIFF
--- a/cloudflare/resource_cloudflare_ip_list.go
+++ b/cloudflare/resource_cloudflare_ip_list.go
@@ -3,13 +3,14 @@ package cloudflare
 import (
 	"context"
 	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/pkg/errors"
-	"log"
-	"regexp"
-	"strings"
 )
 
 func resourceCloudflareIPList() *schema.Resource {
@@ -53,10 +54,6 @@ func resourceCloudflareIPList() *schema.Resource {
 
 var listItemElem = &schema.Resource{
 	Schema: map[string]*schema.Schema{
-		"id": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
 		"value": {
 			Type:     schema.TypeString,
 			Required: true,


### PR DESCRIPTION
Despite the `item` ID being marked as Computed, it is showing
unnecessary changes when running `apply` without any changes. For
whatever reason, the ID being returned is changing and Terraform is
trying to keep it in sync.

As we aren't using it, let's get rid of it and avoid the hassle of
keeping it in sync.