### PR TITLE
set logpush job id to "" when not found

### DIFF
--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -90,6 +90,7 @@ func resourceCloudflareLogpushJobRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			log.Printf("[INFO] Could not find LogpushJob with id: %q", jobID)
+			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("error finding logpush job %q: %s", jobID, err)

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -164,10 +164,17 @@ func resourceCloudflareLogpushJobDelete(d *schema.ResourceData, meta interface{}
 
 	deleteErr := client.DeleteLogpushJob(d.Get("zone_id").(string), job.ID)
 	if deleteErr != nil {
+		if strings.Contains(err.Error(), "job not found") {
+			log.Printf("[INFO] Could not find logpush job with id: %q", job.ID)
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("error deleting logpush job: %+v", job.ID)
 	}
 
-	return resourceCloudflareLogpushJobRead(d, meta)
+	d.SetId("")
+
+	return nil
 }
 
 func resourceCloudflareLogpushJobImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {


### PR DESCRIPTION
fixes #797 

There are currently no tests for the `logpush_job` resource that I could find so I haven't added or amended any. I assume that is because it requires resources external to Cloudflare?

Either way I have build the provider with this change and tested it ourselves and it's working as intended.