### PR TITLE
Change cloudflare_certificate_pack hosts to TypeSet

### DIFF
--- a/cloudflare/resource_cloudflare_certificate_pack_test.go
+++ b/cloudflare/resource_cloudflare_certificate_pack_test.go
@@ -23,8 +23,7 @@ func TestAccCertificatePackAdvancedDigicert(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(name, "type", "advanced"),
-					resource.TestCheckResourceAttr(name, "hosts.0", fmt.Sprintf("%s.%s", rnd, domain)),
-					resource.TestCheckResourceAttr(name, "hosts.1", domain),
+					resource.TestCheckResourceAttr(name, "hosts.#", "2"),
 					resource.TestCheckResourceAttr(name, "validation_method", "http"),
 					resource.TestCheckResourceAttr(name, "validity_days", "365"),
 					resource.TestCheckResourceAttr(name, "certificate_authority", "digicert"),
@@ -66,8 +65,7 @@ func TestAccCertificatePackAdvancedLetsEncrypt(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(name, "type", "advanced"),
-					resource.TestCheckResourceAttr(name, "hosts.0", fmt.Sprintf("*.%s", domain)),
-					resource.TestCheckResourceAttr(name, "hosts.1", domain),
+					resource.TestCheckResourceAttr(name, "hosts.#", "2"),
 					resource.TestCheckResourceAttr(name, "validation_method", "txt"),
 					resource.TestCheckResourceAttr(name, "validity_days", "90"),
 					resource.TestCheckResourceAttr(name, "certificate_authority", "lets_encrypt"),
@@ -109,8 +107,7 @@ func TestAccCertificatePackDedicatedCustom(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(name, "type", "dedicated_custom"),
-					resource.TestCheckResourceAttr(name, "hosts.0", fmt.Sprintf("%s.%s", rnd, domain)),
-					resource.TestCheckResourceAttr(name, "hosts.1", domain),
+					resource.TestCheckResourceAttr(name, "hosts.#", "2"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes #799

The ordering of `hosts` within a Certificate Pack does not matter and it's not consistent. I observed that the ordering can change when the certificate status transitions from "pending_deployment" to "active".

Changing it to a TypeSet prevents the Certificate Pack from being unnecessarily replaced when the ordering changes.