### PR TITLE
Possible typo in cloudflare_certificate_pack example

### DIFF
--- a/website/docs/r/certificate_pack.html.markdown
+++ b/website/docs/r/certificate_pack.html.markdown
@@ -47,7 +47,7 @@ resource "cloudflare_certificate_pack" "advanced_example_for_lets_encrypt" {
   hosts                 = ["example.com", "*.example.com"]
   validation_method     = "http"
   validity_days         = 90
-  certificate_authority = "lets_encrypot"
+  certificate_authority = "lets_encrypt"
   cloudflare_branding   = false
 }
 ```


### PR DESCRIPTION
I suspect that it should be "lets_encrypt" instead of "lets_encrypot".