### PR TITLE
Add support for zone-level routes to Access resources

### DIFF
--- a/cloudflare/provider_test.go
+++ b/cloudflare/provider_test.go
@@ -32,20 +32,24 @@ func TestProvider_impl(t *testing.T) {
 type preCheckFunc = func(*testing.T)
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("CLOUDFLARE_EMAIL"); v == "" {
-		t.Fatal("CLOUDFLARE_EMAIL must be set for acceptance tests")
-	}
-
-	if v := os.Getenv("CLOUDFLARE_API_KEY"); v == "" {
-		t.Fatal("CLOUDFLARE_API_KEY must be set for acceptance tests")
-	}
-
-	if v := os.Getenv("CLOUDFLARE_DOMAIN"); v == "" {
-		t.Fatal("CLOUDFLARE_DOMAIN must be set for acceptance tests. The domain is used to create and destroy record against.")
-	}
+	testAccPreCheckEmail(t)
+	testAccPreCheckApiKey(t)
+	testAccPreCheckDomain(t)
 
 	if v := os.Getenv("CLOUDFLARE_ZONE_ID"); v == "" {
 		t.Fatal("CLOUDFLARE_ZONE_ID must be set for this acceptance test")
+	}
+}
+
+func testAccessAccPreCheck(t *testing.T) {
+	testAccPreCheckEmail(t)
+	testAccPreCheckApiKey(t)
+	testAccPreCheckDomain(t)
+
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if zoneID == "" && accountID == "" {
+		t.Fatal("CLOUDFLARE_ZONE_ID or CLOUDFLARE_ACCOUNT_ID must be set for this acceptance test")
 	}
 }
 
@@ -64,6 +68,24 @@ func testAccPreCheckAltZoneID(t *testing.T) {
 func testAccPreCheckAccount(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_ACCOUNT_ID"); v == "" {
 		t.Fatal("CLOUDFLARE_ACCOUNT_ID must be set for this acceptance test")
+	}
+}
+
+func testAccPreCheckEmail(t *testing.T) {
+	if v := os.Getenv("CLOUDFLARE_EMAIL"); v == "" {
+		t.Fatal("CLOUDFLARE_EMAIL must be set for acceptance tests")
+	}
+}
+
+func testAccPreCheckApiKey(t *testing.T) {
+	if v := os.Getenv("CLOUDFLARE_API_KEY"); v == "" {
+		t.Fatal("CLOUDFLARE_API_KEY must be set for acceptance tests")
+	}
+}
+
+func testAccPreCheckDomain(t *testing.T) {
+	if v := os.Getenv("CLOUDFLARE_DOMAIN"); v == "" {
+		t.Fatal("CLOUDFLARE_DOMAIN must be set for acceptance tests. The domain is used to create and destroy record against.")
 	}
 }
 

--- a/cloudflare/resource_cloudflare_access_identity_provider_test.go
+++ b/cloudflare/resource_cloudflare_access_identity_provider_test.go
@@ -47,20 +47,36 @@ func testSweepCloudflareAccessIdentityProviders(r string) error {
 
 func TestAccCloudflareAccessIdentityProviderOneTimePin(t *testing.T) {
 	t.Parallel()
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := generateRandomResourceName()
 	resourceName := "cloudflare_access_identity_provider." + rnd
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudflareAccessIdentityProviderOneTimePin(accountID, rnd),
+				Config: testAccCheckCloudflareAccessIdentityProviderOneTimePin(rnd, AccessIdentifier{Type: AccountType, Value: accountID}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "account_id", accountID),
+					resource.TestCheckResourceAttr(resourceName, "name", rnd),
+					resource.TestCheckResourceAttr(resourceName, "type", "onetimepin"),
+				),
+			},
+		},
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccessAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareAccessIdentityProviderOneTimePin(rnd, AccessIdentifier{Type: ZoneType, Value: zoneID}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(resourceName, "name", rnd),
 					resource.TestCheckResourceAttr(resourceName, "type", "onetimepin"),
 				),
@@ -76,7 +92,7 @@ func TestAccCloudflareAccessIdentityProviderOAuth(t *testing.T) {
 	resourceName := "cloudflare_access_identity_provider." + rnd
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		Providers: testAccProviders,
@@ -102,7 +118,7 @@ func TestAccCloudflareAccessIdentityProviderOAuthWithUpdate(t *testing.T) {
 	resourceName := "cloudflare_access_identity_provider." + rnd
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		Providers: testAccProviders,
@@ -138,7 +154,7 @@ func TestAccCloudflareAccessIdentityProviderSAML(t *testing.T) {
 	resourceName := "cloudflare_access_identity_provider." + rnd
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		Providers: testAccProviders,
@@ -162,13 +178,13 @@ func TestAccCloudflareAccessIdentityProviderSAML(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudflareAccessIdentityProviderOneTimePin(accountID, name string) string {
+func testAccCheckCloudflareAccessIdentityProviderOneTimePin(name string, identifier AccessIdentifier) string {
 	return fmt.Sprintf(`
-resource "cloudflare_access_identity_provider" "%[2]s" {
-  account_id = "%[1]s"
-  name = "%[2]s"
-  type = "onetimepin"
-}`, accountID, name)
+resource "cloudflare_access_identity_provider" "%[1]s" {
+  %[2]s_id = "%[3]s"
+  name     = "%[1]s"
+  type     = "onetimepin"
+}`, name, identifier.Type, identifier.Value)
 }
 
 func testAccCheckCloudflareAccessIdentityProviderOAuth(accountID, name string) string {

--- a/cloudflare/resource_cloudflare_access_policy_test.go
+++ b/cloudflare/resource_cloudflare_access_policy_test.go
@@ -26,7 +26,7 @@ func TestAccAccessPolicyServiceToken(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		Providers: testAccProviders,
@@ -51,7 +51,7 @@ func TestAccAccessPolicyAnyServiceToken(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		Providers: testAccProviders,
@@ -72,14 +72,11 @@ func TestAccAccessPolicyWithZoneID(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "cloudflare_access_policy." + rnd
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	updatedName := fmt.Sprintf("%s-updated", rnd)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckAccount(t)
+			testAccessAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -87,7 +84,7 @@ func TestAccAccessPolicyWithZoneID(t *testing.T) {
 				Config: testAccessPolicyWithZoneID(rnd, zone, zoneID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", rnd),
-					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(name, "include.0.any_valid_service_token", "true"),
 				),
 			},
@@ -95,7 +92,7 @@ func TestAccAccessPolicyWithZoneID(t *testing.T) {
 				Config: testAccessPolicyWithZoneIDUpdated(rnd, zone, zoneID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", updatedName),
-					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(name, "include.0.any_valid_service_token", "true"),
 				),
 			},
@@ -208,7 +205,7 @@ func TestAccessPolicyGroup(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		Providers: testAccProviders,
@@ -265,7 +262,7 @@ func TestAccessPolicyMTLS(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		Providers: testAccProviders,
@@ -313,7 +310,7 @@ func TestAccessPolicyCommonName(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		Providers: testAccProviders,

--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -114,7 +114,6 @@ func resourceCloudflareAccessRuleRead(d *schema.ResourceData, meta interface{}) 
 		if client.AccountID != "" {
 			accessRuleResponse, err = client.AccountAccessRule(client.AccountID, d.Id())
 		} else {
-
 			accessRuleResponse, err = client.UserAccessRule(d.Id())
 		}
 	} else {

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -153,3 +153,42 @@ func getAccountIDFromZoneID(d *schema.ResourceData, client *cloudflare.API) (str
 	d.Set("account_id", accountID)
 	return accountID, nil
 }
+
+// AccessIdentifier represents the identifier provided in a resource
+type AccessIdentifier struct {
+	Type  AccessIdentifierType
+	Value string
+}
+
+// AccessIdentifierType represents the identifier type for access resources
+type AccessIdentifierType string
+
+const (
+	// AccountType is the access identifier type for an account
+	AccountType AccessIdentifierType = "account"
+
+	// ZoneType is the access identifier type for a zone
+	ZoneType AccessIdentifierType = "zone"
+)
+
+func initIdentifier(d *schema.ResourceData) (*AccessIdentifier, error) {
+	accountID := d.Get("account_id").(string)
+	zoneID := d.Get("zone_id").(string)
+	if accountID == "" && zoneID == "" {
+		return nil, fmt.Errorf("error creating Access Application: zone_id or account_id required")
+	}
+
+	if accountID != "" {
+		d.Set("account_id", accountID)
+		return &AccessIdentifier{
+			Type:  AccountType,
+			Value: accountID,
+		}, nil
+	}
+
+	d.Set("zone_id", zoneID)
+	return &AccessIdentifier{
+		Type:  ZoneType,
+		Value: zoneID,
+	}, nil
+}

--- a/website/docs/r/access_application.html.markdown
+++ b/website/docs/r/access_application.html.markdown
@@ -42,6 +42,8 @@ resource "cloudflare_access_application" "staging_app" {
 
 The following arguments are supported:
 
+-> **Note:** It's required that an `account_id` or `zone_id` is provided and in most cases using either is fine. However, if you're using a scoped access token, you must provide the argument that matches the token's scope. For example, an access token that is scoped to the "example.com" zone needs to use the `zone_id` argument.
+
 * `account_id` - (Optional) The account to which the access application should be added. Conflicts with `zone_id`.
 * `zone_id` - (Optional) The DNS zone to which the access application should be added. Conflicts with `account_id`.
 * `name` - (Required) Friendly name of the Access Application.

--- a/website/docs/r/access_application.html.markdown
+++ b/website/docs/r/access_application.html.markdown
@@ -42,7 +42,8 @@ resource "cloudflare_access_application" "staging_app" {
 
 The following arguments are supported:
 
-* `zone_id` - (Required) The DNS zone to which the access rule should be added.
+* `account_id` - (Optional) The account to which the access application should be added. Conflicts with `zone_id`.
+* `zone_id` - (Optional) The DNS zone to which the access application should be added. Conflicts with `account_id`.
 * `name` - (Required) Friendly name of the Access Application.
 * `domain` - (Required) The complete URL of the asset you wish to put
   Cloudflare Access in front of. Can include subdomains or paths. Or both.

--- a/website/docs/r/access_group.html.markdown
+++ b/website/docs/r/access_group.html.markdown
@@ -45,6 +45,8 @@ resource "cloudflare_access_group" "test_group" {
 
 The following arguments are supported:
 
+-> **Note:** It's required that an `account_id` or `zone_id` is provided and in most cases using either is fine. However, if you're using a scoped access token, you must provide the argument that matches the token's scope. For example, an access token that is scoped to the "example.com" zone needs to use the `zone_id` argument.
+
 * `account_id` - (Optional) The ID of the account the group is associated with. Conflicts with `zone_id`.
 * `zone_id` - (Optional) The ID of the zone the group is associated with. Conflicts with `account_id`.
 * `name` - (Required) Friendly name of the Access Group.

--- a/website/docs/r/access_group.html.markdown
+++ b/website/docs/r/access_group.html.markdown
@@ -45,8 +45,8 @@ resource "cloudflare_access_group" "test_group" {
 
 The following arguments are supported:
 
-* `account_id` - (Required) The ID of the account the group is
-  associated with.
+* `account_id` - (Optional) The ID of the account the group is associated with. Conflicts with `zone_id`.
+* `zone_id` - (Optional) The ID of the zone the group is associated with. Conflicts with `account_id`.
 * `name` - (Required) Friendly name of the Access Group.
 * `require` - (Optional) A series of access conditions, see below for
   full list.

--- a/website/docs/r/access_identity_provider.html.markdown
+++ b/website/docs/r/access_identity_provider.html.markdown
@@ -54,6 +54,8 @@ for full reference on what is available and how to configure your provider.
 
 The following arguments are supported:
 
+-> **Note:** It's required that an `account_id` or `zone_id` is provided and in most cases using either is fine. However, if you're using a scoped access token, you must provide the argument that matches the token's scope. For example, an access token that is scoped to the "example.com" zone needs to use the `zone_id` argument.
+
 * `account_id` - (Optional) The account ID the provider should be associated with. Conflicts with `zone_id`.
 * `zone_id` - (Optional) The zone ID the provider should be associated with. Conflicts with `account_id`.
 * `name` - (Required) Friendly name of the Access Identity Provider configuration.

--- a/website/docs/r/access_identity_provider.html.markdown
+++ b/website/docs/r/access_identity_provider.html.markdown
@@ -54,7 +54,8 @@ for full reference on what is available and how to configure your provider.
 
 The following arguments are supported:
 
-* `account` - (Required) The account ID the provider should be associated with.
+* `account_id` - (Optional) The account ID the provider should be associated with. Conflicts with `zone_id`.
+* `zone_id` - (Optional) The zone ID the provider should be associated with. Conflicts with `account_id`.
 * `name` - (Required) Friendly name of the Access Identity Provider configuration.
 * `type` - (Required) The provider type to use. Must be one of: `"centrify"`,
   `"facebook"`, `"google-apps"`, `"oidc"`, `"github"`, `"google"`, `"saml"`,

--- a/website/docs/r/access_policy.html.markdown
+++ b/website/docs/r/access_policy.html.markdown
@@ -51,6 +51,8 @@ resource "cloudflare_access_policy" "test_policy" {
 
 The following arguments are supported:
 
+-> **Note:** It's required that an `account_id` or `zone_id` is provided and in most cases using either is fine. However, if you're using a scoped access token, you must provide the argument that matches the token's scope. For example, an access token that is scoped to the "example.com" zone needs to use the `zone_id` argument.
+
 * `application_id` - (Required) The ID of the application the policy is associated with.
 * `account_id` - (Optional) The account to which the access rule should be added. Conflicts with `zone_id`.
 * `zone_id` - (Optional) The DNS zone to which the access rule should be added. Conflicts with `account_id`.

--- a/website/docs/r/access_policy.html.markdown
+++ b/website/docs/r/access_policy.html.markdown
@@ -51,10 +51,9 @@ resource "cloudflare_access_policy" "test_policy" {
 
 The following arguments are supported:
 
-* `application_id` - (Required) The ID of the application the policy is
-  associated with.
-* `zone_id` - (Required) The DNS zone to which the access rule should be
-  added.
+* `application_id` - (Required) The ID of the application the policy is associated with.
+* `account_id` - (Optional) The account to which the access rule should be added. Conflicts with `zone_id`.
+* `zone_id` - (Optional) The DNS zone to which the access rule should be added. Conflicts with `account_id`.
 * `decision` - (Required) Defines the action Access will take if the policy matches the user.
   Allowed values: `allow`, `deny`, `non_identity`, `bypass`
 * `name` - (Required) Friendly name of the Access Application.

--- a/website/docs/r/access_service_token.html.markdown
+++ b/website/docs/r/access_service_token.html.markdown
@@ -24,8 +24,8 @@ resource "cloudflare_access_service_token" "my_app" {
 
 The following arguments are supported:
 
-* `account_id` - (Required) The ID of the account where the Access
-Service is being created.
+* `account_id` - (Optional) The ID of the account where the Access Service is being created. Conflicts with `zone_id`.
+* `zone_id` - (Optional) The ID of the zone where the Access Service is being created. Conflicts with `account_id`.
 * `name` - (Required) Friendly name of the token's intent.
 
 ## Attributes Reference

--- a/website/docs/r/access_service_token.html.markdown
+++ b/website/docs/r/access_service_token.html.markdown
@@ -24,6 +24,8 @@ resource "cloudflare_access_service_token" "my_app" {
 
 The following arguments are supported:
 
+-> **Note:** It's required that an `account_id` or `zone_id` is provided and in most cases using either is fine. However, if you're using a scoped access token, you must provide the argument that matches the token's scope. For example, an access token that is scoped to the "example.com" zone needs to use the `zone_id` argument.
+
 * `account_id` - (Optional) The ID of the account where the Access Service is being created. Conflicts with `zone_id`.
 * `zone_id` - (Optional) The ID of the zone where the Access Service is being created. Conflicts with `account_id`.
 * `name` - (Required) Friendly name of the token's intent.


### PR DESCRIPTION
Requires a new cloudflare-go version with https://github.com/cloudflare/cloudflare-go/pull/538 before this can be merged.

Closes https://github.com/cloudflare/terraform-provider-cloudflare/issues/812.