### PR TITLE
Waf rule docs update

### DIFF
--- a/website/docs/d/waf_rules.html.md
+++ b/website/docs/d/waf_rules.html.md
@@ -41,7 +41,7 @@ values must match in order to be included, see below for full list.
 **filter**
 
 - `description` - (Optional) A regular expression matching the description of the WAF Rules to lookup.
-- `mode` - (Optional) Mode of the WAF Rules to lookup. Valid values: `"on"` and `"off"`.
+- `mode` - (Optional) Mode of the WAF Rules to lookup. Valid values: one of ["block", "challenge", "default", "disable", "simulate"] or ["on", "off"] depending on the the WAF Rule type.
 - `group_id` - (Optional) The ID of the WAF Rule Group in which the WAF Rules to lookup have to be.
 
 ## Attributes Reference

--- a/website/docs/d/waf_rules.html.md
+++ b/website/docs/d/waf_rules.html.md
@@ -41,7 +41,7 @@ values must match in order to be included, see below for full list.
 **filter**
 
 - `description` - (Optional) A regular expression matching the description of the WAF Rules to lookup.
-- `mode` - (Optional) Mode of the WAF Rules to lookup. Valid values: one of ["block", "challenge", "default", "disable", "simulate"] or ["on", "off"] depending on the the WAF Rule type.
+- `mode` - (Optional) Mode of the WAF Rules to lookup. Valid values: one of ["block", "challenge", "default", "disable", "simulate"] or ["on", "off"] depending on the WAF Rule type.
 - `group_id` - (Optional) The ID of the WAF Rule Group in which the WAF Rules to lookup have to be.
 
 ## Attributes Reference

--- a/website/docs/r/waf_rule.html.markdown
+++ b/website/docs/r/waf_rule.html.markdown
@@ -27,7 +27,7 @@ The following arguments are supported:
 * `zone_id` - (Required) The DNS zone ID to apply to.
 * `rule_id` - (Required) The WAF Rule ID.
 * `package_id` - (Optional) The ID of the WAF Rule Package that contains the rule.
-* `mode` - (Required) The mode of the rule, can be one of ["block", "challenge", "default", "disable", "simulate"].
+* `mode` - (Required) The mode of the rule, can be one of ["block", "challenge", "default", "disable", "simulate"] or ["on", "off"] depending on the the WAF Rule type.
 
 
 ## Attributes Reference

--- a/website/docs/r/waf_rule.html.markdown
+++ b/website/docs/r/waf_rule.html.markdown
@@ -27,7 +27,7 @@ The following arguments are supported:
 * `zone_id` - (Required) The DNS zone ID to apply to.
 * `rule_id` - (Required) The WAF Rule ID.
 * `package_id` - (Optional) The ID of the WAF Rule Package that contains the rule.
-* `mode` - (Required) The mode of the rule, can be one of ["block", "challenge", "default", "disable", "simulate"] or ["on", "off"] depending on the the WAF Rule type.
+* `mode` - (Required) The mode of the rule, can be one of ["block", "challenge", "default", "disable", "simulate"] or ["on", "off"] depending on the WAF Rule type.
 
 
 ## Attributes Reference


### PR DESCRIPTION
# What & Why

Some cloudflare WAF rules have `["block", "challenge", "default", "disable", "simulate"]` as available modes, but others have `["on", "off"]` instead. The current documentation doesn't explain the whole story.

Example from cloudflare WordPress managed WAF group:
![cloudflare-wordpress-waf-group](https://user-images.githubusercontent.com/8621162/95919895-079c8e00-0d74-11eb-8a55-2aa31d0b3997.png)
