### PR TITLE
zone: Remove `DiffSuppressFunc` causing `jump_start` issues

### DIFF
--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -59,9 +59,6 @@ func resourceCloudflareZone() *schema.Resource {
 			"jump_start": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return true
-				},
 			},
 			"paused": {
 				Type:     schema.TypeBool,

--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -30,6 +30,29 @@ func TestAccCloudflareZoneBasic(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareZoneBasicWithJumpStartEnabled(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_zone." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testZoneConfig(rnd, "example.cfapi.net", "true", "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "zone", "example.cfapi.net"),
+					resource.TestCheckResourceAttr(name, "paused", "true"),
+					resource.TestCheckResourceAttr(name, "name_servers.#", "2"),
+					resource.TestCheckResourceAttr(name, "plan", planIDFree),
+					resource.TestCheckResourceAttr(name, "type", "full"),
+					resource.TestCheckResourceAttr(name, "jump_start", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudflareZoneWithPlan(t *testing.T) {
 	name := "cloudflare_zone.tf-acc-with-plan-zone"
 	resourceName := strings.Split(name, ".")[1]


### PR DESCRIPTION
Updates the `cloudflare_zone` schema to remove `DiffSuppressFunc` for
`jump_start`. From the test case in #826, this attribute is causing the
value to always be set to "false" which is preventing the end users
value from being passed through to the API call.

The history suggests this has always been the case since the resource
was introduced so I'm not sure if it was intentional, however this
addresses the bug in question.

Fixes #826