### PR TITLE
datasource/cloudflare_ips: Support China colo IPS

### DIFF
--- a/cloudflare/data_source_ip_ranges.go
+++ b/cloudflare/data_source_ip_ranges.go
@@ -2,13 +2,11 @@ package cloudflare
 
 import (
 	"fmt"
-	"io/ioutil"
-	"log"
 	"sort"
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/go-cleanhttp"
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -23,17 +21,27 @@ func dataSourceCloudflareIPRanges() *schema.Resource {
 		Read: dataSourceCloudflareIPRangesRead,
 
 		Schema: map[string]*schema.Schema{
-			"cidr_blocks": &schema.Schema{
+			"cidr_blocks": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"ipv4_cidr_blocks": &schema.Schema{
+			"ipv4_cidr_blocks": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"ipv6_cidr_blocks": &schema.Schema{
+			"ipv6_cidr_blocks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"china_ipv4_cidr_blocks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"china_ipv6_cidr_blocks": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -43,56 +51,46 @@ func dataSourceCloudflareIPRanges() *schema.Resource {
 }
 
 func dataSourceCloudflareIPRangesRead(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] Reading IPv4 ranges")
-	ipv4s, err := dataSourceCloudflareIPRangesGet(urlIPV4s)
+	ranges, err := cloudflare.IPs()
 	if err != nil {
-		return fmt.Errorf("Error listing IPV4 ranges: %s", err)
+		return fmt.Errorf("failed to fetch Cloudflare IP ranges: %s", err)
 	}
-	sort.Strings(ipv4s)
 
-	log.Printf("[DEBUG] Reading IPv6 ranges")
-	ipv6s, err := dataSourceCloudflareIPRangesGet(urlIPV6s)
-	if err != nil {
-		return fmt.Errorf("Error listing IPV6 ranges: %s", err)
-	}
-	sort.Strings(ipv6s)
+	IPv4s := ranges.IPv4CIDRs
+	IPv6s := ranges.IPv6CIDRs
+	chinaIPv4s := ranges.ChinaIPv4CIDRs
+	chinaIPv6s := ranges.ChinaIPv6CIDRs
 
-	all := append([]string{}, ipv4s...)
-	all = append(all, ipv6s...)
+	sort.Strings(IPv4s)
+	sort.Strings(IPv6s)
+	sort.Strings(chinaIPv4s)
+	sort.Strings(chinaIPv6s)
+
+	all := append([]string{}, IPv4s...)
+	all = append(all, IPv6s...)
+	sort.Strings(all)
 
 	d.SetId(strconv.Itoa(hashcode.String(strings.Join(all, "|"))))
 
 	if err := d.Set("cidr_blocks", all); err != nil {
-		return fmt.Errorf("Error setting all cidr blocks: %s", err)
+		return fmt.Errorf("error setting all cidr blocks: %s", err)
 	}
 
-	if err := d.Set("ipv4_cidr_blocks", ipv4s); err != nil {
-		return fmt.Errorf("Error setting ipv4 cidr blocks: %s", err)
+	if err := d.Set("ipv4_cidr_blocks", IPv4s); err != nil {
+		return fmt.Errorf("error setting ipv4 cidr blocks: %s", err)
 	}
 
-	if err := d.Set("ipv6_cidr_blocks", ipv6s); err != nil {
-		return fmt.Errorf("Error setting ipv6 cidr blocks: %s", err)
+	if err := d.Set("ipv6_cidr_blocks", IPv6s); err != nil {
+		return fmt.Errorf("error setting ipv6 cidr blocks: %s", err)
+	}
+
+	if err := d.Set("china_ipv4_cidr_blocks", chinaIPv4s); err != nil {
+		return fmt.Errorf("error setting china ipv4 cidr blocks: %s", err)
+	}
+
+	if err := d.Set("china_ipv6_cidr_blocks", chinaIPv6s); err != nil {
+		return fmt.Errorf("error setting china ipv6 cidr blocks: %s", err)
 	}
 
 	return nil
-}
-
-// dataSourceCloudflareIPRangesGet performs an HTTP GET on the given URL and
-// parses each line as an IP address.
-func dataSourceCloudflareIPRangesGet(url string) ([]string, error) {
-	conn := cleanhttp.DefaultClient()
-
-	res, err := conn.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	list := strings.Split(strings.TrimSpace(string(body)), "\n")
-	return list, nil
 }

--- a/website/docs/d/ip_ranges.html.md
+++ b/website/docs/d/ip_ranges.html.md
@@ -20,7 +20,7 @@ resource "google_compute_firewall" "allow_cloudflare_ingress" {
   network = "default"
 
   source_ranges = data.cloudflare_ip_ranges.cloudflare.ipv4_cidr_blocks
-  
+
   allow {
     ports    = "443"
     protocol = "tcp"
@@ -30,10 +30,10 @@ resource "google_compute_firewall" "allow_cloudflare_ingress" {
 
 ## Attributes Reference
 
-- `cidr_blocks` - The lexically ordered list of all CIDR blocks.
-
+- `cidr_blocks` - The lexically ordered list of all non-China CIDR blocks.
 - `ipv4_cidr_blocks` - The lexically ordered list of only the IPv4 CIDR blocks.
-
 - `ipv6_cidr_blocks` - The lexically ordered list of only the IPv6 CIDR blocks.
+- `china_ipv4_cidr_blocks` - The lexically ordered list of only the IPv4 China CIDR blocks.
+- `china_ipv6_cidr_blocks` - The lexically ordered list of only the IPv6 China CIDR blocks.
 
 [1]: https://www.cloudflare.com/ips/


### PR DESCRIPTION
Updates the `cloudflare_ip_ranges` datasource to expose the China colo
IPs.

This change swaps the source of the data from
`cloudflare.com/ips-{v4,v6}` to use the API (without authentication) to
offload the connection and management to `cloudflare-go` instead of
using a snowflake approach.

In order to maintain backwards compatibitily, `cidr_blocks` *does not*
include the China colo IPs and instead, if you're wanting to use them as
one, you will need to use Terraform's [`concat`](https://www.terraform.io/docs/configuration/functions/concat.html) function or have two
separate resource rules utilising them.

Closes #809