### PR TITLE
Unset API token use for some tests

### DIFF
--- a/cloudflare/resource_cloudflare_access_identity_provider_test.go
+++ b/cloudflare/resource_cloudflare_access_identity_provider_test.go
@@ -46,6 +46,16 @@ func testSweepCloudflareAccessIdentityProviders(r string) error {
 }
 
 func TestAccCloudflareAccessIdentityProviderOneTimePin(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the OTP Access
+	// endpoint does not yet support the API tokens for updates and it results in
+	// state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	t.Parallel()
 	rnd := generateRandomResourceName()
 	resourceName := "cloudflare_access_identity_provider." + rnd

--- a/cloudflare/resource_cloudflare_custom_hostname_fallback_origin_test.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_fallback_origin_test.go
@@ -11,6 +11,16 @@ import (
 )
 
 func TestAccCloudflareCustomHostnameFallbackOrigin(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the custom hostname
+	// fallback endpoint does not yet support the API tokens for updates and it
+	// results in state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := generateRandomResourceName()
@@ -50,6 +60,16 @@ resource "cloudflare_record" "%[2]s" {
 }
 
 func TestAccCloudflareCustomHostnameFallbackOriginUpdate(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the custom hostname
+	// fallback endpoint does not yet support the API tokens for updates and it
+	// results in state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := generateRandomResourceName()


### PR DESCRIPTION
Updates the following tests to unset the API token value as the endpoint
doesn't support API tokens yet and it's causing the integration tests to
fail.

- TestAccCloudflareAccessIdentityProviderOneTimePin
- TestAccCloudflareCustomHostnameFallbackOrigin
- TestAccCloudflareCustomHostnameFallbackOriginUpdate

Closes #838
Closes #840