### PR TITLE
Make `testAccCheckCloudflareAccessGroupExists` AccessIdentifer aware

### DIFF
--- a/cloudflare/resource_cloudflare_access_group_test.go
+++ b/cloudflare/resource_cloudflare_access_group_test.go
@@ -31,7 +31,7 @@ func TestAccCloudflareAccessGroupConfig_Basic(t *testing.T) {
 			{
 				Config: testAccCloudflareAccessGroupConfigBasic(rnd, email, AccessIdentifier{Type: AccountType, Value: accountID}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareAccessGroupExists(name, &accessGroup),
+					testAccCheckCloudflareAccessGroupExists(name, AccessIdentifier{Type: AccountType, Value: accountID}, &accessGroup),
 					resource.TestCheckResourceAttr(name, "account_id", accountID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "include.0.email.0", email),
@@ -43,7 +43,6 @@ func TestAccCloudflareAccessGroupConfig_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccessAccPreCheck(t)
-			testAccPreCheckAccount(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudflareAccessGroupDestroy,
@@ -51,7 +50,7 @@ func TestAccCloudflareAccessGroupConfig_Basic(t *testing.T) {
 			{
 				Config: testAccCloudflareAccessGroupConfigBasic(rnd, email, AccessIdentifier{Type: ZoneType, Value: zoneID}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareAccessGroupExists(name, &accessGroup),
+					testAccCheckCloudflareAccessGroupExists(name, AccessIdentifier{Type: ZoneType, Value: zoneID}, &accessGroup),
 					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "include.0.email.0", email),
@@ -76,7 +75,7 @@ func TestAccCloudflareAccessGroup_Exclude(t *testing.T) {
 			{
 				Config: testAccessGroupConfigExclude(rnd, accountID, email),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareAccessGroupExists(name, &accessGroup),
+					testAccCheckCloudflareAccessGroupExists(name, AccessIdentifier{Type: AccountType, Value: accountID}, &accessGroup),
 					resource.TestCheckResourceAttr(name, "account_id", accountID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "include.0.email.0", email),
@@ -102,7 +101,7 @@ func TestAccCloudflareAccessGroup_Require(t *testing.T) {
 			{
 				Config: testAccessGroupConfigRequire(rnd, accountID, email),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareAccessGroupExists(name, &accessGroup),
+					testAccCheckCloudflareAccessGroupExists(name, AccessIdentifier{Type: AccountType, Value: accountID}, &accessGroup),
 					resource.TestCheckResourceAttr(name, "account_id", accountID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "include.0.email.0", email),
@@ -128,7 +127,7 @@ func TestAccCloudflareAccessGroup_FullConfig(t *testing.T) {
 			{
 				Config: testAccessGroupConfigFullConfig(rnd, accountID, email),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareAccessGroupExists(name, &accessGroup),
+					testAccCheckCloudflareAccessGroupExists(name, AccessIdentifier{Type: AccountType, Value: accountID}, &accessGroup),
 					resource.TestCheckResourceAttr(name, "account_id", accountID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "include.0.email.0", email),
@@ -157,7 +156,7 @@ func TestAccCloudflareAccessGroupWithIDP(t *testing.T) {
 			{
 				Config: testAccCloudflareAccessGroupWithIDP(accountID, rnd, githubOrg, team),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareAccessGroupExists(groupName, &accessGroup),
+					testAccCheckCloudflareAccessGroupExists(groupName, AccessIdentifier{Type: AccountType, Value: accountID}, &accessGroup),
 					resource.TestCheckResourceAttr(groupName, "account_id", accountID),
 					resource.TestCheckResourceAttr(groupName, "name", rnd),
 					resource.TestCheckResourceAttrSet(groupName, "include.0.github.0.identity_provider_id"),
@@ -185,13 +184,13 @@ func TestAccCloudflareAccessGroup_Updated(t *testing.T) {
 			{
 				Config: testAccCloudflareAccessGroupConfigBasic(rnd, email, AccessIdentifier{Type: AccountType, Value: accountID}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareAccessGroupExists(name, &before),
+					testAccCheckCloudflareAccessGroupExists(name, AccessIdentifier{Type: AccountType, Value: accountID}, &before),
 				),
 			},
 			{
 				Config: testAccCloudflareAccessGroupConfigBasic(rnd, "test-changed@example.com", AccessIdentifier{Type: AccountType, Value: accountID}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareAccessGroupExists(name, &after),
+					testAccCheckCloudflareAccessGroupExists(name, AccessIdentifier{Type: AccountType, Value: accountID}, &after),
 					testAccCheckCloudflareAccessGroupIDUnchanged(&before, &after),
 					resource.TestCheckResourceAttr(name, "include.0.email.0", "test-changed@example.com"),
 				),
@@ -217,7 +216,7 @@ func TestAccCloudflareAccessGroup_CreateAfterManualDestroy(t *testing.T) {
 			{
 				Config: testAccCloudflareAccessGroupConfigBasic(rnd, email, AccessIdentifier{Type: AccountType, Value: accountID}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareAccessGroupExists(name, &before),
+					testAccCheckCloudflareAccessGroupExists(name, AccessIdentifier{Type: AccountType, Value: accountID}, &before),
 					testAccManuallyDeleteAccessGroup(name, &initialID),
 				),
 				ExpectNonEmptyPlan: true,
@@ -225,7 +224,7 @@ func TestAccCloudflareAccessGroup_CreateAfterManualDestroy(t *testing.T) {
 			{
 				Config: testAccCloudflareAccessGroupConfigBasicWithUpdate(rnd, accountID, email),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareAccessGroupExists(name, &after),
+					testAccCheckCloudflareAccessGroupExists(name, AccessIdentifier{Type: AccountType, Value: accountID}, &after),
 					testAccCheckCloudflareAccessGroupRecreated(&before, &after),
 					resource.TestCheckResourceAttr(name, "account_id", accountID),
 					resource.TestCheckResourceAttr(name, "name", fmt.Sprintf("%s-updated", rnd)),
@@ -338,7 +337,7 @@ resource "cloudflare_access_group" "%[2]s" {
 }`, accountID, rnd, githubOrg, team)
 }
 
-func testAccCheckCloudflareAccessGroupExists(n string, accessGroup *cloudflare.AccessGroup) resource.TestCheckFunc {
+func testAccCheckCloudflareAccessGroupExists(n string, accessIdentifier AccessIdentifier, accessGroup *cloudflare.AccessGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -350,9 +349,20 @@ func testAccCheckCloudflareAccessGroupExists(n string, accessGroup *cloudflare.A
 		}
 
 		client := testAccProvider.Meta().(*cloudflare.API)
-		foundAccessGroup, err := client.AccessGroup(rs.Primary.Attributes["account_id"], rs.Primary.ID)
-		if err != nil {
-			return err
+		var foundAccessGroup cloudflare.AccessGroup
+		var err error
+
+		if accessIdentifier.Type == AccountType {
+			foundAccessGroup, err = client.AccessGroup(rs.Primary.Attributes["account_id"], rs.Primary.ID)
+			if err != nil {
+				return err
+			}
+		} else {
+			foundAccessGroups, _, err := client.ZoneLevelAccessGroups(rs.Primary.Attributes["zone_id"], cloudflare.PaginationOptions{})
+			if err != nil {
+				return err
+			}
+			foundAccessGroup = foundAccessGroups[0]
 		}
 
 		if foundAccessGroup.ID != rs.Primary.ID {


### PR DESCRIPTION
When the zone/account refactor was performed, the
`testAccCheckCloudflareAccessGroupExists` method wasn't updated and it
assumed the Access identifier type was always `Account`. This meant that
HTTP requests were being sent to the `accounts` endpoint without a
valid ID and would fail the integration test step.

Closes #835