### PR TITLE
doc: update provider key usage

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -48,8 +48,9 @@ The following arguments are supported:
   with the `CLOUDFLARE_API_TOKEN` shell environment variable. This is an
   alternative to `email`+`api_key`. If both are specified, `api_token` will be
   used over `email`+`api_key` fields.
-* `api_user_service_key` - (Optional) The Cloudflare API User Service Key. This can also 
-  be specified with the `CLOUDFLARE_API_USER_SERVICE_KEY` shell environment variable. 
+* `api_user_service_key` - (Optional) The Cloudflare API User Service Key. This can also be specified 
+  with the `CLOUDFLARE_API_USER_SERVICE_KEY` shell environment variable. The value is 
+  to be used in combination with an `api_token`, or `email` and `api_key`.
   This is used for a specific set of endpoints, such as creating Origin CA certificates.
 * `rps` - (Optional) RPS limit to apply when making calls to the API. Default: 4.
   This can also be specified with the `CLOUDFLARE_RPS` shell environment variable.

--- a/website/docs/r/origin_ca_certificate.html.markdown
+++ b/website/docs/r/origin_ca_certificate.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a Cloudflare Origin CA certificate used to protect traffic to your origin without involving a third party Certificate Authority.
 
-**This resource requires you use your Origin CA Key as the [`api_user_service_key`](../index.html#api_user_service_key).**
+**This resource requires you use your Origin CA Key as the [`api_user_service_key`](../index.html#api_user_service_key), in conjunction with an `api_token` or `email` and `api_key`.**
 
 ## Example Usage
 


### PR DESCRIPTION
Added a note about using `api_user_service_key` with other required keys/values in the provider doc, along with the `origin_ca_certificate` resource doc.

Resolves #851.