### PR TITLE
Err check for importing aop resources now checks for three params rather than two

### DIFF
--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls.go
@@ -155,7 +155,7 @@ func resourceCloudflareAuthenticatedOriginPullsImport(d *schema.ResourceData, me
 	// split the id so we can lookup
 	idAttr := strings.SplitN(d.Id(), "/", 3)
 
-	if len(idAttr) != 2 {
+	if len(idAttr) != 3 {
 		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneID/certID/hostname\"", d.Id())
 	}
 	zoneID, certID, hostname := idAttr[0], idAttr[1], idAttr[2]

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
@@ -202,7 +202,7 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateImport(d *schema.Resou
 	// split the id so we can lookup
 	idAttr := strings.SplitN(d.Id(), "/", 3)
 
-	if len(idAttr) != 2 {
+	if len(idAttr) != 3 {
 		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneID/type/certID\"", d.Id())
 	}
 	zoneID, aopType, certID := idAttr[0], idAttr[1], idAttr[2]


### PR DESCRIPTION
- "I think off by one errors are turing tests to make sure the dev is human" - @wolfmd

Closes #858