### PR TITLE
filter: Propagate schema validation error to end user

### DIFF
--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -10,6 +10,7 @@ import (
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/pkg/errors"
 )
 
 func resourceCloudflareFilter() *schema.Resource {
@@ -45,7 +46,8 @@ func resourceCloudflareFilter() *schema.Resource {
 					// interface available that holds the configured client.
 					api, err := cloudflare.New(os.Getenv("CLOUDFLARE_API_KEY"), os.Getenv("CLOUDFLARE_EMAIL"))
 					if err != nil {
-						log.Fatal(err)
+						errs = append(errs, errors.New("cloudflare_api_key and cloudflare_email are required for validating filter expressions but they are missing"))
+						return
 					}
 
 					expression := val.(string)


### PR DESCRIPTION
#848 introduced better validation for filters using the Terraform
schema. Despite handling the error, the error wasn't returned to the end
user and instead the RPC exception is shown the end user.

```
Error: rpc error: code = Unavailable desc = transport is closing
```

This fixes the user experience by returning the errors which now passes
the exception onto the end user instead of swallowing it or causing a
panic.

Example of the exception to the end user:

```
Error: cloudflare_api_key and cloudflare_email are required for validating filter expressions but they are missing

  on main.tf line 37, in resource "cloudflare_filter" "example_filter":
  37: resource "cloudflare_filter" "example_filter" {
````