### PR TITLE
Revert schema based filter validation

### DIFF
--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"html"
 	"log"
-	"os"
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"github.com/pkg/errors"
 )
 
 func resourceCloudflareFilter() *schema.Resource {
@@ -38,23 +36,6 @@ func resourceCloudflareFilter() *schema.Resource {
 				Required: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return strings.TrimSpace(new) == old
-				},
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					// Validating the filter expression doesn't support API tokens (yet!)
-					// so use API key and email for now. Establishing a new client here
-					// isn't the best solution either however we don't have the `meta`
-					// interface available that holds the configured client.
-					api, err := cloudflare.New(os.Getenv("CLOUDFLARE_API_KEY"), os.Getenv("CLOUDFLARE_EMAIL"))
-					if err != nil {
-						errs = append(errs, errors.New("cloudflare_api_key and cloudflare_email are required for validating filter expressions but they are missing"))
-						return
-					}
-
-					expression := val.(string)
-					if err := api.ValidateFilterExpression(expression); err != nil {
-						errs = append(errs, fmt.Errorf("filter expression is invalid: %s", err))
-					}
-					return
 				},
 			},
 			"description": {

--- a/cloudflare/resource_cloudflare_filter_test.go
+++ b/cloudflare/resource_cloudflare_filter_test.go
@@ -67,59 +67,6 @@ func TestAccFilterSimple(t *testing.T) {
 	})
 }
 
-func TestAccFilterInvalid(t *testing.T) {
-	rnd := generateRandomResourceName()
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testFilterConfig(rnd, zoneID, "true", "this is notes", "invalid expression"),
-				ExpectError: regexp.MustCompile("config is invalid: filter expression is invalid"),
-			},
-		},
-	})
-}
-
-func TestAccFilterMissingCredentials(t *testing.T) {
-	// Intentionally unset all credentials to trigger the lack of credentials
-	// check schema validation.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		defer func(apiToken string) {
-			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
-		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
-		os.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
-	if os.Getenv("CLOUDFLARE_API_KEY") != "" {
-		defer func(apiKey string) {
-			os.Setenv("CLOUDFLARE_API_KEY", apiKey)
-		}(os.Getenv("CLOUDFLARE_API_KEY"))
-		os.Setenv("CLOUDFLARE_API_KEY", "")
-	}
-
-	if os.Getenv("CLOUDFLARE_EMAIL") != "" {
-		defer func(email string) {
-			os.Setenv("CLOUDFLARE_EMAIL", email)
-		}(os.Getenv("CLOUDFLARE_EMAIL"))
-		os.Setenv("CLOUDFLARE_EMAIL", "")
-	}
-
-	rnd := generateRandomResourceName()
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
-
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testFilterConfig(rnd, zoneID, "true", "this is notes", "invalid expression"),
-				ExpectError: regexp.MustCompile("cloudflare_api_key and cloudflare_email are required for validating filter expressions but they are missing"),
-			},
-		},
-	})
-}
 func TestAccFilterInvalidOver4kbString(t *testing.T) {
 	rnd := generateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")

--- a/cloudflare/resource_cloudflare_filter_test.go
+++ b/cloudflare/resource_cloudflare_filter_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/cloudflare/cloudflare-go"
@@ -62,27 +61,6 @@ func TestAccFilterSimple(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "paused", "true"),
 					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 				),
-			},
-		},
-	})
-}
-
-func TestAccFilterInvalidOver4kbString(t *testing.T) {
-	rnd := generateRandomResourceName()
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
-
-	output := ""
-	for i := 1; i < 4100; i++ {
-		output += "x"
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testFilterConfig(rnd, zoneID, "true", "this is notes", output),
-				ExpectError: regexp.MustCompile("config is invalid: filter expression is invalid"),
 			},
 		},
 	})


### PR DESCRIPTION
Due to the endpoint not supporting API tokens, we needed to build a
standalone client which hasn't worked out well and the workarounds to
fix it are against the grain of how the Terraform schema is intended to
be used leaving us in situation where change in upstream functionality
may force us to be on an older version of the SDK if we were to
continue. Instead, this reverts #848 and #860 and once API token support
is added to the endpoint, we can reintroduce this without a standalone
client.

Closes #861