### PR TITLE
readme: Improve building provider instructions

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -65,4 +65,20 @@ endif
 	ln -sf ../../../ext/providers/cloudflare/website/cloudflare.erb $(GOPATH)/src/github.com/hashicorp/terraform-website/content/source/layouts/cloudflare.erb
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test sweep testacc vet fmt fmtcheck errcheck test-compile website website-test
+os = $(shell go env GOOS)
+arch = $(shell go env GOARCH)
+dev_version = 99.0.0
+provider_path = registry.terraform.io/cloudflare/cloudflare/$(dev_version)/$(os)_$(arch)/
+
+build-and-install-dev-version:
+	go build -o terraform-provider-cloudflare_$(dev_version)
+ifeq ($(os), darwin)
+	mkdir -p ~/Library/Application\ Support/io.terraform/plugins/$(provider_path)
+	cp terraform-provider-cloudflare_$(dev_version) ~/Library/Application\ Support/io.terraform/plugins/$(provider_path)
+endif
+ifeq ($(os), linux)
+	mkdir -p /usr/local/share/terraform/plugins/$(provider_path)
+	cp terraform-provider-cloudflare_$(dev_version) /usr/local/share/terraform/plugins/$(provider_path)
+endif
+
+.PHONY: build test sweep testacc vet fmt fmtcheck errcheck test-compile website website-test build-and-install-dev-version

--- a/README.md
+++ b/README.md
@@ -20,43 +20,33 @@ $ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com
 $ git clone https://github.com/cloudflare/terraform-provider-cloudflare.git
 ```
 
-When it comes to building you have two options:
-
-#### `make build` and install it globally
-
-If you don't mind installing the development version of the provider
-globally, you can use `make build` in the provider directory which will
-build and link the binary into your `$GOPATH/bin` directory.
-
-```sh
-$ cd $GOPATH/src/github.com/cloudflare/terraform-provider-cloudflare
-$ make build
-```
-
-#### `go build` and install it local to your changes
-
-If you would rather install the provider locally and not impact the
-stable version you already have installed, you can use the
-`~/.terraformrc` file to tell Terraform where your provider is. You do
-this by building the provider using Go.
-
-```sh
-$ cd $GOPATH/src/github.com/cloudflare/terraform-provider-cloudflare
-$ go build -o terraform-provider-cloudflare
-```
-
-And then update your `~/.terraformrc` file to point at the location
-you've built it.
+Since Terraform 0.13, all providers (including local ones) require a version and
+need to meet stricter load conditions. To simplify this there is a `make` target
+available which will handle building and putting the executable in the correct
+place.
 
 ```
-providers {
-  cloudflare = "${GOPATH}/src/github.com/cloudflare/terraform-provider-cloudflare/terraform-provider-cloudflare"
+make build-and-install-dev-version
+```
+
+Once this completes, you will need to update your Terraform provider
+configuration to reference version 99.0.0 (the version of the development build)
+in order to use it. Example configuration:
+
+```hcl
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+      version = "99.0.0"
+    }
+  }
 }
 ```
 
-A caveat with this approach is that you will need to run `terraform
-init` whenever the provider is rebuilt. You'll also need to remember to
-comment it/remove it when it's not in use to avoid tripping yourself up.
+Be sure to remove any additional configuration from your `~/.terraformrc` and
+`.terraform` directories to prevent load issues.
 
 ## Developing the Provider
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,14 @@ terraform {
 ```
 
 Be sure to remove any additional configuration from your `~/.terraformrc` and
-`.terraform` directories to prevent load issues.
+`.terraform` directories to prevent load issues. You will also need to update
+*all* `version` references to use 99.0.0 in order to fully initialise the 
+development provider. If you see other versions (like the example below) you
+need to track them down and remove them.
+
+```
+Finding cloudflare/cloudflare versions matching "99.0.0, ~> 2.*"...
+```
 
 ## Developing the Provider
 


### PR DESCRIPTION
Terraform 0.13.x [introduced stricter requirements for loading
providers](https://www.terraform.io/docs/commands/cli-config.html#provider-installation) to use unreleased versions. I fumbled my way through and
decided to codify this as a `make` target instead.

*Note:* This has only been tested on Mac. Linux support should work but
Windows isn't.