### PR TITLE
Replace ids with checksum of the resource ids

### DIFF
--- a/cloudflare/data_source_waf_groups.go
+++ b/cloudflare/data_source_waf_groups.go
@@ -135,6 +135,7 @@ func dataSourceCloudflareWAFGroupsRead(d *schema.ResourceData, meta interface{})
 				"modified_rules_count": group.ModifiedRulesCount,
 				"package_id":           pkg.ID,
 			})
+			groupIds = append(groupIds, group.ID)
 		}
 	}
 

--- a/cloudflare/data_source_waf_groups.go
+++ b/cloudflare/data_source_waf_groups.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"time"
+	"sort"
+	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -110,6 +111,7 @@ func dataSourceCloudflareWAFGroupsRead(d *schema.ResourceData, meta interface{})
 	}
 
 	log.Printf("[DEBUG] Reading WAF Groups")
+	groupIds := make([]string, 0)
 	groupDetails := make([]interface{}, 0)
 	for _, pkg := range pkgList {
 		groupList, err := client.ListWAFGroups(zoneID, pkg.ID)
@@ -143,7 +145,9 @@ func dataSourceCloudflareWAFGroupsRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error setting WAF groups: %s", err)
 	}
 
-	d.SetId("WAFGroups " + time.Now().UTC().String())
+	sort.Strings(groupIds)
+	id := generateShaId(strings.Join(groupIds, ""))
+	d.SetId(id)
 	return nil
 }
 

--- a/cloudflare/data_source_waf_groups.go
+++ b/cloudflare/data_source_waf_groups.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"sort"
-	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -145,9 +143,7 @@ func dataSourceCloudflareWAFGroupsRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error setting WAF groups: %s", err)
 	}
 
-	sort.Strings(groupIds)
-	id := generateShaId(strings.Join(groupIds, ""))
-	d.SetId(id)
+	d.SetId(genarteIdSha(groupIds))
 	return nil
 }
 

--- a/cloudflare/data_source_waf_groups.go
+++ b/cloudflare/data_source_waf_groups.go
@@ -143,7 +143,7 @@ func dataSourceCloudflareWAFGroupsRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error setting WAF groups: %s", err)
 	}
 
-	d.SetId(genarteIdSha(groupIds))
+	d.SetId(stringListChecksum(groupIds))
 	return nil
 }
 

--- a/cloudflare/data_source_waf_packages.go
+++ b/cloudflare/data_source_waf_packages.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"time"
+	"sort"
+	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -96,6 +97,7 @@ func dataSourceCloudflareWAFPackagesRead(d *schema.ResourceData, meta interface{
 	}
 
 	log.Printf("[DEBUG] Reading WAF Packages")
+	packageIds := make([]string, 0)
 	packageDetails := make([]interface{}, 0)
 	pkgList, err := client.ListWAFPackages(zoneID)
 	if err != nil {
@@ -134,7 +136,9 @@ func dataSourceCloudflareWAFPackagesRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error setting WAF packages: %s", err)
 	}
 
-	d.SetId("WAFPackages " + time.Now().UTC().String())
+	sort.Strings(packageIds)
+	id := generateShaId(strings.Join(packageIds, ""))
+	d.SetId(id)
 	return nil
 }
 

--- a/cloudflare/data_source_waf_packages.go
+++ b/cloudflare/data_source_waf_packages.go
@@ -127,6 +127,7 @@ func dataSourceCloudflareWAFPackagesRead(d *schema.ResourceData, meta interface{
 			"sensitivity":    pkg.Sensitivity,
 			"action_mode":    pkg.ActionMode,
 		})
+		packageIds = append(packageIds, pkg.ID)
 	}
 
 	err = d.Set("packages", packageDetails)

--- a/cloudflare/data_source_waf_packages.go
+++ b/cloudflare/data_source_waf_packages.go
@@ -134,7 +134,7 @@ func dataSourceCloudflareWAFPackagesRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error setting WAF packages: %s", err)
 	}
 
-	d.SetId(genarteIdSha(packageIds))
+	d.SetId(stringListChecksum(packageIds))
 	return nil
 }
 

--- a/cloudflare/data_source_waf_packages.go
+++ b/cloudflare/data_source_waf_packages.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"sort"
-	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -136,9 +134,7 @@ func dataSourceCloudflareWAFPackagesRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error setting WAF packages: %s", err)
 	}
 
-	sort.Strings(packageIds)
-	id := generateShaId(strings.Join(packageIds, ""))
-	d.SetId(id)
+	d.SetId(genarteIdSha(packageIds))
 	return nil
 }
 

--- a/cloudflare/data_source_waf_rules.go
+++ b/cloudflare/data_source_waf_rules.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"sort"
-	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -172,9 +170,7 @@ func dataSourceCloudflareWAFRulesRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error setting WAF rules: %s", err)
 	}
 
-	sort.Strings(ruleIds)
-	id := generateShaId(strings.Join(ruleIds, ""))
-	d.SetId(id)
+	d.SetId(genarteIdSha(ruleIds))
 	return nil
 }
 

--- a/cloudflare/data_source_waf_rules.go
+++ b/cloudflare/data_source_waf_rules.go
@@ -155,6 +155,7 @@ func dataSourceCloudflareWAFRulesRead(d *schema.ResourceData, meta interface{}) 
 				"package_id":    pkg.ID,
 				"allowed_modes": rule.AllowedModes,
 			})
+			ruleIds = append(ruleIds, rule.ID)
 		}
 
 		if foundGroup {

--- a/cloudflare/data_source_waf_rules.go
+++ b/cloudflare/data_source_waf_rules.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"time"
+	"sort"
+	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -119,6 +120,7 @@ func dataSourceCloudflareWAFRulesRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	log.Printf("[DEBUG] Reading WAF Rules")
+	ruleIds := make([]string, 0)
 	ruleDetails := make([]interface{}, 0)
 	for _, pkg := range pkgList {
 		ruleList, err := client.ListWAFRules(zoneID, pkg.ID)
@@ -170,7 +172,9 @@ func dataSourceCloudflareWAFRulesRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error setting WAF rules: %s", err)
 	}
 
-	d.SetId(fmt.Sprintf("WAFRules_%s", time.Now().UTC().String()))
+	sort.Strings(ruleIds)
+	id := generateShaId(strings.Join(ruleIds, ""))
+	d.SetId(id)
 	return nil
 }
 

--- a/cloudflare/data_source_waf_rules.go
+++ b/cloudflare/data_source_waf_rules.go
@@ -170,7 +170,7 @@ func dataSourceCloudflareWAFRulesRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error setting WAF rules: %s", err)
 	}
 
-	d.SetId(genarteIdSha(ruleIds))
+	d.SetId(stringListChecksum(ruleIds))
 	return nil
 }
 

--- a/cloudflare/data_source_zones.go
+++ b/cloudflare/data_source_zones.go
@@ -117,7 +117,7 @@ func dataSourceCloudflareZonesRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error setting zones: %s", err)
 	}
 
-	d.SetId(genarteIdSha(zoneIds))
+	d.SetId(stringListChecksum(zoneIds))
 	return nil
 }
 

--- a/cloudflare/data_source_zones.go
+++ b/cloudflare/data_source_zones.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"time"
+	"sort"
+	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -93,6 +94,7 @@ func dataSourceCloudflareZonesRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error listing Zone: %s", err)
 	}
 
+	zoneIds := make([]string, 0)
 	zoneDetails := make([]interface{}, 0)
 	for _, v := range zones.Result {
 		if filter.regexValue != nil {
@@ -109,6 +111,7 @@ func dataSourceCloudflareZonesRead(d *schema.ResourceData, meta interface{}) err
 			"id":   v.ID,
 			"name": v.Name,
 		})
+		zoneIds = append(zoneIds, v.ID)
 	}
 
 	err = d.Set("zones", zoneDetails)
@@ -116,8 +119,9 @@ func dataSourceCloudflareZonesRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error setting zones: %s", err)
 	}
 
-	d.SetId(time.Now().UTC().String())
-
+	sort.Strings(zoneIds)
+	id := generateShaId(strings.Join(zoneIds, ""))
+	d.SetId(id)
 	return nil
 }
 

--- a/cloudflare/data_source_zones.go
+++ b/cloudflare/data_source_zones.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"sort"
-	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -119,9 +117,7 @@ func dataSourceCloudflareZonesRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error setting zones: %s", err)
 	}
 
-	sort.Strings(zoneIds)
-	id := generateShaId(strings.Join(zoneIds, ""))
-	d.SetId(id)
+	d.SetId(genarteIdSha(zoneIds))
 	return nil
 }
 

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"sort"
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
@@ -195,8 +196,9 @@ func initIdentifier(d *schema.ResourceData) (*AccessIdentifier, error) {
 	}, nil
 }
 
-func generateShaId(content string) string {
-	sha := sha256.Sum256([]byte(content))
+func genarteIdSha(ids []string) string {
+	sort.Strings(ids)
+	sha := sha256.Sum256([]byte(strings.Join(ids, "")))
 	id := hex.EncodeToString(sha[:])
 	return id
 }

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -196,8 +196,7 @@ func initIdentifier(d *schema.ResourceData) (*AccessIdentifier, error) {
 }
 
 func generateShaId(content string) string {
-	hasher := sha256.New()
-	hasher.Write([]byte(content))
-	id := hex.EncodeToString(hasher.Sum(nil))
+	sha := sha256.Sum256([]byte(content))
+	id := hex.EncodeToString(sha[:])
 	return id
 }

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -2,8 +2,6 @@ package cloudflare
 
 import (
 	"crypto/md5"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -67,6 +65,11 @@ func stringChecksum(s string) string {
 	bs := h.Sum(nil)
 
 	return fmt.Sprintf("%x", bs)
+}
+
+func stringListChecksum(s []string) string {
+	sort.Strings(s)
+	return stringChecksum(strings.Join(s, ""))
 }
 
 // Returns true if string value exists in string slice
@@ -194,11 +197,4 @@ func initIdentifier(d *schema.ResourceData) (*AccessIdentifier, error) {
 		Type:  ZoneType,
 		Value: zoneID,
 	}, nil
-}
-
-func genarteIdSha(ids []string) string {
-	sort.Strings(ids)
-	sha := sha256.Sum256([]byte(strings.Join(ids, "")))
-	id := hex.EncodeToString(sha[:])
-	return id
 }

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -2,6 +2,8 @@ package cloudflare
 
 import (
 	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -191,4 +193,11 @@ func initIdentifier(d *schema.ResourceData) (*AccessIdentifier, error) {
 		Type:  ZoneType,
 		Value: zoneID,
 	}, nil
+}
+
+func generateShaId(content string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(content))
+	id := hex.EncodeToString(hasher.Sum(nil))
+	return id
 }


### PR DESCRIPTION
Fixes: https://github.com/cloudflare/terraform-provider-cloudflare/issues/764

I was not sure if you would prefer to use `sha1` or some other function, but I think this should get the job done.

I chose to leave `generateShaId` as a separate function but repeat `sort` and `.join` because I thought there could be non list ids we could want to produce a sha for, but then noticed we do not. I think leaving it reusable its not bad, but let me know if this is not your preferred choice.