### PR TITLE
corrected docs for load balancer TCP monitor

### DIFF
--- a/website/docs/r/healthcheck.html.markdown
+++ b/website/docs/r/healthcheck.html.markdown
@@ -95,7 +95,7 @@ The following arguments are supported:
 * `notification_suspended` - (Optional) Whether the notifications are suspended or not. Useful for maintenance periods. Valid values: `true` or `false` (Default: `false`).
 * `notification_email_addresses` - (Optional) A list of email addresses we want to send the notifications to.
 * `type` - (Required) The protocol to use for the health check. Valid values: `HTTP`, `HTTPS`, `TCP`.
-* `port` - (Optional) Port number to connect to for the health check.  Valid values are in the rage `0-65535` (Default: `80`).
+* `port` - (Optional) Port number to connect to for the health check.  Valid values are in the range `0-65535` (Default: `80`).
 * `timeout` - (Optional) The timeout (in seconds) before marking the health check as failed. (Default: `5`)
 * `retries` - (Optional) The number of retries to attempt in case of a timeout before marking the origin as unhealthy. Retries are attempted immediately. (Default: `2`)
 * `interval` - (Optional) The interval between each health check. Shorter intervals may give quicker notifications if the origin status changes, but will increase load on the origin as we check from multiple locations. (Default: `60`)

--- a/website/docs/r/load_balancer_monitor.html.markdown
+++ b/website/docs/r/load_balancer_monitor.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 If you're using Cloudflare's Load Balancing to load-balance across multiple origin servers or data centers, you configure one of these Monitors to actively check the availability of those servers over HTTP(S) or TCP.
 
--> **Note:** When creating a monitor, you have to pass `account_id` to the provider configuration.
+-> **Note:** When creating a monitor, you have to pass `account_id` to the provider configuration in order to create account level resources. Otherwise, by default, it will be a user level resource.
 
 ## Example Usage
 

--- a/website/docs/r/load_balancer_monitor.html.markdown
+++ b/website/docs/r/load_balancer_monitor.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 If you're using Cloudflare's Load Balancing to load-balance across multiple origin servers or data centers, you configure one of these Monitors to actively check the availability of those servers over HTTP(S) or TCP.
 
+*Note*
+When creating a monitor, you have to pass `account_id` to the provider configuration.
+
 ## Example Usage
 
 ### HTTP Monitor
@@ -39,6 +42,7 @@ resource "cloudflare_load_balancer_monitor" "tcp_monitor" {
   type = "tcp"
   method = "connection_established"
   timeout = 7
+  port = 8080
   interval = 60
   retries = 5
   description = "example tcp load balancer"
@@ -58,6 +62,7 @@ The following arguments are supported:
 * `retries` - (Optional) The number of retries to attempt in case of a timeout before marking the origin as unhealthy. Retries are attempted immediately. Default: 2.
 * `header` - (Optional) The HTTP request headers to send in the health check. It is recommended you set a Host header by default. The User-Agent header cannot be overridden. Fields documented below. Only valid if `type` is "http" or "https".
 * `type` - (Optional) The protocol to use for the healthcheck. Currently supported protocols are 'HTTP', 'HTTPS' and 'TCP'. Default: "http".
+* `port` - The port to use for the healthcheck, required when creating a TCP monitor.
 * `description` - (Optional) Free text description.
 * `allow_insecure` - (Optional) Do not validate the certificate when monitor use HTTPS. Only valid if `type` is "http" or "https".
 * `follow_redirects` - (Optional) Follow redirects if returned by the origin. Only valid if `type` is "http" or "https".

--- a/website/docs/r/load_balancer_monitor.html.markdown
+++ b/website/docs/r/load_balancer_monitor.html.markdown
@@ -10,8 +10,7 @@ description: |-
 
 If you're using Cloudflare's Load Balancing to load-balance across multiple origin servers or data centers, you configure one of these Monitors to actively check the availability of those servers over HTTP(S) or TCP.
 
-*Note*
-When creating a monitor, you have to pass `account_id` to the provider configuration.
+-> **Note:** When creating a monitor, you have to pass `account_id` to the provider configuration.
 
 ## Example Usage
 

--- a/website/docs/r/load_balancer_monitor.html.markdown
+++ b/website/docs/r/load_balancer_monitor.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 * `retries` - (Optional) The number of retries to attempt in case of a timeout before marking the origin as unhealthy. Retries are attempted immediately. Default: 2.
 * `header` - (Optional) The HTTP request headers to send in the health check. It is recommended you set a Host header by default. The User-Agent header cannot be overridden. Fields documented below. Only valid if `type` is "http" or "https".
 * `type` - (Optional) The protocol to use for the healthcheck. Currently supported protocols are 'HTTP', 'HTTPS' and 'TCP'. Default: "http".
-* `port` - The port to use for the healthcheck, required when creating a TCP monitor.
+* `port` - The port number to use for the healthcheck, required when creating a TCP monitor. Valid values are in the range `0-65535`.
 * `description` - (Optional) Free text description.
 * `allow_insecure` - (Optional) Do not validate the certificate when monitor use HTTPS. Only valid if `type` is "http" or "https".
 * `follow_redirects` - (Optional) Follow redirects if returned by the origin. Only valid if `type` is "http" or "https".


### PR DESCRIPTION
What was updated?

The docs did not mention that port is required when configuring a TCP load balancer monitor.

This fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/871


