### PR TITLE
resource/cloudflare_load_balancer: Add support for session affinity attributes

### DIFF
--- a/cloudflare/resource_cloudflare_load_balancer_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_test.go
@@ -71,6 +71,9 @@ func TestAccCloudflareLoadBalancer_SessionAffinity(t *testing.T) {
 					// explicitly verify that our session_affinity has been set
 					resource.TestCheckResourceAttr(name, "session_affinity", "cookie"),
 					resource.TestCheckResourceAttr(name, "session_affinity_ttl", "1800"),
+					resource.TestCheckResourceAttr(name, "session_affinity_attributes.samesite", "Auto"),
+					resource.TestCheckResourceAttr(name, "session_affinity_attributes.secure", "Auto"),
+					resource.TestCheckResourceAttr(name, "session_affinity_attributes.drain_duration", "60"),
 					// dont check that other specified values are set, this will be evident by lack
 					// of plan diff some values will get empty values
 					resource.TestCheckResourceAttr(name, "pop_pools.#", "0"),
@@ -94,6 +97,7 @@ func TestAccCloudflareLoadBalancer_SessionAffinity(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "session_affinity", "ip_cookie"),
 					// session_affinity_ttl should not be present as it isn't set
 					resource.TestCheckNoResourceAttr(name, "session_affinity_ttl"),
+					resource.TestCheckNoResourceAttr(name, "session_affinity_attributes"),
 					// dont check that other specified values are set, this will be evident by lack
 					// of plan diff some values will get empty values
 					resource.TestCheckResourceAttr(name, "pop_pools.#", "0"),
@@ -366,6 +370,11 @@ resource "cloudflare_load_balancer" "%[3]s" {
   default_pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
 	session_affinity = "cookie"
 	session_affinity_ttl = 1800
+	session_affinity_attributes = {
+    samesite = "Auto"
+    secure = "Auto"
+    drain_duration = 60
+	}
 }`, zoneID, zone, id)
 }
 

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -61,6 +61,7 @@ The following arguments are supported:
 * `pop_pools` - (Optional) A set containing mappings of Cloudflare Point-of-Presence (PoP) identifiers to a list of pool IDs (ordered by their failover priority) for the PoP (datacenter). This feature is only available to enterprise customers. Fields documented below.
 * `session_affinity` - (Optional) Associates all requests coming from an end-user with a single origin. Cloudflare will set a cookie on the initial response to the client, such that consequent requests with the cookie in the request will go to the same origin, so long as it is available.  Valid values are: `""`, `"none"`, `"cookie"`, and `"ip_cookie"`.  Default is `""`.
 * `session_affinity_ttl` - (Optional) Time, in seconds, until this load balancers session affinity cookie expires after being created. This parameter is ignored unless a supported session affinity policy is set. The current default of 23 hours will be used unless `session_affinity_ttl` is explicitly set. Once the expiry time has been reached, subsequent requests may get sent to a different origin server. Valid values are between 1800 and 604800.
+* `session_affinity_attributes` - (Optional) Configure cookie attributes for session affinity cookie. See the field documentation below.
 
 **region_pools** requires the following:
 
@@ -71,6 +72,12 @@ The following arguments are supported:
 
 * `pop` - (Required) A 3-letter code for the Point-of-Presence. Allowed values can be found in the list of datacenters on the [status page](https://www.cloudflarestatus.com/). Multiple entries should not be specified with the same PoP.
 * `pool_ids` - (Required) A list of pool IDs in failover priority to use for traffic reaching the given PoP.
+
+**session_affinity_attributes** optionally as the following:
+
+* `samesite` - (Optional) Configures the SameSite attribute on session affinity cookie. Value "Auto" will be translated to "Lax" or "None" depending if Always Use HTTPS is enabled. Note: when using value "None", the secure attribute can not be set to "Never". Valid values: `"Auto"`, `"Lax"`, `"None"` or `"Strict"`.
+* `secure` - (Optional) Configures the Secure attribute on session affinity cookie. Value "Always" indicates the Secure attribute will be set in the Set-Cookie header, "Never" indicates the Secure attribute will not be set, and "Auto" will set the Secure attribute depending if Always Use HTTPS is enabled. Valid values: `"Auto"`, `"Always"` or `"Never"`.
+* `drain_duration` - (Optional) Configures the drain duration in seconds. This field is only used when session affinity is enabled on the load balancer.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Updates the load balancer resource with the ability to manage the
`session_affinity_attributes`.

Depends on cloudflare/cloudflare-go#560 for the new struct field.

Documentation: https://api.cloudflare.com/#load-balancers-create-load-balancer