### PR TITLE
more accurate cloudflare_load_balancer example

### DIFF
--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -18,7 +18,7 @@ Provides a Cloudflare Load Balancer resource. This sits in front of a number of 
 # Within each pop or region we can define multiple pools in failover order
 resource "cloudflare_load_balancer" "bar" {
   zone_id = "d41d8cd98f00b204e9800998ecf8427e"
-  name = "example-load-balancer"
+  name = "example-load-balancer.mysite.com"
   fallback_pool_id = cloudflare_load_balancer_pool.foo.id
   default_pool_ids = [cloudflare_load_balancer_pool.foo.id]
   description = "example load balancer using geo-balancing"

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -18,7 +18,7 @@ Provides a Cloudflare Load Balancer resource. This sits in front of a number of 
 # Within each pop or region we can define multiple pools in failover order
 resource "cloudflare_load_balancer" "bar" {
   zone_id = "d41d8cd98f00b204e9800998ecf8427e"
-  name = "example-load-balancer.mysite.com"
+  name = "example-load-balancer.example.com"
   fallback_pool_id = cloudflare_load_balancer_pool.foo.id
   default_pool_ids = [cloudflare_load_balancer_pool.foo.id]
   description = "example load balancer using geo-balancing"


### PR DESCRIPTION
I am a silly user that copy pastes examples like a pro. I'd propose a more accurate example to help silly users like me.

also sorry for not opening an issue for these 11 characters. hopefully we can all agree we don't need one for a small docs patch.

```
* cloudflare_load_balancer.manifestlb: error creating load balancer for zone: error from makeRequest: HTTP status 400: content "{\n  \"result\": null,\n  \"success\": false,\n  \"errors\": [\n    {\n      \"code\": 1002,\n      \"message\": \"invalid hostname: subdomain-here: validation failed\"\n    }\n  ],\n  \"messages\": []\n}\n"
```