### PR TITLE
Fixed crash in Page Rules update when using custom cache key

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -866,18 +866,23 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, d *schema
 			for sectionID, sectionValue := range cacheKeyActionSchema[0].(map[string]interface{}) {
 				sectionOutput := map[string]interface{}{}
 
-				for fieldID, fieldValue := range sectionValue.([]interface{})[0].(map[string]interface{}) {
-					sectionOutput[fieldID] = fieldValue
+				if sectionValue.([]interface{})[0] != nil {
+					for fieldID, fieldValue := range sectionValue.([]interface{})[0].(map[string]interface{}) {
+						sectionOutput[fieldID] = fieldValue
+					}
 				}
 
 				if sectionID == "query_string" {
 					queryKey := "include"
-					if sectionOutput["ignore"].(bool) {
+					if ignore, ok := sectionOutput["ignore"]; ok && ignore.(bool) {
 						queryKey = "exclude"
 					}
 					delete(sectionOutput, "ignore")
 
-					if len(sectionOutput["exclude"].([]interface{})) == 0 && len(sectionOutput["include"].([]interface{})) == 0 {
+					exclude, ok1 := sectionOutput["exclude"]
+					include, ok2 := sectionOutput["include"]
+
+					if (!ok1 || len(exclude.([]interface{})) == 0) && (!ok2 || len(include.([]interface{})) == 0) {
 						sectionOutput[queryKey] = "*"
 					}
 				}


### PR DESCRIPTION
This PR fixes a crash that occurs when the existing Page Rule that did not have `custom_cache_key` is updated to have one.

```
panic: interface conversion: interface {} is nil, not map[string]interface {}
2020-12-16T18:00:09.106Z [DEBUG] plugin.terraform-provider-cloudflare_v2.14.0:
2020-12-16T18:00:09.106Z [DEBUG] plugin.terraform-provider-cloudflare_v2.14.0: goroutine 54 [running]:
2020-12-16T18:00:09.106Z [DEBUG] plugin.terraform-provider-cloudflare_v2.14.0: github.com/cloudflare/terraform-provider-cloudflare/cloudflare.transformToCloudflarePageRuleAction(0x1f2589b, 0x10, 0x1cf5740, 0xc000690ec0, 0xc0000caa80, 0x1f2573b, 0x10, 0x0, 0x0, 0x0, ...)
2020-12-16T18:00:09.106Z [DEBUG] plugin.terraform-provider-cloudflare_v2.14.0: 	github.com/cloudflare/terraform-provider-cloudflare/cloudflare/resource_cloudflare_page_rule.go:869 +0x14df
2020-12-16T18:00:09.106Z [DEBUG] plugin.terraform-provider-cloudflare_v2.14.0: github.com/cloudflare/terraform-provider-cloudflare/cloudflare.resourceCloudflarePageRuleUpdate(0xc0000caa80, 0x1f160c0, 0xc0005fc6c0, 0x24, 0x2819ca0)
2020-12-16T18:00:09.106Z [DEBUG] plugin.terraform-provider-cloudflare_v2.14.0: 	github.com/cloudflare/terraform-provider-cloudflare/cloudflare/resource_cloudflare_page_rule.go:622 +0x305
```