### PR TITLE
Adds ciphers to zone settings override

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -126,6 +126,15 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 			86400, 604800, 2592000, 31536000}),
 	},
 
+	"ciphers": {
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	},
+
 	"development_mode": {
 		Type:         schema.TypeString,
 		ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),

--- a/cloudflare/resource_cloudflare_zone_settings_override_test.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override_test.go
@@ -62,6 +62,8 @@ func TestAccCloudflareZoneSettingsOverride_Full(t *testing.T) {
 						name, "settings.0.zero_rtt", "off"),
 					resource.TestCheckResourceAttr(
 						name, "settings.0.universal_ssl", "off"),
+					resource.TestCheckResourceAttr(
+						name, "settings.0.ciphers", "[\"ECDHE-RSA-AES128-GCM-SHA256\", \"AES128-SHA\"]"),
 				),
 			},
 		},
@@ -245,6 +247,7 @@ resource "cloudflare_zone_settings_override" "test" {
 	zone_id = "%s"
 	settings {
 		brotli = "on"
+		ciphers = ["ECDHE-RSA-AES128-GCM-SHA256", "AES128-SHA"]
 		challenge_ttl = 2700
 		security_level = "high"
 		opportunistic_encryption = "on"

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -91,6 +91,7 @@ These can be specified as "on" or "off" string. Similar to boolean values, but h
 
 ### String Values
 
+* `ciphers`. An allowlist of ciphers for TLS termination. These ciphers must be in the BoringSSL format. Default: `[]`
 * `cache_level`. Allowed values: "aggressive" (default) - delivers a different resource each time the query string changes, "basic" - delivers resources from cache when there is no query string, "simplified" - delivers the same resource to everyone independent of the query string.
 * `cname_flattening`. Allowed values: "flatten_at_root" (default), "flatten_all", "flatten_none".
 * `h2_prioritization`. Allowed values: "on", "off" (default), "custom".


### PR DESCRIPTION
Adds zone settings override for `ciphers`: https://api.cloudflare.com/#zone-settings-change-ciphers-setting

Also I've noticed that `client/v4/zones/.../settings` returns some more options that are not available in terraform:
```
{
  "result": [

...

    {
      "id": "ciphers",
      "value": [],
      "modified_on": null,
      "editable": true
    },

...

    {
      "id": "edge_cache_ttl",
      "value": 7200,
      "modified_on": null,
      "editable": true
    },

...

    {
      "id": "orange_to_orange",
      "value": "off",
      "modified_on": null,
      "editable": true
    },

...

    {
      "id": "visitor_ip",
      "value": "on",
      "modified_on": null,
      "editable": true
    },

...

  ],
  "success": true,
  "errors": [],
  "messages": []
}
```

Should I also add `visitor_ip`, `orange_to_orange`, `edge_cache_ttl` settings? Also I do not see anything for these settings in the docs...