### PR TITLE
resource/cloudfare_api_token: allow empty conditions

### DIFF
--- a/cloudflare/resource_cloudflare_api_token_test.go
+++ b/cloudflare/resource_cloudflare_api_token_test.go
@@ -11,7 +11,6 @@ import (
 func TestAccAPIToken(t *testing.T) {
 	rnd := generateRandomResourceName()
 	resourceID := "cloudflare_api_token." + rnd
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	permissionID := "82e64a83756745bbbb1c9c2701bf816b" // DNS read
 
 	resource.Test(t, resource.TestCase{
@@ -19,19 +18,15 @@ func TestAccAPIToken(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAPITokenConfig(rnd, rnd, permissionID, zoneID, true),
+				Config: testAccCloudflareAPITokenWithoutCondition(rnd, rnd, permissionID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceID, "name", rnd),
-					resource.TestCheckResourceAttr(resourceID, "condition.0.request_ip.0.in.0", "192.0.2.1/32"),
-					resource.TestCheckResourceAttr(resourceID, "condition.0.request_ip.0.not_in.0", "198.51.100.1/32"),
 				),
 			},
 			{
-				Config: testAPITokenConfig(rnd, rnd, permissionID, zoneID, false),
+				Config: testAccCloudflareAPITokenWithoutCondition(rnd, rnd+"-updated", permissionID),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceID, "name", rnd),
-					resource.TestCheckNoResourceAttr(resourceID, "condition.0.request_ip.0.in.0"),
-					resource.TestCheckNoResourceAttr(resourceID, "condition.0.request_ip.0.not_in.0"),
+					resource.TestCheckResourceAttr(resourceID, "name", rnd+"-updated"),
 				),
 			},
 		},
@@ -60,36 +55,122 @@ func TestAccAPITokenAllowDeny(t *testing.T) {
 	})
 }
 
-func testAPITokenConfig(resourceID, name, permissionID, zoneID string, ips bool) string {
-	var condition string
+func TestAccAPITokenDoesNotSetConditions(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_api_token." + rnd
+	permissionID := "82e64a83756745bbbb1c9c2701bf816b" // DNS read
 
-	if ips {
-		condition = `
-			condition {
-			  request_ip {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareAPITokenWithoutCondition(rnd, rnd, permissionID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckNoResourceAttr(name, "condition.0.request_ip.0.in"),
+					resource.TestCheckNoResourceAttr(name, "condition.0.request_ip.0.not_in"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareAPITokenWithoutCondition(resourceName, rnd, permissionID string) string {
+	return fmt.Sprintf(`
+	resource "cloudflare_api_token" "%[1]s" {
+		name = "%[2]s"
+
+		policy {
+			effect = "allow"
+			permission_groups = [ "%[3]s" ]
+			resources = { "com.cloudflare.api.account.zone.*" = "*" }
+		}
+	}
+`, resourceName, rnd, permissionID)
+}
+
+func TestAccAPITokenSetIndividualCondition(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_api_token." + rnd
+	permissionID := "82e64a83756745bbbb1c9c2701bf816b" // DNS read
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareAPITokenWithIndividualCondition(rnd, permissionID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "condition.0.request_ip.0.in.0", "192.0.2.1/32"),
+					resource.TestCheckNoResourceAttr(name, "condition.0.request_ip.0.not_in"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareAPITokenWithIndividualCondition(rnd string, permissionID string) string {
+	return fmt.Sprintf(`
+	resource "cloudflare_api_token" "%[1]s" {
+		name = "%[1]s"
+
+		policy {
+			effect = "allow"
+			permission_groups = [ "%[2]s" ]
+			resources = { "com.cloudflare.api.account.zone.*" = "*" }
+		}
+
+		condition {
+			request_ip {
+				in = ["192.0.2.1/32"]
+			}
+		}
+	}
+`, rnd, permissionID)
+}
+
+func TestAccAPITokenSetAllCondition(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_api_token." + rnd
+	permissionID := "82e64a83756745bbbb1c9c2701bf816b" // DNS read
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareAPITokenWithAllCondition(rnd, permissionID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "condition.0.request_ip.0.in.0", "192.0.2.1/32"),
+					resource.TestCheckResourceAttr(name, "condition.0.request_ip.0.not_in.0", "198.51.100.1/32"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareAPITokenWithAllCondition(rnd string, permissionID string) string {
+	return fmt.Sprintf(`
+	resource "cloudflare_api_token" "%[1]s" {
+		name = "%[1]s"
+
+		policy {
+			effect = "allow"
+			permission_groups = [ "%[2]s" ]
+			resources = { "com.cloudflare.api.account.zone.*" = "*" }
+		}
+
+		condition {
+			request_ip {
 				in     = ["192.0.2.1/32"]
 				not_in = ["198.51.100.1/32"]
-			  }
-			}`
-	}
-
-	return fmt.Sprintf(`
-		resource "cloudflare_api_token" "%[1]s" {
-		  name = "%[2]s"
-
-          %[5]s
-		
-		  policy {
-			effect = "allow"
-			permission_groups = [
-			  "%[3]s", 
-			]
-			resources = {
-			  "com.cloudflare.api.account.zone.%[4]s" = "*"
 			}
-		  }
 		}
-		`, resourceID, name, permissionID, zoneID, condition)
+	}
+`, rnd, permissionID)
 }
 
 func testAPITokenConfigAllowDeny(resourceID, name, permissionID, zoneID string, allowAllZonesExceptOne bool) string {
@@ -99,7 +180,7 @@ func testAPITokenConfigAllowDeny(resourceID, name, permissionID, zoneID string, 
     		policy {
 			  effect = "deny"
 			  permission_groups = [
-			    "%[1]s", 
+			    "%[1]s",
 			  ]
 			  resources = {
 			    "com.cloudflare.api.account.zone.%[2]s" = "*"
@@ -111,11 +192,11 @@ func testAPITokenConfigAllowDeny(resourceID, name, permissionID, zoneID string, 
 	return fmt.Sprintf(`
 		resource "cloudflare_api_token" "%[1]s" {
 		  name = "%[2]s"
-		
+
 		  policy {
 			effect = "allow"
 			permission_groups = [
-			  "%[3]s", 
+			  "%[3]s",
 			]
 			resources = {
 			  "com.cloudflare.api.account.zone.*" = "*"


### PR DESCRIPTION
In the initial PR for adding API token support to Terraform (#862), an
assumption was made that empty `condition` blocks would allow all
traffic; this is incorrect and puts the end user in a state where no
traffic is allowed.

To address this, we need to conditionally build the API token based on
what fields are non-zero values. This requires a bit of a rewrite as
this assumption ran deep into the methods and the structure of the code
itself.

While this increases the test coverage, we do now have a restriction in
the API itself whereby if you create an API token with IP restrictions
and then wish to remove them, you cannot -- you must recreate the token.
This issue is outside the scope of this work so I'll leave it as a known
factor for now.

Closes #897