### PR TITLE
Add new resource `cloudflare_argo_tunnel`

### DIFF
--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -113,6 +113,7 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_account_member":                         resourceCloudflareAccountMember(),
 			"cloudflare_api_token":                              resourceCloudflareApiToken(),
 			"cloudflare_argo":                                   resourceCloudflareArgo(),
+			"cloudflare_argo_tunnel":                            resourceCloudflareArgoTunnel(),
 			"cloudflare_authenticated_origin_pulls":             resourceCloudflareAuthenticatedOriginPulls(),
 			"cloudflare_authenticated_origin_pulls_certificate": resourceCloudflareAuthenticatedOriginPullsCertificate(),
 			"cloudflare_byo_ip_prefix":                          resourceCloudflareBYOIPPrefix(),

--- a/cloudflare/resource_cloudflare_argo_tunnel.go
+++ b/cloudflare/resource_cloudflare_argo_tunnel.go
@@ -1,0 +1,105 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/pkg/errors"
+)
+
+func resourceCloudflareArgoTunnel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareArgoTunnelCreate,
+		Read:   resourceCloudflareArgoTunnelRead,
+		Update: resourceCloudflareArgoTunnelUpdate,
+		Delete: resourceCloudflareArgoTunnelDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareArgoTunnelImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"secret": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceCloudflareArgoTunnelCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accID := d.Get("account_id").(string)
+	name := d.Get("name").(string)
+	secret := d.Get("secret").(string)
+
+	tunnel, err := client.CreateArgoTunnel(context.Background(), accID, name, secret)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to create Argo Tunnel"))
+	}
+
+	d.SetId(tunnel.ID)
+
+	return resourceCloudflareArgoTunnelRead(d, meta)
+}
+
+func resourceCloudflareArgoTunnelRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceCloudflareArgoTunnelUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceCloudflareArgoTunnelDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accID := d.Get("account_id").(string)
+
+	cleanupErr := client.CleanupArgoTunnelConnections(context.Background(), accID, d.Id())
+	if cleanupErr != nil {
+		return errors.Wrap(cleanupErr, fmt.Sprintf("failed to clean up Argo Tunnel connections"))
+	}
+
+	deleteErr := client.DeleteArgoTunnel(context.Background(), accID, d.Id())
+	if deleteErr != nil {
+		return errors.Wrap(deleteErr, fmt.Sprintf("failed to delete Argo Tunnel"))
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceCloudflareArgoTunnelImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*cloudflare.API)
+	attributes := strings.Split(d.Id(), "/")
+
+	if len(attributes) != 2 {
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"accountID/argoTunnelUUID\"", d.Id())
+	}
+
+	accID, tunnelID := attributes[0], attributes[1]
+
+	tunnel, err := client.ArgoTunnel(context.Background(), accID, tunnelID)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch Argo Tunnel %s", tunnelID))
+	}
+
+	d.Set("name", tunnel.Name)
+	d.SetId(tunnel.ID)
+
+	resourceCloudflareArgoTunnelRead(d, meta)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/cloudflare/resource_cloudflare_argo_tunnel_test.go
+++ b/cloudflare/resource_cloudflare_argo_tunnel_test.go
@@ -1,0 +1,68 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCloudflareArgoTunnelCreate(t *testing.T) {
+	accID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_argo_tunnel.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareArgoTunnelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareArgoTunnelBasic(accID, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "secret", "AQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIAQIDBAUGBwg="),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareArgoTunnelBasic(accID, name string) string {
+	return fmt.Sprintf(`
+	resource "cloudflare_argo_tunnel" "%[2]s" {
+		account_id = "%[1]s"
+		name       = "%[2]s"
+		secret     = "AQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIAQIDBAUGBwg="
+	}`, accID, name)
+}
+
+func testAccCheckCloudflareArgoTunnelDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_argo_tunnel" {
+			continue
+		}
+
+		accountID := rs.Primary.Attributes["account_id"]
+		tunnelID := rs.Primary.ID
+		client := testAccProvider.Meta().(*cloudflare.API)
+		tunnel, err := client.ArgoTunnel(context.Background(), accountID, tunnelID)
+
+		if err != nil {
+			return err
+		}
+
+		if tunnel.DeletedAt == nil {
+			return fmt.Errorf("argo tunnel with ID %s still exists", tunnel.ID)
+		}
+
+	}
+
+	return nil
+}

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -73,6 +73,9 @@
             <li<%= sidebar_current("docs-cloudflare-resource-argo") %>>
               <a href="/docs/providers/cloudflare/r/argo.html">cloudflare_argo</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-argo-tunnel") %>>
+              <a href="/docs/providers/cloudflare/r/argo_tunnel.html">cloudflare_argo_tunnel</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-byo-ip-prefix") %>>
               <a href="/docs/providers/cloudflare/r/byo_ip_prefix.html">cloudflare_byo_ip_prefix</a>
             </li>

--- a/website/docs/r/argo_tunnel.html.markdown
+++ b/website/docs/r/argo_tunnel.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_argo_tunnel"
+sidebar_current: "docs-cloudflare-resource-argo-tunnel"
+description: |-
+  Provides the ability to manage Cloudflare Argo Tunnels.
+---
+
+# cloudflare_argo_tunnel
+
+Argo Tunnel exposes applications running on your local web server on any network with an internet connection without manually adding DNS records or configuring a firewall or router.
+
+## Example Usage
+
+```hcl
+resource "cloudflare_argo_tunnel" "example" {
+  account_id = "d41d8cd98f00b204e9800998ecf8427e"
+  name       = "my-tunnel"
+  secret     = "AQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIAQIDBAUGBwg="
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Required) The Cloudflare account ID that you wish to manage the Argo Tunnel on.
+* `name` - (Required) A user-friendly name chosen when the tunnel is created. Cannot be empty.
+* `secret` - (Required) 32 or more bytes, encoded as a base64 string. The Create Argo Tunnel endpoint sets this as the tunnel's password. Anyone wishing to run the tunnel needs this password.
+
+
+## Import
+
+Argo Tunnels can be imported a composite ID of the account ID and tunnel UUID.
+
+-> **Note:** The tunnel secret cannot be imported due to it not being available outside of the creation API calls. It is recommended that you re-create if you don't have the secret saved securely before importing.
+
+```
+$ terraform import cloudflare_argo_tunnel.example d41d8cd98f00b204e9800998ecf8427e/fd2455cb-5fcc-4c13-8738-8d8d2605237f
+```
+
+where
+- `d41d8cd98f00b204e9800998ecf8427e` is the account ID
+- `fd2455cb-5fcc-4c13-8738-8d8d2605237f` is the Argo Tunnel UUID


### PR DESCRIPTION
Creates a new resource for managing Argo Tunnels.

Depends on cloudflare/cloudflare-go#572 for V4 response structure.

Closes #603