### PR TITLE
Add support for all allowed session_duration values

### DIFF
--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -47,10 +48,17 @@ func resourceCloudflareAccessApplication() *schema.Resource {
 				Required: true,
 			},
 			"session_duration": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "24h",
-				ValidateFunc: validation.StringInSlice([]string{"0s", "15m", "30m", "6h", "12h", "24h", "168h", "730h"}, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "24h",
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					_, err := time.ParseDuration(v)
+					if err != nil {
+						errs = append(errs, fmt.Errorf(`%q only supports "ns", "us" (or "µs"), "ms", "s", "m", or "h" as valid units.`, key))
+					}
+					return
+				},
 			},
 			"cors_headers": {
 				Type:     schema.TypeList,

--- a/cloudflare/resource_cloudflare_access_application_test.go
+++ b/cloudflare/resource_cloudflare_access_application_test.go
@@ -428,7 +428,7 @@ func TestAccCloudflareAccessApplicationWithInvalidSessionDuration(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccessApplicationWithInvalidSessionDuration(rnd, zone, zoneID),
-				ExpectError: regexp.MustCompile(`session_duration only supports "ns", "us" (or "µs"), "ms", "s", "m", or "h" as valid units.`),
+				ExpectError: regexp.MustCompile(regexp.QuoteMeta(`"session_duration" only supports "ns", "us" (or "µs"), "ms", "s", "m", or "h" as valid units.`)),
 			},
 		},
 	})

--- a/website/docs/r/access_application.html.markdown
+++ b/website/docs/r/access_application.html.markdown
@@ -50,7 +50,8 @@ The following arguments are supported:
 * `domain` - (Required) The complete URL of the asset you wish to put
   Cloudflare Access in front of. Can include subdomains or paths. Or both.
 * `session_duration` - (Optional) How often a user will be forced to
-  re-authorise. Must be one of `0s`, `15m`, `30m`, `6h`, `12h`, `24h`, `168h`, `730h`.
+  re-authorise. Must be in the format `"300ms"`, `"-1.5h"`, or `"2h45m"`. 
+  Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Defaults to `24h`.
 * `cors_headers` - (Optional) CORS configuration for the Access Application. See
   below for reference structure.
 * `allowed_idps` - (Optional) The identity providers selected for the application.


### PR DESCRIPTION
We're currently limited in what values we can use for session duration; however, the API allows any value that is parsable from https://golang.org/pkg/time/#ParseDuration.

Cloudflare's API documentation will be updated with these changes shortly.