### PR TITLE
resource/cloudflare_page_rule: Swap `cache_key_fields` to use TypeSet

### DIFF
--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -308,7 +308,7 @@ func resourceCloudflarePageRule() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"check_presence": {
-													Type:     schema.TypeList,
+													Type:     schema.TypeSet,
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
@@ -316,7 +316,7 @@ func resourceCloudflarePageRule() *schema.Resource {
 													},
 												},
 												"include": {
-													Type:     schema.TypeList,
+													Type:     schema.TypeSet,
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
@@ -335,7 +335,7 @@ func resourceCloudflarePageRule() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"check_presence": {
-													Type:     schema.TypeList,
+													Type:     schema.TypeSet,
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
@@ -343,7 +343,7 @@ func resourceCloudflarePageRule() *schema.Resource {
 													},
 												},
 												"exclude": {
-													Type:     schema.TypeList,
+													Type:     schema.TypeSet,
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
@@ -351,7 +351,7 @@ func resourceCloudflarePageRule() *schema.Resource {
 													},
 												},
 												"include": {
-													Type:     schema.TypeList,
+													Type:     schema.TypeSet,
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
@@ -386,7 +386,7 @@ func resourceCloudflarePageRule() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"exclude": {
-													Type:     schema.TypeList,
+													Type:     schema.TypeSet,
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
@@ -394,7 +394,7 @@ func resourceCloudflarePageRule() *schema.Resource {
 													},
 												},
 												"include": {
-													Type:     schema.TypeList,
+													Type:     schema.TypeSet,
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -891,8 +891,11 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, d *schema
 					exclude, ok1 := sectionOutput["exclude"]
 					include, ok2 := sectionOutput["include"]
 
+					// Ensure that if no `include`, `exlude` or `ignore` attributes are
+					// set, we default to including all query string parameters in the
+					// cache key.
 					if (!ok1 || len(exclude.([]interface{})) == 0) && (!ok2 || len(include.([]interface{})) == 0) {
-						sectionOutput["exclude"] = []interface{}{"*"}
+						sectionOutput["include"] = []interface{}{"*"}
 					}
 
 					output[sectionID] = sectionOutput

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -872,26 +872,31 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, d *schema
 						sectionOutput[fieldID] = fieldValue.(*schema.Set).List()
 					}
 				case "query_string":
-					for fieldID, fieldValue := range sectionValue.([]interface{})[0].(map[string]interface{}) {
-						switch fieldID {
-						case "exclude", "include":
-							if fieldValue.(*schema.Set).Len() > 0 {
+					if sectionValue.([]interface{})[0] != nil {
+						for fieldID, fieldValue := range sectionValue.([]interface{})[0].(map[string]interface{}) {
+							switch fieldID {
+							case "exclude", "include":
+								if fieldValue.(*schema.Set).Len() > 0 {
+									sectionOutput[fieldID] = fieldValue.(*schema.Set).List()
+								}
+							case "ignore":
+								sectionOutput[fieldID] = fieldValue
+							default:
 								sectionOutput[fieldID] = fieldValue.(*schema.Set).List()
 							}
-						default:
-							sectionOutput[fieldID] = fieldValue
 						}
-					}
 
-					if sectionOutput["ignore"].(bool) {
-						sectionOutput["exclude"] = []interface{}{"*"}
+						if sectionOutput["ignore"].(bool) {
+							sectionOutput["exclude"] = []interface{}{"*"}
+						}
+
+						delete(sectionOutput, "ignore")
 					}
-					delete(sectionOutput, "ignore")
 
 					exclude, ok1 := sectionOutput["exclude"]
 					include, ok2 := sectionOutput["include"]
 
-					// Ensure that if no `include`, `exlude` or `ignore` attributes are
+					// Ensure that if no `include`, `exclude` or `ignore` attributes are
 					// set, we default to including all query string parameters in the
 					// cache key.
 					if (!ok1 || len(exclude.([]interface{})) == 0) && (!ok2 || len(include.([]interface{})) == 0) {

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -505,7 +505,7 @@ func TestAccCloudflarePageRuleCacheKeyFields2(t *testing.T) {
 				Config: testAccCheckCloudflarePageRuleConfigCacheKeyFields2(zoneID, target),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
-					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.header.0.exclude.#", "1"),
+					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.header.0.include.#", "1"),
 					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.host.0.resolved", "false"),
 					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.user.0.device_type", "true"),
 					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.user.0.geo", "true"),

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -9,6 +9,7 @@ import (
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
@@ -284,7 +285,38 @@ func TestTranformForwardingURL(t *testing.T) {
 func TestCacheKeyFieldsNilValue(t *testing.T) {
 	pageRuleAction, err := transformToCloudflarePageRuleAction(
 		"cache_key_fields",
-		[]interface{}{map[string]interface{}{"cookie": []interface{}{map[string]interface{}{"check_presence": []interface{}{}, "include": []interface{}{"next-i18next"}}}, "header": []interface{}{map[string]interface{}{"check_presence": []interface{}{}, "exclude": []interface{}{}, "include": []interface{}{"x-forwarded-host"}}}, "host": []interface{}{map[string]interface{}{"resolved": false}}, "query_string": []interface{}{interface{}(nil)}, "user": []interface{}{map[string]interface{}{"device_type": true, "geo": true, "lang": true}}}},
+		[]interface{}{
+			map[string]interface{}{
+				"cookie": []interface{}{
+					map[string]interface{}{
+						"include":        schema.NewSet(schema.HashString, []interface{}{}),
+						"check_presence": schema.NewSet(schema.HashString, []interface{}{"next-i18next"}),
+					},
+				},
+				"header": []interface{}{
+					map[string]interface{}{
+						"check_presence": schema.NewSet(schema.HashString, []interface{}{}),
+						"exclude":        schema.NewSet(schema.HashString, []interface{}{}),
+						"include":        schema.NewSet(schema.HashString, []interface{}{"x-forwarded-host"}),
+					},
+				},
+				"host": []interface{}{
+					map[string]interface{}{
+						"resolved": false,
+					},
+				},
+				"query_string": []interface{}{
+					interface{}(nil),
+				},
+				"user": []interface{}{
+					map[string]interface{}{
+						"device_type": true,
+						"geo":         true,
+						"lang":        true,
+					},
+				},
+			},
+		},
 		nil,
 	)
 
@@ -292,8 +324,8 @@ func TestCacheKeyFieldsNilValue(t *testing.T) {
 		t.Fatalf("Unexpected error transforming page rule action: %s", err)
 	}
 
-	if !reflect.DeepEqual(pageRuleAction.Value.(map[string]interface{})["query_string"], map[string]interface{}{"include": "*"}) {
-		t.Fatalf("Unexpected transformToCloudflarePageRuleAction result, expected %#v, got %#v", map[string]interface{}{"include": "*"}, pageRuleAction.Value.(map[string]interface{})["query_string"])
+	if !reflect.DeepEqual(pageRuleAction.Value.(map[string]interface{})["query_string"], map[string]interface{}{"include": []interface{}{"*"}}) {
+		t.Fatalf("Unexpected transformToCloudflarePageRuleAction result, expected %#v, got %#v", map[string]interface{}{"include": []interface{}{"*"}}, pageRuleAction.Value.(map[string]interface{})["query_string"])
 	}
 }
 

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -420,12 +420,70 @@ func TestAccCloudflarePageRuleCacheKeyFieldsBasic(t *testing.T) {
 				Config: testAccCheckCloudflarePageRuleConfigCacheKeyFields(zoneID, target),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
-					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.cookie.0.check_presence.0", "cookie_presence"),
-					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.cookie.0.include.0", "cookie_include"),
-					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.header.0.check_presence.0", "header_presence"),
-					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.header.0.include.0", "header_include"),
+					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.cookie.0.check_presence.#", "1"),
+					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.cookie.0.include.#", "1"),
+					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.header.0.check_presence.#", "1"),
+					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.header.0.include.#", "1"),
 					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.host.0.resolved", "true"),
-					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.query_string.0.exclude.0", "qs_exclude"),
+					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.query_string.0.exclude.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflarePageRuleCacheKeyFieldsIgnoreQueryStringOrdering(t *testing.T) {
+	var pageRule cloudflare.PageRule
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := generateRandomResourceName()
+	pageRuleTarget := fmt.Sprintf("%s.%s", rnd, domain)
+	resourceName := fmt.Sprintf("cloudflare_page_rule.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflarePageRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflarePageRuleConfigCacheKeyFieldsWithUnorderedEntries(zoneID, rnd, pageRuleTarget),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_key_fields.0.cookie.0.check_presence.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_key_fields.0.cookie.0.include.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_key_fields.0.header.0.check_presence.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_key_fields.0.header.0.include.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_key_fields.0.host.0.resolved", "true"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_key_fields.0.query_string.0.include.#", "7"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflarePageRuleCacheKeyFieldsExcludeAllQueryString(t *testing.T) {
+	var pageRule cloudflare.PageRule
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := generateRandomResourceName()
+	pageRuleTarget := fmt.Sprintf("%s.%s", rnd, domain)
+	resourceName := fmt.Sprintf("cloudflare_page_rule.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflarePageRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflarePageRuleConfigCacheKeyFieldsIgnoreAllQueryString(zoneID, rnd, pageRuleTarget),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_key_fields.0.cookie.0.check_presence.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_key_fields.0.cookie.0.include.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_key_fields.0.header.0.check_presence.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_key_fields.0.header.0.include.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_key_fields.0.host.0.resolved", "true"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_key_fields.0.query_string.0.exclude.#", "1"),
 				),
 			},
 		},
@@ -447,7 +505,7 @@ func TestAccCloudflarePageRuleCacheKeyFields2(t *testing.T) {
 				Config: testAccCheckCloudflarePageRuleConfigCacheKeyFields2(zoneID, target),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
-					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.header.0.exclude.0", "origin"),
+					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.header.0.exclude.#", "1"),
 					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.host.0.resolved", "false"),
 					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.user.0.device_type", "true"),
 					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.user.0.geo", "true"),
@@ -786,6 +844,68 @@ resource "cloudflare_page_rule" "test" {
 		}
 	}
 }`, zoneID, target)
+}
+
+func testAccCheckCloudflarePageRuleConfigCacheKeyFieldsWithUnorderedEntries(zoneID, rnd, target string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_page_rule" "%[3]s" {
+	zone_id = "%[1]s"
+	target = "%[3]s"
+	actions {
+		cache_key_fields {
+			cookie {
+				check_presence = ["cookie_presence"]
+				include = ["cookie_include"]
+			}
+			header {
+				check_presence = ["header_presence"]
+				include = ["header_include"]
+			}
+			host {
+				resolved = true
+			}
+			query_string {
+				include = [
+          "test.anothertest",
+          "test.regiontest",
+          "test.devicetest",
+          "test.testthis",
+          "test.hello",
+          "test.segmenttest",
+          "test.usertype"
+				]
+			}
+			user {}
+		}
+	}
+}`, zoneID, target, rnd)
+}
+
+func testAccCheckCloudflarePageRuleConfigCacheKeyFieldsIgnoreAllQueryString(zoneID, rnd, target string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_page_rule" "%[3]s" {
+	zone_id = "%[1]s"
+	target = "%[3]s"
+	actions {
+		cache_key_fields {
+			cookie {
+				check_presence = ["cookie_presence"]
+				include = ["cookie_include"]
+			}
+			header {
+				check_presence = ["header_presence"]
+				include = ["header_include"]
+			}
+			host {
+				resolved = true
+			}
+			query_string {
+				ignore = true
+			}
+			user {}
+		}
+	}
+}`, zoneID, target, rnd)
 }
 
 func testAccCheckCloudflarePageRuleConfigCacheKeyFields2(zoneID, target string) string {

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -537,7 +537,7 @@ func TestAccCloudflarePageRuleCacheKeyFields2(t *testing.T) {
 				Config: testAccCheckCloudflarePageRuleConfigCacheKeyFields2(zoneID, target),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists("cloudflare_page_rule.test", &pageRule),
-					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.header.0.include.#", "1"),
+					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.header.0.exclude.#", "1"),
 					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.host.0.resolved", "false"),
 					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.user.0.device_type", "true"),
 					resource.TestCheckResourceAttr("cloudflare_page_rule.test", "actions.0.cache_key_fields.0.user.0.geo", "true"),

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -81,6 +82,22 @@ func contains(slice []string, item string) bool {
 
 	_, ok := set[item]
 	return ok
+}
+
+func itemExistsInSlice(slice interface{}, item interface{}) bool {
+	s := reflect.ValueOf(slice)
+
+	if s.Kind() != reflect.Slice {
+		panic("Invalid data-type")
+	}
+
+	for i := 0; i < s.Len(); i++ {
+		if s.Index(i).Interface() == item {
+			return true
+		}
+	}
+
+	return false
 }
 
 // findIndex returns the smallest index i at which x == a[i],


### PR DESCRIPTION
When this resource was introduced, it was done so using `TypeList` for
the inner structure. In Terraform, `TypeList` is used for ordered lists
whereas `TypeSet` is for unordered.

This was working for the most part however the `cache_key_fields` fields
don't place any importance on the order so they are returned from the
API with inconsistent ordering.

To address this issue, we need to swap the representation to be
`TypeSet` and ignore any changes in the ordering when comparing to the
state. With this internal change comes more test coverage -- please take 
a look at the test cases and ensure they match our expectations of the 
defaults and functionality.

Fixes #890