### PR TITLE
cloudflare_ip_list import set correct account_id

### DIFF
--- a/cloudflare/import_resource_cloudflare_ip_list_test.go
+++ b/cloudflare/import_resource_cloudflare_ip_list_test.go
@@ -1,0 +1,31 @@
+package cloudflare
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccCloudflareIPList_Import(t *testing.T) {
+	rnd := generateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	name := "cloudflare_ip_list." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareIPList(rnd, rnd, rnd, accountID),
+			},
+			{
+				ResourceName:        name,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}

--- a/cloudflare/resource_cloudflare_ip_list.go
+++ b/cloudflare/resource_cloudflare_ip_list.go
@@ -88,7 +88,6 @@ func resourceCloudflareIPListCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceCloudflareIPListImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := meta.(*cloudflare.API)
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -97,7 +96,7 @@ func resourceCloudflareIPListImport(d *schema.ResourceData, meta interface{}) ([
 
 	accountID, listID := attributes[0], attributes[1]
 	d.SetId(listID)
-	client.AccountID = accountID
+	d.Set("account_id", accountID)
 
 	resourceCloudflareIPListRead(d, meta)
 


### PR DESCRIPTION
The account id is set on L100 but overriden with the empty string (because it's an import action) on L109

https://github.com/cloudflare/terraform-provider-cloudflare/blob/4b7fbd98b4e354ae2866d85a95347003ff5bf6a9/cloudflare/resource_cloudflare_ip_list.go#L100-L109

Fixes #915 