### PR TITLE
Correctly handle Access Group schema transformations

### DIFF
--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -212,6 +212,7 @@ func resourceCloudflareAccessApplicationRead(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error finding Access Application %q: %s", d.Id(), err)
 	}
 
+	d.Set("name", accessApplication.Name)
 	d.Set("aud", accessApplication.AUD)
 	d.Set("session_duration", accessApplication.SessionDuration)
 	d.Set("domain", accessApplication.Domain)

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -531,7 +531,7 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 	for _, group := range accessGroup {
 		for groupKey, groupValue := range group.(map[string]interface{}) {
 			switch groupKey {
-			case "everyone":
+			case "everyone", "any_valid_service_token", "certificate":
 				data = append(data, map[string]interface{}{
 					groupKey: true,
 				})

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -523,6 +523,10 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 	data := []map[string]interface{}{}
 	emails := []string{}
 	emailDomains := []string{}
+	ips := []string{}
+	serviceTokens := []string{}
+	commonName := ""
+	geos := []string{}
 
 	for _, group := range accessGroup {
 		for groupKey, groupValue := range group.(map[string]interface{}) {
@@ -539,6 +543,19 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 				for _, domain := range groupValue.(map[string]interface{}) {
 					emailDomains = append(emailDomains, domain.(string))
 				}
+			case "ip":
+				for _, ip := range groupValue.(map[string]interface{}) {
+					ips = append(ips, ip.(string))
+				}
+			case "service_token":
+				for _, serviceToken := range groupValue.(map[string]interface{}) {
+					serviceTokens = append(serviceTokens, serviceToken.(string))
+				}
+
+			case "geo":
+				for _, geo := range groupValue.(map[string]interface{}) {
+					geos = append(geos, geo.(string))
+				}
 			}
 		}
 	}
@@ -552,6 +569,30 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 	if len(emailDomains) > 0 {
 		data = append(data, map[string]interface{}{
 			"email_domain": emailDomains,
+		})
+	}
+
+	if len(ips) > 0 {
+		data = append(data, map[string]interface{}{
+			"ip": ips,
+		})
+	}
+
+	if len(serviceTokens) > 0 {
+		data = append(data, map[string]interface{}{
+			"service_token": serviceTokens,
+		})
+	}
+
+	if commonName != "" {
+		data = append(data, map[string]interface{}{
+			"common_name": commonName,
+		})
+	}
+
+	if len(geos) > 0 {
+		data = append(data, map[string]interface{}{
+			"geo": geos,
 		})
 	}
 

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -530,6 +530,8 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 	geos := []string{}
 	oktaID := ""
 	oktaGroups := []string{}
+	gsuiteID := ""
+	gsuiteEmails := []string{}
 
 	for _, group := range accessGroup {
 		for groupKey, groupValue := range group.(map[string]interface{}) {
@@ -567,6 +569,10 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 				oktaCfg := groupValue.(map[string]interface{})
 				oktaID = oktaCfg["identity_provider_id"].(string)
 				oktaGroups = append(oktaGroups, oktaCfg["name"].(string))
+			case "gsuite":
+				gsuiteCfg := groupValue.(map[string]interface{})
+				gsuiteID = gsuiteCfg["identity_provider_id"].(string)
+				gsuiteEmails = append(gsuiteEmails, gsuiteCfg["name"].(string))
 			}
 		}
 	}
@@ -619,6 +625,16 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 				map[string]interface{}{
 					"identity_provider_id": oktaID,
 					"name":                 oktaGroups,
+				}},
+		})
+	}
+
+	if len(gsuiteEmails) > 0 && gsuiteID != "" {
+		data = append(data, map[string]interface{}{
+			"gsuite": []interface{}{
+				map[string]interface{}{
+					"identity_provider_id": gsuiteID,
+					"email":                gsuiteEmails,
 				}},
 		})
 	}

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -527,6 +527,7 @@ func TransformAccessGroupForSchema(accessGroup []interface{}) []map[string]inter
 	emailDomains := []string{}
 	ips := []string{}
 	serviceTokens := []string{}
+	groups := []string{}
 	commonName := ""
 	authMethod := ""
 	geos := []string{}
@@ -600,6 +601,10 @@ func TransformAccessGroupForSchema(accessGroup []interface{}) []map[string]inter
 				samlID = samlCfg["identity_provider_id"].(string)
 				samlAttrName = samlCfg["attribute_name"].(string)
 				samlAttrValue = samlCfg["attribute_value"].(string)
+			case "group":
+				for _, group := range groupValue.(map[string]interface{}) {
+					groups = append(groups, group.(string))
+				}
 			default:
 				log.Printf("[DEBUG] Access Group key %q not transformed", groupKey)
 			}
@@ -697,6 +702,12 @@ func TransformAccessGroupForSchema(accessGroup []interface{}) []map[string]inter
 					"attribute_name":       samlAttrName,
 					"attribute_value":      samlAttrValue,
 				}},
+		})
+	}
+
+	if len(groups) > 0 {
+		data = append(data, map[string]interface{}{
+			"group": groups,
 		})
 	}
 

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -564,7 +564,10 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 				for _, serviceToken := range groupValue.(map[string]interface{}) {
 					serviceTokens = append(serviceTokens, serviceToken.(string))
 				}
-
+			case "common_name":
+				for _, name := range groupValue.(map[string]interface{}) {
+					commonName = name.(string)
+				}
 			case "auth_method":
 				for _, method := range groupValue.(map[string]interface{}) {
 					authMethod = method.(string)

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -535,6 +535,8 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 	githubName := ""
 	githubTeams := []string{}
 	githubID := ""
+	azureID := ""
+	azureIDs := []string{}
 
 	for _, group := range accessGroup {
 		for groupKey, groupValue := range group.(map[string]interface{}) {
@@ -581,6 +583,10 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 				githubID = githubCfg["identity_provider_id"].(string)
 				githubName = githubCfg["name"].(string)
 				githubTeams = append(githubTeams, githubCfg["team"].(string))
+			case "azure":
+				azureCfg := groupValue.(map[string]interface{})
+				azureID = azureCfg["identity_provider_id"].(string)
+				azureIDs = append(azureIDs, azureCfg["id"].(string))
 			}
 		}
 	}
@@ -654,6 +660,16 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 					"name":                 githubName,
 					"team":                 githubTeams,
 					"identity_provider_id": githubID,
+				}},
+		})
+	}
+
+	if len(azureIDs) > 0 && azureID != "" {
+		data = append(data, map[string]interface{}{
+			"azure": []interface{}{
+				map[string]interface{}{
+					"identity_provider_id": azureID,
+					"id":                   azureIDs,
 				}},
 		})
 	}

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -526,6 +526,7 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 	ips := []string{}
 	serviceTokens := []string{}
 	commonName := ""
+	authMethod := ""
 	geos := []string{}
 
 	for _, group := range accessGroup {
@@ -552,6 +553,10 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 					serviceTokens = append(serviceTokens, serviceToken.(string))
 				}
 
+			case "auth_method":
+				for _, method := range groupValue.(map[string]interface{}) {
+					authMethod = method.(string)
+				}
 			case "geo":
 				for _, geo := range groupValue.(map[string]interface{}) {
 					geos = append(geos, geo.(string))
@@ -587,6 +592,12 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 	if commonName != "" {
 		data = append(data, map[string]interface{}{
 			"common_name": commonName,
+		})
+	}
+
+	if authMethod != "" {
+		data = append(data, map[string]interface{}{
+			"auth_method": authMethod,
 		})
 	}
 

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -528,6 +528,8 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 	commonName := ""
 	authMethod := ""
 	geos := []string{}
+	oktaID := ""
+	oktaGroups := []string{}
 
 	for _, group := range accessGroup {
 		for groupKey, groupValue := range group.(map[string]interface{}) {
@@ -561,6 +563,10 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 				for _, geo := range groupValue.(map[string]interface{}) {
 					geos = append(geos, geo.(string))
 				}
+			case "okta":
+				oktaCfg := groupValue.(map[string]interface{})
+				oktaID = oktaCfg["identity_provider_id"].(string)
+				oktaGroups = append(oktaGroups, oktaCfg["name"].(string))
 			}
 		}
 	}
@@ -604,6 +610,16 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 	if len(geos) > 0 {
 		data = append(data, map[string]interface{}{
 			"geo": geos,
+		})
+	}
+
+	if len(oktaGroups) > 0 && oktaID != "" {
+		data = append(data, map[string]interface{}{
+			"okta": []interface{}{
+				map[string]interface{}{
+					"identity_provider_id": oktaID,
+					"name":                 oktaGroups,
+				}},
 		})
 	}
 

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -518,3 +518,42 @@ func BuildAccessGroupCondition(options map[string]interface{}) []interface{} {
 
 	return group
 }
+
+func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interface{} {
+	data := []map[string]interface{}{}
+	emails := []string{}
+	emailDomains := []string{}
+
+	for _, group := range accessGroup {
+		for groupKey, groupValue := range group.(map[string]interface{}) {
+			switch groupKey {
+			case "everyone":
+				data = append(data, map[string]interface{}{
+					groupKey: true,
+				})
+			case "email":
+				for _, email := range groupValue.(map[string]interface{}) {
+					emails = append(emails, email.(string))
+				}
+			case "email_domain":
+				for _, domain := range groupValue.(map[string]interface{}) {
+					emailDomains = append(emailDomains, domain.(string))
+				}
+			}
+		}
+	}
+
+	if len(emails) > 0 {
+		data = append(data, map[string]interface{}{
+			"email": emails,
+		})
+	}
+
+	if len(emailDomains) > 0 {
+		data = append(data, map[string]interface{}{
+			"email_domain": emailDomains,
+		})
+	}
+
+	return data
+}

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -532,6 +532,9 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 	oktaGroups := []string{}
 	gsuiteID := ""
 	gsuiteEmails := []string{}
+	githubName := ""
+	githubTeams := []string{}
+	githubID := ""
 
 	for _, group := range accessGroup {
 		for groupKey, groupValue := range group.(map[string]interface{}) {
@@ -573,6 +576,11 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 				gsuiteCfg := groupValue.(map[string]interface{})
 				gsuiteID = gsuiteCfg["identity_provider_id"].(string)
 				gsuiteEmails = append(gsuiteEmails, gsuiteCfg["name"].(string))
+			case "github":
+				githubCfg := groupValue.(map[string]interface{})
+				githubID = githubCfg["identity_provider_id"].(string)
+				githubName = githubCfg["name"].(string)
+				githubTeams = append(githubTeams, githubCfg["team"].(string))
 			}
 		}
 	}
@@ -635,6 +643,17 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 				map[string]interface{}{
 					"identity_provider_id": gsuiteID,
 					"email":                gsuiteEmails,
+				}},
+		})
+	}
+
+	if len(githubTeams) > 0 && githubID != "" && githubName != "" {
+		data = append(data, map[string]interface{}{
+			"github": []interface{}{
+				map[string]interface{}{
+					"name":                 githubName,
+					"team":                 githubTeams,
+					"identity_provider_id": githubID,
 				}},
 		})
 	}

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -537,6 +537,9 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 	githubID := ""
 	azureID := ""
 	azureIDs := []string{}
+	samlAttrName := ""
+	samlAttrValue := ""
+	samlID := ""
 
 	for _, group := range accessGroup {
 		for groupKey, groupValue := range group.(map[string]interface{}) {
@@ -587,6 +590,11 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 				azureCfg := groupValue.(map[string]interface{})
 				azureID = azureCfg["identity_provider_id"].(string)
 				azureIDs = append(azureIDs, azureCfg["id"].(string))
+			case "saml":
+				samlCfg := groupValue.(map[string]interface{})
+				samlID = samlCfg["identity_provider_id"].(string)
+				samlAttrName = samlCfg["attribute_name"].(string)
+				samlAttrValue = samlCfg["attribute_value"].(string)
 			}
 		}
 	}
@@ -670,6 +678,17 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 				map[string]interface{}{
 					"identity_provider_id": azureID,
 					"id":                   azureIDs,
+				}},
+		})
+	}
+
+	if samlID != "" && samlAttrName != "" && samlAttrValue != "" {
+		data = append(data, map[string]interface{}{
+			"saml": []interface{}{
+				map[string]interface{}{
+					"identity_provider_id": samlID,
+					"attribute_name":       samlAttrName,
+					"attribute_value":      samlAttrValue,
 				}},
 		})
 	}

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -519,7 +519,9 @@ func BuildAccessGroupCondition(options map[string]interface{}) []interface{} {
 	return group
 }
 
-func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interface{} {
+// TransformAccessGroupForSchema takes the incoming `accessGroup` from the API
+// response and converts it to a usable schema for the conditions.
+func TransformAccessGroupForSchema(accessGroup []interface{}) []map[string]interface{} {
 	data := []map[string]interface{}{}
 	emails := []string{}
 	emailDomains := []string{}

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -598,6 +598,8 @@ func FlattenAccessGroupForSchema(accessGroup []interface{}) []map[string]interfa
 				samlID = samlCfg["identity_provider_id"].(string)
 				samlAttrName = samlCfg["attribute_name"].(string)
 				samlAttrValue = samlCfg["attribute_value"].(string)
+			default:
+				log.Printf("[DEBUG] Access Group key %q not transformed", groupKey)
 			}
 		}
 	}

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -96,9 +96,18 @@ func resourceCloudflareAccessPolicyRead(d *schema.ResourceData, meta interface{}
 	d.Set("name", accessPolicy.Name)
 	d.Set("decision", accessPolicy.Decision)
 	d.Set("precedence", accessPolicy.Precedence)
-	d.Set("require", accessPolicy.Require)
-	d.Set("exclude", accessPolicy.Exclude)
-	d.Set("include", accessPolicy.Include)
+
+	if err := d.Set("require", accessPolicy.Require); err != nil {
+		return fmt.Errorf("failed to set require attribute: %s", err)
+	}
+
+	if err := d.Set("exclude", accessPolicy.Exclude); err != nil {
+		return fmt.Errorf("failed to set exclude attribute: %s", err)
+	}
+
+	if err := d.Set("include", accessPolicy.Include); err != nil {
+		return fmt.Errorf("failed to set include attribute: %s", err)
+	}
 
 	return nil
 }

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -97,15 +97,15 @@ func resourceCloudflareAccessPolicyRead(d *schema.ResourceData, meta interface{}
 	d.Set("decision", accessPolicy.Decision)
 	d.Set("precedence", accessPolicy.Precedence)
 
-	if err := d.Set("require", accessPolicy.Require); err != nil {
+	if err := d.Set("require", TransformAccessGroupForSchema(accessPolicy.Require)); err != nil {
 		return fmt.Errorf("failed to set require attribute: %s", err)
 	}
 
-	if err := d.Set("exclude", accessPolicy.Exclude); err != nil {
+	if err := d.Set("exclude", TransformAccessGroupForSchema(accessPolicy.Exclude)); err != nil {
 		return fmt.Errorf("failed to set exclude attribute: %s", err)
 	}
 
-	if err := d.Set("include", FlattenAccessGroupForSchema(accessPolicy.Include)); err != nil {
+	if err := d.Set("include", TransformAccessGroupForSchema(accessPolicy.Include)); err != nil {
 		return fmt.Errorf("failed to set include attribute: %s", err)
 	}
 

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -105,7 +105,7 @@ func resourceCloudflareAccessPolicyRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("failed to set exclude attribute: %s", err)
 	}
 
-	if err := d.Set("include", accessPolicy.Include); err != nil {
+	if err := d.Set("include", FlattenAccessGroupForSchema(accessPolicy.Include)); err != nil {
 		return fmt.Errorf("failed to set include attribute: %s", err)
 	}
 

--- a/cloudflare/resource_cloudflare_access_policy_test.go
+++ b/cloudflare/resource_cloudflare_access_policy_test.go
@@ -643,3 +643,57 @@ func testAccessPolicyGeoConfig(resourceID, zone, accountID string) string {
 
 	`, resourceID, zone, accountID)
 }
+
+func TestAccessPolicyOkta(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_access_policy." + rnd
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccessAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccessPolicyOktaConfig(rnd, zone, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "include.0.okta.0.name.#", "2"),
+					resource.TestCheckResourceAttr(name, "include.0.okta.0.name.0", "jacob-group"),
+					resource.TestCheckResourceAttr(name, "include.0.okta.0.name.1", "jacob-group1"),
+					resource.TestCheckResourceAttr(name, "include.0.okta.0.identity_provider_id", "225934dc-14e4-4f55-87be-f5d798d23f91"),
+				),
+			},
+		},
+	})
+}
+
+func testAccessPolicyOktaConfig(resourceID, zone, accountID string) string {
+	return fmt.Sprintf(`
+		resource "cloudflare_access_application" "%[1]s" {
+			name       = "%[1]s"
+			account_id = "%[3]s"
+			domain     = "%[1]s.%[2]s"
+		}
+
+		resource "cloudflare_access_policy" "%[1]s" {
+			application_id = "${cloudflare_access_application.%[1]s.id}"
+			name           = "%[1]s"
+			account_id     = "%[3]s"
+			decision       = "allow"
+			precedence     = "1"
+
+			include {
+				okta {
+					name = ["jacob-group", "jacob-group1"]
+					identity_provider_id = "225934dc-14e4-4f55-87be-f5d798d23f91"
+				}
+			}
+		}
+
+	`, resourceID, zone, accountID)
+}

--- a/cloudflare/resource_cloudflare_access_policy_test.go
+++ b/cloudflare/resource_cloudflare_access_policy_test.go
@@ -564,9 +564,7 @@ func TestAccessPolicyAuthMethod(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "account_id", accountID),
-					resource.TestCheckResourceAttr(name, "include.0.auth_method.#", "1"),
-					resource.TestCheckResourceAttr(name, "include.0.auth_method.0", "10.0.0.1/32"),
-					resource.TestCheckResourceAttr(name, "include.0.ip.1", "10.0.0.2/32"),
+					resource.TestCheckResourceAttr(name, "include.0.auth_method", "hwk"),
 				),
 			},
 		},
@@ -589,7 +587,7 @@ func testAccessPolicyAuthMethodConfig(resourceID, zone, accountID string) string
 			precedence     = "1"
 
 			include {
-				ip = ["10.0.0.1/32", "10.0.0.2/32"]
+				auth_method = "hwk"
 			}
 		}
 

--- a/cloudflare/resource_cloudflare_access_policy_test.go
+++ b/cloudflare/resource_cloudflare_access_policy_test.go
@@ -339,8 +339,8 @@ func testAccessPolicyCommonNameConfig(resourceID, zone, accountID string) string
 			application_id = "${cloudflare_access_application.%[1]s.id}"
 			name           = "%[1]s"
 			account_id     = "%[3]s"
-			decision       = "non_identity"
-			precedence     = "10"
+			decision       = "allow"
+			precedence     = "1"
 
 			include {
 				common_name = "example@example.com"
@@ -416,6 +416,7 @@ func TestAccessPolicyEmails(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "include.0.email.#", "2"),
 					resource.TestCheckResourceAttr(name, "include.0.email.0", "a@example.com"),
 					resource.TestCheckResourceAttr(name, "include.0.email.1", "b@example.com"),
 				),
@@ -489,6 +490,156 @@ func testAccessPolicyEveryoneConfig(resourceID, zone, accountID string) string {
 
 			include {
 				everyone = true
+			}
+		}
+
+	`, resourceID, zone, accountID)
+}
+
+func TestAccessPolicyIPs(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_access_policy." + rnd
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccessAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccessPolicyIPsConfig(rnd, zone, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "include.0.ip.#", "2"),
+					resource.TestCheckResourceAttr(name, "include.0.ip.0", "10.0.0.1/32"),
+					resource.TestCheckResourceAttr(name, "include.0.ip.1", "10.0.0.2/32"),
+				),
+			},
+		},
+	})
+}
+
+func testAccessPolicyIPsConfig(resourceID, zone, accountID string) string {
+	return fmt.Sprintf(`
+		resource "cloudflare_access_application" "%[1]s" {
+			name       = "%[1]s"
+			account_id = "%[3]s"
+			domain     = "%[1]s.%[2]s"
+		}
+
+		resource "cloudflare_access_policy" "%[1]s" {
+			application_id = "${cloudflare_access_application.%[1]s.id}"
+			name           = "%[1]s"
+			account_id     = "%[3]s"
+			decision       = "allow"
+			precedence     = "1"
+
+			include {
+				ip = ["10.0.0.1/32", "10.0.0.2/32"]
+			}
+		}
+
+	`, resourceID, zone, accountID)
+}
+
+func TestAccessPolicyAuthMethod(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_access_policy." + rnd
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccessAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccessPolicyAuthMethodConfig(rnd, zone, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "include.0.auth_method.#", "1"),
+					resource.TestCheckResourceAttr(name, "include.0.auth_method.0", "10.0.0.1/32"),
+					resource.TestCheckResourceAttr(name, "include.0.ip.1", "10.0.0.2/32"),
+				),
+			},
+		},
+	})
+}
+
+func testAccessPolicyAuthMethodConfig(resourceID, zone, accountID string) string {
+	return fmt.Sprintf(`
+		resource "cloudflare_access_application" "%[1]s" {
+			name       = "%[1]s"
+			account_id = "%[3]s"
+			domain     = "%[1]s.%[2]s"
+		}
+
+		resource "cloudflare_access_policy" "%[1]s" {
+			application_id = "${cloudflare_access_application.%[1]s.id}"
+			name           = "%[1]s"
+			account_id     = "%[3]s"
+			decision       = "allow"
+			precedence     = "1"
+
+			include {
+				ip = ["10.0.0.1/32", "10.0.0.2/32"]
+			}
+		}
+
+	`, resourceID, zone, accountID)
+}
+
+func TestAccessPolicyGeo(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_access_policy." + rnd
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccessAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccessPolicyGeoConfig(rnd, zone, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "include.0.geo.#", "2"),
+					resource.TestCheckResourceAttr(name, "include.0.geo.0", "US"),
+					resource.TestCheckResourceAttr(name, "include.0.geo.1", "AU"),
+				),
+			},
+		},
+	})
+}
+
+func testAccessPolicyGeoConfig(resourceID, zone, accountID string) string {
+	return fmt.Sprintf(`
+		resource "cloudflare_access_application" "%[1]s" {
+			name       = "%[1]s"
+			account_id = "%[3]s"
+			domain     = "%[1]s.%[2]s"
+		}
+
+		resource "cloudflare_access_policy" "%[1]s" {
+			application_id = "${cloudflare_access_application.%[1]s.id}"
+			name           = "%[1]s"
+			account_id     = "%[3]s"
+			decision       = "allow"
+			precedence     = "1"
+
+			include {
+				geo = ["US", "AU"]
 			}
 		}
 

--- a/cloudflare/resource_cloudflare_access_policy_test.go
+++ b/cloudflare/resource_cloudflare_access_policy_test.go
@@ -349,3 +349,148 @@ func testAccessPolicyCommonNameConfig(resourceID, zone, accountID string) string
 
 	`, resourceID, zone, accountID)
 }
+
+func TestAccessPolicyEmailDomain(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_access_policy." + rnd
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccessAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccessPolicyEmailDomainConfig(rnd, zone, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "include.0.email_domain.0", "example.com"),
+				),
+			},
+		},
+	})
+}
+
+func testAccessPolicyEmailDomainConfig(resourceID, zone, accountID string) string {
+	return fmt.Sprintf(`
+		resource "cloudflare_access_application" "%[1]s" {
+			name       = "%[1]s"
+			account_id = "%[3]s"
+			domain     = "%[1]s.%[2]s"
+		}
+
+		resource "cloudflare_access_policy" "%[1]s" {
+			application_id = "${cloudflare_access_application.%[1]s.id}"
+			name           = "%[1]s"
+			account_id     = "%[3]s"
+			decision       = "allow"
+			precedence     = "1"
+
+			include {
+				email_domain = ["example.com"]
+			}
+		}
+
+	`, resourceID, zone, accountID)
+}
+
+func TestAccessPolicyEmails(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_access_policy." + rnd
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccessAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccessPolicyEmailsConfig(rnd, zone, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "include.0.email.0", "a@example.com"),
+					resource.TestCheckResourceAttr(name, "include.0.email.1", "b@example.com"),
+				),
+			},
+		},
+	})
+}
+
+func testAccessPolicyEmailsConfig(resourceID, zone, accountID string) string {
+	return fmt.Sprintf(`
+		resource "cloudflare_access_application" "%[1]s" {
+			name       = "%[1]s"
+			account_id = "%[3]s"
+			domain     = "%[1]s.%[2]s"
+		}
+
+		resource "cloudflare_access_policy" "%[1]s" {
+			application_id = "${cloudflare_access_application.%[1]s.id}"
+			name           = "%[1]s"
+			account_id     = "%[3]s"
+			decision       = "allow"
+			precedence     = "1"
+
+			include {
+				email = ["a@example.com", "b@example.com"]
+			}
+		}
+
+	`, resourceID, zone, accountID)
+}
+
+func TestAccessPolicyEveryone(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_access_policy." + rnd
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccessAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccessPolicyEveryoneConfig(rnd, zone, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "include.0.everyone", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccessPolicyEveryoneConfig(resourceID, zone, accountID string) string {
+	return fmt.Sprintf(`
+		resource "cloudflare_access_application" "%[1]s" {
+			name       = "%[1]s"
+			account_id = "%[3]s"
+			domain     = "%[1]s.%[2]s"
+		}
+
+		resource "cloudflare_access_policy" "%[1]s" {
+			application_id = "${cloudflare_access_application.%[1]s.id}"
+			name           = "%[1]s"
+			account_id     = "%[3]s"
+			decision       = "allow"
+			precedence     = "1"
+
+			include {
+				everyone = true
+			}
+		}
+
+	`, resourceID, zone, accountID)
+}


### PR DESCRIPTION
This fixes the ability to have Access Policies be able to be imported and still
maintain the policy conditions. The cause of the bug is due to the change in 
schema made many moons ago and the schema not matching the API responses. This
was an issue as out of the box, Terraform can do some conversion however the 
Access Policy resources are complex structures. The issue was made worse by the
omission of error handling `d.Set` calls which can slightly fail.

Looking at this PR, I bet you're thinking "this looks really verbose, surely 
there is a better way" and you'd be partially correct. This *is* pretty verbose. 
It's essentially the counterpart to `BuildAccessGroupCondition` which 
conditionally builds the API request whereas this focused on the API response => 
schema conversion. The reason it is so verbose is due to the remote API and the 
flexibility this API has in the conditions and combinations. You can have a 
myriad of `include`, `exclude` and `require` conditions that all work in unison 
to provide a fitting policy.

Fixes #681