### PR TITLE
cloudflare_access_rule: add validation to discover errors during planning phase

### DIFF
--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -290,7 +290,7 @@ func validateAccessRuleConfigurationIPRange(v string) (warnings []string, errors
 
 	if ip.To4() != nil {
 		ones, _ := ipNet.Mask.Size()
-		if ones != 24 && ones != 32 {
+		if ones != 16 && ones != 24 {
 			errors = append(errors, fmt.Errorf("ip_range with ipv4 address must be a /24 or /32, got a /%d", ones))
 			return warnings, errors
 		}

--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -291,13 +291,13 @@ func validateAccessRuleConfigurationIPRange(v string) (warnings []string, errors
 	if ip.To4() != nil {
 		ones, _ := ipNet.Mask.Size()
 		if ones != 16 && ones != 24 {
-			errors = append(errors, fmt.Errorf("ip_range with ipv4 address must be a /24 or /32, got a /%d", ones))
+			errors = append(errors, fmt.Errorf("ip_range with ipv4 address must be a /16 or /24, got a /%d", ones))
 			return warnings, errors
 		}
 	} else {
 		ones, _ := ipNet.Mask.Size()
 		if ones != 32 && ones != 48 && ones != 64 {
-			errors = append(errors, fmt.Errorf("ip_range with ipv4 address must be in (/32, /48, /64), instead got a /%d", ones))
+			errors = append(errors, fmt.Errorf("ip_range with ipv6 address must be in (/32, /48, /64), instead got a /%d", ones))
 			return warnings, errors
 		}
 	}

--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -42,6 +42,7 @@ func resourceCloudflareAccessRule() *schema.Resource {
 				Required:         true,
 				ForceNew:         true,
 				DiffSuppressFunc: configurationDiffSuppress,
+				ValidateFunc:     validateAccessRuleConfiguration,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"target": {

--- a/cloudflare/resource_cloudflare_access_rule_test.go
+++ b/cloudflare/resource_cloudflare_access_rule_test.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -21,6 +22,29 @@ func TestAccAccessRuleASN(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "mode", "challenge"),
 					resource.TestCheckResourceAttr(name, "configuration.target", "asn"),
 					resource.TestCheckResourceAttr(name, "configuration.value", "AS112"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAccessRuleIPRange(t *testing.T) {
+	name := "cloudflare_access_rule.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccessRuleAccountConfig("challenge", "this is notes", "ip_range", "104.16.0.0/20"),
+				ExpectError: regexp.MustCompile("ip_range with ipv4 address must be a /16 or /24, got a /20"),
+			}, {
+				Config: testAccessRuleAccountConfig("challenge", "this is notes", "ip_range", "104.16.0.0/24"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "notes", "this is notes"),
+					resource.TestCheckResourceAttr(name, "mode", "challenge"),
+					resource.TestCheckResourceAttr(name, "configuration.target", "ip_range"),
+					resource.TestCheckResourceAttr(name, "configuration.value", "104.16.0.0/24"),
 				),
 			},
 		},

--- a/cloudflare/resource_cloudflare_access_rule_test.go
+++ b/cloudflare/resource_cloudflare_access_rule_test.go
@@ -41,11 +41,11 @@ resource "cloudflare_access_rule" "test" {
 
 func TestValidateAccessRuleConfigurationIPRange(t *testing.T) {
 	ipRangeValid := map[string]bool{
-		"192.168.0.1/32":           true,
+		"192.168.0.1/32":           false,
 		"192.168.0.1/24":           true,
 		"192.168.0.1/64":           false,
 		"192.168.0.1/31":           false,
-		"192.168.0.1/16":           false,
+		"192.168.0.1/16":           true,
 		"fd82:0f75:cf0d:d7b3::/64": true,
 		"fd82:0f75:cf0d:d7b3::/48": true,
 		"fd82:0f75:cf0d:d7b3::/32": true,

--- a/cloudflare/resource_cloudflare_access_rule_test.go
+++ b/cloudflare/resource_cloudflare_access_rule_test.go
@@ -38,3 +38,29 @@ resource "cloudflare_access_rule" "test" {
   }
 }`, mode, notes, target, value)
 }
+
+func TestValidateAccessRuleConfigurationIPRange(t *testing.T) {
+	ipRangeValid := map[string]bool{
+		"192.168.0.1/32":           true,
+		"192.168.0.1/24":           true,
+		"192.168.0.1/64":           false,
+		"192.168.0.1/31":           false,
+		"192.168.0.1/16":           false,
+		"fd82:0f75:cf0d:d7b3::/64": true,
+		"fd82:0f75:cf0d:d7b3::/48": true,
+		"fd82:0f75:cf0d:d7b3::/32": true,
+		"fd82:0f75:cf0d:d7b3::/63": false,
+		"fd82:0f75:cf0d:d7b3::/16": false,
+	}
+
+	for ipRange, valid := range ipRangeValid {
+		warnings, errors := validateAccessRuleConfigurationIPRange(ipRange)
+		isValid := len(errors) == 0
+		if len(warnings) != 0 {
+			t.Fatalf("ipRange is either invalid or valid, no room for warnings")
+		}
+		if isValid != valid {
+			t.Fatalf("%s resulted in %v, expected %v", ipRange, isValid, valid)
+		}
+	}
+}


### PR DESCRIPTION
The goal of this PR is to discover preventable mistakes during a terraform plan rather than an apply. Specifically, preventing developers from attempting to apply non /24 and /32 `ip_range`s, resulting in partial changes and leaving them exposed. 

I didn't create an issue because writing the code took about the same time as describing the problem. I'm open to other solutions.