### PR TITLE
CI fixes

### DIFF
--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -597,7 +597,7 @@ func TransformAccessGroupForSchema(accessGroup []interface{}) []map[string]inter
 				gsuiteCfg := groupValue.(map[string]interface{})
 				gsuiteID = gsuiteCfg["identity_provider_id"].(string)
 				gsuiteEmails = append(gsuiteEmails, gsuiteCfg["name"].(string))
-			case "github":
+			case "github-organization":
 				githubCfg := groupValue.(map[string]interface{})
 				githubID = githubCfg["identity_provider_id"].(string)
 				githubName = githubCfg["name"].(string)

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -688,7 +688,7 @@ func TransformAccessGroupForSchema(accessGroup []interface{}) []map[string]inter
 			"github": []interface{}{
 				map[string]interface{}{
 					"name":                 githubName,
-					"team":                 githubTeams,
+					"teams":                githubTeams,
 					"identity_provider_id": githubID,
 				}},
 		})

--- a/cloudflare/resource_cloudflare_access_policy_test.go
+++ b/cloudflare/resource_cloudflare_access_policy_test.go
@@ -235,7 +235,7 @@ func testAccessPolicyGroupConfig(resourceID, zone, accountID string) string {
   			name           = "%[1]s"
 
   			include {
-				ip = ["127.0.0.1"]
+				  ip = ["127.0.0.1/32"]
   			}
 		}
 


### PR DESCRIPTION
Gets the CI runs for acceptance tests _closer_ to a fully green run.

- updates access policy to append CIDR ranges to assertions
- adds sweeper to access group to ensure off by one errors are not causing intermittent failures
- fix access policy transformation key for `github` => `github-organization`(follow up from #917/#918)
- adds sweeper for `cloudflare_authenticated_origin_pulls_certificate` to make sure we are only testing the managed resources