### PR TITLE
test/cloudflare_magic_firewall_ruleset: skip CI tests for default zone

### DIFF
--- a/cloudflare/provider_test.go
+++ b/cloudflare/provider_test.go
@@ -122,3 +122,13 @@ func testAccPreCheckBYOIPPrefix(t *testing.T) {
 func generateRandomResourceName() string {
 	return acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 }
+
+// skipMagicTransitTestForNonConfiguredDefaultZone will force an acceptance test
+// to skip instead of running and failing due to not having setup Magic Transit.
+// This will allow those who intentionally want to run the test to do so while
+// keeping CI sane.
+func skipMagicTransitTestForNonConfiguredDefaultZone(t *testing.T) {
+	if os.Getenv("CLOUDFLARE_ZONE_ID") == testAccCloudflareZoneID {
+		t.Skipf("Skipping acceptance test as %s is not configured for Magic Transit", testAccCloudflareZoneID)
+	}
+}

--- a/cloudflare/provider_test.go
+++ b/cloudflare/provider_test.go
@@ -9,8 +9,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-var testAccProviders map[string]terraform.ResourceProvider
-var testAccProvider *schema.Provider
+var (
+	testAccProviders map[string]terraform.ResourceProvider
+	testAccProvider  *schema.Provider
+
+	// Integration test account ID
+	testAccCloudflareAccountID string = "f037e56e89293a057740de681ac9abbe"
+
+	// Integration test account zone ID
+	testAccCloudflareZoneID string = "0da42c8d2132a9ddaf714f9e7c920711"
+	// Integration test account zone name
+	testAccCloudflareZoneName string = "terraform.cfapi.net"
+
+	// Integration test account alternate zone ID
+	testAccCloudflareAltZoneID string = "b72110c08e3382597095c29ba7e661ea"
+	// Integration test account alternate zone name
+	testAccCloudflareAltZoneName string = "terraform2.cfapi.net"
+)
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)

--- a/cloudflare/resource_cloudflare_magic_firewall_ruleset_test.go
+++ b/cloudflare/resource_cloudflare_magic_firewall_ruleset_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccCloudflareMagicFirewallRulesetExists(t *testing.T) {
+	skipMagicTransitTestForNonConfiguredDefaultZone(t)
+
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_magic_firewall_ruleset.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -35,6 +37,8 @@ func TestAccCloudflareMagicFirewallRulesetExists(t *testing.T) {
 }
 
 func TestAccCloudflareMagicFirewallRulesetUpdateName(t *testing.T) {
+	skipMagicTransitTestForNonConfiguredDefaultZone(t)
+
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_magic_firewall_ruleset.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -77,6 +81,8 @@ func TestAccCloudflareMagicFirewallRulesetUpdateName(t *testing.T) {
 }
 
 func TestAccCloudflareMagicFirewallRulesetUpdateDescription(t *testing.T) {
+	skipMagicTransitTestForNonConfiguredDefaultZone(t)
+
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_magic_firewall_ruleset.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -119,6 +125,8 @@ func TestAccCloudflareMagicFirewallRulesetUpdateDescription(t *testing.T) {
 }
 
 func TestAccCloudflareMagicFirewallRulesetSingleRule(t *testing.T) {
+	skipMagicTransitTestForNonConfiguredDefaultZone(t)
+
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_magic_firewall_ruleset.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -147,6 +155,8 @@ func TestAccCloudflareMagicFirewallRulesetSingleRule(t *testing.T) {
 }
 
 func TestAccCloudflareMagicFirewallRulesetUpdateWithHigherPriority(t *testing.T) {
+	skipMagicTransitTestForNonConfiguredDefaultZone(t)
+
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_magic_firewall_ruleset.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")


### PR DESCRIPTION
Like BYOIP, Magic Transit doesn't really lend itself to the typical CI
setup where we create and destroy resources on the fly. As such, we need
to update the test suite to work accordingly. The tests are very
valuable and we want them around however we shouldn't run them on a zone
we know isn't configured (in this case, able to be configured to do so).

This updates the acceptance tests to skip when the default zone ID is in
use however will allow everyone else to run the tests like normal.

Fixes https://github.com/cloudflare/terraform-provider-cloudflare/runs/1810568088?check_suite_focus=true#step:6:317
