### PR TITLE
More test fixes

### DIFF
--- a/cloudflare/resource_cloudflare_access_identity_provider_test.go
+++ b/cloudflare/resource_cloudflare_access_identity_provider_test.go
@@ -56,7 +56,6 @@ func TestAccCloudflareAccessIdentityProviderOneTimePin(t *testing.T) {
 		os.Setenv("CLOUDFLARE_API_TOKEN", "")
 	}
 
-	t.Parallel()
 	rnd := generateRandomResourceName()
 	resourceName := "cloudflare_access_identity_provider." + rnd
 	resource.Test(t, resource.TestCase{

--- a/cloudflare/resource_cloudflare_custom_hostname_test.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_test.go
@@ -260,6 +260,7 @@ func TestAccCloudflareCustomHostname_UpdatingZoneForcesNewResource(t *testing.T)
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAltZoneID(t)
+			testAccPreCheckAltDomain(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -272,8 +273,7 @@ func TestAccCloudflareCustomHostname_UpdatingZoneForcesNewResource(t *testing.T)
 				),
 			},
 			{
-				ExpectNonEmptyPlan: true,
-				Config:             testAccCheckCloudflareCustomHostnameBasic(altZoneID, rnd, altDomain),
+				Config: testAccCheckCloudflareCustomHostnameBasic(altZoneID, rnd, altDomain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareCustomHostnameExists(resourceName, &after),
 					testAccCheckCloudflareCustomHostnameRecreated(&before, &after),

--- a/cloudflare/resource_cloudflare_waf_override_test.go
+++ b/cloudflare/resource_cloudflare_waf_override_test.go
@@ -21,7 +21,6 @@ func TestAccCloudflareWAFOverrideCreateAndUpdate(t *testing.T) {
 		os.Setenv("CLOUDFLARE_API_TOKEN", "")
 	}
 
-	t.Parallel()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 

--- a/cloudflare/resource_cloudflare_worker_route_test.go
+++ b/cloudflare/resource_cloudflare_worker_route_test.go
@@ -15,8 +15,6 @@ const (
 )
 
 func TestAccCloudflareWorkerRoute_MultiScriptEnt(t *testing.T) {
-	t.Parallel()
-
 	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Workers
 	// service does not yet support the API tokens and it results in
 	// misleading state error messages.
@@ -97,8 +95,6 @@ resource "cloudflare_worker_script" "%[3]s" {
 }
 
 func TestAccCloudflareWorkerRoute_MultiScriptDisabledRoute(t *testing.T) {
-	t.Parallel()
-
 	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Workers
 	// service does not yet support the API tokens and it results in
 	// misleading state error messages.


### PR DESCRIPTION
- Removes use of `t.Parallel()` in tests where the `CLOUDFLARE_API_TOKEN` is unset due to some race issues
- Don't need to assert an empty plan for new resources