### PR TITLE
unset CLOUDFLARE_API_TOKEN in more tests

### DIFF
--- a/cloudflare/resource_cloudflare_api_token_test.go
+++ b/cloudflare/resource_cloudflare_api_token_test.go
@@ -9,6 +9,15 @@ import (
 )
 
 func TestAccAPIToken(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
+	// endpoint does not yet support the API tokens without an explicit scope.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	rnd := generateRandomResourceName()
 	resourceID := "cloudflare_api_token." + rnd
 	permissionID := "82e64a83756745bbbb1c9c2701bf816b" // DNS read
@@ -34,6 +43,15 @@ func TestAccAPIToken(t *testing.T) {
 }
 
 func TestAccAPITokenAllowDeny(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
+	// endpoint does not yet support the API tokens without an explicit scope.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	rnd := generateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	permissionID := "82e64a83756745bbbb1c9c2701bf816b" // DNS read
@@ -56,6 +74,15 @@ func TestAccAPITokenAllowDeny(t *testing.T) {
 }
 
 func TestAccAPITokenDoesNotSetConditions(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
+	// endpoint does not yet support the API tokens without an explicit scope.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	rnd := generateRandomResourceName()
 	name := "cloudflare_api_token." + rnd
 	permissionID := "82e64a83756745bbbb1c9c2701bf816b" // DNS read
@@ -91,6 +118,15 @@ func testAccCloudflareAPITokenWithoutCondition(resourceName, rnd, permissionID s
 }
 
 func TestAccAPITokenSetIndividualCondition(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
+	// endpoint does not yet support the API tokens without an explicit scope.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	rnd := generateRandomResourceName()
 	name := "cloudflare_api_token." + rnd
 	permissionID := "82e64a83756745bbbb1c9c2701bf816b" // DNS read
@@ -132,6 +168,15 @@ func testAccCloudflareAPITokenWithIndividualCondition(rnd string, permissionID s
 }
 
 func TestAccAPITokenSetAllCondition(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
+	// endpoint does not yet support the API tokens without an explicit scope.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	rnd := generateRandomResourceName()
 	name := "cloudflare_api_token." + rnd
 	permissionID := "82e64a83756745bbbb1c9c2701bf816b" // DNS read

--- a/cloudflare/resource_cloudflare_argo_tunnel_test.go
+++ b/cloudflare/resource_cloudflare_argo_tunnel_test.go
@@ -12,6 +12,15 @@ import (
 )
 
 func TestAccCloudflareArgoTunnelCreate(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Argo Tunnel
+	// endpoint does not yet support the API tokens.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	accID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_argo_tunnel.%s", rnd)

--- a/cloudflare/resource_cloudflare_ip_list_test.go
+++ b/cloudflare/resource_cloudflare_ip_list_test.go
@@ -12,6 +12,15 @@ import (
 )
 
 func TestAccCloudflareIPListExists(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the IP List
+	// endpoint does not yet support the API tokens.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_ip_list.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -35,6 +44,15 @@ func TestAccCloudflareIPListExists(t *testing.T) {
 }
 
 func TestAccCloudflareIPListUpdateDescription(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the IP List
+	// endpoint does not yet support the API tokens.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_ip_list.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -76,6 +94,15 @@ func TestAccCloudflareIPListUpdateDescription(t *testing.T) {
 }
 
 func TestAccCloudflareIPListUpdate(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the IP List
+	// endpoint does not yet support the API tokens.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_ip_list.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")


### PR DESCRIPTION
API token support still isn't everywhere and in some of the places it
is, we require specific permissions to be assigned.

Instead of doing that, let's just use CLOUDFLARE_API_KEY until we have
broader support.