### PR TITLE
access_policy: make `precedence` required

### DIFF
--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -43,7 +43,7 @@ func resourceCloudflareAccessPolicy() *schema.Resource {
 			},
 			"precedence": {
 				Type:     schema.TypeInt,
-				Optional: true,
+				Required: true,
 			},
 			"decision": {
 				Type:         schema.TypeString,

--- a/website/docs/r/access_policy.html.markdown
+++ b/website/docs/r/access_policy.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 * `decision` - (Required) Defines the action Access will take if the policy matches the user.
   Allowed values: `allow`, `deny`, `non_identity`, `bypass`
 * `name` - (Required) Friendly name of the Access Application.
-* `precedence` - (Optional) The unique precedence for policies on a single application. Integer.
+* `precedence` - (Required) The unique precedence for policies on a single application. Integer.
 * `require` - (Optional) A series of access conditions, see [Access Groups](/providers/cloudflare/cloudflare/latest/docs/resources/access_group#conditions).
 * `exclude` - (Optional) A series of access conditions, see [Access Groups](/providers/cloudflare/cloudflare/latest/docs/resources/access_group#conditions).
 * `include` - (Required) A series of access conditions, see [Access Groups](/providers/cloudflare/cloudflare/latest/docs/resources/access_group#conditions).


### PR DESCRIPTION
Despite the API optionally allowing `precedence` values, it opens a
potential foot gun scenario if we aren't explicit about our expected
policy ordering. To mitigate, I've swapped the key to be `Required` and
force end users to be explicit about their intended policy ordering.

Closes #937
