### PR TITLE
make csr optional for origin ca

### DIFF
--- a/cloudflare/provider_test.go
+++ b/cloudflare/provider_test.go
@@ -98,6 +98,12 @@ func testAccPreCheckApiKey(t *testing.T) {
 	}
 }
 
+func testAccPreCheckApiUserServiceKey(t *testing.T) {
+	if v := os.Getenv("CLOUDFLARE_API_USER_SERVICE_KEY"); v == "" {
+		t.Fatal("CLOUDFLARE_API_USER_SERVICE_KEY must be set for acceptance tests")
+	}
+}
+
 func testAccPreCheckDomain(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_DOMAIN"); v == "" {
 		t.Fatal("CLOUDFLARE_DOMAIN must be set for acceptance tests. The domain is used to create and destroy record against.")

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -55,7 +55,6 @@ func resourceCloudflareOriginCACertificate() *schema.Resource {
 			"requested_validity": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntInSlice([]int{7, 30, 90, 365, 730, 1095, 5475}),
 			},
 		},

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"log"
+	"math"
 	"strings"
 	"time"
 
@@ -127,6 +128,19 @@ func resourceCloudflareOriginCACertificateRead(d *schema.ResourceData, meta inte
 	d.Set("expires_on", cert.ExpiresOn.Format(time.RFC3339))
 	d.Set("hostnames", hostnames)
 	d.Set("request_type", cert.RequestType)
+
+	// lazy approach to extracting the date from a known timestamp in order to
+	// `time.Parse` it correctly. Here we are getting the certificate expiry and
+	// calculating the validity as the API doesn't return it yet it is present in
+	// the schema.
+	date := strings.Split(cert.ExpiresOn.Format(time.RFC3339), "T")
+	certDate, _ := time.Parse("2006-01-02", date[0])
+	now := time.Now()
+	duration := certDate.Sub(now)
+	var validityDays int
+	validityDays = int(math.Ceil(duration.Hours() / 24))
+
+	d.Set("requested_validity", validityDays)
 
 	return nil
 }

--- a/cloudflare/resource_cloudflare_origin_ca_certificate_test.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate_test.go
@@ -31,7 +31,10 @@ func TestAccCloudflareOriginCACertificate_Basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckApiUserServiceKey(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudflareOriginCACertificateDestroy,
 		Steps: []resource.TestStep{
@@ -44,6 +47,10 @@ func TestAccCloudflareOriginCACertificate_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "csr", csr),
 					resource.TestCheckResourceAttr(name, "request_type", "origin-rsa"),
 				),
+			},
+			{
+				ResourceName: name,
+				ImportState:  true,
 			},
 		},
 	})

--- a/cloudflare/resource_cloudflare_origin_ca_certificate_test.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate_test.go
@@ -46,6 +46,7 @@ func TestAccCloudflareOriginCACertificate_Basic(t *testing.T) {
 					resource.TestMatchResourceAttr(name, "id", regexp.MustCompile("^[0-9]+$")),
 					resource.TestCheckResourceAttr(name, "csr", csr),
 					resource.TestCheckResourceAttr(name, "request_type", "origin-rsa"),
+					resource.TestCheckResourceAttr(name, "requested_validity", "7"),
 				),
 			},
 			{

--- a/website/docs/r/origin_ca_certificate.html.markdown
+++ b/website/docs/r/origin_ca_certificate.html.markdown
@@ -43,7 +43,7 @@ resource "cloudflare_origin_ca_certificate" "example" {
 * `csr`  - (Optional) The Certificate Signing Request. Must be newline-encoded.
 * `hostnames` - (Required) An array of hostnames or wildcard names bound to the certificate.
 * `request_type` - (Required) The signature type desired on the certificate.
-* `requested_validity` - (Required) The number of days for which the certificate should be valid.
+* `requested_validity` - (Optional) The number of days for which the certificate should be valid.
 
 ## Attributes Reference
 

--- a/website/docs/r/origin_ca_certificate.html.markdown
+++ b/website/docs/r/origin_ca_certificate.html.markdown
@@ -40,7 +40,7 @@ resource "cloudflare_origin_ca_certificate" "example" {
 
 ## Argument Reference
 
-* `csr`  - (Required) The Certificate Signing Request. Must be newline-encoded.
+* `csr`  - (Optional) The Certificate Signing Request. Must be newline-encoded.
 * `hostnames` - (Required) An array of hostnames or wildcard names bound to the certificate.
 * `request_type` - (Required) The signature type desired on the certificate.
 * `requested_validity` - (Required) The number of days for which the certificate should be valid.


### PR DESCRIPTION
In the past, the CSR was required as it was the only method of generating
certificates. That isn't the case anymore and in some scenarios, we don't need
to enforce the CSR as we may be importing. Instead of enforcing this at the
schema level, we can make it optional and apply it within the `Create` should
it be present.

Fixes #950

As a bonus I've also fixed a bug with the `requested_validity` not being
persisted within the state which prevents storing unnecessary `null` values.
