### PR TITLE
resource/access_policy: support importing zone and account level resources

### DIFF
--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -222,6 +222,7 @@ func resourceCloudflareAccessPolicyImport(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Importing Cloudflare Access Policy: %s %q, appID %q, accessPolicyID %q", identifierType, identifierID, accessAppID, accessPolicyID)
 
+	//lintignore:R001
 	d.Set(fmt.Sprintf("%s_id", identifierType), identifierID)
 	d.Set("application_id", accessAppID)
 	d.SetId(accessPolicyID)

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -207,17 +207,22 @@ func resourceCloudflareAccessPolicyDelete(d *schema.ResourceData, meta interface
 }
 
 func resourceCloudflareAccessPolicyImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	attributes := strings.SplitN(d.Id(), "/", 3)
+	attributes := strings.SplitN(d.Id(), "/", 4)
 
-	if len(attributes) != 3 {
-		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"accountID/accessApplicationID/accessPolicyID\"", d.Id())
+	if len(attributes) != 4 {
+		return nil, fmt.Errorf(
+			"invalid id (%q) specified, should be in format %q or %q",
+			d.Id(),
+			"account/accountID/accessApplicationID/accessPolicyID",
+			"zone/zoneID/accessApplicationID/accessPolicyID",
+		)
 	}
 
-	accountID, accessAppID, accessPolicyID := attributes[0], attributes[1], attributes[2]
+	identifierType, identifierID, accessAppID, accessPolicyID := attributes[0], attributes[1], attributes[2], attributes[3]
 
-	log.Printf("[DEBUG] Importing Cloudflare Access Policy: accountID %q, appID %q, accessPolicyID %q", accountID, accessAppID, accessPolicyID)
+	log.Printf("[DEBUG] Importing Cloudflare Access Policy: %s %q, appID %q, accessPolicyID %q", identifierType, identifierID, accessAppID, accessPolicyID)
 
-	d.Set("account_id", accountID)
+	d.Set(fmt.Sprintf("%s_id", identifierType), identifierID)
 	d.Set("application_id", accessAppID)
 	d.SetId(accessPolicyID)
 

--- a/website/docs/r/access_policy.html.markdown
+++ b/website/docs/r/access_policy.html.markdown
@@ -67,15 +67,14 @@ The following arguments are supported:
 
 ## Import
 
-Access Policies can be imported using a composite ID formed of zone
-ID, application ID and policy ID.
+Access Policies can be imported using a composite ID formed of identifier type
+(`zone` or `account`), identifier ID (`zone_id` or `account_id`), application ID
+and policy ID.
 
 ```
-$ terraform import cloudflare_access_policy.staging cb029e245cfdd66dc8d2e570d5dd3322/d41d8cd98f00b204e9800998ecf8427e/67ea780ce4982c1cfbe6b7293afc765d
+# import a zone level Access policy
+$ terraform import cloudflare_access_policy.staging zone/cb029e245cfdd66dc8d2e570d5dd3322/d41d8cd98f00b204e9800998ecf8427e/67ea780ce4982c1cfbe6b7293afc765d
+
+# import an account level Access policy
+$ terraform import cloudflare_access_policy.production account/0d599f0ec05c3bda8c3b8a68c32a1b47/d41d8cd98f00b204e9800998ecf8427e/67ea780ce4982c1cfbe6b7293afc765d
 ```
-
-where
-
-* `cb029e245cfdd66dc8d2e570d5dd3322` - Zone ID
-* `d41d8cd98f00b204e9800998ecf8427e` - Access Application ID
-* `67ea780ce4982c1cfbe6b7293afc765d` - Access Policy ID


### PR DESCRIPTION
Updates the `Import` to support managing zone and account level
policies.

Closes #929
