### PR TITLE
Fixing typo on cloudflare_zones data resource documentation

### DIFF
--- a/website/docs/d/zones.html.md
+++ b/website/docs/d/zones.html.md
@@ -84,7 +84,7 @@ resource "cloudflare_zone_lockdown" "endpoint_lockdown" {
   }
 }
 
-resource "cloudflare_zone" "example" {
+resource "cloudflare_record" "example" {
   zone_id     = lookup(data.cloudflare_zones.test.zones[0], "id")
   name        = "www"
   value       = "203.0.113.1"


### PR DESCRIPTION
Changing example resource from `cloudflare_zone` to `cloudflare_record` as all the attributes of the resource match a record. I believe this is a typo.