### PR TITLE
Fix mTLS cert parsing

### DIFF
--- a/cloudflare/resource_cloudflare_access_mutual_tls_certificate_test.go
+++ b/cloudflare/resource_cloudflare_access_mutual_tls_certificate_test.go
@@ -11,6 +11,16 @@ import (
 )
 
 func TestAccCloudflareAccessMutualTLSBasic(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_mutual_tls_certificate.%s", rnd)
 	cert := os.Getenv("CLOUDFLARE_MUTUAL_TLS_CERTIFICATE")

--- a/cloudflare/resource_cloudflare_access_mutual_tls_certificate_test.go
+++ b/cloudflare/resource_cloudflare_access_mutual_tls_certificate_test.go
@@ -119,7 +119,9 @@ resource "cloudflare_access_mutual_tls_certificate" "%[1]s" {
 	name                 = "%[1]s"
 	%[2]s_id             = "%[3]s"
 	associated_hostnames = ["%[5]s"]
-	certificate          = "%[4]s"
+	certificate          = <<-EOF
+	%[4]s
+	EOF
 }
 `, rnd, identifier.Type, identifier.Value, cert, domain)
 }
@@ -130,7 +132,9 @@ resource "cloudflare_access_mutual_tls_certificate" "%[1]s" {
 	name                 = "%[1]s"
 	%[2]s_id             = "%[3]s"
 	associated_hostnames = []
-	certificate          = "%[4]s"
+	certificate          = <<-EOF
+	%[4]s
+	EOF
 }
 `, rnd, identifier.Type, identifier.Value, cert)
 }


### PR DESCRIPTION
YAML => HCL => JSON wasn't working great with `\n` but works with heredocs for the multiline string value.

This fixes the tests but the test case is failing with

> error creating Access Mutual TLS Certificate for zone "0da42c8d2132a9ddaf714f9e7c920711": error from makeRequest: HTTP status 401: access.api.error.missing_required_permissions

which we are tracking internally and once resolved, this will be 👌 