### PR TITLE
cloudflare_record: check `record.Priority` using the API, not the schema

### DIFF
--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -437,7 +437,7 @@ func resourceCloudflareRecordRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	d.Set("proxiable", record.Proxiable)
 
-	if _, ok := d.GetOkExists("priority"); ok {
+	if record.Priority != nil {
 		priority := record.Priority
 		p := *priority
 		d.Set("priority", fmt.Sprintf("%d", int(p)))


### PR DESCRIPTION
Following on from the changes in 2.19.0 (and 2.19.1 to actually ship the
change), a regression was introduced that is inadvertantly causing a
panic due to the `d.GetOkExists` failing to accurately determine when to
apply the `record.Priority` value to the state.

`d.GetOkExists` is documented as:

> GetOkExists can check if TypeBool attributes that are Optional with
> no Default value have been set.

While the value isn't a bool, it acts similarly as 0 in this context is
both a valid value and a zero value for the field.

To combat the panic, I've swapped the check to instead compare the value
provided by the API to determine whether or not we want to set it. This
approach wasn't initially taken as the API used to return 0 in all cases
where the value wasn't explicitly set and the underlying library would
ignore it. Hopefully, with MX records allowing 0, this is no longer an
issue going forward.

Closes #988