### PR TITLE
Add firewall_rules data source

### DIFF
--- a/cloudflare/data_source_firewall_rule.go
+++ b/cloudflare/data_source_firewall_rule.go
@@ -1,0 +1,161 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceCloudflareFirewallRules() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCloudflareFirewallRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"filter": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"priority": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 2147483647),
+						},
+						"match_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"lt", "lte", "eq", "gte", "gt"}, false),
+						},
+						"paused": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+
+			"firewall_rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"action": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"priority": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"paused": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCloudflareFirewallRulesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	filter, err := expandFilterFirewallRules(d.Get("filter"))
+	if err != nil {
+		return err
+	}
+
+	zoneID := d.Get("zone_id").(string)
+	rules, err := client.FirewallRules(context.Background(), zoneID, cloudflare.PaginationOptions{})
+	if err != nil {
+		return fmt.Errorf("error listing Firewall Rules: %s", err)
+	}
+
+	filteredRules := make([]map[string]interface{}, 0)
+	for _, v := range rules {
+		if filter.paused != v.Paused {
+			continue
+		}
+
+		rulePrio, ok := v.Priority.(int)
+		if !ok {
+			rulePrio = 2147483647
+		}
+		if !filter.matchPriority(rulePrio) {
+			continue
+		}
+
+		filteredRules = append(filteredRules, map[string]interface{}{
+			"id":       v.ID,
+			"action":   v.Action,
+			"priority": v.Priority,
+			"paused":   v.Paused,
+		})
+	}
+
+	err = d.Set("firewall_rules", filteredRules)
+	if err != nil {
+		return fmt.Errorf("error setting Firewall Rules: %s", err)
+	}
+
+	return nil
+}
+
+func expandFilterFirewallRules(d interface{}) (*firewallRulesFilter, error) {
+	cfg := d.([]interface{})
+	filter := &firewallRulesFilter{}
+
+	m := cfg[0].(map[string]interface{})
+	priority, ok := m["priority"]
+	if ok {
+		filter.priority = priority.(int)
+	}
+
+	matchType, ok := m["match_type"]
+	if ok {
+		filter.matchType = matchType.(string)
+	}
+
+	paused, ok := m["paused"]
+	if ok {
+		filter.paused = paused.(bool)
+	}
+
+	return filter, nil
+}
+
+type firewallRulesFilter struct {
+	priority  int
+	matchType string
+	paused    bool
+}
+
+func (f *firewallRulesFilter) matchPriority(match int) bool {
+	switch f.matchType {
+	case "lte":
+		return match <= f.priority
+	case "lt":
+		return match < f.priority
+	case "eq":
+		return match == f.priority
+	case "gt":
+		return match > f.priority
+	case "gte":
+		return match >= f.priority
+	default:
+		return true
+	}
+}

--- a/cloudflare/data_source_firewall_rule_test.go
+++ b/cloudflare/data_source_firewall_rule_test.go
@@ -8,13 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func init() {
-	resource.AddTestSweepers("cloudflare_firewall_rule", &resource.Sweeper{
-		Name: "cloudflare_firewall_rule",
-		F:    testSweepCloudflareFirewallRuleSweeper,
-	})
-}
-
 func TestAccCloudflareFirewallRulesMatchPaused(t *testing.T) {
 	t.Parallel()
 	rnd := generateRandomResourceName()

--- a/cloudflare/data_source_firewall_rule_test.go
+++ b/cloudflare/data_source_firewall_rule_test.go
@@ -1,0 +1,129 @@
+package cloudflare
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("cloudflare_firewall_rule", &resource.Sweeper{
+		Name: "cloudflare_firewall_rule",
+		F:    testSweepCloudflareFirewallRuleSweeper,
+	})
+}
+
+func TestAccCloudflareFirewallRulesMatchPaused(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("data.cloudflare_firewall_rules.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareFirewallRulesConfigMatchPaused(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "filter.0.paused", "true"),
+					resource.TestCheckResourceAttr(name, "firewall_rules.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareFirewallRulesMatchPriorityFilter(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("data.cloudflare_zones.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareFirewallRulesConfigMatchPriority(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareFirewallRulesDataSourceID(name),
+					resource.TestCheckResourceAttr(name, "filter.0.priority", "2"),
+					resource.TestCheckResourceAttr(name, "filter.0.match_type", "gte"),
+					resource.TestCheckResourceAttr(name, "firewall_rules.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareFirewallRulesDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		all := s.RootModule().Resources
+		rs, ok := all[n]
+		if !ok {
+			return fmt.Errorf("Can't find firewall rule data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Snapshot firewall rule source ID not set")
+		}
+		return nil
+	}
+}
+
+func testAccCloudflareFirewallRulesConfigMatchPaused(rnd string) string {
+	return fmt.Sprintf(`
+data "cloudflare_firewall_rules" "%[2]s" {
+  filter {
+    paused = "${cloudflare_firewall_rule.baa_com.paused}"
+  }
+}
+
+%[1]s
+`, testRules, rnd)
+}
+
+func testAccCloudflareFirewallRulesConfigMatchPriority(rnd string) string {
+	return fmt.Sprintf(`
+data "cloudflare_firewall_rules" "%[2]s" {
+  filter {
+    priority   = 2
+	match_type = "gte"
+    // This is an ordering fix to ensure that the test suite doesn't assert
+    // state before all the resources are available.
+    paused = "${cloudflare_firewall_rule.baa_net.paused}"
+  }
+}
+
+%[1]s
+`, testRules, rnd)
+}
+
+const testRules = `resource "cloudflare_firewall_rule" "baa_com" {
+  zone_id  = "0da42c8d2132a9ddaf714f9e7c920711"
+  paused   = true
+  action   = "block"
+  priority = 1
+}
+
+resource "cloudflare_firewall_rule" "baa_org" {
+  zone_id  = "0da42c8d2132a9ddaf714f9e7c920711"
+  paused   = false
+  action   = "block"
+  priority = 2
+}
+
+resource "cloudflare_firewall_rule" "baa_net" {
+  zone_id  = "0da42c8d2132a9ddaf714f9e7c920711"
+  paused   = false
+  action   = "block"
+  priority = 3
+}
+
+resource "cloudflare_firewall_rule" "foo_net" {
+  zone_id    = "0da42c8d2132a9ddaf714f9e7c920711"
+  paused     = false
+  action     = "block"
+  depends_on = ["cloudflare_firewall_rule.baa_net", "cloudflare_firewall_rule.baa_org", "cloudflare_firewall_rule.baa_com"]
+}`


### PR DESCRIPTION
This change adds a new data source `firewall_rules` which can query existing firewall rules based on their `paused` and `priority` attributes.

fixes #997 

