### PR TITLE
waf_{group,package,rule}: simplify error check handling

### DIFF
--- a/cloudflare/resource_cloudflare_waf_package.go
+++ b/cloudflare/resource_cloudflare_waf_package.go
@@ -10,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
-const CLOUDFLARE_INVALID_OR_REMOVED_WAF_PACKAGE_ID_ERROR = 1002
-
 func resourceCloudflareWAFPackage() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCloudflareWAFPackageCreate,
@@ -54,12 +52,6 @@ func resourceCloudflareWAFPackage() *schema.Resource {
 	}
 }
 
-func errorIsWAFPackageNotFound(err error) bool {
-	return cloudflareErrorIsOneOfCodes(err, []int{
-		CLOUDFLARE_INVALID_OR_REMOVED_WAF_PACKAGE_ID_ERROR,
-	})
-}
-
 func resourceCloudflareWAFPackageRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
@@ -68,7 +60,7 @@ func resourceCloudflareWAFPackageRead(d *schema.ResourceData, meta interface{}) 
 
 	pkg, err := client.WAFPackage(context.Background(), zoneID, packageID)
 	if err != nil {
-		if errorIsWAFPackageNotFound(err) {
+		if err.(*cloudflare.APIRequestError).InternalErrorCodeIs(1002) {
 			d.SetId("")
 			return nil
 		}

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -3,17 +3,14 @@ package cloudflare
 import (
 	"context"
 	"crypto/md5"
-	"encoding/json"
 	"fmt"
 	"log"
 	"reflect"
-	"regexp"
 	"sort"
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	errors "github.com/pkg/errors"
 )
 
 func expandInterfaceToStringList(list interface{}) []string {
@@ -111,43 +108,6 @@ func findIndex(a []interface{}, x interface{}) (int, bool) {
 		}
 	}
 	return 0, false
-}
-
-type CloudflareAPIError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
-}
-
-type CloudflareAPIErrorResponse struct {
-	Errors []CloudflareAPIError `json:"errors"`
-}
-
-func cloudflareErrorIsOneOfCodes(err error, codes []int) bool {
-	errorMsg := errors.Cause(err).Error()
-
-	// We will parse the error message only if it's an error 400, in which
-	// case we need to verify the kind of error.
-	r := regexp.MustCompile(`^HTTP status 400: content "(.*)"$`)
-	submatchs := r.FindStringSubmatch(errorMsg)
-	if submatchs != nil {
-		jsonData := strings.Replace(submatchs[1], "\\\"", "\"", -1)
-		log.Printf("[DEBUG][cloudflareErrorIsCode] error matching status 400, content: %#v", jsonData)
-
-		var cfer CloudflareAPIErrorResponse
-		unmarshalErr := json.Unmarshal([]byte(jsonData), &cfer)
-
-		// We check that there is only one error and that its code
-		// matches what we expected
-		if unmarshalErr == nil && len(cfer.Errors) == 1 {
-			for _, code := range codes {
-				if cfer.Errors[0].Code == code {
-					return true
-				}
-			}
-		}
-	}
-
-	return false
 }
 
 func boolFromString(status string) bool {


### PR DESCRIPTION
Removes custom Terraform handler for error codes and instead relies on some
changes from cloudflare/cloudflare-go#616 to make it more user friendly.

Pending changes from cloudflare/cloudflare-go#616 to land