### PR TITLE
deps: bump cloudflare-go to 0.16.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudflare/terraform-provider-cloudflare
 go 1.15
 
 require (
-	github.com/cloudflare/cloudflare-go v0.15.0
+	github.com/cloudflare/cloudflare-go v0.16.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/terraform-plugin-sdk v1.16.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.15.0 h1:vdnz+Wi5M/09xr2GbKX1OgfzW3QHFfyWevWLwUoVmOE=
 github.com/cloudflare/cloudflare-go v0.15.0/go.mod h1:EnwdgGMaFOruiPZRFSgn+TsQ3hQ7C/YWzIGLeu5c304=
+github.com/cloudflare/cloudflare-go v0.16.0 h1:Z6sTsoDXSFYNdbj0JVK0s4CRnlhQagmNqZw4pwm3X4Y=
+github.com/cloudflare/cloudflare-go v0.16.0/go.mod h1:EnwdgGMaFOruiPZRFSgn+TsQ3hQ7C/YWzIGLeu5c304=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
### Improvements

- errors: Add helper methods for searching in slices

### Features

- Adds `GetWorker` route API (singular) endpoint
- Add `login_method` rule for Access