### PR TITLE
Fix geoType references to prevent nil pointer panic

### DIFF
--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -663,11 +663,11 @@ func flattenRules(d *schema.ResourceData, rules []*cloudflare.LoadBalancerRule) 
 				m["overrides"] = []interface{}{om}
 			}
 			if _, ok := d.GetOkExists(fmt.Sprintf("rules.%d.overrides.0.pop_pools", idx)); ok {
-				om["pop_pools"] = flattenGeoPools(o.PoPPools, "rules_pop")
+				om["pop_pools"] = flattenGeoPools(o.PoPPools, "pop")
 				m["overrides"] = []interface{}{om}
 			}
 			if _, ok := d.GetOkExists(fmt.Sprintf("rules.%d.overrides.0.region_pools", idx)); ok {
-				om["region_pools"] = flattenGeoPools(o.RegionPools, "rules_region")
+				om["region_pools"] = flattenGeoPools(o.RegionPools, "region")
 				m["overrides"] = []interface{}{om}
 			}
 			if _, ok := d.GetOkExists(fmt.Sprintf("rules.%d.overrides.0.session_affinity_attributes", idx)); o.SessionAffinityAttrs != nil && ok {

--- a/cloudflare/resource_cloudflare_load_balancer_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_test.go
@@ -166,8 +166,9 @@ func TestAccCloudflareLoadBalancer_Rules(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "rules.0.overrides.0.steering_policy", "geo"),
 					resource.TestCheckResourceAttr(name, "rules.0.overrides.0.session_affinity_attributes.samesite", "Auto"),
 					resource.TestCheckResourceAttr(name, "rules.0.overrides.0.session_affinity_attributes.secure", "Auto"),
-					resource.TestCheckResourceAttr(name, "rules.#", "2"),
+					resource.TestCheckResourceAttr(name, "rules.#", "3"),
 					resource.TestCheckResourceAttr(name, "rules.1.fixed_response.message_body", "hello"),
+					resource.TestCheckResourceAttr(name, "rules.2.overrides.0.region_pools.0.region", "ENAM"),
 				),
 			},
 		},
@@ -491,6 +492,16 @@ resource "cloudflare_load_balancer" "%[3]s" {
       status_code = "200"
       content_type = "html"
       location = "www.example.com"
+    }
+  }
+  rules {
+    name = "test rule 3"
+    condition = "dns.qry.type == 28"
+    overrides {
+      region_pools {
+		    region = "ENAM"
+		    pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
+	    }
     }
   }
 }`, zoneID, zone, id)

--- a/cloudflare/resource_cloudflare_load_balancer_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_test.go
@@ -168,7 +168,7 @@ func TestAccCloudflareLoadBalancer_Rules(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "rules.0.overrides.0.session_affinity_attributes.secure", "Auto"),
 					resource.TestCheckResourceAttr(name, "rules.#", "3"),
 					resource.TestCheckResourceAttr(name, "rules.1.fixed_response.message_body", "hello"),
-					resource.TestCheckResourceAttr(name, "rules.2.overrides.0.region_pools.0.region", "ENAM"),
+					resource.TestCheckResourceAttr(name, "rules.2.overrides.0.region_pools.#", "1"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes #1032. The`geoType` arguments to `flattenGeoPools` do not match the map keys in `localPoolElems`, and this PR corrects that while adding an acceptance test case that should validate that region_pool modification actually works.