### PR TITLE
logpush_job: make ownership_challenge optional

### DIFF
--- a/website/docs/r/logpush_job.html.markdown
+++ b/website/docs/r/logpush_job.html.markdown
@@ -8,9 +8,9 @@ description: |-
 
 # cloudflare_logpush_job
 
-Provides a resource which manages Cloudflare Logpush jobs. On it's own, this
-resource cannot be automatically created. In order to have this automated, you
-must have:
+Provides a resource which manages Cloudflare Logpush jobs. For Logpush jobs pushing to Amazon S3, Google Cloud Storage,
+Microsoft Azure or Sumo Logic, this resource cannot be automatically created. In order to have this automated, you must
+have:
 
 - `cloudflare_logpush_ownership_challenge`: Configured to generate the challenge
   to confirm ownership of the destination.
@@ -84,7 +84,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the logpush job to create. Must match the regular expression `^[a-zA-Z0-9\-\.]*$`.
 * `zone_id` - (Required) The zone ID where the logpush job should be created.
 * `destination_conf` - (Required) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included. See [Logpush destination documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#destination).
-* `ownership_challenge` - (Required) Ownership challenge token to prove destination ownership. See [Developer documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#usage).
 * `dataset` - (Required) Which type of dataset resource to use. Available values are `"firewall_events"`, `"http_requests"`, and `"spectrum_events"`.
 * `logpull_options` - (Optional) Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpull options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options).
+* `ownership_challenge` - (Optional) Ownership challenge token to prove destination ownership, required when destination is Amazon S3, Google Cloud Storage,
+  Microsoft Azure or Sumo Logic. See [Developer documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#usage).
 * `enabled` - (Optional) Whether to enable the job.


### PR DESCRIPTION
Makes `ownership_challenge` argument optional when the `destination_conf` is Datadog, Splunk or S3-Compatible (non-AWS).

closes cloudflare/terraform-provider-cloudflare#1010