### PR TITLE
Add type to Access applications

### DIFF
--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -27,13 +27,11 @@ func resourceCloudflareAccessApplication() *schema.Resource {
 			"account_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Computed:      true,
 				ConflictsWith: []string{"zone_id"},
 			},
 			"zone_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Computed:      true,
 				ConflictsWith: []string{"account_id"},
 			},
 			"aud": {
@@ -47,6 +45,12 @@ func resourceCloudflareAccessApplication() *schema.Resource {
 			"domain": {
 				Type:     schema.TypeString,
 				Required: true,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "self_hosted",
+				ValidateFunc: validation.StringInSlice([]string{"self_hosted", "ssh", "vnc", "file"}, false),
 			},
 			"session_duration": {
 				Type:     schema.TypeString,
@@ -144,10 +148,12 @@ func resourceCloudflareAccessApplicationCreate(d *schema.ResourceData, meta inte
 	client := meta.(*cloudflare.API)
 
 	allowedIDPList := expandInterfaceToStringList(d.Get("allowed_idps"))
+	appType := d.Get("type").(string)
 
 	newAccessApplication := cloudflare.AccessApplication{
 		Name:                   d.Get("name").(string),
 		Domain:                 d.Get("domain").(string),
+		Type:                   cloudflare.AccessApplicationType(appType),
 		SessionDuration:        d.Get("session_duration").(string),
 		AutoRedirectToIdentity: d.Get("auto_redirect_to_identity").(bool),
 		EnableBindingCookie:    d.Get("enable_binding_cookie").(bool),
@@ -217,6 +223,7 @@ func resourceCloudflareAccessApplicationRead(d *schema.ResourceData, meta interf
 	d.Set("aud", accessApplication.AUD)
 	d.Set("session_duration", accessApplication.SessionDuration)
 	d.Set("domain", accessApplication.Domain)
+	d.Set("type", accessApplication.Type)
 	d.Set("auto_redirect_to_identity", accessApplication.AutoRedirectToIdentity)
 	d.Set("enable_binding_cookie", accessApplication.EnableBindingCookie)
 	d.Set("custom_deny_message", accessApplication.CustomDenyMessage)
@@ -235,11 +242,13 @@ func resourceCloudflareAccessApplicationUpdate(d *schema.ResourceData, meta inte
 	client := meta.(*cloudflare.API)
 
 	allowedIDPList := expandInterfaceToStringList(d.Get("allowed_idps"))
+	appType := d.Get("type").(string)
 
 	updatedAccessApplication := cloudflare.AccessApplication{
 		ID:                     d.Id(),
 		Name:                   d.Get("name").(string),
 		Domain:                 d.Get("domain").(string),
+		Type:                   cloudflare.AccessApplicationType(appType),
 		SessionDuration:        d.Get("session_duration").(string),
 		AutoRedirectToIdentity: d.Get("auto_redirect_to_identity").(bool),
 		EnableBindingCookie:    d.Get("enable_binding_cookie").(bool),

--- a/cloudflare/resource_cloudflare_access_application_test.go
+++ b/cloudflare/resource_cloudflare_access_application_test.go
@@ -34,6 +34,7 @@ func TestAccCloudflareAccessApplicationBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "domain", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(name, "type", "self_hosted"),
 					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
 					resource.TestCheckResourceAttr(name, "cors_headers.#", "0"),
 					resource.TestCheckResourceAttr(name, "auto_redirect_to_identity", "false"),
@@ -56,6 +57,7 @@ func TestAccCloudflareAccessApplicationBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "account_id", accountID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "domain", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(name, "type", "self_hosted"),
 					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
 					resource.TestCheckResourceAttr(name, "cors_headers.#", "0"),
 					resource.TestCheckResourceAttr(name, "auto_redirect_to_identity", "false"),
@@ -82,6 +84,7 @@ func TestAccCloudflareAccessApplicationWithCORS(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "domain", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(name, "type", "self_hosted"),
 					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
 					resource.TestCheckResourceAttr(name, "cors_headers.#", "1"),
 					resource.TestCheckResourceAttr(name, "cors_headers.0.allowed_methods.#", "3"),
@@ -111,6 +114,7 @@ func TestAccCloudflareAccessApplicationWithAutoRedirectToIdentity(t *testing.T) 
 					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "domain", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(name, "type", "self_hosted"),
 					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
 					resource.TestCheckResourceAttr(name, "auto_redirect_to_identity", "true"),
 				),
@@ -136,6 +140,7 @@ func TestAccCloudflareAccessApplicationWithEnableBindingCookie(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "domain", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(name, "type", "self_hosted"),
 					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
 					resource.TestCheckResourceAttr(name, "enable_binding_cookie", "true"),
 				),
@@ -161,6 +166,7 @@ func TestAccCloudflareAccessApplicationWithCustomDenyFields(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "domain", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(name, "type", "self_hosted"),
 					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
 					resource.TestCheckResourceAttr(name, "custom_deny_message", "denied!"),
 					resource.TestCheckResourceAttr(name, "custom_deny_url", "https://www.cloudflare.com"),
@@ -187,6 +193,7 @@ func TestAccCloudflareAccessApplicationWithADefinedIdps(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "domain", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(name, "type", "self_hosted"),
 					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
 					resource.TestCheckResourceAttr(name, "auto_redirect_to_identity", "true"),
 					resource.TestCheckResourceAttr(name, "allowed_idps.#", "1"),
@@ -202,6 +209,7 @@ resource "cloudflare_access_application" "%[1]s" {
   %[3]s_id                  = "%[4]s"
   name                      = "%[1]s"
   domain                    = "%[1]s.%[2]s"
+  type                      = "self_hosted"
   session_duration          = "24h"
   auto_redirect_to_identity = false
 }
@@ -214,6 +222,7 @@ resource "cloudflare_access_application" "%[1]s" {
   zone_id          = "%[2]s"
   name             = "%[1]s"
   domain           = "%[1]s.%[3]s"
+  type             = "self_hosted"
   session_duration = "24h"
   cors_headers {
     allowed_methods = ["GET", "POST", "OPTIONS"]
@@ -232,6 +241,7 @@ resource "cloudflare_access_application" "%[1]s" {
   zone_id                   = "%[2]s"
   name                      = "%[1]s"
   domain                    = "%[1]s.%[3]s"
+  type                      = "self_hosted"
   session_duration          = "24h"
   auto_redirect_to_identity = true
 }
@@ -244,6 +254,7 @@ resource "cloudflare_access_application" "%[1]s" {
   zone_id                   = "%[2]s"
   name                      = "%[1]s"
   domain                    = "%[1]s.%[3]s"
+  type                      = "self_hosted"
   session_duration          = "24h"
   enable_binding_cookie     = true
 }
@@ -256,6 +267,7 @@ resource "cloudflare_access_application" "%[1]s" {
   zone_id                   = "%[2]s"
   name                      = "%[1]s"
   domain                    = "%[1]s.%[3]s"
+  type                      = "self_hosted"
   session_duration          = "24h"
   custom_deny_message       = "denied!"
   custom_deny_url           = "https://www.cloudflare.com"
@@ -274,6 +286,7 @@ resource "cloudflare_access_application" "%[1]s" {
   zone_id                   = "%[2]s"
   name                      = "%[1]s"
   domain                    = "%[1]s.%[3]s"
+  type                      = "self_hosted"
   session_duration          = "24h"
   auto_redirect_to_identity = true
   allowed_idps              = [cloudflare_access_identity_provider.%[1]s.id]
@@ -501,6 +514,7 @@ func testAccessApplicationWithZoneID(resourceID, zone, zoneID string) string {
       name    = "%[1]s"
       zone_id = "%[3]s"
       domain  = "%[1]s.%[2]s"
+      type    = "self_hosted"
     }
   `, resourceID, zone, zoneID)
 }
@@ -511,6 +525,7 @@ func testAccessApplicationWithZoneIDUpdated(resourceID, zone, zoneID string) str
       name    = "%[1]s-updated"
       zone_id = "%[3]s"
       domain  = "%[1]s.%[2]s"
+      type    = "self_hosted"
     }
   `, resourceID, zone, zoneID)
 }
@@ -521,6 +536,7 @@ func testAccessApplicationWithMissingCORSMethods(resourceID, zone, zoneID string
       name    = "%[1]s-updated"
       zone_id = "%[3]s"
       domain  = "%[1]s.%[2]s"
+      type    = "self_hosted"
 
     cors_headers {
       allow_all_origins = true
@@ -535,6 +551,7 @@ func testAccessApplicationWithMissingCORSOrigins(resourceID, zone, zoneID string
       name    = "%[1]s-updated"
       zone_id = "%[3]s"
       domain  = "%[1]s.%[2]s"
+      type    = "self_hosted"
 
     cors_headers {
       allow_all_methods = true
@@ -549,6 +566,7 @@ func testAccessApplicationWithInvalidSessionDuration(resourceID, zone, zoneID st
       name             = "%[1]s-updated"
       zone_id          = "%[3]s"
       domain           = "%[1]s.%[2]s"
+      type             = "self_hosted"
       session_duration = "24z"
   }
   `, resourceID, zone, zoneID)
@@ -560,6 +578,7 @@ func testAccessApplicationMisconfiguredCORSAllowAllOriginsWithCredentials(resour
       name             = "%[1]s-updated"
       zone_id          = "%[3]s"
       domain           = "%[1]s.%[2]s"
+      type             = "self_hosted"
 
       cors_headers {
         allowed_methods = ["GET"]
@@ -576,6 +595,7 @@ func testAccessApplicationMisconfiguredCORSAllowWildcardOriginWithCredentials(re
       name             = "%[1]s-updated"
       zone_id          = "%[3]s"
       domain           = "%[1]s.%[2]s"
+      type             = "self_hosted"
 
       cors_headers {
         allowed_methods = ["GET"]

--- a/website/docs/r/access_application.html.markdown
+++ b/website/docs/r/access_application.html.markdown
@@ -19,6 +19,7 @@ resource "cloudflare_access_application" "staging_app" {
   zone_id                   = "1d5fdc9e88c8a8c4518b068cd94331fe"
   name                      = "staging application"
   domain                    = "staging.example.com"
+  type                      = "self_hosted"
   session_duration          = "24h"
   auto_redirect_to_identity = false
 }
@@ -28,6 +29,7 @@ resource "cloudflare_access_application" "staging_app" {
   zone_id          = "1d5fdc9e88c8a8c4518b068cd94331fe"
   name             = "staging application"
   domain           = "staging.example.com"
+  type             = "self_hosted"
   session_duration = "24h"
   cors_headers {
     allowed_methods = ["GET", "POST", "OPTIONS"]
@@ -49,6 +51,8 @@ The following arguments are supported:
 * `name` - (Required) Friendly name of the Access Application.
 * `domain` - (Required) The complete URL of the asset you wish to put
   Cloudflare Access in front of. Can include subdomains or paths. Or both.
+* `type` - (Optional) The application type. Defaults to `self_hosted`. Valid
+  values are `self_hosted`, `ssh`, `vnc`, or `file`.
 * `session_duration` - (Optional) How often a user will be forced to
   re-authorise. Must be in the format `"48h"` or `"2h45m"`.
   Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Defaults to `24h`.


### PR DESCRIPTION
Supports the type field for Access applications. 

Requires https://github.com/cloudflare/cloudflare-go/pull/646 before this can be merged.