### PR TITLE
resource/cloudflare_origin_ca: ignore decreasing `requested_validity`

### DIFF
--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -57,6 +57,9 @@ func resourceCloudflareOriginCACertificate() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntInSlice([]int{7, 30, 90, 365, 730, 1095, 5475}),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This is an optional field and not required for anything other than new
resources so it's fine to suppress all diffs for the field.

Closes #1031