### PR TITLE
datasource/cloudflare_waf_rule: expose `default_mode`

### DIFF
--- a/cloudflare/data_source_waf_rules.go
+++ b/cloudflare/data_source_waf_rules.go
@@ -87,6 +87,10 @@ func dataSourceCloudflareWAFRules() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
+						"default_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -155,6 +159,7 @@ func dataSourceCloudflareWAFRulesRead(d *schema.ResourceData, meta interface{}) 
 				"group_name":    rule.Group.Name,
 				"package_id":    pkg.ID,
 				"allowed_modes": rule.AllowedModes,
+				"default_mode":  rule.DefaultMode,
 			})
 			ruleIds = append(ruleIds, rule.ID)
 		}


### PR DESCRIPTION
Updates the data source to expose the `default_mode` field for people to
use.

Closes #979 