### PR TITLE
1083: Prevent imports on Authenticated Origin Pull Certs that do not specify a valid aop type

### DIFF
--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
@@ -207,6 +207,10 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateImport(d *schema.Resou
 		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneID/type/certID\"", d.Id())
 	}
 	zoneID, aopType, certID := idAttr[0], idAttr[1], idAttr[2]
+	if aopType != "per-zone" && aopType != "per-hostname" {
+		return nil, fmt.Errorf("invalid aop type (\"%s\") specified, should be either format \"per-zone\" or \"per-hostname\"", aopType)
+	}
+
 	d.Set("zone_id", zoneID)
 	d.Set("type", aopType)
 	d.SetId(certID)


### PR DESCRIPTION


closes #1083