### PR TITLE
fix(APITokens): change permission_groups type from list to set of strings

### DIFF
--- a/cloudflare/resource_cloudflare_api_token.go
+++ b/cloudflare/resource_cloudflare_api_token.go
@@ -22,9 +22,10 @@ func resourceCloudflareApiToken() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"permission_groups": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 			},
 			"effect": {
 				Type:         schema.TypeString,
@@ -165,7 +166,8 @@ func resourceDataToApiTokenPolices(d *schema.ResourceData) []cloudflare.APIToken
 	for _, p := range policies {
 		policy := p.(map[string]interface{})
 
-		permissionGroups := expandInterfaceToStringList(policy["permission_groups"])
+		permissionGroups := expandSetToStringList(policy["permission_groups"])
+
 		if len(permissionGroups) == 0 {
 			continue
 		}

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -22,6 +22,16 @@ func expandInterfaceToStringList(list interface{}) []string {
 	return vs
 }
 
+func expandSetToStringList(setInterface interface{}) []string {
+	set := setInterface.(*schema.Set)
+	list := make([]string, set.Len())
+	for i, ele := range set.List() {
+		list[i] = ele.(string)
+	}
+
+	return list
+}
+
 func expandStringListToSet(list []string) *schema.Set {
 	values := schema.NewSet(schema.HashString, []interface{}{})
 	for _, h := range list {


### PR DESCRIPTION
**Problem**
A diff can be detected when creating API Tokens with multiple permission_groups in a single policy.

```hcl
resource "cloudflare_api_token" "test" {
  name = "test"

  policy {
    effect = "allow"
    permission_groups = [
      "3030687196b94b638145a3953da2b699",
      "da6d2d6f2ec8442eaadda60d13f42bca",
      "e6d2666161e84845a636613608cee8d5",
      "ed07f6c337da4195b4e72a1fb2c6bcae",
      "4755a26eedb94da69e1066d98aa820be",
      "1af1fa2adc104452b74a9a3364202f20",
      "43137f8d07884d3198dc0ee77ca6e79b",
    ]
    resources = { "com.cloudflare.api.account.*" = "*" }
  }
}
```

```terminal
$ terraform apply && terraform plan
...
Terraform will perform the following actions:

  # cloudflare_api_token.test will be updated in-place
  ~ resource "cloudflare_api_token" "test" {
      ...
      - policy {
          - effect            = "allow" -> null
          - permission_groups = [
              - "3030687196b94b638145a3953da2b699",
              - "da6d2d6f2ec8442eaadda60d13f42bca",
              - "e6d2666161e84845a636613608cee8d5",
              - "ed07f6c337da4195b4e72a1fb2c6bcae",
              - "43137f8d07884d3198dc0ee77ca6e79b",
              - "4755a26eedb94da69e1066d98aa820be",
              - "1af1fa2adc104452b74a9a3364202f20",
            ] -> null
          - resources         = {
              - "com.cloudflare.api.account.*" = "*"
            } -> null
        }
      + policy {
          + effect            = "allow"
          + permission_groups = [
              + "3030687196b94b638145a3953da2b699",
              + "da6d2d6f2ec8442eaadda60d13f42bca",
              + "e6d2666161e84845a636613608cee8d5",
              + "ed07f6c337da4195b4e72a1fb2c6bcae",
              + "4755a26eedb94da69e1066d98aa820be",
              + "1af1fa2adc104452b74a9a3364202f20",
              + "43137f8d07884d3198dc0ee77ca6e79b",
            ]
          + resources         = {
              + "com.cloudflare.api.account.*" = "*"
            }
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
...
```

**Why?**
 CloudFlare API can return permission_groups in a different order then the posted/updated one.

**Solution**
Make permission_groups set of strings where order doesn't matter.