### PR TITLE
Adds cloudflare_static_route

### DIFF
--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -141,6 +141,7 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_rate_limit":                             resourceCloudflareRateLimit(),
 			"cloudflare_record":                                 resourceCloudflareRecord(),
 			"cloudflare_spectrum_application":                   resourceCloudflareSpectrumApplication(),
+			"cloudflare_static_route":                           resourceCloudflareStaticRoute(),
 			"cloudflare_teams_list":                             resourceCloudflareTeamsList(),
 			"cloudflare_waf_group":                              resourceCloudflareWAFGroup(),
 			"cloudflare_waf_package":                            resourceCloudflareWAFPackage(),

--- a/cloudflare/resource_cloudflare_static_route.go
+++ b/cloudflare/resource_cloudflare_static_route.go
@@ -1,0 +1,193 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/pkg/errors"
+)
+
+func resourceCloudflareStaticRoute() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareStaticRouteCreate,
+		Read:   resourceCloudflareStaticRouteRead,
+		Update: resourceCloudflareStaticRouteUpdate,
+		Delete: resourceCloudflareStaticRouteDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareStaticRouteImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"prefix": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"nexthop": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"priority": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"weight": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Required: false,
+				// API does not allow to reset weights when attribute isn't send. To avoid generating unnecessary changes
+				// we will trigger a re-create when weights change
+				ForceNew: true,
+			},
+			"colo_regions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"colo_names": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceCloudflareStaticRouteCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	client.AccountID = d.Get("account_id").(string)
+
+	newStaticRoute, err := client.CreateMagicTransitStaticRoute(context.Background(), staticRouteFromResource(d))
+
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error creating static route for prefix %s", d.Get("prefix").(string)))
+	}
+
+	d.SetId(newStaticRoute[0].ID)
+
+	return resourceCloudflareStaticRouteRead(d, meta)
+}
+
+func resourceCloudflareStaticRouteImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*cloudflare.API)
+	attributes := strings.SplitN(d.Id(), "/", 2)
+
+	if len(attributes) != 2 {
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"accountID/routeID\"", d.Id())
+	}
+
+	accountID, routeID := attributes[0], attributes[1]
+	d.SetId(routeID)
+	d.Set("account_id", accountID)
+	client.AccountID = accountID
+
+	resourceCloudflareStaticRouteRead(d, meta)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceCloudflareStaticRouteRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	client.AccountID = d.Get("account_id").(string)
+
+	staticRoute, err := client.GetMagicTransitStaticRoute(context.Background(), d.Id())
+	if err != nil {
+		if strings.Contains(err.Error(), "Route not found") {
+			log.Printf("[INFO] Static Route %s not found", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return errors.Wrap(err, fmt.Sprintf("error reading Static Route ID %q", d.Id()))
+	}
+
+	d.Set("prefix", staticRoute.Prefix)
+	d.Set("nexthop", staticRoute.Nexthop)
+	d.Set("priority", staticRoute.Priority)
+	d.Set("weight", staticRoute.Weight)
+
+	if len(staticRoute.Description) > 0 {
+		d.Set("description", staticRoute.Description)
+	}
+
+	if len(staticRoute.Scope.ColoRegions) > 0 {
+		d.Set("colo_regions", staticRoute.Scope.ColoRegions)
+	}
+
+	if len(staticRoute.Scope.ColoNames) > 0 {
+		d.Set("colo_names", staticRoute.Scope.ColoNames)
+	}
+
+	return nil
+}
+
+func resourceCloudflareStaticRouteUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	client.AccountID = d.Get("account_id").(string)
+
+	_, err := client.UpdateMagicTransitStaticRoute(context.Background(), d.Id(), staticRouteFromResource(d))
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error updating static route with ID %q", d.Id()))
+	}
+
+	return resourceCloudflareStaticRouteRead(d, meta)
+}
+
+func resourceCloudflareStaticRouteDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	client.AccountID = d.Get("account_id").(string)
+
+	log.Printf("[INFO] Deleting Static Route:  %s", d.Id())
+
+	_, err := client.DeleteMagicTransitStaticRoute(context.Background(), d.Id())
+	if err != nil {
+		return fmt.Errorf("Error deleting Static Route: %s", err)
+	}
+
+	return nil
+}
+
+func staticRouteFromResource(d *schema.ResourceData) cloudflare.MagicTransitStaticRoute {
+	staticRoute := cloudflare.MagicTransitStaticRoute{
+		Prefix:   d.Get("prefix").(string),
+		Nexthop:  d.Get("nexthop").(string),
+		Priority: d.Get("priority").(int),
+	}
+
+	description, descriptionOk := d.GetOk("description")
+	if descriptionOk {
+		staticRoute.Description = description.(string)
+	}
+
+	weight, weightOk := d.GetOk("weight")
+	if weightOk {
+		staticRoute.Weight = weight.(int)
+	}
+
+	coloRegions, coloRegionsOk := d.GetOk("colo_regions")
+	if coloRegionsOk {
+		staticRoute.Scope.ColoRegions = expandInterfaceToStringList(coloRegions)
+	}
+
+	coloNames, coloNamesOk := d.GetOk("colo_names")
+	if coloNamesOk {
+		staticRoute.Scope.ColoNames = expandInterfaceToStringList(coloNames)
+	}
+
+	return staticRoute
+}

--- a/cloudflare/resource_cloudflare_static_route_test.go
+++ b/cloudflare/resource_cloudflare_static_route_test.go
@@ -142,7 +142,7 @@ func testAccCheckCloudflareStaticRouteSimple(ID, description, accountID string, 
 	return fmt.Sprintf(`
   resource "cloudflare_static_route" "%[1]s" {
 	account_id = "%[3]s"
-    prefix = "10.100.0.0/24"
+	prefix = "10.100.0.0/24"
 	nexthop = "10.0.0.0"
 	priority = "100"
 	description = "%[2]s"

--- a/cloudflare/resource_cloudflare_static_route_test.go
+++ b/cloudflare/resource_cloudflare_static_route_test.go
@@ -1,0 +1,153 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccCloudflareStaticRouteExists(t *testing.T) {
+	skipMagicTransitTestForNonConfiguredDefaultZone(t)
+
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_static_route.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	var StaticRoute cloudflare.MagicTransitStaticRoute
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckAccount(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareStaticRouteSimple(rnd, rnd, accountID, 100),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareStaticRouteExists(name, &StaticRoute),
+					resource.TestCheckResourceAttr(name, "description", rnd),
+					resource.TestCheckResourceAttr(name, "prefix", "10.100.0.0/24"),
+					resource.TestCheckResourceAttr(name, "nexthop", "10.0.0.0"),
+					resource.TestCheckResourceAttr(name, "priority", "100"),
+					resource.TestCheckResourceAttr(name, "weight", "100"),
+					resource.TestCheckResourceAttr(name, "colo_regions.0", "APAC"),
+					resource.TestCheckResourceAttr(name, "colo_names.0", "den01"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareStaticRouteExists(n string, route *cloudflare.MagicTransitStaticRoute) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No static route is set")
+		}
+
+		client := testAccProvider.Meta().(*cloudflare.API)
+		foundStaticRoute, err := client.GetMagicTransitStaticRoute(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*route = foundStaticRoute
+
+		return nil
+	}
+}
+
+func TestAccCloudflareStaticRouteUpdateDescription(t *testing.T) {
+	skipMagicTransitTestForNonConfiguredDefaultZone(t)
+
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_static_route.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	var StaticRoute cloudflare.MagicTransitStaticRoute
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckAccount(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareStaticRouteSimple(rnd, rnd, accountID, 100),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareStaticRouteExists(name, &StaticRoute),
+					resource.TestCheckResourceAttr(name, "description", rnd),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareStaticRouteSimple(rnd, rnd+"-updated", accountID, 100),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareStaticRouteExists(name, &StaticRoute),
+					resource.TestCheckResourceAttr(name, "description", rnd+"-updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareStaticRouteUpdateWeight(t *testing.T) {
+	skipMagicTransitTestForNonConfiguredDefaultZone(t)
+
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_static_route.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	var StaticRoute cloudflare.MagicTransitStaticRoute
+	var initialID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckAccount(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareStaticRouteSimple(rnd, rnd, accountID, 100),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareStaticRouteExists(name, &StaticRoute),
+					resource.TestCheckResourceAttr(name, "weight", "100"),
+				),
+			},
+			{
+				PreConfig: func() {
+					initialID = StaticRoute.ID
+				},
+				Config: testAccCheckCloudflareStaticRouteSimple(rnd, rnd+"-updated", accountID, 200),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareStaticRouteExists(name, &StaticRoute),
+					func(state *terraform.State) error {
+						if initialID == StaticRoute.ID {
+							return fmt.Errorf("forced recreation but Static Route got updated (id %q)",
+								StaticRoute.ID)
+						}
+						return nil
+					},
+					resource.TestCheckResourceAttr(name, "description", rnd+"-updated"),
+					resource.TestCheckResourceAttr(name, "weight", "200"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareStaticRouteSimple(ID, description, accountID string, weight int) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_static_route" "%[1]s" {
+	account_id = "%[3]s"
+    prefix = "10.100.0.0/24"
+	nexthop = "10.0.0.0"
+	priority = "100"
+	description = "%[2]s"
+	weight = %[4]d
+	colo_regions = ["APAC"]
+	colo_names = ["den01"]
+  }`, ID, description, accountID, weight)
+}


### PR DESCRIPTION
This PR resolves #1094 and adds a new resource `cloudflare_static_route`. Static Routes are used by Magic Transit and Magic WAN. They define where traffic for a given prefix should be routed to.

This PR requires some cloudflare-go changes:
https://github.com/cloudflare/cloudflare-go/pull/652

Resource Layout:
```
resource "cloudflare_static_route" "example" {
  account_id = "b66603270ac98750f6598cba38ec720b"
  prefix = "80.64.223.10/32"
  nexthop = "10.0.0.0"
  priority = 210
  weight = 1
  colo_names = [
    "fra03"
  ]
  colo_regions = [
    "WEUR"
  ]
}
```

Acceptance Tests:
```
$ go test $(go list ./...) -v -run TestAccCloudflareStaticRoute
?       github.com/cloudflare/terraform-provider-cloudflare     [no test files]
=== RUN   TestAccCloudflareStaticRouteExists
--- PASS: TestAccCloudflareStaticRouteExists (8.07s)
=== RUN   TestAccCloudflareStaticRouteUpdateDescription
--- PASS: TestAccCloudflareStaticRouteUpdateDescription (14.60s)
=== RUN   TestAccCloudflareStaticRouteUpdateWeight
--- PASS: TestAccCloudflareStaticRouteUpdateWeight (16.03s)
```