### PR TITLE
Fix DNS record import handling

### DIFF
--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -565,7 +565,7 @@ func resourceCloudflareRecordImport(d *schema.ResourceData, meta interface{}) ([
 	d.Set("zone_id", zoneID)
 	d.SetId(recordID)
 
-	resourceCloudflareZoneRead(d, meta)
+	resourceCloudflareRecordRead(d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -440,7 +440,7 @@ func resourceCloudflareRecordRead(d *schema.ResourceData, meta interface{}) erro
 	if record.Priority != nil {
 		priority := record.Priority
 		p := *priority
-		d.Set("priority", fmt.Sprintf("%d", int(p)))
+		d.Set("priority", int(p))
 	}
 
 	return nil


### PR DESCRIPTION
Within this PR, there are two fixes which will allow better compatibility with
importing existing resources.

The first is using the correct `Read` method (:facepalm:) for DNS records. This
method was pointing to Zones which wouldn't actually do anything on `Import`.

The second handles importing `priority` values as integers which used to be
presented as strings from the API but are now handled correctly as integers.

Closes #1114
