### PR TITLE
access_application: revert Computed schema removal

### DIFF
--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -27,11 +27,13 @@ func resourceCloudflareAccessApplication() *schema.Resource {
 			"account_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"zone_id"},
 			},
 			"zone_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"account_id"},
 			},
 			"aud": {


### PR DESCRIPTION
Removed in #1076 but required for existing applications to function (not required for new ones). 