### PR TITLE
Add optional api_token field to Access IdP configuration

### DIFF
--- a/cloudflare/resource_cloudflare_access_identity_provider.go
+++ b/cloudflare/resource_cloudflare_access_identity_provider.go
@@ -50,6 +50,10 @@ func resourceCloudflareAccessIdentityProvider() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"api_token": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"apps_domain": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -312,6 +316,7 @@ func convertSchemaToStruct(d *schema.ResourceData) (cloudflare.AccessIdentityPro
 			IDPConfig.Attributes = attrData
 		}
 
+		IDPConfig.APIToken = d.Get("config.0.api_token").(string)
 		IDPConfig.AppsDomain = d.Get("config.0.apps_domain").(string)
 		IDPConfig.AuthURL = d.Get("config.0.auth_url").(string)
 		IDPConfig.CentrifyAccount = d.Get("config.0.centrify_account").(string)
@@ -346,6 +351,7 @@ func convertStructToSchema(d *schema.ResourceData, options cloudflare.AccessIden
 	}
 
 	m := map[string]interface{}{
+		"api_token":            options.APIToken,
 		"apps_domain":          options.AppsDomain,
 		"attributes":           attributes,
 		"auth_url":             options.AuthURL,

--- a/website/docs/r/access_identity_provider.html.markdown
+++ b/website/docs/r/access_identity_provider.html.markdown
@@ -45,6 +45,18 @@ resource "cloudflare_access_identity_provider" "jumpcloud_saml" {
     idp_public_cert = "MIIDpDCCAoygAwIBAgIGAV2ka+55MA0GCSqGSIb3DQEBCwUAMIGSMQswCQ...GF/Q2/MHadws97cZg\nuTnQyuOqPuHbnN83d/2l1NSYKCbHt24o"
   }
 }
+
+# okta
+resource "cloudflare_access_identity_provider" "okta" {
+  account_id = "1d5fdc9e88c8a8c4518b068cd94331fe"
+  name       = "Okta"
+  type       = "okta"
+  config {
+    client_id     = "example"
+    client_secret = "secret_key"
+    api_token     = "okta_api_token"
+  }
+}
 ```
 
 Please refer to the [developers.cloudflare.com Access documentation][access_identity_provider_guide]


### PR DESCRIPTION
Adds an optional API token field for Okta IdP configurations. Developer docs will have instructions on how to set that up here: https://github.com/cloudflare/cloudflare-docs/pull/1680.