### PR TITLE
resource/cloudflare_worker_cron_trigger: account for missing scripts

### DIFF
--- a/cloudflare/resource_cloudflare_worker_cron_trigger.go
+++ b/cloudflare/resource_cloudflare_worker_cron_trigger.go
@@ -3,6 +3,7 @@ package cloudflare
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -58,6 +59,12 @@ func resourceCloudflareWorkerCronTriggerRead(d *schema.ResourceData, meta interf
 
 	s, err := client.ListWorkerCronTriggers(context.Background(), scriptName)
 	if err != nil {
+		// If the script is removed, we also need to remove the triggers.
+		if strings.Contains(err.Error(), "workers.api.error.script_not_found") {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf("failed to read Worker Cron Trigger: %s", err)
 	}
 


### PR DESCRIPTION
If the script is removed, the associated relationships (triggers,
environment variables, etc) need to be removed from the state to ensure
that the dashboard behaviour of total cleanup is handled within
Terraform.

Closes #1120
