### PR TITLE
resource/cloudflare_record: support `allow_overwrite`

### DIFF
--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -52,6 +52,7 @@ The following arguments are supported:
 * `ttl` - (Optional) The TTL of the record ([automatic: '1'](https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record))
 * `priority` - (Optional) The priority of the record
 * `proxied` - (Optional) Whether the record gets Cloudflare's origin protection; defaults to `false`.
+* `allow_overwrite` - (Optional) Allow creation of this record in Terraform to overwrite an existing record, if any. This does not affect the ability to update the record in Terraform and does not prevent other resources within Terraform or manual changes outside Terraform from overwriting this record. `false` by default. **This configuration is not recommended for most environments**.
 
 ## Attributes Reference
 


### PR DESCRIPTION
There are scenarios, such as AWS ACM, which provide a DNS record for
ownership validation and due to these validation strings not being
unique users can hit problems with duplicated DNS records even though
the validation string remains the same.

While this **isn't** the norm for most it is painful for some so to
alleviate that, we've introduce the `allow_overwrite` argument which
will allow users to disregard certain record values and force their own
regardless of whether a record exists in that space or not. This will
allow modules that handle this on behalf of users to operate freely
without manual intervention.

Closes #960
