### PR TITLE
resource/cloudflare_rate_limit: handle `origin_traffic` missing from API response

### DIFF
--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -553,6 +553,8 @@ func flattenRateLimitResponseMatcher(cfg cloudflare.RateLimitResponseMatcher) []
 
 	if cfg.OriginTraffic != nil {
 		data["origin_traffic"] = *cfg.OriginTraffic
+	} else {
+		data["origin_traffic"] = false
 	}
 
 	if len(cfg.Statuses) > 0 {

--- a/cloudflare/resource_cloudflare_rate_limit_test.go
+++ b/cloudflare/resource_cloudflare_rate_limit_test.go
@@ -111,6 +111,7 @@ func TestAccCloudflareRateLimit_FullySpecified(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "match.0.request.0.methods.#", "6"),
 					resource.TestCheckResourceAttr(name, "match.0.request.0.schemes.#", "2"),
 					resource.TestMatchResourceAttr(name, "match.0.request.0.url_pattern", regexp.MustCompile("tfacc-full")),
+					resource.TestCheckResourceAttr(name, "match.0.response.0.origin_traffic", "false"),
 					resource.TestCheckResourceAttr(name, "match.0.response.0.statuses.#", "5"),
 					resource.TestCheckResourceAttr(name, "match.0.response.0.headers.#", "2"),
 					resource.TestCheckResourceAttr(name, "match.0.response.0.headers.0.name", "Test"),


### PR DESCRIPTION
On the service side, when `origin_traffic = false` it is omitted from
the payload which throws off Terraform as the value isn't presented.
This results in the `apply`/`plan` operations showing changes in the
state when it nothing has actually changed.

Closes #1062