### PR TITLE
fix: don't concatenate domain during lookup if it is root domain

### DIFF
--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -378,7 +378,7 @@ func resourceCloudflareRecordCreate(d *schema.ResourceData, meta interface{}) er
 					var r cloudflare.DNSRecord
 					log.Printf("[DEBUG] Cloudflare Record already exists however we are overwriting it")
 					zone, _ := client.ZoneDetails(context.Background(), d.Get("zone_id").(string))
-					if d.Get("name").(string) == "@" {
+					if d.Get("name").(string) == "@" || d.Get("name").(string) == zone.Name {
 						r = cloudflare.DNSRecord{
 							Name: zone.Name,
 							Type: d.Get("type").(string),

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -374,8 +374,8 @@ func resourceCloudflareRecordCreate(d *schema.ResourceData, meta interface{}) er
 		r, err := client.CreateDNSRecord(context.Background(), newRecord.ZoneID, newRecord)
 		if err != nil {
 			if strings.Contains(err.Error(), "already exist") {
-				var r cloudflare.DNSRecord
 				if d.Get("allow_overwrite").(bool) {
+					var r cloudflare.DNSRecord
 					log.Printf("[DEBUG] Cloudflare Record already exists however we are overwriting it")
 					zone, _ := client.ZoneDetails(context.Background(), d.Get("zone_id").(string))
 					if d.Get("name").(string) == "@" {

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -374,13 +374,20 @@ func resourceCloudflareRecordCreate(d *schema.ResourceData, meta interface{}) er
 		r, err := client.CreateDNSRecord(context.Background(), newRecord.ZoneID, newRecord)
 		if err != nil {
 			if strings.Contains(err.Error(), "already exist") {
-
+				var r cloudflare.DNSRecord
 				if d.Get("allow_overwrite").(bool) {
 					log.Printf("[DEBUG] Cloudflare Record already exists however we are overwriting it")
 					zone, _ := client.ZoneDetails(context.Background(), d.Get("zone_id").(string))
-					r := cloudflare.DNSRecord{
-						Name: d.Get("name").(string) + "." + zone.Name,
-						Type: d.Get("type").(string),
+					if d.Get("name").(string) == "@" {
+						r = cloudflare.DNSRecord{
+							Name: zone.Name,
+							Type: d.Get("type").(string),
+						}
+					} else {
+						r = cloudflare.DNSRecord{
+							Name: d.Get("name").(string) + "." + zone.Name,
+							Type: d.Get("type").(string),
+						}
 					}
 					rs, _ := client.DNSRecords(context.Background(), d.Get("zone_id").(string), r)
 


### PR DESCRIPTION
This adds a check to see if domain being queried is the root domain value.

This is required when using `allow_overwrite` as it wil fail to overwrite when the `name` variable equals `@`, representing the root domain.

Closes #1128