### PR TITLE
fix cloudflare_access_group github teams key

### DIFF
--- a/website/docs/r/access_group.html.markdown
+++ b/website/docs/r/access_group.html.markdown
@@ -102,7 +102,7 @@ conditions which can be applied. The conditions are:
   include {
     github {
       name = "my-github-org-name" # (Required) GitHub organization name
-      team = ["my-github-team-name"] # (Optional) GitHub teams
+      teams = ["my-github-team-name"] # (Optional) GitHub teams
       identity_provider_id = "ca298b82-93b5-41bf-bc2d-10493f09b761"
     }
   }


### PR DESCRIPTION
The orginzation team specified in the github argument of the cloudflare_access_group resource should be `teams`, but the documentation says `team`.

```shell
$ terraform plan                                                                                                                                                                       1 ↵
╷
│ Error: Unsupported argument
│ 
│   on groups.tf line 20, in resource "cloudflare_access_group" "admin":
│   20:       team                 = ["admin"]
│ 
│ An argument named "team" is not expected here. Did you mean "teams"?
╵
```
