### PR TITLE
ruleset: initial support

### DIFF
--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -140,6 +140,7 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_page_rule":                              resourceCloudflarePageRule(),
 			"cloudflare_rate_limit":                             resourceCloudflareRateLimit(),
 			"cloudflare_record":                                 resourceCloudflareRecord(),
+			"cloudflare_ruleset":                                resourceCloudflareRuleset(),
 			"cloudflare_spectrum_application":                   resourceCloudflareSpectrumApplication(),
 			"cloudflare_static_route":                           resourceCloudflareStaticRoute(),
 			"cloudflare_teams_list":                             resourceCloudflareTeamsList(),

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -1,0 +1,486 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/pkg/errors"
+)
+
+func resourceCloudflareRuleset() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareRulesetCreate,
+		Read:   resourceCloudflareRulesetRead,
+		Update: resourceCloudflareRulesetUpdate,
+		Delete: resourceCloudflareRulesetDelete,
+		// Importer: &schema.ResourceImporter{
+		// 	State: resourceCloudflareRulesetImport,
+		// },
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"zone_id"},
+			},
+			"zone_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"account_id"},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"kind": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(cloudflare.RulesetKindValues(), false),
+			},
+			"phase": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(cloudflare.RulesetPhaseValues(), false),
+			},
+			"shareable_entitlement_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ref": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"action": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(cloudflare.RulesetRuleActionValues(), false),
+						},
+						"expression": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"action_parameters": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"products": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+									"uri": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"path": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"expression": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+												"query": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"expression": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+												"origin": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"increment": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"version": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"ruleset": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"current"}, false),
+									},
+									"overrides": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enabled": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"categories": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"category": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"action": {
+																Type:         schema.TypeString,
+																Optional:     true,
+																ValidateFunc: validation.StringInSlice(cloudflare.RulesetRuleActionValues(), false),
+															},
+															"enabled": {
+																Type:     schema.TypeBool,
+																Optional: true,
+															},
+														},
+													},
+												},
+												"rules": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"id": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"action": {
+																Type:         schema.TypeString,
+																Optional:     true,
+																ValidateFunc: validation.StringInSlice(cloudflare.RulesetRuleActionValues(), false),
+															},
+															"enabled": {
+																Type:     schema.TypeBool,
+																Optional: true,
+															},
+															"score_threshold": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceCloudflareRulesetCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get("account_id").(string)
+	zoneID := d.Get("zone_id").(string)
+
+	rs := cloudflare.Ruleset{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Kind:        d.Get("kind").(string),
+		Phase:       d.Get("phase").(string),
+	}
+
+	rules, err := buildRulesetRulesFromResource(d.Get("rules"))
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error building ruleset from resource"))
+	}
+
+	if len(rules) > 0 {
+		rs.Rules = rules
+	}
+
+	var ruleset cloudflare.Ruleset
+	if accountID != "" {
+		ruleset, err = client.CreateAccountRuleset(context.Background(), accountID, rs)
+	} else {
+		ruleset, err = client.CreateZoneRuleset(context.Background(), zoneID, rs)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error creating ruleset %s", d.Get("name").(string)))
+	}
+
+	for i, rule := range rules {
+		if rule.Action == string(cloudflare.RulesetRuleActionExecute) {
+			rulesetEntryPoint := cloudflare.Ruleset{
+				Description: d.Get("description").(string),
+				Rules:       []cloudflare.RulesetRule{rules[i]},
+			}
+
+			if accountID != "" {
+				_, err = client.UpdateAccountRulesetPhase(context.Background(), accountID, rs.Phase, rulesetEntryPoint)
+			} else {
+				_, err = client.UpdateZoneRulesetPhase(context.Background(), zoneID, rs.Phase, rulesetEntryPoint)
+			}
+
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("error updating ruleset phase entrypoint %s", d.Get("name").(string)))
+			}
+		}
+	}
+
+	d.SetId(ruleset.ID)
+
+	return resourceCloudflareRulesetRead(d, meta)
+}
+
+// func resourceCloudflareRulesetImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+// 	client := meta.(*cloudflare.API)
+// 	attributes := strings.SplitN(d.Id(), "/", 2)
+
+// 	if len(attributes) != 2 {
+// 		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"accountID/rulesetID\"", d.Id())
+// 	}
+
+// 	accountID, rulesetID := attributes[0], attributes[1]
+// 	d.SetId(rulesetID)
+// 	d.Set("account_id", accountID)
+// 	client.AccountID = accountID
+
+// 	resourceCloudflareRulesetRead(d, meta)
+
+// 	return []*schema.ResourceData{d}, nil
+// }
+
+func resourceCloudflareRulesetRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get("account_id").(string)
+	zoneID := d.Get("zone_id").(string)
+
+	var ruleset cloudflare.Ruleset
+	var err error
+
+	if accountID != "" {
+		ruleset, err = client.GetAccountRuleset(context.Background(), accountID, d.Id())
+	} else {
+		ruleset, err = client.GetZoneRuleset(context.Background(), zoneID, d.Id())
+	}
+
+	if err != nil {
+		if strings.Contains(err.Error(), "could not find ruleset") {
+			log.Printf("[INFO] Ruleset %s no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return errors.Wrap(err, fmt.Sprintf("error reading ruleset ID: %s", d.Id()))
+	}
+
+	d.Set("name", ruleset.Name)
+	d.Set("description", ruleset.Description)
+	d.Set("rules", buildStateFromRulesetRules(ruleset.Rules))
+
+	return nil
+}
+
+func resourceCloudflareRulesetUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get("account_id").(string)
+	zoneID := d.Get("zone_id").(string)
+
+	rules, err := buildRulesetRulesFromResource(d.Get("rules"))
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error building ruleset from resource"))
+	}
+
+	description := d.Get("description").(string)
+	if accountID != "" {
+		_, err = client.UpdateAccountRuleset(context.Background(), accountID, d.Id(), description, rules)
+	} else {
+		_, err = client.UpdateZoneRuleset(context.Background(), zoneID, d.Id(), description, rules)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error updating ruleset with ID %q", d.Id()))
+	}
+
+	return resourceCloudflareRulesetRead(d, meta)
+}
+
+func resourceCloudflareRulesetDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get("account_id").(string)
+	zoneID := d.Get("zone_id").(string)
+	var err error
+
+	if accountID != "" {
+		err = client.DeleteAccountRuleset(context.Background(), accountID, d.Id())
+	} else {
+		err = client.DeleteZoneRuleset(context.Background(), zoneID, d.Id())
+	}
+
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error deleting ruleset with ID %q", d.Id()))
+	}
+
+	return nil
+}
+
+// receives the current rules and returns an interface for the state file
+func buildStateFromRulesetRules(r []cloudflare.RulesetRule) interface{} {
+	var ruleset []interface{}
+	var rulesetRule map[string]interface{}
+
+	for _, rule := range r {
+		rulesetRule = make(map[string]interface{})
+
+		rulesetRule["expression"] = rule.Expression
+		rulesetRule["action"] = rule.Action
+		if rule.Description != "" {
+			rulesetRule["description"] = rule.Description
+		}
+
+		if rule.Enabled {
+			rulesetRule["enabled"] = "true"
+		} else {
+			rulesetRule["enabled"] = "false"
+		}
+
+		ruleset = append(ruleset, rulesetRule)
+	}
+
+	return ruleset
+}
+
+// receives the resource config and builds a ruleset rule array
+func buildRulesetRulesFromResource(r interface{}) ([]cloudflare.RulesetRule, error) {
+	var rulesetRules []cloudflare.RulesetRule
+
+	rules, ok := r.([]interface{})
+	if !ok {
+		return nil, errors.New("unable to create interface array type assertion")
+	}
+
+	for _, v := range rules {
+		var rule cloudflare.RulesetRule
+
+		resourceRule, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, errors.New("unable to create interface map type assertion for rule")
+		}
+
+		rule.ActionParameters = &cloudflare.RulesetRuleActionParameters{}
+		for _, parameter := range resourceRule["action_parameters"].([]interface{}) {
+			for pKey, pValue := range parameter.(map[string]interface{}) {
+				switch pKey {
+				case "id":
+					rule.ActionParameters.ID = pValue.(string)
+				case "overrides":
+					categories := []cloudflare.RulesetRuleActionParametersCategories{}
+					rules := []cloudflare.RulesetRuleActionParametersRules{}
+
+					for _, overrideParamValue := range pValue.([]interface{}) {
+						// Category based overrides
+						if val, ok := overrideParamValue.(map[string]interface{})["categories"]; ok {
+							for _, category := range val.([]interface{}) {
+								cData := category.(map[string]interface{})
+								categories = append(categories, cloudflare.RulesetRuleActionParametersCategories{
+									Category: cData["category"].(string),
+									Action:   cData["action"].(string),
+									Enabled:  cData["enabled"].(bool),
+								})
+							}
+						}
+
+						// Rule ID based overrides
+						if val, ok := overrideParamValue.(map[string]interface{})["rules"]; ok {
+							for _, rule := range val.([]interface{}) {
+								rData := rule.(map[string]interface{})
+								rules = append(rules, cloudflare.RulesetRuleActionParametersRules{
+									ID:             rData["id"].(string),
+									Action:         rData["action"].(string),
+									Enabled:        rData["enabled"].(bool),
+									ScoreThreshold: rData["score_threshold"].(int),
+								})
+							}
+						}
+					}
+
+					if len(categories) > 0 || len(rules) > 0 {
+						rule.ActionParameters.Overrides = &cloudflare.RulesetRuleActionParametersOverrides{
+							Categories: categories,
+							Rules:      rules,
+						}
+					}
+
+				default:
+					log.Printf("[DEBUG] unknown key encountered in buildRulesetRulesFromResource for action parameters: %s", pKey)
+				}
+			}
+		}
+
+		rule.Action = resourceRule["action"].(string)
+		rule.Enabled = resourceRule["enabled"].(bool)
+
+		if resourceRule["expression"] != nil {
+			rule.Expression = resourceRule["expression"].(string)
+		}
+
+		if resourceRule["description"] != nil {
+			rule.Description = resourceRule["description"].(string)
+		}
+
+		rulesetRules = append(rulesetRules, rule)
+	}
+
+	return rulesetRules, nil
+}

--- a/cloudflare/resource_cloudflare_ruleset_test.go
+++ b/cloudflare/resource_cloudflare_ruleset_test.go
@@ -1,0 +1,924 @@
+package cloudflare
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCloudflareRuleset_WAFBasic(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetCustomWAFBasic(rnd, "my basic WAF ruleset", accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "my basic WAF ruleset"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "custom"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_firewall_custom"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "log"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", rnd+" ruleset rule description"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_WAFManagedRuleset(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetManagedWAF(rnd, "my basic managed WAF ruleset", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "my basic managed WAF ruleset"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_firewall_managed"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.id", "efb7b8c949ac4650a09736fc376e9aee"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "Execute Cloudflare Managed Ruleset on my zone-level phase ruleset"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_WAFManagedRulesetOWASP(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetManagedWAFOWASP(rnd, "Cloudflare OWASP managed ruleset", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "Cloudflare OWASP managed ruleset"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_firewall_managed"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.id", "4814384a9e5d4991b9815dcfc25d2f1f"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "Execute Cloudflare Managed OWASP Ruleset on my zone-level phase ruleset"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_WAFManagedRulesetOWASPBlockXSSWithAnomalyOver60(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetManagedWAFOWASPBlockXSSAndAnomalyOver60(rnd, "Cloudflare OWASP managed ruleset blocking all XSS and anomaly scores over 60", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "Cloudflare OWASP managed ruleset blocking all XSS and anomaly scores over 60"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_firewall_managed"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.id", "efb7b8c949ac4650a09736fc376e9aee"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.0.category", "xss"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.0.action", "block"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.0.enabled", "true"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action_parameters.0.id", "4814384a9e5d4991b9815dcfc25d2f1f"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action_parameters.0.overrides.0.rules.0.id", "6179ae15870a4bb7b2d480d4843b323c"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action_parameters.0.overrides.0.rules.0.action", "block"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action_parameters.0.overrides.0.rules.0.score_threshold", "60"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "zone"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_WAFManagedRulesetOWASPOnlyPL1(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetManagedWAFOWASPOnlyPL1(rnd, "Cloudflare OWASP managed ruleset only setting PL1", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "Cloudflare OWASP managed ruleset only setting PL1"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_firewall_managed"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.id", "4814384a9e5d4991b9815dcfc25d2f1f"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.0.category", "paranoia-level-2"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.1.category", "paranoia-level-3"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.1.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.2.category", "paranoia-level-4"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.2.enabled", "false"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.0.id", "6179ae15870a4bb7b2d480d4843b323c"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.0.action", "block"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.0.score_threshold", "60"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.0.enabled", "true"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "zone"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_WAFManagedRulesetDeployMultiple(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetManagedWAFDeployMultiple(rnd, "enable all Cloudflare managed rulesets", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "enable all Cloudflare managed rulesets"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_firewall_managed"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "3"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.id", "4814384a9e5d4991b9815dcfc25d2f1f"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "zone deployment test"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action_parameters.0.id", "efb7b8c949ac4650a09736fc376e9aee"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.description", "zone deployment test"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.2.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.2.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.2.action_parameters.0.id", "c2e184081120413c86c3ab7e14069605"),
+					resource.TestCheckResourceAttr(resourceName, "rules.2.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.2.description", "zone deployment test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithSkip(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetManagedWAFDeployMultipleWithSkip(rnd, "enable all Cloudflare managed rulesets with a skip first", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "enable all Cloudflare managed rulesets with a skip first"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_firewall_managed"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "4"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "skip"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.ruleset", "current"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", fmt.Sprintf(`(http.host eq "%s" and http.request.method eq "GET")`, zoneName)),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "not this zone"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action_parameters.0.id", "4814384a9e5d4991b9815dcfc25d2f1f"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.description", "zone deployment test"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.2.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.2.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.2.action_parameters.0.id", "efb7b8c949ac4650a09736fc376e9aee"),
+					resource.TestCheckResourceAttr(resourceName, "rules.2.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.2.description", "zone deployment test"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.3.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.3.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.3.action_parameters.0.id", "c2e184081120413c86c3ab7e14069605"),
+					resource.TestCheckResourceAttr(resourceName, "rules.3.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.3.description", "zone deployment test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithTopSkipAndLastSkip(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetManagedWAFDeployMultipleWithTopSkipAndLastSkip(rnd, "enable all Cloudflare managed rulesets with a skip first", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "enable all Cloudflare managed rulesets with a skip first"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_firewall_managed"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "5"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "skip"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.ruleset", "current"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", fmt.Sprintf(`(http.host eq "%s" and http.request.uri.path contains "/app/")`, zoneName)),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "not this path"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.action_parameters.0.id", "4814384a9e5d4991b9815dcfc25d2f1f"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.description", "zone deployment test"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.2.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.2.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.2.action_parameters.0.id", "efb7b8c949ac4650a09736fc376e9aee"),
+					resource.TestCheckResourceAttr(resourceName, "rules.2.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.2.description", "zone deployment test"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.3.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.3.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.3.action_parameters.0.id", "c2e184081120413c86c3ab7e14069605"),
+					resource.TestCheckResourceAttr(resourceName, "rules.3.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.3.description", "zone deployment test"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.4.action", "skip"),
+					resource.TestCheckResourceAttr(resourceName, "rules.4.action_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.4.action_parameters.0.ruleset", "current"),
+					resource.TestCheckResourceAttr(resourceName, "rules.4.expression", fmt.Sprintf(`(http.host eq "%s" and http.request.uri.path contains "/httpbin/")`, zoneName)),
+					resource.TestCheckResourceAttr(resourceName, "rules.4.description", "not this path either"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_WAFManagedRulesetWithCategoryBasedOverrides(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetManagedWAFWithCategoryBasedOverrides(rnd, "my managed WAF ruleset with overrides", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "my managed WAF ruleset with overrides"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_firewall_managed"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "overrides to only enable wordpress rules to block"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.#", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.id", "efb7b8c949ac4650a09736fc376e9aee"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.0.category", "wordpress"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.0.action", "block"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.1.category", "joomla"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.1.action", "block"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_WAFManagedRulesetWithIDBasedOverrides(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetManagedWAFWithIDBasedOverrides(rnd, "my managed WAF ruleset with overrides", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "my managed WAF ruleset with overrides"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_firewall_managed"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "execute"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "make 5de7edfa648c4d6891dc3e7f84534ffa and e3a567afc347477d9702d9047e97d760 log only"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.#", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.id", "efb7b8c949ac4650a09736fc376e9aee"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.0.id", "5de7edfa648c4d6891dc3e7f84534ffa"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.0.action", "log"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.1.id", "e3a567afc347477d9702d9047e97d760"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.1.action", "log"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_MagicTransitSingleRule(t *testing.T) {
+	skipMagicTransitTestForNonConfiguredDefaultZone(t)
+
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckAccount(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetMagicTransitSingleRule(rnd, rnd, rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rnd),
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "Allow TCP Ephemeral Ports"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", "tcp.dstport in { 32768..65535 }"),
+				),
+			},
+		},
+	})
+}
+
+// func TestAccCloudflareRuleset_MagicTransitUpdateWithHigherPriority(t *testing.T) {
+// 	skipMagicTransitTestForNonConfiguredDefaultZone(t)
+
+// 	rnd := generateRandomResourceName()
+// 	name := fmt.Sprintf("cloudflare_ruleset.%s", rnd)
+// 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+// 	var MagicFirewallRuleset cloudflare.MagicFirewallRuleset
+
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:  func() { testAccPreCheckAccount(t) },
+// 		Providers: testAccProviders,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccCheckCloudflareMagicFirewallRulesetSingleRule(rnd, rnd, rnd, accountID),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckCloudflareMagicFirewallRulesetExists(name, &MagicFirewallRuleset),
+// 					resource.TestCheckResourceAttr(
+// 						name, "name", rnd),
+// 					resource.TestCheckResourceAttr(name, "rules.#", "1"),
+// 					resource.TestCheckResourceAttr(name, "rules.0.action", "allow"),
+// 					resource.TestCheckResourceAttr(name, "rules.0.description", "Allow TCP Ephemeral Ports"),
+// 					resource.TestCheckResourceAttr(name, "rules.0.enabled", "true"),
+// 					resource.TestCheckResourceAttr(name, "rules.0.expression", "tcp.dstport in { 32768..65535 }"),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccCheckCloudflareMagicFirewallRulesetUpdateWithHigherPriority(rnd, rnd, rnd, accountID),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckCloudflareMagicFirewallRulesetExists(name, &MagicFirewallRuleset),
+// 					resource.TestCheckResourceAttr(
+// 						name, "name", rnd),
+// 					resource.TestCheckResourceAttr(name, "rules.#", "2"),
+// 					resource.TestCheckResourceAttr(name, "rules.0.action", "block"),
+// 					resource.TestCheckResourceAttr(name, "rules.0.description", "Block UDP Ephemeral Ports"),
+// 					resource.TestCheckResourceAttr(name, "rules.0.enabled", "true"),
+// 					resource.TestCheckResourceAttr(name, "rules.0.expression", "udp.dstport in { 32768..65535 }"),
+// 					resource.TestCheckResourceAttr(name, "rules.1.action", "allow"),
+// 					resource.TestCheckResourceAttr(name, "rules.1.description", "Allow TCP Ephemeral Ports"),
+// 					resource.TestCheckResourceAttr(name, "rules.1.enabled", "true"),
+// 					resource.TestCheckResourceAttr(name, "rules.1.expression", "tcp.dstport in { 32768..65535 }"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+
+func testAccCheckCloudflareRulesetExists(n string, ruleset *cloudflare.Ruleset) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// rs, ok := s.RootModule().Resources[n]
+		// if !ok {
+		// 	return fmt.Errorf("Not found: %s", n)
+		// }
+
+		// if rs.Primary.ID == "" {
+		// 	return fmt.Errorf("No Magic Firewall Ruleset is set")
+		// }
+
+		// var foundRuleset cloudflare.Ruleset
+		// client := testAccProvider.Meta().(*cloudflare.API)
+		// foundRuleset, err := client.GetZoneRuleset(context.Background(), rs.Primary.ID)
+		// if err != nil {
+		// 	return err
+		// }
+
+		// *ruleset = foundRuleset
+
+		return nil
+	}
+}
+
+func testAccCheckCloudflareRulesetCustomWAFBasic(rnd, name, accountID string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    account_id  = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "custom"
+    phase       = "http_request_firewall_custom"
+
+    rules {
+      action = "log"
+      expression = "true"
+      description = "%[1]s ruleset rule description"
+    }
+  }`, rnd, name, accountID)
+}
+
+func testAccCheckCloudflareRulesetManagedWAF(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id  = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_firewall_managed"
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "efb7b8c949ac4650a09736fc376e9aee"
+      }
+      expression = "true"
+      description = "Execute Cloudflare Managed Ruleset on my zone-level phase ruleset"
+      enabled = true
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetManagedWAFOWASP(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id  = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_firewall_managed"
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "4814384a9e5d4991b9815dcfc25d2f1f"
+      }
+      expression = "true"
+      description = "Execute Cloudflare Managed OWASP Ruleset on my zone-level phase ruleset"
+      enabled = true
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetManagedWAFOWASPBlockXSSAndAnomalyOver60(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id  = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_firewall_managed"
+
+    # enable all "XSS" rules
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "efb7b8c949ac4650a09736fc376e9aee"
+        overrides {
+          categories {
+            category = "xss"
+            action = "block"
+            enabled = true
+          }
+        }
+      }
+      expression = "true"
+      description = "zone"
+      enabled = true
+    }
+
+    # set Anomaly Score for 60+ (low)
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "4814384a9e5d4991b9815dcfc25d2f1f"
+        overrides {
+          rules {
+            id = "6179ae15870a4bb7b2d480d4843b323c"
+            action = "block"
+            score_threshold = 60
+          }
+        }
+      }
+      expression = "true"
+      description = "zone"
+      enabled = true
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetManagedWAFOWASPOnlyPL1(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id  = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_firewall_managed"
+
+    # disable PL2, PL3 and PL4
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "4814384a9e5d4991b9815dcfc25d2f1f"
+        overrides {
+          categories {
+            category = "paranoia-level-2"
+            enabled = false
+          }
+
+          categories {
+            category = "paranoia-level-3"
+            enabled = false
+          }
+
+          categories {
+            category = "paranoia-level-4"
+            enabled = false
+          }
+
+          rules {
+            id = "6179ae15870a4bb7b2d480d4843b323c"
+            action = "block"
+            score_threshold = 60
+            enabled = true
+          }
+        }
+      }
+      expression = "true"
+      description = "zone"
+      enabled = true
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetManagedWAFDeployMultiple(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id  = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_firewall_managed"
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "4814384a9e5d4991b9815dcfc25d2f1f"
+      }
+      expression = "true"
+      description = "zone deployment test"
+      enabled = true
+    }
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "efb7b8c949ac4650a09736fc376e9aee"
+      }
+      expression = "true"
+      description = "zone deployment test"
+      enabled = true
+    }
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "c2e184081120413c86c3ab7e14069605"
+      }
+      expression = "true"
+      description = "zone deployment test"
+      enabled = true
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetManagedWAFDeployMultipleWithSkip(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id  = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_firewall_managed"
+
+    rules {
+      action = "skip"
+      action_parameters {
+        ruleset = "current"
+      }
+      description = "not this zone"
+      expression = "(http.host eq \"%[4]s\" and http.request.method eq \"GET\")"
+      enabled = true
+    }
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "4814384a9e5d4991b9815dcfc25d2f1f"
+      }
+      expression = "true"
+      description = "zone deployment test"
+      enabled = true
+    }
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "efb7b8c949ac4650a09736fc376e9aee"
+      }
+      expression = "true"
+      description = "zone deployment test"
+      enabled = true
+    }
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "c2e184081120413c86c3ab7e14069605"
+      }
+      expression = "true"
+      description = "zone deployment test"
+      enabled = true
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetManagedWAFDeployMultipleWithTopSkipAndLastSkip(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id  = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_firewall_managed"
+
+    rules {
+      action = "skip"
+      action_parameters {
+        ruleset = "current"
+      }
+      description = "not this path"
+      expression = "(http.host eq \"%[4]s\" and http.request.uri.path contains \"/app/\")"
+      enabled = true
+    }
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "4814384a9e5d4991b9815dcfc25d2f1f"
+      }
+      expression = "true"
+      description = "zone deployment test"
+      enabled = true
+    }
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "efb7b8c949ac4650a09736fc376e9aee"
+      }
+      expression = "true"
+      description = "zone deployment test"
+      enabled = true
+    }
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "c2e184081120413c86c3ab7e14069605"
+      }
+      expression = "true"
+      description = "zone deployment test"
+      enabled = true
+    }
+
+    rules {
+      action = "skip"
+      action_parameters {
+        ruleset = "current"
+      }
+      description = "not this path either"
+      expression = "(http.host eq \"%[4]s\" and http.request.uri.path contains \"/httpbin/\")"
+      enabled = true
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetManagedWAFWithCategoryBasedOverrides(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id  = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_firewall_managed"
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "efb7b8c949ac4650a09736fc376e9aee"
+        overrides {
+          categories {
+            category = "wordpress"
+            action = "block"
+            enabled = true
+          }
+
+          categories {
+            category = "joomla"
+            action = "block"
+            enabled = true
+          }
+        }
+      }
+
+      expression = "true"
+      description = "overrides to only enable wordpress rules to block"
+      enabled = false
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetManagedWAFWithIDBasedOverrides(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id  = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_firewall_managed"
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "efb7b8c949ac4650a09736fc376e9aee"
+        overrides {
+          rules {
+            id = "5de7edfa648c4d6891dc3e7f84534ffa"
+            action = "log"
+            enabled = true
+          }
+
+          rules {
+            id = "e3a567afc347477d9702d9047e97d760"
+            action = "log"
+            enabled = true
+          }
+        }
+      }
+
+      expression = "true"
+      description = "make 5de7edfa648c4d6891dc3e7f84534ffa and e3a567afc347477d9702d9047e97d760 log only"
+      enabled = false
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetMagicTransitSingleRule(ID, name, description, accountID string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    account_id = "%[4]s"
+    name = "%[2]s"
+    description = "%[3]s"
+
+    rules {
+      action = "allow"
+      expression = "tcp.dstport in { 32768..65535 }"
+      description = "Allow TCP Ephemeral Ports"
+      enabled = "true"
+    }
+  }`, ID, name, description, accountID)
+}
+
+func testAccCheckCloudflareRulesetMagicTransitUpdateWithHigherPriority(ID, name, description, accountID string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    account_id = "%[4]s"
+    name = "%[2]s"
+    description = "%[3]s"
+
+    rules  {
+      action = "block"
+      expression = "udp.dstport in { 32768..65535 }"
+      description = "Block UDP Ephemeral Ports"
+      enabled = "true"
+    }
+
+    rules {
+      action = "allow"
+      expression = "tcp.dstport in { 32768..65535 }"
+      description = "Allow TCP Ephemeral Ports"
+      enabled = "true"
+    }
+  }`, ID, name, description, accountID)
+}


### PR DESCRIPTION
Introduces support for Rulesets as a generalised and reusable resource.
This initial support largely tackles v2 WAF however it does have support
for Transformation Rules and Magic Transit by proxy.

Closes #1071