### PR TITLE
New data source - `cloudflare_origin_ca_root_certificate`

### DIFF
--- a/cloudflare/data_source_origin_ca_root_certificate.go
+++ b/cloudflare/data_source_origin_ca_root_certificate.go
@@ -33,7 +33,7 @@ func dataSourceCloudflareOriginCARootCertificateRead(d *schema.ResourceData, met
 	algorithm := strings.ToLower(fmt.Sprintf("%v", d.Get("algorithm")))
 	certBytes, err := cloudflare.OriginCARootCertificate(algorithm)
 	if err != nil {
-		return fmt.Errorf("failed to fetch Cloudflare IP ranges: %s", err)
+		return fmt.Errorf("failed to fetch Cloudflare Origin CA root %s certificate: %s", algorithm, err)
 	}
 
 	cert := string(certBytes[:])

--- a/cloudflare/data_source_origin_ca_root_certificate.go
+++ b/cloudflare/data_source_origin_ca_root_certificate.go
@@ -30,7 +30,7 @@ func dataSourceCloudflareOriginCARootCertificate() *schema.Resource {
 }
 
 func dataSourceCloudflareOriginCARootCertificateRead(d *schema.ResourceData, meta interface{}) error {
-	algorithm := strings.ToLower(fmt.Sprintf("%v", d.Get("algorithm")))
+	algorithm := strings.ToLower(fmt.Sprintf("%s", d.Get("algorithm")))
 	certBytes, err := cloudflare.OriginCARootCertificate(algorithm)
 	if err != nil {
 		return fmt.Errorf("failed to fetch Cloudflare Origin CA root %s certificate: %s", algorithm, err)

--- a/cloudflare/data_source_origin_ca_root_certificate.go
+++ b/cloudflare/data_source_origin_ca_root_certificate.go
@@ -1,0 +1,48 @@
+package cloudflare
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceCloudflareOriginCARootCertificate() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCloudflareOriginCARootCertificateRead,
+
+		Schema: map[string]*schema.Schema{
+			"algorithm": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"rsa", "ecc"}, true),
+			},
+
+			"cert_pem": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceCloudflareOriginCARootCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	algorithm := strings.ToLower(fmt.Sprintf("%v", d.Get("algorithm")))
+	certBytes, err := cloudflare.OriginCARootCertificate(algorithm)
+	if err != nil {
+		return fmt.Errorf("failed to fetch Cloudflare IP ranges: %s", err)
+	}
+
+	cert := string(certBytes[:])
+
+	d.SetId(stringChecksum(cert))
+
+	if err := d.Set("cert_pem", cert); err != nil {
+		return fmt.Errorf("error setting cert_pem: %s", err)
+	}
+
+	return nil
+}

--- a/cloudflare/data_source_origin_ca_root_certificate_test.go
+++ b/cloudflare/data_source_origin_ca_root_certificate_test.go
@@ -1,0 +1,50 @@
+package cloudflare
+
+import (
+	"encoding/pem"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCloudflareOriginCARootCertificate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareOriginCARootCertConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCloudflareOriginCARootCert("data.cloudflare_origin_ca_root_certificate.ecc"),
+					testAccCloudflareOriginCARootCert("data.cloudflare_origin_ca_root_certificate.rsa"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareOriginCARootCert(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		cert := r.Primary.Attributes["cert_pem"]
+
+		p, _ := pem.Decode([]byte(cert))
+		if p == nil || p.Type != "CERTIFICATE" {
+			return fmt.Errorf("invalid certificate: %s", cert)
+		}
+
+		return nil
+	}
+}
+
+const testAccCloudflareOriginCARootCertConfig = `
+data "cloudflare_origin_ca_root_certificate" "rsa" {
+	algorithm = "RSA"
+}
+
+data "cloudflare_origin_ca_root_certificate" "ecc" {
+	algorithm = "ecc"
+}
+`

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -96,6 +96,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"cloudflare_api_token_permission_groups": dataSourceCloudflareApiTokenPermissionGroups(),
 			"cloudflare_ip_ranges":                   dataSourceCloudflareIPRanges(),
+			"cloudflare_origin_ca_root_certificate":  dataSourceCloudflareOriginCARootCertificate(),
 			"cloudflare_waf_groups":                  dataSourceCloudflareWAFGroups(),
 			"cloudflare_waf_packages":                dataSourceCloudflareWAFPackages(),
 			"cloudflare_waf_rules":                   dataSourceCloudflareWAFRules(),

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -28,7 +28,7 @@
             <li<%= sidebar_current("docs-cloudflare-datasource-ip_ranges") %>>
               <a href="/docs/providers/cloudflare/d/ip_ranges.html">cloudflare_ip_ranges</a>
             </li>
-            <li<%= sidebar_current("docs-cloudflare-datasource-origin_ca_root_certificate") %>>
+            <li<%= sidebar_current("docs-cloudflare-datasource-origin-ca-root-certificate") %>>
               <a href="/docs/providers/cloudflare/d/origin_ca_root_certificate.html">cloudflare_origin_ca_root_certificate</a>
             </li>
             <li<%= sidebar_current("docs-cloudflare-datasource-waf-groups") %>>

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -28,6 +28,9 @@
             <li<%= sidebar_current("docs-cloudflare-datasource-ip_ranges") %>>
               <a href="/docs/providers/cloudflare/d/ip_ranges.html">cloudflare_ip_ranges</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-datasource-origin_ca_root_certificate") %>>
+              <a href="/docs/providers/cloudflare/d/origin_ca_root_certificate.html">cloudflare_origin_ca_root_certificate</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-datasource-waf-groups") %>>
                 <a href="/docs/providers/cloudflare/d/waf_groups.html">cloudflare_waf_groups</a>
             </li>

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -25,7 +25,7 @@
             <li<%= sidebar_current("docs-cloudflare-api-token-permission-groups") %>>
               <a href="/docs/providers/cloudflare/d/api_token_permission_groups.html">cloudflare_api_token_permission_groups</a>
             </li>
-            <li<%= sidebar_current("docs-cloudflare-datasource-ip_ranges") %>>
+            <li<%= sidebar_current("docs-cloudflare-datasource-ip-ranges") %>>
               <a href="/docs/providers/cloudflare/d/ip_ranges.html">cloudflare_ip_ranges</a>
             </li>
             <li<%= sidebar_current("docs-cloudflare-datasource-origin-ca-root-certificate") %>>

--- a/website/docs/d/ip_ranges.html.md
+++ b/website/docs/d/ip_ranges.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "cloudflare"
 page_title: "Cloudflare: cloudflare_ip_ranges"
-sidebar_current: "docs-cloudflare-datasource-ip_ranges"
+sidebar_current: "docs-cloudflare-datasource-ip-ranges"
 description: |-
   Get information on Cloudflare IP ranges.
 ---

--- a/website/docs/d/origin_ca_root_certificate.html.md
+++ b/website/docs/d/origin_ca_root_certificate.html.md
@@ -1,0 +1,29 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_origin_ca_root_certificate"
+sidebar_current: "docs-cloudflare-datasource-origin_ca_root_certificate"
+description: |-
+  Get Cloudflare Origin CA root certificate.
+---
+
+# cloudflare_origin_ca_root_certificate
+
+Use this data source to get the [Origin CA root certificate][1] for a given algorithm.
+
+## Example Usage
+
+```hcl
+data "cloudflare_origin_ca_root_certificate" "origin_ca" {
+  algorithm = "<algorithm>"
+}
+```
+
+## Arguments Reference
+
+- `algorithm` - (Required) The name of the algorithm used when creating an Origin CA certificate. Currently-supported values are "rsa" and "ecc" (case-insensitive).
+
+## Attributes Reference
+
+- `cert_pem` - The Origin CA root certificate in PEM format.
+
+[1]: https://developers.cloudflare.com/ssl/origin-configuration/origin-ca#4-required-for-some-add-cloudflare-origin-ca-root-certificates

--- a/website/docs/d/origin_ca_root_certificate.html.md
+++ b/website/docs/d/origin_ca_root_certificate.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "cloudflare"
 page_title: "Cloudflare: cloudflare_origin_ca_root_certificate"
-sidebar_current: "docs-cloudflare-datasource-origin_ca_root_certificate"
+sidebar_current: "docs-cloudflare-datasource-origin-ca-root-certificate"
 description: |-
   Get Cloudflare Origin CA root certificate.
 ---


### PR DESCRIPTION
Introduces new data source `cloudflare_origin_ca_root_certificate` which can be used to read the Origin CA root certificate for a given algorithm. 

Closes #1096 