### PR TITLE
resource/cloudflare_ruleset: add support for transform rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v3.2.0
+        uses: crazy-max/ghaction-import-gpg@v4
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 2.26.1 (August 30th, 2021)
+
+**Fixes**
+
+* `resource/cloudflare_ruleset`: Send a single payload for rules instead of many individual payloads to prevent overwriting previous rules ([#1171](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1171))
+
 ## 2.26.0 (August 27th, 2021)
 
 * **New resource**: `cloudflare_notification_policy` ([#1138](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1138)) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 **Fixes**
 
 * `resource/cloudflare_zone_settings_override`: remap `zero_rtt` => `0rtt` for resource delete ([#1175](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1175))
- 
+* `resource/cloudflare_ruleset`: fix state handling for terraform-plugin-sdk v2 ([#1183](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1183))
+
 ## 2.26.1 (August 30th, 2021)
 
 **Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * **New resource**: `cloudflare_teams_account` ([#1173](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1173)) 
 * **New resource**: `cloudflare_teams_rule` ([#1173](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1173))
 
+**Improvements**
+
+* provider: Update to cloudflare-go v0.22.0 ([#1184](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1184)
+
 **Fixes**
 
 * `resource/cloudflare_zone_settings_override`: remap `zero_rtt` => `0rtt` for resource delete ([#1175](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1175))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* **New resource**: `cloudflare_teams_account` ([#1173](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1173)) 
+* **New resource**: `cloudflare_teams_rule` ([#1173](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1173))
+
 **Fixes**
 
 * `resource/cloudflare_zone_settings_override`: remap `zero_rtt` => `0rtt` for resource delete ([#1175](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1175))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+**Fixes**
+
+* `resource/cloudflare_zone_settings_override`: remap `zero_rtt` => `0rtt` for resource delete ([#1175](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1175))
+ 
 ## 2.26.1 (August 30th, 2021)
 
 **Fixes**

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -146,6 +146,8 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_static_route":                           resourceCloudflareStaticRoute(),
 			"cloudflare_teams_list":                             resourceCloudflareTeamsList(),
 			"cloudflare_teams_location":                         resourceCloudflareTeamsLocation(),
+			"cloudflare_teams_account":                          resourceCloudflareTeamsAccount(),
+			"cloudflare_teams_rule":                             resourceCloudflareTeamsRule(),
 			"cloudflare_waf_group":                              resourceCloudflareWAFGroup(),
 			"cloudflare_waf_package":                            resourceCloudflareWAFPackage(),
 			"cloudflare_waf_rule":                               resourceCloudflareWAFRule(),

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -264,23 +264,19 @@ func resourceCloudflareRulesetCreate(d *schema.ResourceData, meta interface{}) e
 		return errors.Wrap(err, fmt.Sprintf("error creating ruleset %s", d.Get("name").(string)))
 	}
 
-	for i, rule := range rules {
-		if rule.Action == string(cloudflare.RulesetRuleActionExecute) {
-			rulesetEntryPoint := cloudflare.Ruleset{
-				Description: d.Get("description").(string),
-				Rules:       []cloudflare.RulesetRule{rules[i]},
-			}
+	rulesetEntryPoint := cloudflare.Ruleset{
+		Description: d.Get("description").(string),
+		Rules:       rules,
+	}
 
-			if accountID != "" {
-				_, err = client.UpdateAccountRulesetPhase(context.Background(), accountID, rs.Phase, rulesetEntryPoint)
-			} else {
-				_, err = client.UpdateZoneRulesetPhase(context.Background(), zoneID, rs.Phase, rulesetEntryPoint)
-			}
+	if accountID != "" {
+		_, err = client.UpdateAccountRulesetPhase(context.Background(), accountID, rs.Phase, rulesetEntryPoint)
+	} else {
+		_, err = client.UpdateZoneRulesetPhase(context.Background(), zoneID, rs.Phase, rulesetEntryPoint)
+	}
 
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error updating ruleset phase entrypoint %s", d.Get("name").(string)))
-			}
-		}
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error updating ruleset phase entrypoint %s", d.Get("name").(string)))
 	}
 
 	d.SetId(ruleset.ID)

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -155,6 +155,30 @@ func resourceCloudflareRuleset() *schema.Resource {
 											},
 										},
 									},
+									"headers": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"expression": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"operation": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
 									"increment": {
 										Type:     schema.TypeInt,
 										Optional: true,
@@ -523,6 +547,20 @@ func buildRulesetRulesFromResource(r interface{}) ([]cloudflare.RulesetRule, err
 							}
 						}
 					}
+
+				case "headers":
+					headers := make(map[string]cloudflare.RulesetRuleActionParametersHTTPHeader)
+					for _, headerList := range pValue.([]interface{}) {
+						name := headerList.(map[string]interface{})["name"].(string)
+
+						headers[name] = cloudflare.RulesetRuleActionParametersHTTPHeader{
+							Value:      headerList.(map[string]interface{})["value"].(string),
+							Expression: headerList.(map[string]interface{})["expression"].(string),
+							Operation:  headerList.(map[string]interface{})["operation"].(string),
+						}
+					}
+
+					rule.ActionParameters.Headers = headers
 
 				default:
 					log.Printf("[DEBUG] unknown key encountered in buildRulesetRulesFromResource for action parameters: %s", pKey)

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -111,11 +111,13 @@ func resourceCloudflareRuleset() *schema.Resource {
 									"uri": {
 										Type:     schema.TypeList,
 										Optional: true,
+										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"path": {
 													Type:     schema.TypeList,
 													Optional: true,
+													MaxItems: 1,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"value": {
@@ -132,6 +134,7 @@ func resourceCloudflareRuleset() *schema.Resource {
 												"query": {
 													Type:     schema.TypeList,
 													Optional: true,
+													MaxItems: 1,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"value": {
@@ -495,6 +498,29 @@ func buildRulesetRulesFromResource(r interface{}) ([]cloudflare.RulesetRule, err
 						rule.ActionParameters.Overrides = &cloudflare.RulesetRuleActionParametersOverrides{
 							Categories: categories,
 							Rules:      rules,
+						}
+					}
+
+				case "uri":
+					for _, uriValue := range pValue.([]interface{}) {
+						if val, ok := uriValue.(map[string]interface{})["path"]; ok && len(val.([]interface{})) > 0 {
+							uriPathConfig := val.([]interface{})[0].(map[string]interface{})
+							rule.ActionParameters.URI = &cloudflare.RulesetRuleActionParametersURI{
+								Path: &cloudflare.RulesetRuleActionParametersURIPath{
+									Value:      uriPathConfig["value"].(string),
+									Expression: uriPathConfig["expression"].(string),
+								},
+							}
+						}
+
+						if val, ok := uriValue.(map[string]interface{})["query"]; ok && len(val.([]interface{})) > 0 {
+							uriQueryConfig := val.([]interface{})[0].(map[string]interface{})
+							rule.ActionParameters.URI = &cloudflare.RulesetRuleActionParametersURI{
+								Query: &cloudflare.RulesetRuleActionParametersURIQuery{
+									Value:      uriQueryConfig["value"].(string),
+									Expression: uriQueryConfig["expression"].(string),
+								},
+							}
 						}
 					}
 

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -414,6 +414,8 @@ func buildStateFromRulesetRules(rules []cloudflare.RulesetRule) interface{} {
 			var overrides []map[string]interface{}
 			var idBasedOverrides []map[string]interface{}
 			var categoryBasedOverrides []map[string]interface{}
+			var headers []map[string]interface{}
+			var uri []map[string]interface{}
 
 			if !reflect.ValueOf(r.ActionParameters.Overrides).IsNil() {
 				for _, overrideRule := range r.ActionParameters.Overrides.Rules {
@@ -440,15 +442,54 @@ func buildStateFromRulesetRules(rules []cloudflare.RulesetRule) interface{} {
 				})
 			}
 
+			if !reflect.ValueOf(r.ActionParameters.Headers).IsNil() {
+				for headerName, header := range r.ActionParameters.Headers {
+					headers = append(headers, map[string]interface{}{
+						"name":       headerName,
+						"value":      header.Value,
+						"expression": header.Expression,
+						"operation":  header.Operation,
+					})
+				}
+			}
+
+			if !reflect.ValueOf(r.ActionParameters.URI).IsNil() {
+				var query []map[string]interface{}
+				var path []map[string]interface{}
+				originValue := false
+				if r.ActionParameters.URI.Origin {
+					originValue = true
+				}
+
+				if !reflect.ValueOf(r.ActionParameters.URI.Query).IsNil() {
+					query = append(query, map[string]interface{}{
+						"value":      r.ActionParameters.URI.Query.Value,
+						"expression": r.ActionParameters.URI.Query.Expression,
+					})
+				}
+
+				if !reflect.ValueOf(r.ActionParameters.URI.Path).IsNil() {
+					path = append(path, map[string]interface{}{
+						"value":      r.ActionParameters.URI.Path.Value,
+						"expression": r.ActionParameters.URI.Path.Expression,
+					})
+				}
+
+				uri = append(uri, map[string]interface{}{
+					"origin": originValue,
+					"query":  query,
+					"path":   path,
+				})
+			}
+
 			actionParameters = append(actionParameters, map[string]interface{}{
 				"id":        r.ActionParameters.ID,
 				"increment": r.ActionParameters.Increment,
-				// "headers":   r.ActionParameters.Headers,
+				"headers":   headers,
 				"overrides": overrides,
 				"products":  r.ActionParameters.Products,
 				"ruleset":   r.ActionParameters.Ruleset,
-				"uri":       r.ActionParameters.URI,
-				// "version":   r.ActionParameters.Version,
+				"uri":       uri,
 			})
 
 			rule["action_parameters"] = actionParameters

--- a/cloudflare/resource_cloudflare_ruleset_test.go
+++ b/cloudflare/resource_cloudflare_ruleset_test.go
@@ -498,7 +498,7 @@ func TestAccCloudflareRuleset_WAFManagedRulesetWithIDBasedOverrides(t *testing.T
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.#", "1"),
 
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.id", "efb7b8c949ac4650a09736fc376e9aee"),
-					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.#", "1"),
+
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.0.id", "5de7edfa648c4d6891dc3e7f84534ffa"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.0.action", "log"),
@@ -546,8 +546,7 @@ func TestAccCloudflareRuleset_MagicTransitUpdateWithHigherPriority(t *testing.T)
 			{
 				Config: testAccCheckCloudflareRulesetMagicTransitMultiple(rnd, rnd, accountID),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "rules.#", "2"),
 					resource.TestCheckResourceAttr(name, "rules.0.action", "block"),
 					resource.TestCheckResourceAttr(name, "rules.0.description", "Block UDP Ephemeral Ports"),

--- a/cloudflare/resource_cloudflare_ruleset_test.go
+++ b/cloudflare/resource_cloudflare_ruleset_test.go
@@ -562,6 +562,104 @@ func TestAccCloudflareRuleset_MagicTransitUpdateWithHigherPriority(t *testing.T)
 	})
 }
 
+func TestAccCloudflareRuleset_TransformationRuleURIPath(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetTransformationRuleURIPath(rnd, "transform rule for URI path", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "transform rule for URI path"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_transform"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "rewrite"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.uri.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.uri.0.path.0.value", "/static-rewrite"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_TransformationRuleURIQuery(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetTransformationRuleURIQuery(rnd, "transform rule for URI query", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "transform rule for URI query"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_transform"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "rewrite"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.uri.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.uri.0.query.0.value", "a=b"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_TransformationRuleHeaders(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetTransformationRuleHeaders(rnd, "transform rule for headers", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "transform rule for headers"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_late_transform"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "rewrite"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.#", "3"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.0.name", "example1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.0.value", "my-http-header-value1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.0.operation", "set"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.1.name", "example2"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.1.operation", "set"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.1.expression", "cf.zone.name"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.2.name", "example3"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.2.operation", "remove"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCloudflareRulesetMagicTransitSingle(rnd, name, accountID string) string {
 	return fmt.Sprintf(`
   resource "cloudflare_ruleset" "%[1]s" {
@@ -973,6 +1071,95 @@ func testAccCheckCloudflareRulesetManagedWAFWithIDBasedOverrides(rnd, name, zone
 
       expression = "true"
       description = "make 5de7edfa648c4d6891dc3e7f84534ffa and e3a567afc347477d9702d9047e97d760 log only"
+      enabled = false
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetTransformationRuleURIPath(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id     = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_transform"
+
+    rules {
+      action = "rewrite"
+      action_parameters {
+        uri {
+          path {
+            value = "/static-rewrite"
+          }
+        }
+      }
+
+      expression = "(http.host eq \"%[4]s\")"
+      description = "URI transformation path example"
+      enabled = false
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetTransformationRuleURIQuery(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id     = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_transform"
+
+    rules {
+      action = "rewrite"
+      action_parameters {
+        uri {
+          query {
+            value = "a=b"
+          }
+        }
+      }
+
+      expression = "(http.host eq \"%[4]s\")"
+      description = "URI transformation query example"
+      enabled = false
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetTransformationRuleHeaders(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id     = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_late_transform"
+
+    rules {
+      action = "rewrite"
+      action_parameters {
+        headers {
+          name      = "example1"
+          operation = "set"
+          value     = "my-http-header-value1"
+        }
+
+        headers {
+          name       = "example2"
+          operation  = "set"
+          expression = "cf.zone.name"
+        }
+
+        headers {
+          name      = "example3"
+          operation = "remove"
+        }
+      }
+
+      expression = "true"
+      description = "example header transformation rule"
       enabled = false
     }
   }`, rnd, name, zoneID, zoneName)

--- a/cloudflare/resource_cloudflare_ruleset_test.go
+++ b/cloudflare/resource_cloudflare_ruleset_test.go
@@ -563,6 +563,16 @@ func TestAccCloudflareRuleset_MagicTransitUpdateWithHigherPriority(t *testing.T)
 }
 
 func TestAccCloudflareRuleset_TransformationRuleURIPath(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	t.Parallel()
 	rnd := generateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
@@ -592,6 +602,16 @@ func TestAccCloudflareRuleset_TransformationRuleURIPath(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_TransformationRuleURIQuery(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	t.Parallel()
 	rnd := generateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
@@ -621,6 +641,16 @@ func TestAccCloudflareRuleset_TransformationRuleURIQuery(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_TransformationRuleHeaders(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
 	t.Parallel()
 	rnd := generateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")

--- a/cloudflare/resource_cloudflare_teams_accounts.go
+++ b/cloudflare/resource_cloudflare_teams_accounts.go
@@ -1,0 +1,229 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/pkg/errors"
+)
+
+func resourceCloudflareTeamsAccount() *schema.Resource {
+	return &schema.Resource{
+		Read:   resourceCloudflareTeamsAccountRead,
+		Update: resourceCloudflareTeamsAccountUpdate,
+		Create: resourceCloudflareTeamsAccountUpdate,
+		// This resource is a top-level account configuration and cant be "deleted"
+		Delete: func(_ *schema.ResourceData, _ interface{}) error { return nil },
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareTeamsAccountImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"block_page": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: blockPageSchema,
+				},
+			},
+			"antivirus": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: antivirusSchema,
+				},
+			},
+			"tls_decrypt_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"activity_log_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+var blockPageSchema = map[string]*schema.Schema{
+	"enabled": {
+		Type:     schema.TypeBool,
+		Optional: true,
+	},
+	"footer_text": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"header_text": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"logo_path": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"background_color": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"name": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+}
+
+var antivirusSchema = map[string]*schema.Schema{
+	"enabled_download_phase": {
+		Type:     schema.TypeBool,
+		Required: true,
+	},
+	"enabled_upload_phase": {
+		Type:     schema.TypeBool,
+		Required: true,
+	},
+	"fail_closed": {
+		Type:     schema.TypeBool,
+		Required: true,
+	},
+}
+
+func resourceCloudflareTeamsAccountRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get("account_id").(string)
+
+	configuration, err := client.TeamsAccountConfiguration(context.Background(), accountID)
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP status 400") {
+			log.Printf("[INFO] Teams Account config %s does not exists", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error finding Teams Account config %q: %s", d.Id(), err)
+	}
+
+	if configuration.Settings.BlockPage != nil {
+		if err := d.Set("block_page", flattenBlockPageConfig(configuration.Settings.BlockPage)); err != nil {
+			return errors.Wrap(err, "error parsing account block page config")
+		}
+	}
+
+	if configuration.Settings.Antivirus != nil {
+		if err := d.Set("antivirus", flattenAntivirusConfig(configuration.Settings.Antivirus)); err != nil {
+			return errors.Wrap(err, "error parsing account antivirus config")
+		}
+	}
+
+	if configuration.Settings.TLSDecrypt != nil {
+		if err := d.Set("tls_decrypt_enabled", configuration.Settings.TLSDecrypt.Enabled); err != nil {
+			return errors.Wrap(err, "error parsing account tls decrypt enablement")
+		}
+	}
+
+	if configuration.Settings.ActivityLog != nil {
+		if err := d.Set("activity_log_enabled", configuration.Settings.ActivityLog.Enabled); err != nil {
+			return errors.Wrap(err, "error parsing account activity log enablement")
+		}
+	}
+	return nil
+}
+
+func resourceCloudflareTeamsAccountUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get("account_id").(string)
+	blockPageConfig := inflateBlockPageConfig(d.Get("block_page"))
+	antivirusConfig := inflateAntivirusConfig(d.Get("antivirus"))
+	updatedTeamsAccount := cloudflare.TeamsConfiguration{
+		Settings: cloudflare.TeamsAccountSettings{
+			Antivirus: antivirusConfig,
+			BlockPage: blockPageConfig,
+		},
+	}
+
+	tlsDecrypt, ok := d.GetOkExists("tls_decrypt_enabled")
+	if ok {
+		updatedTeamsAccount.Settings.TLSDecrypt = &cloudflare.TeamsTLSDecrypt{Enabled: tlsDecrypt.(bool)}
+	}
+
+	activtyLog, ok := d.GetOkExists("activity_log_enabled")
+	if ok {
+		updatedTeamsAccount.Settings.ActivityLog = &cloudflare.TeamsActivityLog{Enabled: activtyLog.(bool)}
+	}
+	log.Printf("[DEBUG] Updating Cloudflare Teams Account configuration from struct: %+v", updatedTeamsAccount)
+
+	if _, err := client.TeamsAccountUpdateConfiguration(context.Background(), accountID, updatedTeamsAccount); err != nil {
+		return fmt.Errorf("error updating Teams Account configuration for account %q: %s", accountID, err)
+	}
+
+	d.SetId(accountID)
+	return resourceCloudflareTeamsAccountRead(d, meta)
+}
+
+func resourceCloudflareTeamsAccountImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.SetId(d.Id())
+	d.Set("account_id", d.Id())
+
+	err := resourceCloudflareTeamsAccountRead(d, meta)
+	return []*schema.ResourceData{d}, err
+}
+
+func flattenBlockPageConfig(blockPage *cloudflare.TeamsBlockPage) []interface{} {
+	return []interface{}{map[string]interface{}{
+		"enabled":          *blockPage.Enabled,
+		"footer_text":      blockPage.FooterText,
+		"header_text":      blockPage.HeaderText,
+		"logo_path":        blockPage.LogoPath,
+		"background_color": blockPage.BackgroundColor,
+		"name":             blockPage.Name,
+	}}
+}
+
+func inflateBlockPageConfig(blockPage interface{}) *cloudflare.TeamsBlockPage {
+	blockPageList := blockPage.([]interface{})
+	if len(blockPageList) != 1 {
+		return nil
+	}
+
+	blockPageMap := blockPageList[0].(map[string]interface{})
+	enabled := blockPageMap["enabled"].(bool)
+	return &cloudflare.TeamsBlockPage{
+		Enabled:         &enabled,
+		FooterText:      blockPageMap["footer_text"].(string),
+		HeaderText:      blockPageMap["header_text"].(string),
+		LogoPath:        blockPageMap["logo_path"].(string),
+		BackgroundColor: blockPageMap["background_color"].(string),
+		Name:            blockPageMap["name"].(string),
+	}
+}
+
+func flattenAntivirusConfig(antivirusConfig *cloudflare.TeamsAntivirus) []interface{} {
+	return []interface{}{map[string]interface{}{
+		"enabled_download_phase": antivirusConfig.EnabledDownloadPhase,
+		"enabled_upload_phase":   antivirusConfig.EnabledUploadPhase,
+		"fail_closed":            antivirusConfig.FailClosed,
+	}}
+}
+
+func inflateAntivirusConfig(antivirus interface{}) *cloudflare.TeamsAntivirus {
+	avList := antivirus.([]interface{})
+
+	if len(avList) != 1 {
+		return nil
+	}
+
+	avMap := avList[0].(map[string]interface{})
+	return &cloudflare.TeamsAntivirus{
+		EnabledDownloadPhase: avMap["enabled_download_phase"].(bool),
+		EnabledUploadPhase:   avMap["enabled_upload_phase"].(bool),
+		FailClosed:           avMap["fail_closed"].(bool),
+	}
+}

--- a/cloudflare/resource_cloudflare_teams_accounts_test.go
+++ b/cloudflare/resource_cloudflare_teams_accounts_test.go
@@ -1,0 +1,68 @@
+package cloudflare
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccCloudflareTeamsAccountConfigurationBasic(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_teams_account.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccessAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareTeamsAccountBasic(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "tls_decrypt_enabled", "true"),
+					resource.TestCheckResourceAttr(name, "block_page.0.name", rnd),
+					resource.TestCheckResourceAttr(name, "block_page.0.enabled", "true"),
+					resource.TestCheckResourceAttr(name, "block_page.0.footer_text", "hello"),
+					resource.TestCheckResourceAttr(name, "block_page.0.header_text", "hello"),
+					resource.TestCheckResourceAttr(name, "block_page.0.background_color", "#000000"),
+					resource.TestCheckResourceAttr(name, "block_page.0.logo_path", "https://example.com"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareTeamsAccountBasic(rnd, accountID string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_teams_account" "%[1]s" {
+  account_id = "%[2]s"
+  tls_decrypt_enabled = true
+  block_page {
+    name = "%[1]s"
+    enabled = true
+    footer_text = "hello"
+    header_text = "hello"
+    logo_path = "https://example.com"
+    background_color = "#000000"
+  }
+  antivirus {
+    enabled_download_phase = true
+    enabled_upload_phase = false
+    fail_closed = true
+  }
+}
+`, rnd, accountID)
+}

--- a/cloudflare/resource_cloudflare_teams_rules.go
+++ b/cloudflare/resource_cloudflare_teams_rules.go
@@ -1,0 +1,395 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+var teamsRuleActions = []string{
+	"allow",
+	"block",
+	"safesearch",
+	"ytrestricted",
+	"on",
+	"off",
+	"scan",
+	"noscan",
+	"isolate",
+	"noisolate",
+	"override",
+	"l4_override",
+}
+
+func resourceCloudflareTeamsRule() *schema.Resource {
+	return &schema.Resource{
+		Read:   resourceCloudflareTeamsRuleRead,
+		Update: resourceCloudflareTeamsRuleUpdate,
+		Create: resourceCloudflareTeamsRuleCreate,
+		Delete: resourceCloudflareTeamsRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareTeamsRuleImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"precedence": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"action": {
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice(teamsRuleActions, false),
+				Required:     true,
+			},
+			"filters": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"traffic": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"identity": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"rule_settings": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: teamsRuleSettings,
+				},
+			},
+		},
+	}
+}
+
+var teamsRuleSettings = map[string]*schema.Schema{
+	"block_page_enabled": {
+		Type:     schema.TypeBool,
+		Optional: true,
+	},
+	"block_page_reason": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"override_ips": {
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	},
+	"override_host": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"l4override": {
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: teamsL4OverrideSettings,
+		},
+	},
+	"biso_admin_controls": {
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: teamsBisoAdminControls,
+		},
+	},
+}
+
+var teamsL4OverrideSettings = map[string]*schema.Schema{
+	"ip": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"port": {
+		Type:     schema.TypeInt,
+		Required: true,
+	},
+}
+
+var teamsBisoAdminControls = map[string]*schema.Schema{
+	"disable_printing": {
+		Type:     schema.TypeBool,
+		Optional: true,
+	},
+	"disable_copy_paste": {
+		Type:     schema.TypeBool,
+		Optional: true,
+	},
+}
+
+func resourceCloudflareTeamsRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get("account_id").(string)
+
+	rule, err := client.TeamsRule(context.Background(), accountID, d.Id())
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP status 400") {
+			log.Printf("[INFO] Teams Rule config %s doesnt exists", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error finding Teams Rule %q: %s", d.Id(), err)
+	}
+	if err := d.Set("name", rule.Name); err != nil {
+		return fmt.Errorf("error parsing rule name")
+	}
+	if err := d.Set("description", rule.Description); err != nil {
+		return fmt.Errorf("error parsing rule description")
+	}
+	if err := d.Set("precedence", int64(rule.Precedence)); err != nil {
+		return fmt.Errorf("error parsing rule precedence")
+	}
+	if err := d.Set("enabled", rule.Enabled); err != nil {
+		return fmt.Errorf("error parsing rule enablement")
+	}
+	if err := d.Set("action", rule.Action); err != nil {
+		return fmt.Errorf("error parsing rule action")
+	}
+	if err := d.Set("filters", rule.Filters); err != nil {
+		return fmt.Errorf("error parsing rule filters")
+	}
+	if err := d.Set("traffic", rule.Traffic); err != nil {
+		return fmt.Errorf("error parsing rule traffic")
+	}
+	if err := d.Set("identity", rule.Identity); err != nil {
+		return fmt.Errorf("error parsing rule identity")
+	}
+	if err := d.Set("version", int64(rule.Version)); err != nil {
+		return fmt.Errorf("error parsing rule version")
+	}
+	if err := d.Set("rule_settings", flattenTeamsRuleSettings(&rule.RuleSettings)); err != nil {
+		return fmt.Errorf("error parsing rule settings")
+	}
+	return nil
+}
+
+func resourceCloudflareTeamsRuleCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+
+	accountID := d.Get("account_id").(string)
+	settings := inflateTeamsRuleSettings(d.Get("rule_settings"))
+
+	var filters []cloudflare.TeamsFilterType
+	for _, f := range d.Get("filters").([]interface{}) {
+		filters = append(filters, cloudflare.TeamsFilterType(f.(string)))
+	}
+
+	newTeamsRule := cloudflare.TeamsRule{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Precedence:  uint64(d.Get("precedence").(int)),
+		Enabled:     d.Get("enabled").(bool),
+		Action:      cloudflare.TeamsGatewayAction(d.Get("action").(string)),
+		Filters:     filters,
+		Traffic:     d.Get("traffic").(string),
+		Identity:    d.Get("identity").(string),
+		Version:     uint64(d.Get("version").(int)),
+	}
+
+	if settings != nil {
+		newTeamsRule.RuleSettings = *settings
+	}
+
+	log.Printf("[DEBUG] Creating Cloudflare Teams Rule from struct: %+v", newTeamsRule)
+
+	rule, err := client.TeamsCreateRule(context.Background(), accountID, newTeamsRule)
+	if err != nil {
+		return fmt.Errorf("error creating Teams rule for account %q: %s", accountID, err)
+	}
+
+	d.SetId(rule.ID)
+	return resourceCloudflareTeamsRuleRead(d, meta)
+}
+
+func resourceCloudflareTeamsRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get("account_id").(string)
+	settings := inflateTeamsRuleSettings(d.Get("rule_settings"))
+
+	var filters []cloudflare.TeamsFilterType
+	for _, f := range d.Get("filters").([]interface{}) {
+		filters = append(filters, cloudflare.TeamsFilterType(f.(string)))
+	}
+
+	teamsRule := cloudflare.TeamsRule{
+		ID:          d.Id(),
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Precedence:  uint64(d.Get("precedence").(int)),
+		Enabled:     d.Get("enabled").(bool),
+		Action:      cloudflare.TeamsGatewayAction(d.Get("action").(string)),
+		Filters:     filters,
+		Traffic:     d.Get("traffic").(string),
+		Identity:    d.Get("identity").(string),
+		Version:     uint64(d.Get("version").(int)),
+	}
+
+	if settings != nil {
+		teamsRule.RuleSettings = *settings
+	}
+	log.Printf("[DEBUG] Updating Cloudflare Teams rule from struct: %+v", teamsRule)
+
+	updatedTeamsRule, err := client.TeamsUpdateRule(context.Background(), accountID, teamsRule.ID, teamsRule)
+	if err != nil {
+		return fmt.Errorf("error updating Teams rule for account %q: %s", accountID, err)
+	}
+	if updatedTeamsRule.ID == "" {
+		return fmt.Errorf("failed to find Teams Rule ID in update response; resource was empty")
+	}
+	return resourceCloudflareTeamsRuleRead(d, meta)
+}
+
+func resourceCloudflareTeamsRuleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	id := d.Id()
+	accountID := d.Get("account_id").(string)
+
+	log.Printf("[DEBUG] Deleting Cloudflare Teams Rule using ID: %s", id)
+
+	err := client.TeamsDeleteRule(context.Background(), accountID, id)
+	if err != nil {
+		return fmt.Errorf("error deleting Teams Rule for account %q: %s", accountID, err)
+	}
+
+	return resourceCloudflareTeamsRuleRead(d, meta)
+}
+
+func resourceCloudflareTeamsRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	attributes := strings.SplitN(d.Id(), "/", 2)
+
+	if len(attributes) != 2 {
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"accountID/teamsRuleID\"", d.Id())
+	}
+
+	accountID, teamsRuleID := attributes[0], attributes[1]
+
+	log.Printf("[DEBUG] Importing Cloudflare Teams Rule: id %s for account %s", teamsRuleID, accountID)
+
+	d.Set("account_id", accountID)
+	d.SetId(teamsRuleID)
+
+	err := resourceCloudflareTeamsRuleRead(d, meta)
+
+	return []*schema.ResourceData{d}, err
+}
+
+func flattenTeamsRuleSettings(settings *cloudflare.TeamsRuleSettings) []interface{} {
+	return []interface{}{map[string]interface{}{
+		"block_page_enabled":  settings.BlockPageEnabled,
+		"block_page_reason":   settings.BlockReason,
+		"override_ips":        settings.OverrideIPs,
+		"override_host":       settings.OverrideHost,
+		"l4override":          flattenTeamsL4Override(settings.L4Override),
+		"biso_admin_controls": flattenTeamsRuleBisoAdminControls(settings.BISOAdminControls),
+	}}
+}
+
+func inflateTeamsRuleSettings(settings interface{}) *cloudflare.TeamsRuleSettings {
+	settingsList := settings.([]interface{})
+	if len(settingsList) != 1 {
+		return nil
+	}
+	settingsMap := settingsList[0].(map[string]interface{})
+	enabled := settingsMap["block_page_enabled"].(bool)
+	reason := settingsMap["block_page_reason"].(string)
+
+	var overrideIPs []string
+	for _, ip := range settingsMap["override_ips"].([]interface{}) {
+		overrideIPs = append(overrideIPs, ip.(string))
+	}
+
+	overrideHost := settingsMap["override_host"].(string)
+	l4Override := inflateTeamsL4Override(settingsMap["l4override"].([]interface{}))
+
+	bisoAdminControls := inflateTeamsRuleBisoAdminControls(settingsMap["biso_admin_controls"].([]interface{}))
+
+	return &cloudflare.TeamsRuleSettings{
+		BlockPageEnabled:  enabled,
+		BlockReason:       reason,
+		OverrideIPs:       overrideIPs,
+		OverrideHost:      overrideHost,
+		L4Override:        l4Override,
+		BISOAdminControls: bisoAdminControls,
+	}
+}
+
+func flattenTeamsRuleBisoAdminControls(settings *cloudflare.TeamsBISOAdminControlSettings) []interface{} {
+	if settings == nil {
+		return nil
+	}
+	return []interface{}{map[string]interface{}{
+		"disable_printing":   settings.DisablePrinting,
+		"disable_copy_paste": settings.DisableCopyPaste,
+	}}
+}
+
+func inflateTeamsRuleBisoAdminControls(settings interface{}) *cloudflare.TeamsBISOAdminControlSettings {
+	settingsList := settings.([]interface{})
+	if len(settingsList) != 1 {
+		return nil
+	}
+	settingsMap := settingsList[0].(map[string]interface{})
+	disablePrinting := settingsMap["disable_printing"].(bool)
+	disableCopyPaste := settingsMap["disable_copy_paste"].(bool)
+	return &cloudflare.TeamsBISOAdminControlSettings{
+		DisablePrinting:  disablePrinting,
+		DisableCopyPaste: disableCopyPaste,
+	}
+}
+
+func flattenTeamsL4Override(settings *cloudflare.TeamsL4OverrideSettings) []interface{} {
+	if settings == nil {
+		return nil
+	}
+	return []interface{}{map[string]interface{}{
+		"ip":   settings.IP,
+		"port": settings.Port,
+	}}
+
+}
+
+func inflateTeamsL4Override(settings interface{}) *cloudflare.TeamsL4OverrideSettings {
+	settingsList := settings.([]interface{})
+	if len(settingsList) != 1 {
+		return nil
+	}
+	settingsMap := settingsList[0].(map[string]interface{})
+	ip := settingsMap["ip"].(string)
+	port := settingsMap["port"].(int)
+	return &cloudflare.TeamsL4OverrideSettings{
+		IP:   ip,
+		Port: port,
+	}
+}

--- a/cloudflare/resource_cloudflare_teams_rules_test.go
+++ b/cloudflare/resource_cloudflare_teams_rules_test.go
@@ -1,0 +1,88 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCloudflareTeamsRuleBasic(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_teams_rule.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccessAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareTeamsRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareTeamsRuleConfigBasic(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "description", "desc"),
+					resource.TestCheckResourceAttr(name, "precedence", "12302"),
+					resource.TestCheckResourceAttr(name, "action", "override"),
+					resource.TestCheckResourceAttr(name, "filters.0", "l4"),
+					resource.TestCheckResourceAttr(name, "traffic", "any(dns.domains[*] == \"com.stupidchess\")"),
+					resource.TestCheckResourceAttr(name, "rule_settings.0.block_page_enabled", "false"),
+					resource.TestCheckResourceAttr(name, "rule_settings.0.block_page_reason", "cuz"),
+					resource.TestCheckResourceAttr(name, "rule_settings.0.override_host", "host.com"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareTeamsRuleConfigBasic(rnd, accountID string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_teams_rule" "%[1]s" {
+  name = "%[1]s"
+  account_id = "%[2]s"
+  description = "desc"
+  precedence = 12302
+  action = "override"
+  filters = ["l4"]
+  traffic = "any(dns.domains[*] == \"com.stupidchess\")"
+  rule_settings {
+    block_page_enabled = false
+    block_page_reason = "cuz"
+    override_host = "host.com"
+  }
+}
+`, rnd, accountID)
+}
+
+func testAccCheckCloudflareTeamsRuleDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*cloudflare.API)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_teams_rule" {
+			continue
+		}
+
+		_, err := client.TeamsRule(context.Background(), rs.Primary.Attributes["account_id"], rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("teams rule still exists")
+		}
+	}
+
+	return nil
+}

--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -870,6 +870,10 @@ func expandRevertibleZoneSettings(d *schema.ResourceData, readOnlySettings []str
 		initialVal := d.Get(initialKey)
 		currentKey := fmt.Sprintf("settings.0.%s", k)
 
+		if k == "zero_rtt" {
+			k = "0rtt"
+		}
+
 		// if the value was never set we don't need to revert it
 		if currentVal, ok := d.GetOk(currentKey); ok && !schemaValueEquals(initialVal, currentVal) {
 

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/cloudflare/terraform-provider-cloudflare
 go 1.15
 
 require (
-	github.com/cloudflare/cloudflare-go v0.21.0
+	github.com/cloudflare/cloudflare-go v0.22.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
 	github.com/pkg/errors v0.9.1
-	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985
+	golang.org/x/net v0.0.0-20210908191846-a5e095526f91
+	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.21.0 h1:DWCTuT3E6piKVeeG/o8475cYINsRPMttP3zEs9NTbzY=
 github.com/cloudflare/cloudflare-go v0.21.0/go.mod h1:sPWL/lIC6biLEdyGZwBQ1rGQKF1FhM7N60fuNiFdYTI=
+github.com/cloudflare/cloudflare-go v0.22.0 h1:3TYbkyz/IBbM6XozrTKWiNpv7RjJGamALy9yu2SBqTo=
+github.com/cloudflare/cloudflare-go v0.22.0/go.mod h1:sPWL/lIC6biLEdyGZwBQ1rGQKF1FhM7N60fuNiFdYTI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -433,6 +435,8 @@ golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5o
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 h1:4CSI6oo7cOjJKajidEljs9h+uP0rRZBPPPhcCbj5mw8=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210908191846-a5e095526f91 h1:E8wdt+zBjoxD3MA65wEc3pl25BsTi7tbkpwc4ANThjc=
+golang.org/x/net v0.0.0-20210908191846-a5e095526f91/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -495,6 +499,8 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -154,6 +154,15 @@
             <li<%= sidebar_current("docs-cloudflare-static-route") %>>
               <a href="/docs/providers/cloudflare/r/static_route.html">cloudflare_static_route</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-teams-account") %>>
+              <a href="/docs/providers/cloudflare/r/teams_account.html">cloudflare_teams_account</a>
+            </li>
+            <li<%= sidebar_current("docs-cloudflare-teams-location") %>>
+              <a href="/docs/providers/cloudflare/r/teams_location.html">cloudflare_teams_location</a>
+            </li>
+            <li<%= sidebar_current("docs-cloudflare-teams-rule") %>>
+              <a href="/docs/providers/cloudflare/r/teams_rule.html">cloudflare_teams_rule</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-waf-group") %>>
               <a href="/docs/providers/cloudflare/r/waf_group.html">cloudflare_waf_group</a>
             </li>

--- a/website/docs/r/ruleset.html.markdown
+++ b/website/docs/r/ruleset.html.markdown
@@ -8,7 +8,8 @@ description: |-
 
 # cloudflare_ruleset
 
-The Cloudflare Ruleset Engine allows you to create and deploy rules and rulesets.
+The [Cloudflare Ruleset Engine](https://developers.cloudflare.com/firewall/cf-rulesets)
+allows you to create and deploy rules and rulesets.
 The engine syntax, inspired by the Wireshark Display Filter language, is the
 same syntax used in custom Firewall Rules. Cloudflare uses the Ruleset Engine
 in different products, allowing you to configure several products using the same

--- a/website/docs/r/ruleset.html.markdown
+++ b/website/docs/r/ruleset.html.markdown
@@ -83,6 +83,88 @@ resource "cloudflare_ruleset" "zone_level_managed_waf_with_category_based_overri
     enabled = false
   }
 }
+
+# Rewrite the URI path component to a static path
+resource "cloudflare_ruleset" "transform_uri_rule_path" {
+  zone_id     = "cb029e245cfdd66dc8d2e570d5dd3322"
+  name        = "transformation rule for URI path"
+  description = "change the URI path to a new static path"
+  kind        = "zone"
+  phase       = "http_request_transform"
+
+  rules {
+    action = "rewrite"
+    action_parameters {
+      uri {
+        path {
+          value = "/my-new-route"
+        }
+      }
+    }
+
+    expression = "(http.host eq \"example.com\" and http.uri.path eq \"/old-path\")"
+    description = "URI transformation path example"
+    enabled = true
+  }
+}
+
+# Rewrite the URI query component to a static query
+resource "cloudflare_ruleset" "transform_uri_rule_query" {
+  zone_id     = "cb029e245cfdd66dc8d2e570d5dd3322"
+  name        = "transformation rule for URI query parameter"
+  description = "change the URI query to a new static query"
+  kind        = "zone"
+  phase       = "http_request_transform"
+
+  rules {
+    action = "rewrite"
+    action_parameters {
+      uri {
+        query {
+          value = "old=new_again"
+        }
+      }
+    }
+
+    expression = "true"
+    description = "URI transformation query example"
+    enabled = true
+  }
+}
+
+# Rewrite HTTP headers to a modified values
+resource "cloudflare_ruleset" "transform_uri_http_headers" {
+  zone_id     = "cb029e245cfdd66dc8d2e570d5dd3322"
+  name        = "transformation rule for HTTP headers"
+  description = "modify HTTP headers before reaching origin"
+  kind        = "zone"
+  phase       = "http_request_late_transform"
+
+rules {
+  action = "rewrite"
+  action_parameters {
+    headers {
+      name      = "example-http-header-1"
+      operation = "set"
+      value     = "my-http-header-value-1"
+    }
+
+    headers {
+      name       = "example-http-header-2"
+      operation  = "set"
+      expression = "cf.zone.name"
+    }
+
+    headers {
+      name      = "example-http-header-3-to-remove"
+      operation = "remove"
+    }
+
+    expression = "true"
+    description = "example header transformation rule"
+    enabled = false
+  }
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/ruleset.html.markdown
+++ b/website/docs/r/ruleset.html.markdown
@@ -87,7 +87,7 @@ resource "cloudflare_ruleset" "zone_level_managed_waf_with_category_based_overri
 # Rewrite the URI path component to a static path
 resource "cloudflare_ruleset" "transform_uri_rule_path" {
   zone_id     = "cb029e245cfdd66dc8d2e570d5dd3322"
-  name        = "transformation rule for URI path"
+  name        = "transform rule for URI path"
   description = "change the URI path to a new static path"
   kind        = "zone"
   phase       = "http_request_transform"
@@ -103,7 +103,7 @@ resource "cloudflare_ruleset" "transform_uri_rule_path" {
     }
 
     expression = "(http.host eq \"example.com\" and http.uri.path eq \"/old-path\")"
-    description = "URI transformation path example"
+    description = "example URI path transform rule"
     enabled = true
   }
 }
@@ -111,7 +111,7 @@ resource "cloudflare_ruleset" "transform_uri_rule_path" {
 # Rewrite the URI query component to a static query
 resource "cloudflare_ruleset" "transform_uri_rule_query" {
   zone_id     = "cb029e245cfdd66dc8d2e570d5dd3322"
-  name        = "transformation rule for URI query parameter"
+  name        = "transform rule for URI query parameter"
   description = "change the URI query to a new static query"
   kind        = "zone"
   phase       = "http_request_transform"
@@ -135,7 +135,7 @@ resource "cloudflare_ruleset" "transform_uri_rule_query" {
 # Rewrite HTTP headers to a modified values
 resource "cloudflare_ruleset" "transform_uri_http_headers" {
   zone_id     = "cb029e245cfdd66dc8d2e570d5dd3322"
-  name        = "transformation rule for HTTP headers"
+  name        = "transform rule for HTTP headers"
   description = "modify HTTP headers before reaching origin"
   kind        = "zone"
   phase       = "http_request_late_transform"
@@ -161,7 +161,7 @@ resource "cloudflare_ruleset" "transform_uri_http_headers" {
       }
 
       expression = "true"
-      description = "example header transformation rule"
+      description = "example request header transform rule"
       enabled = false
     }
   }
@@ -202,7 +202,7 @@ The following arguments are supported:
 * `products` - (Optional) Products to target with the actions. Valid values are `"bic"`, `"hot"`, `"ratelimit"`, `"securityLevel"`, `"uablock"`, `"waf"` or `"zonelockdown"`.
 * `ruleset` - (Optional) Which ruleset to target. Valid value is `"current"`.
 * `uri` - (Optional) List of URI properties to configure for the ruleset rule when performing URL rewrite transformations (refer to the [nested schema](#nestedblock--action-parameters-uri)).
-* `headers` - (Optional) List of HTTP header configurations to perform rewrite transformations (refer to the [nested schema](#nestedblock--action-parameters-headers)).
+* `headers` - (Optional) List of HTTP header modifications to perform in the ruleset rule (refer to the [nested schema](#nestedblock--action-parameters-headers)).
 * `version` - (Optional)
 
 <a id="nestedblock--action-parameters-uri"></a>
@@ -214,10 +214,10 @@ The following arguments are supported:
 <a id="nestedblock--action-parameters-headers"></a>
 **Nested schema for `headers`**
 
-* `name` - (Optional) Name of the HTTP header to target.
-* `operation` - (Optional) Action to perform on this HTTP header. Valid values are `"set"` or `"remove"`.
+* `name` - (Optional) Name of the HTTP request header to target.
+* `operation` - (Optional) Action to perform on the HTTP request header. Valid values are `"set"` or `"remove"`.
 * `expression` - (Optional) Use a value dynamically determined by the Firewall Rules expression language based on Wireshark display filters. Refer to the [Firewall Rules language](https://developers.cloudflare.com/firewall/cf-firewall-language) documentation for all available fields, operators, and functions. Conflicts with `value`.
-* `value` - (Optional) Static value to provide as a value. Conflicts with `expression`.
+* `value` - (Optional) Static value to provide as the HTTP request header value. Conflicts with `expression`.
 
 <a id="nestedblock--action-parameters-uri-shared"></a>
 **Nested schema for `path`/`query`**

--- a/website/docs/r/ruleset.html.markdown
+++ b/website/docs/r/ruleset.html.markdown
@@ -140,29 +140,30 @@ resource "cloudflare_ruleset" "transform_uri_http_headers" {
   kind        = "zone"
   phase       = "http_request_late_transform"
 
-rules {
-  action = "rewrite"
-  action_parameters {
-    headers {
-      name      = "example-http-header-1"
-      operation = "set"
-      value     = "my-http-header-value-1"
-    }
+  rules {
+    action = "rewrite"
+    action_parameters {
+      headers {
+        name      = "example-http-header-1"
+        operation = "set"
+        value     = "my-http-header-value-1"
+      }
 
-    headers {
-      name       = "example-http-header-2"
-      operation  = "set"
-      expression = "cf.zone.name"
-    }
+      headers {
+        name       = "example-http-header-2"
+        operation  = "set"
+        expression = "cf.zone.name"
+      }
 
-    headers {
-      name      = "example-http-header-3-to-remove"
-      operation = "remove"
-    }
+      headers {
+        name      = "example-http-header-3-to-remove"
+        operation = "remove"
+      }
 
-    expression = "true"
-    description = "example header transformation rule"
-    enabled = false
+      expression = "true"
+      description = "example header transformation rule"
+      enabled = false
+    }
   }
 }
 ```
@@ -201,6 +202,7 @@ The following arguments are supported:
 * `products` - (Optional) Products to target with the actions. Valid values are `"bic"`, `"hot"`, `"ratelimit"`, `"securityLevel"`, `"uablock"`, `"waf"` or `"zonelockdown"`.
 * `ruleset` - (Optional) Which ruleset to target. Valid value is `"current"`.
 * `uri` - (Optional) List of URI properties to configure for the ruleset rule when performing URL rewrite transformations (refer to the [nested schema](#nestedblock--action-parameters-uri)).
+* `headers` - (Optional) List of HTTP header configurations to perform rewrite transformations (refer to the [nested schema](#nestedblock--action-parameters-headers)).
 * `version` - (Optional)
 
 <a id="nestedblock--action-parameters-uri"></a>
@@ -208,6 +210,14 @@ The following arguments are supported:
 
 * `path` - (Optional) URI path configuration when performing a URL rewrite (refer to the [nested schema](#nestedblock--action-parameters-uri-shared)).
 * `query` - (Optional) Query string configuration when performing a URL rewrite (refer to the [nested schema](#nestedblock--action-parameters-uri-shared)).
+
+<a id="nestedblock--action-parameters-headers"></a>
+**Nested schema for `headers`**
+
+* `name` - (Optional) Name of the HTTP header to target.
+* `operation` - (Optional) Action to perform on this HTTP header. Valid values are `"set"` or `"remove"`.
+* `expression` - (Optional) Use a value dynamically determined by the Firewall Rules expression language based on Wireshark display filters. Refer to the [Firewall Rules language](https://developers.cloudflare.com/firewall/cf-firewall-language) documentation for all available fields, operators, and functions. Conflicts with `value`.
+* `value` - (Optional) Static value to provide as a value. Conflicts with `expression`.
 
 <a id="nestedblock--action-parameters-uri-shared"></a>
 **Nested schema for `path`/`query`**

--- a/website/docs/r/teams_account.html.markdown
+++ b/website/docs/r/teams_account.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_teams_account"
+sidebar_current: "docs-cloudflare-resource-teams-account"
+description: |-
+Provides a Cloudflare Teams Account resource.
+---
+
+# cloudflare_teams_account
+
+Provides a Cloudflare Teams Account resource. The Teams Account resource defines configuration for secure web gateway.
+
+## Example Usage
+
+```hcl
+resource "cloudflare_teams_account" "main" {
+  account_id  = "1d5fdc9e88c8a8c4518b068cd94331fe"
+  tls_decrypt_enabled = true
+
+  block_page {
+    footer_text = "hello"
+    header_text = "hello"
+    logo_path = "https://google.com"
+    background_color = "#000000"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Required) The account to which the teams location should be added.
+* `tls_decrypt_enabled` - (Optional) Indicator that decryption of TLS traffic is enabled.
+* `block_page` - (Optional) Configuration for a custom block page.
+* `antivirus` - (Optional) Configuration for antivirus traffic scanning.
+
+The **block_page** block supports:
+* `name` - (Optional) Name of block page configuration.
+* `enabled` - (Optional) Indicator of enablement.
+* `footer_text` - (Optional) Block page header text.
+* `header_text` - (Optional) Block page footer text.
+* `logo_path` - (Optional) URL of block page logo.
+* `background_color` - (Optional) Hex code of block page background color.
+
+## Import
+
+Since a Teams account does not have a unique resource ID, configuration can be
+imported using the account ID.
+
+```
+$ terraform import cloudflare_teams_account.example cb029e245cfdd66dc8d2e570d5dd3322
+```

--- a/website/docs/r/teams_location.html.markdown
+++ b/website/docs/r/teams_location.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_teams_location"
+sidebar_current: "docs-cloudflare-resource-teams-location"
+description: |-
+Provides a Cloudflare Teams Location resource.
+---
+
+# cloudflare_teams_location
+
+Provides a Cloudflare Teams Location resource. Teams Locations are referenced
+when creating secure web gateway policies.
+
+## Example Usage
+
+```hcl
+resource "cloudflare_teams_location" "corporate_office" {
+  name = "office"
+  account_id  = "1d5fdc9e88c8a8c4518b068cd94331fe"
+  client_default = true
+  networks {
+    network = "203.0.113.1/32"
+  }
+  networks {
+    network = "203.0.113.2/32"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Required) The account to which the teams location should be added.
+* `name` - (Required) Name of the teams location.
+* `networks` - (Optional) The networks CIDRs that comprise the location.
+* `client_default` - (Optional) Indicator that this is the default location.
+
+## Attributes Reference
+
+The following additional attributes are exported:
+
+* `id` - ID of the teams location.
+* `ip` - Client IP address
+* `doh_subdomain` - The FQDN that DoH clients should be pointed at.
+* `anonymized_logs_enabled` - Indicator that anonymized logs are enabled.
+* `ipv4_destination` - IP to direct all IPv4 DNS queries too.
+
+## Import
+
+Teams locations can be imported using a composite ID formed of account
+ID and teams location ID.
+
+```
+$ terraform import cloudflare_teams_location.corporate_office cb029e245cfdd66dc8d2e570d5dd3322/d41d8cd98f00b204e9800998ecf8427e
+```

--- a/website/docs/r/teams_rule.html.markdown
+++ b/website/docs/r/teams_rule.html.markdown
@@ -1,0 +1,68 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_teams_rule"
+sidebar_current: "docs-cloudflare-resource-teams-rule"
+description: |-
+Provides a Cloudflare Teams rule resource.
+---
+
+# cloudflare_teams_rule
+
+Provides a Cloudflare Teams rule resource. Teams rules comprise secure web gateway policies.
+
+## Example Usage
+
+```hcl
+resource "cloudflare_teams_rule" "rule1" {
+  name = "office"
+  account_id  = "1d5fdc9e88c8a8c4518b068cd94331fe"
+  description = "desc"
+  precedence = 1
+  action = "l4_override"
+  filters = ["l4"]
+  traffic = "any(dns.domains[*] == \"com.example\")"
+  rule_settings {
+    block_page_enabled = false
+    block_page_reason = "access not permitted"
+    l4override {
+      port = 1234
+      ip = "192.0.2.1"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Required) The account to which the teams rule should be added.
+* `name` - (Required) The name of the teams rule.
+* `description` - (Required) The description of the teams rule.
+* `precedence` - (Required) The evaluation precedence of the teams rule.
+* `action` - (Required) The action executed by matched teams rule.
+* `enabled` - (Optional) Indicator of rule enablement.
+* `filters` - (Optional) The protocol or layer to evaluate the traffic and identity expressions.
+* `traffic` - (Optional) The wirefilter expression to be used for traffic matching.
+* `identity` - (Optional) The wirefilter expression to be used for identity matching.
+* `rule_settings` - (Optional) Additional rule settings.
+
+The **rule_settings** block supports:
+* `block_page_enabled` - (Optional) Indicator of block page enablement.
+* `block_page_reason` - (Optional) The displayed reason for a user being blocked.
+* `override_ips` - (Optional) The IPs to override matching DNS queries with.
+* `override_host` - (Optional) The host to override matching DNS queries with.
+* `l4override` - (Optional) Settings to forward layer 4 traffic.
+
+The **l4override** block supports:
+* `ip` - (Required) Override IP to forward traffic to.
+* `port` - (Required) Override Port to forward traffic to.
+
+## Import
+
+Teams Rules can be imported using a composite ID formed of account
+ID and teams rule ID.
+
+```
+$ terraform import cloudflare_teams_rule.rule1 cb029e245cfdd66dc8d2e570d5dd3322/d41d8cd98f00b204e9800998ecf8427e
+```


### PR DESCRIPTION
Adds support for URI and HTTP header transformation rules.

Depends on https://github.com/cloudflare/cloudflare-go/pull/699

Closes #1036