### PR TITLE
resource/cloudflare_ruleset: send ERE payload as one

### DIFF
--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -264,23 +264,19 @@ func resourceCloudflareRulesetCreate(d *schema.ResourceData, meta interface{}) e
 		return errors.Wrap(err, fmt.Sprintf("error creating ruleset %s", d.Get("name").(string)))
 	}
 
-	for i, rule := range rules {
-		if rule.Action == string(cloudflare.RulesetRuleActionExecute) {
-			rulesetEntryPoint := cloudflare.Ruleset{
-				Description: d.Get("description").(string),
-				Rules:       []cloudflare.RulesetRule{rules[i]},
-			}
+	rulesetEntryPoint := cloudflare.Ruleset{
+		Description: d.Get("description").(string),
+		Rules:       rules,
+	}
 
-			if accountID != "" {
-				_, err = client.UpdateAccountRulesetPhase(context.Background(), accountID, rs.Phase, rulesetEntryPoint)
-			} else {
-				_, err = client.UpdateZoneRulesetPhase(context.Background(), zoneID, rs.Phase, rulesetEntryPoint)
-			}
+	if accountID != "" {
+		_, err = client.UpdateAccountRulesetPhase(context.Background(), accountID, rs.Phase, rulesetEntryPoint)
+	} else {
+		_, err = client.UpdateZoneRulesetPhase(context.Background(), zoneID, rs.Phase, rulesetEntryPoint)
+	}
 
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error updating ruleset phase entrypoint %s", d.Get("name").(string)))
-			}
-		}
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error updating ruleset phase entrypoint %s", d.Get("name").(string)))
 	}
 
 	d.SetId(ruleset.ID)


### PR DESCRIPTION
We don't need to restrict the entrypoint calls to "execute" calls; send it all as one payload.