### PR TITLE
resource/cloudflare_zone_settings_override: remap `zero_rtt` => `0rtt` for resource delete

### DIFF
--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -870,6 +870,10 @@ func expandRevertibleZoneSettings(d *schema.ResourceData, readOnlySettings []str
 		initialVal := d.Get(initialKey)
 		currentKey := fmt.Sprintf("settings.0.%s", k)
 
+		if k == "zero_rtt" {
+			k = "0rtt"
+		}
+
 		// if the value was never set we don't need to revert it
 		if currentVal, ok := d.GetOk(currentKey); ok && !schemaValueEquals(initialVal, currentVal) {
 


### PR DESCRIPTION
Updates the internal methods to handle mapping `zero_rtt` => `0rtt` when
Terraform attempts to delete the managed resource. Originally introduced
at b64c0c2139f66949ab75917c410db25b0e982a79 however was missed from the
`Delete`.

Closes #1157