### PR TITLE
Add proximity to load_balancer steering_policy

### DIFF
--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -90,7 +90,7 @@ func resourceCloudflareLoadBalancer() *schema.Resource {
 			"steering_policy": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"off", "geo", "dynamic_latency", "random", ""}, false),
+				ValidateFunc: validation.StringInSlice([]string{"off", "geo", "dynamic_latency", "random", "proximity", ""}, false),
 				Computed:     true,
 			},
 

--- a/cloudflare/resource_cloudflare_load_balancer_pool_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool_test.go
@@ -213,6 +213,8 @@ func testAccCheckCloudflareLoadBalancerPoolConfigBasic(id string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_load_balancer_pool" "%[1]s" {
   name = "my-tf-pool-basic-%[1]s"
+  latitude = 12.3
+  longitude = 55
   origins {
     name = "example-1"
     address = "192.0.2.1"

--- a/cloudflare/resource_cloudflare_load_balancer_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_test.go
@@ -163,8 +163,6 @@ func TestAccCloudflareLoadBalancer_ProximityBalanced(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "proxied", "true"),
 					resource.TestCheckResourceAttr(name, "ttl", "0"),
 					resource.TestCheckResourceAttr(name, "steering_policy", "proximity"),
-					resource.TestCheckResourceAttr(name, "pop_pools.#", "1"),
-					resource.TestCheckResourceAttr(name, "region_pools.#", "1"),
 				),
 			},
 		},
@@ -487,14 +485,6 @@ resource "cloudflare_load_balancer" "%[3]s" {
   description = "tf-acctest load balancer using proximity-balancing"
   proxied = true // can't set ttl with proxied
   steering_policy = "proximity"
-  pop_pools {
-    pop = "LAX"
-    pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
-  }
-  region_pools {
-    region = "WNAM"
-    pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
-  }
 }`, zoneID, zone, id)
 }
 

--- a/cloudflare/resource_cloudflare_load_balancer_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_test.go
@@ -140,6 +140,37 @@ func TestAccCloudflareLoadBalancer_GeoBalanced(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareLoadBalancer_ProximityBalanced(t *testing.T) {
+	t.Parallel()
+	var loadBalancer cloudflare.LoadBalancer
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := generateRandomResourceName()
+	name := "cloudflare_load_balancer." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudflareLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareLoadBalancerConfigProximityBalanced(zoneID, zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudflareLoadBalancerIDIsValid(name, zoneID),
+					// checking our overrides of default values worked
+					resource.TestCheckResourceAttr(name, "description", "tf-acctest load balancer using proximity-balancing"),
+					resource.TestCheckResourceAttr(name, "proxied", "true"),
+					resource.TestCheckResourceAttr(name, "ttl", "0"),
+					resource.TestCheckResourceAttr(name, "steering_policy", "proximity"),
+					resource.TestCheckResourceAttr(name, "pop_pools.#", "1"),
+					resource.TestCheckResourceAttr(name, "region_pools.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudflareLoadBalancer_Rules(t *testing.T) {
 	t.Parallel()
 	var loadBalancer cloudflare.LoadBalancer
@@ -435,6 +466,27 @@ resource "cloudflare_load_balancer" "%[3]s" {
   description = "tf-acctest load balancer using geo-balancing"
   proxied = true // can't set ttl with proxied
   steering_policy = "geo"
+  pop_pools {
+    pop = "LAX"
+    pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
+  }
+  region_pools {
+    region = "WNAM"
+    pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
+  }
+}`, zoneID, zone, id)
+}
+
+func testAccCheckCloudflareLoadBalancerConfigProximityBalanced(zoneID, zone, id string) string {
+	return testAccCheckCloudflareLoadBalancerPoolConfigBasic(id) + fmt.Sprintf(`
+resource "cloudflare_load_balancer" "%[3]s" {
+  zone_id = "%[1]s"
+  name = "tf-testacc-lb-%[3]s.%[2]s"
+  fallback_pool_id = "${cloudflare_load_balancer_pool.%[3]s.id}"
+  default_pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
+  description = "tf-acctest load balancer using proximity-balancing"
+  proxied = true // can't set ttl with proxied
+  steering_policy = "proximity"
   pop_pools {
     pop = "LAX"
     pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]


### PR DESCRIPTION
The documentation states that it is supported yet, when attempting to use it fails on validation.
https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/load_balancer#steering_policy