### PR TITLE
These should be outside the action_parameters block

### DIFF
--- a/website/docs/r/ruleset.html.markdown
+++ b/website/docs/r/ruleset.html.markdown
@@ -160,11 +160,11 @@ resource "cloudflare_ruleset" "transform_uri_http_headers" {
         name      = "example-http-header-3-to-remove"
         operation = "remove"
       }
-
-      expression = "true"
-      description = "example request header transform rule"
-      enabled = false
     }
+    
+    expression = "true"
+    description = "example request header transform rule"
+    enabled = false
   }
 }
 


### PR DESCRIPTION
Local testing shows expression, enabled, and description should be located within the 'rules' block, not inside the 'action_parameters' block. This lines up with the other examples in this file.