### PR TITLE
Support purpose justification and approval groups in access policies

### DIFF
--- a/.changelog/1199.txt
+++ b/.changelog/1199.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_access_policy: add support for purpose justification and approvals
+```

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -105,7 +105,7 @@ var AccessPolicyApprovalGroupElement = &schema.Resource{
 	},
 }
 
-func APIAccessPolicyApprovalGroupToSchema(approvalGroup cloudflare.AccessApprovalGroup) map[string]interface{} {
+func apiAccessPolicyApprovalGroupToSchema(approvalGroup cloudflare.AccessApprovalGroup) map[string]interface{} {
 	data := make(map[string]interface{})
 	data["approvals_needed"] = approvalGroup.ApprovalsNeeded
 
@@ -119,7 +119,7 @@ func APIAccessPolicyApprovalGroupToSchema(approvalGroup cloudflare.AccessApprova
 	return data
 }
 
-func SchemaAccessPolicyApprovalGroupToApi(data map[string]interface{}) cloudflare.AccessApprovalGroup {
+func schemaAccessPolicyApprovalGroupToAPI(data map[string]interface{}) cloudflare.AccessApprovalGroup {
 	var approvalGroup cloudflare.AccessApprovalGroup
 
 	approvalGroup.ApprovalsNeeded, _ = data["approvals_needed"].(int)
@@ -183,7 +183,7 @@ func resourceCloudflareAccessPolicyRead(d *schema.ResourceData, meta interface{}
 	if len(accessPolicy.ApprovalGroups) != 0 {
 		approvalGroups := make([]map[string]interface{}, 0, len(accessPolicy.ApprovalGroups))
 		for _, apiApprovalGroup := range accessPolicy.ApprovalGroups {
-			approvalGroups = append(approvalGroups, APIAccessPolicyApprovalGroupToSchema(apiApprovalGroup))
+			approvalGroups = append(approvalGroups, apiAccessPolicyApprovalGroupToSchema(apiApprovalGroup))
 		}
 		d.Set("approvalGroups", approvalGroups)
 	}
@@ -346,7 +346,7 @@ func appendConditionalAccessPolicyFields(policy cloudflare.AccessPolicy, d *sche
 	approvalGroups := d.Get("approval_group").([]interface{})
 	for _, approvalGroup := range approvalGroups {
 		approvalGroupAsMap := approvalGroup.(map[string]interface{})
-		policy.ApprovalGroups = append(policy.ApprovalGroups, SchemaAccessPolicyApprovalGroupToApi(approvalGroupAsMap))
+		policy.ApprovalGroups = append(policy.ApprovalGroups, schemaAccessPolicyApprovalGroupToAPI(approvalGroupAsMap))
 	}
 
 	return policy

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -173,11 +173,11 @@ func resourceCloudflareAccessPolicyRead(d *schema.ResourceData, meta interface{}
 	}
 
 	if accessPolicy.PurposeJustificationRequired != nil {
-		d.Set("purpose_justification_required", *accessPolicy.PurposeJustificationRequired)
+		d.Set("purpose_justification_required", accessPolicy.PurposeJustificationRequired)
 	}
 
 	if accessPolicy.PurposeJustificationPrompt != nil {
-		d.Set("purpose_justification_prompt", *accessPolicy.PurposeJustificationPrompt)
+		d.Set("purpose_justification_prompt", accessPolicy.PurposeJustificationPrompt)
 	}
 
 	if len(accessPolicy.ApprovalGroups) != 0 {

--- a/cloudflare/resource_cloudflare_access_policy_test.go
+++ b/cloudflare/resource_cloudflare_access_policy_test.go
@@ -102,99 +102,99 @@ func TestAccCloudflareAccessPolicyWithZoneID(t *testing.T) {
 
 func testAccessPolicyServiceTokenConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_service_token" "%[1]s" {
-			account_id = "%[3]s"
-			name       = "%[1]s"
-		}
+    resource "cloudflare_access_service_token" "%[1]s" {
+      account_id = "%[3]s"
+      name       = "%[1]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "non_identity"
-			precedence     = "10"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "non_identity"
+      precedence     = "10"
 
-			include {
-				service_token = ["${cloudflare_access_service_token.%[1]s.id}"]
-			}
-		}
+      include {
+        service_token = ["${cloudflare_access_service_token.%[1]s.id}"]
+      }
+    }
 
-	`, resourceID, zone, accountID)
+  `, resourceID, zone, accountID)
 }
 
 func testAccessPolicyAnyServiceTokenConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "non_identity"
-			precedence     = "10"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "non_identity"
+      precedence     = "10"
 
-			include {
-				any_valid_service_token = true
-			}
-		}
+      include {
+        any_valid_service_token = true
+      }
+    }
 
-	`, resourceID, zone, accountID)
+  `, resourceID, zone, accountID)
 }
 
 func testAccessPolicyWithZoneID(resourceID, zone, zoneID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name    = "%[1]s"
-			zone_id = "%[3]s"
-			domain  = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name    = "%[1]s"
+      zone_id = "%[3]s"
+      domain  = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			zone_id        = "%[3]s"
-			decision       = "non_identity"
-			precedence     = "10"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      zone_id        = "%[3]s"
+      decision       = "non_identity"
+      precedence     = "10"
 
-			include {
-				any_valid_service_token = true
-			}
-		}
+      include {
+        any_valid_service_token = true
+      }
+    }
 
-	`, resourceID, zone, zoneID)
+  `, resourceID, zone, zoneID)
 }
 
 func testAccessPolicyWithZoneIDUpdated(resourceID, zone, zoneID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name    = "%[1]s"
-			zone_id = "%[3]s"
-			domain  = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name    = "%[1]s"
+      zone_id = "%[3]s"
+      domain  = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s-updated"
-			zone_id        = "%[3]s"
-			decision       = "non_identity"
-			precedence     = "10"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s-updated"
+      zone_id        = "%[3]s"
+      decision       = "non_identity"
+      precedence     = "10"
 
-			include {
-				any_valid_service_token = true
-			}
-		}
+      include {
+        any_valid_service_token = true
+      }
+    }
 
-	`, resourceID, zone, zoneID)
+  `, resourceID, zone, zoneID)
 }
 
 func TestAccCloudflareAccessPolicyGroup(t *testing.T) {
@@ -224,34 +224,34 @@ func TestAccCloudflareAccessPolicyGroup(t *testing.T) {
 
 func testAccessPolicyGroupConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_group" "%[1]s" {
-  			account_id     = "%[3]s"
-  			name           = "%[1]s"
+    resource "cloudflare_access_group" "%[1]s" {
+        account_id     = "%[3]s"
+        name           = "%[1]s"
 
-  			include {
-				  ip = ["127.0.0.1/32"]
-  			}
-		}
+        include {
+          ip = ["127.0.0.1/32"]
+        }
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "non_identity"
-			precedence     = "10"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "non_identity"
+      precedence     = "10"
 
-			include {
-				group = [cloudflare_access_group.%[1]s.id]
-			}
-		}
+      include {
+        group = [cloudflare_access_group.%[1]s.id]
+      }
+    }
 
-	`, resourceID, zone, accountID)
+  `, resourceID, zone, accountID)
 }
 
 func TestAccCloudflareAccessPolicyMTLS(t *testing.T) {
@@ -281,25 +281,25 @@ func TestAccCloudflareAccessPolicyMTLS(t *testing.T) {
 
 func testAccessPolicyMTLSConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "non_identity"
-			precedence     = "10"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "non_identity"
+      precedence     = "10"
 
-			include {
-				certificate = true
-			}
-		}
+      include {
+        certificate = true
+      }
+    }
 
-	`, resourceID, zone, accountID)
+  `, resourceID, zone, accountID)
 }
 
 func TestAccCloudflareAccessPolicyCommonName(t *testing.T) {
@@ -329,25 +329,25 @@ func TestAccCloudflareAccessPolicyCommonName(t *testing.T) {
 
 func testAccessPolicyCommonNameConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "allow"
-			precedence     = "1"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "allow"
+      precedence     = "1"
 
-			include {
-				common_name = "example@example.com"
-			}
-		}
+      include {
+        common_name = "example@example.com"
+      }
+    }
 
-	`, resourceID, zone, accountID)
+  `, resourceID, zone, accountID)
 }
 
 func TestAccCloudflareAccessPolicyEmailDomain(t *testing.T) {
@@ -377,25 +377,25 @@ func TestAccCloudflareAccessPolicyEmailDomain(t *testing.T) {
 
 func testAccessPolicyEmailDomainConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "allow"
-			precedence     = "1"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "allow"
+      precedence     = "1"
 
-			include {
-				email_domain = ["example.com"]
-			}
-		}
+      include {
+        email_domain = ["example.com"]
+      }
+    }
 
-	`, resourceID, zone, accountID)
+  `, resourceID, zone, accountID)
 }
 
 func TestAccCloudflareAccessPolicyEmails(t *testing.T) {
@@ -427,25 +427,25 @@ func TestAccCloudflareAccessPolicyEmails(t *testing.T) {
 
 func testAccessPolicyEmailsConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "allow"
-			precedence     = "1"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "allow"
+      precedence     = "1"
 
-			include {
-				email = ["a@example.com", "b@example.com"]
-			}
-		}
+      include {
+        email = ["a@example.com", "b@example.com"]
+      }
+    }
 
-	`, resourceID, zone, accountID)
+  `, resourceID, zone, accountID)
 }
 
 func TestAccCloudflareAccessPolicyEveryone(t *testing.T) {
@@ -475,25 +475,25 @@ func TestAccCloudflareAccessPolicyEveryone(t *testing.T) {
 
 func testAccessPolicyEveryoneConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "allow"
-			precedence     = "1"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "allow"
+      precedence     = "1"
 
-			include {
-				everyone = true
-			}
-		}
+      include {
+        everyone = true
+      }
+    }
 
-	`, resourceID, zone, accountID)
+  `, resourceID, zone, accountID)
 }
 
 func TestAccCloudflareAccessPolicyIPs(t *testing.T) {
@@ -525,25 +525,25 @@ func TestAccCloudflareAccessPolicyIPs(t *testing.T) {
 
 func testAccessPolicyIPsConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "allow"
-			precedence     = "1"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "allow"
+      precedence     = "1"
 
-			include {
-				ip = ["10.0.0.1/32", "10.0.0.2/32"]
-			}
-		}
+      include {
+        ip = ["10.0.0.1/32", "10.0.0.2/32"]
+      }
+    }
 
-	`, resourceID, zone, accountID)
+  `, resourceID, zone, accountID)
 }
 
 func TestAccCloudflareAccessPolicyAuthMethod(t *testing.T) {
@@ -573,25 +573,25 @@ func TestAccCloudflareAccessPolicyAuthMethod(t *testing.T) {
 
 func testAccessPolicyAuthMethodConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "allow"
-			precedence     = "1"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "allow"
+      precedence     = "1"
 
-			include {
-				auth_method = "hwk"
-			}
-		}
+      include {
+        auth_method = "hwk"
+      }
+    }
 
-	`, resourceID, zone, accountID)
+  `, resourceID, zone, accountID)
 }
 
 func TestAccCloudflareAccessPolicyGeo(t *testing.T) {
@@ -623,25 +623,25 @@ func TestAccCloudflareAccessPolicyGeo(t *testing.T) {
 
 func testAccessPolicyGeoConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "allow"
-			precedence     = "1"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "allow"
+      precedence     = "1"
 
-			include {
-				geo = ["US", "AU"]
-			}
-		}
+      include {
+        geo = ["US", "AU"]
+      }
+    }
 
-	`, resourceID, zone, accountID)
+  `, resourceID, zone, accountID)
 }
 
 func TestAccCloudflareAccessPolicyOkta(t *testing.T) {
@@ -674,31 +674,30 @@ func TestAccCloudflareAccessPolicyOkta(t *testing.T) {
 
 func testAccessPolicyOktaConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "allow"
-			precedence     = "1"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "allow"
+      precedence     = "1"
 
-			include {
-				okta {
-					name = ["jacob-group", "jacob-group1"]
-					identity_provider_id = "225934dc-14e4-4f55-87be-f5d798d23f91"
-				}
-			}
-		}
-
-	`, resourceID, zone, accountID)
+      include {
+        okta {
+          name = ["jacob-group", "jacob-group1"]
+          identity_provider_id = "225934dc-14e4-4f55-87be-f5d798d23f91"
+        }
+      }
+    }
+  `, resourceID, zone, accountID)
 }
 
-func TestAccessPolicyPurposeJustification(t *testing.T) {
+func TestAccCloudflareAccessPolicyPurposeJustification(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "cloudflare_access_policy." + rnd
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -725,31 +724,30 @@ func TestAccessPolicyPurposeJustification(t *testing.T) {
 
 func testAccessPolicyPurposeJustificationConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "allow"
-			precedence     = "1"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "allow"
+      precedence     = "1"
 
-			include {
-				email = ["a@example.com", "b@example.com"]
-			}
+      include {
+        email = ["a@example.com", "b@example.com"]
+      }
 
-			purpose_justification_required = "true"
-			purpose_justification_prompt = "Why should we let you in?"
-		}
-
-	`, resourceID, zone, accountID)
+      purpose_justification_required = "true"
+      purpose_justification_prompt = "Why should we let you in?"
+    }
+  `, resourceID, zone, accountID)
 }
 
-func TestAccessPolicyApprovalGroup(t *testing.T) {
+func TestAccCloudflareAccessPolicyApprovalGroup(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "cloudflare_access_policy." + rnd
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -782,35 +780,35 @@ func TestAccessPolicyApprovalGroup(t *testing.T) {
 
 func testAccessPolicyApprovalGroupConfig(resourceID, zone, accountID string) string {
 	return fmt.Sprintf(`
-		resource "cloudflare_access_application" "%[1]s" {
-			name       = "%[1]s"
-			account_id = "%[3]s"
-			domain     = "%[1]s.%[2]s"
-		}
+    resource "cloudflare_access_application" "%[1]s" {
+      name       = "%[1]s"
+      account_id = "%[3]s"
+      domain     = "%[1]s.%[2]s"
+    }
 
-		resource "cloudflare_access_policy" "%[1]s" {
-			application_id = "${cloudflare_access_application.%[1]s.id}"
-			name           = "%[1]s"
-			account_id     = "%[3]s"
-			decision       = "allow"
-			precedence     = "1"
+    resource "cloudflare_access_policy" "%[1]s" {
+      application_id = "${cloudflare_access_application.%[1]s.id}"
+      name           = "%[1]s"
+      account_id     = "%[3]s"
+      decision       = "allow"
+      precedence     = "1"
 
-			purpose_justification_required = "true"
-			purpose_justification_prompt = "Why should we let you in?"
+      purpose_justification_required = "true"
+      purpose_justification_prompt = "Why should we let you in?"
 
-			include {
-				email = ["a@example.com", "b@example.com"]
-			}
+      include {
+        email = ["a@example.com", "b@example.com"]
+      }
 
-			approval_group {
-				email_addresses = ["test1@cloudflare.com", "test2@cloudflare.com", "test3@cloudflare.com"]
-				approvals_needed = "2"
-			}
+      approval_group {
+        email_addresses = ["test1@cloudflare.com", "test2@cloudflare.com", "test3@cloudflare.com"]
+        approvals_needed = "2"
+      }
 
-			approval_group {
-				email_addresses = ["test4@cloudflare.com"]
-				approvals_needed = "1"
-			}
-		}
-	`, resourceID, zone, accountID)
+      approval_group {
+        email_addresses = ["test4@cloudflare.com"]
+        approvals_needed = "1"
+      }
+    }
+  `, resourceID, zone, accountID)
 }

--- a/cloudflare/resource_cloudflare_access_policy_test.go
+++ b/cloudflare/resource_cloudflare_access_policy_test.go
@@ -766,10 +766,10 @@ func TestAccCloudflareAccessPolicyApprovalGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "purpose_justification_required", "true"),
 					resource.TestCheckResourceAttr(name, "purpose_justification_prompt", "Why should we let you in?"),
-					resource.TestCheckResourceAttr(name, "approval_group.0.email_addresses.0", "test1@cloudflare.com"),
-					resource.TestCheckResourceAttr(name, "approval_group.0.email_addresses.1", "test2@cloudflare.com"),
-					resource.TestCheckResourceAttr(name, "approval_group.0.email_addresses.2", "test3@cloudflare.com"),
-					resource.TestCheckResourceAttr(name, "approval_group.1.email_addresses.0", "test4@cloudflare.com"),
+					resource.TestCheckResourceAttr(name, "approval_group.0.email_addresses.0", "test1@example.com"),
+					resource.TestCheckResourceAttr(name, "approval_group.0.email_addresses.1", "test2@example.com"),
+					resource.TestCheckResourceAttr(name, "approval_group.0.email_addresses.2", "test3@example.com"),
+					resource.TestCheckResourceAttr(name, "approval_group.1.email_addresses.0", "test4@example.com"),
 					resource.TestCheckResourceAttr(name, "approval_group.0.approvals_needed", "2"),
 					resource.TestCheckResourceAttr(name, "approval_group.1.approvals_needed", "1"),
 				),
@@ -801,12 +801,12 @@ func testAccessPolicyApprovalGroupConfig(resourceID, zone, accountID string) str
       }
 
       approval_group {
-        email_addresses = ["test1@cloudflare.com", "test2@cloudflare.com", "test3@cloudflare.com"]
+        email_addresses = ["test1@example.com", "test2@example.com", "test3@example.com"]
         approvals_needed = "2"
       }
 
       approval_group {
-        email_addresses = ["test4@cloudflare.com"]
+        email_addresses = ["test4@example.com"]
         approvals_needed = "1"
       }
     }

--- a/website/docs/r/access_policy.html.markdown
+++ b/website/docs/r/access_policy.html.markdown
@@ -26,7 +26,7 @@ resource "cloudflare_access_policy" "test_policy" {
   include {
     email = ["test@example.com"]
   }
-  
+
   require {
     email = ["test@example.com"]
   }
@@ -64,10 +64,18 @@ The following arguments are supported:
   Allowed values: `allow`, `deny`, `non_identity`, `bypass`
 * `name` - (Required) Friendly name of the Access Application.
 * `precedence` - (Required) The unique precedence for policies on a single application. Integer.
+* `purpose_justification_required` - (Optional) Boolean of whether to prompt the user for a justification for accessing the resource.
+* `purpose_justification_prompt` - (Optional) String to present to the user when purpose justification is enabled.
 * `require` - (Optional) A series of access conditions, see [Access Groups](/providers/cloudflare/cloudflare/latest/docs/resources/access_group#conditions).
 * `exclude` - (Optional) A series of access conditions, see [Access Groups](/providers/cloudflare/cloudflare/latest/docs/resources/access_group#conditions).
 * `include` - (Required) A series of access conditions, see [Access Groups](/providers/cloudflare/cloudflare/latest/docs/resources/access_group#conditions).
+* `approval_group` - (Optional) List of approval group blocks for configuring additional approvals (refer to the [nested schema](#nestedblock--approval-group)).
 
+<a id="#nestedblock--approval-group"></a>
+**Nested schema for `approval_group`**
+
+* `email_addresses` - (Optional) List of emails to request approval from.
+* `approvals_needed` - (Optional) Number of approvals needed.
 
 ## Import
 


### PR DESCRIPTION
AUTH-3696

Adds support for purpose justification and approval groups as part of a new update to access policies.

Depends on https://github.com/cloudflare/cloudflare-go/pull/706
