### PR TITLE
set values to role ID's in resourceCloudflareAccountMemberRead

### DIFF
--- a/.changelog/1202.txt
+++ b/.changelog/1202.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_account_member: fix the issue - provider not able to detect changes made via UI for account member role Id's
+```

--- a/cloudflare/resource_cloudflare_account_member.go
+++ b/cloudflare/resource_cloudflare_account_member.go
@@ -39,7 +39,7 @@ func resourceCloudflareAccountMember() *schema.Resource {
 func resourceCloudflareAccountMemberRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.API)
 
-	_, err := client.AccountMember(context.Background(), client.AccountID, d.Id())
+	member, err := client.AccountMember(context.Background(), client.AccountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "Member not found") ||
 			strings.Contains(err.Error(), "HTTP status 404") {
@@ -49,7 +49,14 @@ func resourceCloudflareAccountMemberRead(d *schema.ResourceData, meta interface{
 		}
 		return err
 	}
-
+	
+	var memberIDs []string
+	for _, role := range member.Roles {
+		memberIDs = append(memberIDs, role.ID)
+	}
+	
+	d.Set("email_address", member.User.Email)
+	d.Set("role_ids", memberIDs)
 	d.SetId(d.Id())
 
 	return nil

--- a/cloudflare/resource_cloudflare_account_member.go
+++ b/cloudflare/resource_cloudflare_account_member.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareAccountMember() *schema.Resource {

--- a/cloudflare/resource_cloudflare_account_member.go
+++ b/cloudflare/resource_cloudflare_account_member.go
@@ -49,12 +49,12 @@ func resourceCloudflareAccountMemberRead(d *schema.ResourceData, meta interface{
 		}
 		return err
 	}
-	
+
 	var memberIDs []string
 	for _, role := range member.Roles {
 		memberIDs = append(memberIDs, role.ID)
 	}
-	
+
 	d.Set("email_address", member.User.Email)
 	d.Set("role_ids", memberIDs)
 	d.SetId(d.Id())

--- a/cloudflare/resource_cloudflare_account_member_test.go
+++ b/cloudflare/resource_cloudflare_account_member_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccCloudflareAccountMemberBasic(t *testing.T) {
 	rnd := generateRandomResourceName()
-	name := "cloudflare_account_mamber." + rnd
+	name := "cloudflare_account_member." + rnd
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/cloudflare/resource_cloudflare_account_member_test.go
+++ b/cloudflare/resource_cloudflare_account_member_test.go
@@ -1,0 +1,40 @@
+package cloudflare
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccCloudflareAccountMemberBasic(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_account_mamber." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckAccount(t)
+			testAccPreCheckEmail(t)
+			testAccPreCheckApiKey(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testCloudflareAccountMemberBasicConfig(rnd, fmt.Sprintf("%s@domain.com", rnd)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "email_address", fmt.Sprintf("%s@domain.com", rnd)),
+					resource.TestCheckResourceAttr(name, "role_ids.#", "1"),
+					resource.TestCheckResourceAttr(name, "role_ids.0", "05784afa30c1afe1440e79d9351c7430"),
+				),
+			},
+		},
+	})
+}
+
+func testCloudflareAccountMemberBasicConfig(resourceID, emailAddress string) string {
+	return fmt.Sprintf(`
+				resource "cloudflare_account_member" "%[1]s" {
+					email_address = "%[2]s"
+					role_ids = [ "05784afa30c1afe1440e79d9351c7430" ]
+				}`, resourceID, emailAddress)
+}

--- a/cloudflare/resource_cloudflare_account_member_test.go
+++ b/cloudflare/resource_cloudflare_account_member_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccCloudflareAccountMemberBasic(t *testing.T) {

--- a/cloudflare/resource_cloudflare_account_member_test.go
+++ b/cloudflare/resource_cloudflare_account_member_test.go
@@ -20,9 +20,9 @@ func TestAccCloudflareAccountMemberBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testCloudflareAccountMemberBasicConfig(rnd, fmt.Sprintf("%s@domain.com", rnd)),
+				Config: testCloudflareAccountMemberBasicConfig(rnd, fmt.Sprintf("%s@example.com", rnd)),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "email_address", fmt.Sprintf("%s@domain.com", rnd)),
+					resource.TestCheckResourceAttr(name, "email_address", fmt.Sprintf("%s@example.com", rnd)),
 					resource.TestCheckResourceAttr(name, "role_ids.#", "1"),
 					resource.TestCheckResourceAttr(name, "role_ids.0", "05784afa30c1afe1440e79d9351c7430"),
 				),

--- a/cloudflare/resource_cloudflare_account_member_test.go
+++ b/cloudflare/resource_cloudflare_account_member_test.go
@@ -33,8 +33,8 @@ func TestAccCloudflareAccountMemberBasic(t *testing.T) {
 
 func testCloudflareAccountMemberBasicConfig(resourceID, emailAddress string) string {
 	return fmt.Sprintf(`
-				resource "cloudflare_account_member" "%[1]s" {
-					email_address = "%[2]s"
-					role_ids = [ "05784afa30c1afe1440e79d9351c7430" ]
-				}`, resourceID, emailAddress)
+  resource "cloudflare_account_member" "%[1]s" {
+    email_address = "%[2]s"
+    role_ids = [ "05784afa30c1afe1440e79d9351c7430" ]
+  }`, resourceID, emailAddress)
 }


### PR DESCRIPTION
Cloudflare provider is not able to give diff for the changes made via UI in role ID's. Fixing it by setting values to role ids in resourceCloudflareAccountMemberRead.