### PR TITLE
Add `cloudflare_zone` data resource (singular)

### DIFF
--- a/.changelog/1213.txt
+++ b/.changelog/1213.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+cloudflare_zone
+```

--- a/cloudflare/data_source_zone.go
+++ b/cloudflare/data_source_zone.go
@@ -97,7 +97,14 @@ func dataSourceCloudflareZoneRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("status", zone.Status)
 	d.Set("paused", zone.Paused)
 	d.Set("plan", zone.Plan.Name)
-	d.Set("name_servers", zone.NameServers)
-	d.Set("vanity_name_servers", zone.VanityNS)
+
+	if err := d.Set("name_servers", zone.NameServers); err != nil {
+		return fmt.Errorf("failed to set name_servers attribute: %s", err)
+	}
+
+	if err := d.Set("vanity_name_servers", zone.VanityNS); err != nil {
+		return fmt.Errorf("failed to set vanity_name_servers attribute: %s", err)
+	}
+
 	return nil
 }

--- a/cloudflare/data_source_zone.go
+++ b/cloudflare/data_source_zone.go
@@ -1,0 +1,116 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
+)
+
+func dataSourceCloudflareZone() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCloudflareZoneRead,
+
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"name"},
+			},
+			"account_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"zone_id"},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"paused": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"plan": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name_servers": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"vanity_name_servers": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceCloudflareZoneRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Reading Zones")
+	client := meta.(*cloudflare.API)
+
+	zoneID, zoneIDExists := d.GetOk("zone_id")
+	zoneID = zoneID.(string)
+
+	name, nameExists := d.GetOk("name")
+	name = name.(string)
+
+	accountID := d.Get("account_id")
+	accountID = accountID.(string)
+
+	if nameExists && zoneIDExists {
+		return fmt.Errorf("zone_id and name arguments can't be used together")
+	}
+
+	if !nameExists && !zoneIDExists {
+		return fmt.Errorf("either zone_id or name must be set")
+	}
+
+	var zone cloudflare.Zone
+	if nameExists && !zoneIDExists { // if only the name was provided
+		zoneFilter := cloudflare.WithZoneFilters(name.(string), accountID.(string), "")
+		zonesResp, err := client.ListZonesContext(context.Background(), zoneFilter)
+
+		if err != nil {
+			return fmt.Errorf("error listing zones: %s", err)
+		}
+
+		if zonesResp.Total > 1 {
+			return fmt.Errorf("more than one zone was returned; consider using `cloudflare_zones` data source with filtering to target the zone more specifically")
+		}
+
+		if zonesResp.Total == 0 {
+			return fmt.Errorf("no zone found")
+		}
+
+		zone = zonesResp.Result[0]
+	} else {
+		var err error
+		zone, err = client.ZoneDetails(context.Background(), zoneID.(string))
+		if err != nil {
+			return fmt.Errorf("error getting zone details: %s", err)
+		}
+	}
+
+	d.SetId(zone.ID)
+	d.Set("zone_id", zone.ID)
+	d.Set("account_id", zone.Account.ID)
+	d.Set("name", zone.Name)
+	d.Set("status", zone.Status)
+	d.Set("paused", zone.Paused)
+	d.Set("plan", zone.Plan.Name)
+	d.Set("name_servers", zone.NameServers)
+	d.Set("vanity_name_servers", zone.VanityNS)
+	return nil
+}

--- a/cloudflare/data_source_zone.go
+++ b/cloudflare/data_source_zone.go
@@ -44,13 +44,17 @@ func dataSourceCloudflareZone() *schema.Resource {
 				Computed: true,
 			},
 			"name_servers": {
-				Type:     schema.TypeList,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 				Computed: true,
 			},
 			"vanity_name_servers": {
-				Type:     schema.TypeList,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 				Computed: true,
 			},
 		},
@@ -74,7 +78,7 @@ func dataSourceCloudflareZoneRead(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		if zonesResp.Total > 1 {
-			return fmt.Errorf("more than one zone was returned; consider using `cloudflare_zones` data source with filtering to target the zone more specifically")
+			return fmt.Errorf("more than one zone was returned; consider adding the `account_id` to the existing resource or use the `cloudflare_zones` data source with filtering to target the zone more specifically")
 		}
 
 		if zonesResp.Total == 0 {
@@ -84,7 +88,7 @@ func dataSourceCloudflareZoneRead(d *schema.ResourceData, meta interface{}) erro
 		zone = zonesResp.Result[0]
 	} else {
 		var err error
-		zone, err = client.ZoneDetails(context.Background(), zoneID.(string))
+		zone, err = client.ZoneDetails(context.Background(), zoneID)
 		if err != nil {
 			return fmt.Errorf("error getting zone details: %s", err)
 		}

--- a/cloudflare/data_source_zone_test.go
+++ b/cloudflare/data_source_zone_test.go
@@ -1,0 +1,65 @@
+package cloudflare
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccCloudflareZone_PreventZoneIdAndNameConflicts(t *testing.T) {
+
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCloudflareZoneConfigConflictingFields(rnd),
+				ExpectError: regexp.MustCompile(regexp.QuoteMeta("only one of `name,zone_id` can be specified")),
+			},
+		},
+	})
+}
+
+func testAccCloudflareZoneConfigConflictingFields(rnd string) string {
+	return fmt.Sprintf(`
+data "cloudflare_zone" "%[1]s" {
+  name    = "terraform.cfapi.net"
+  zone_id = "abc123"
+}
+`, rnd)
+}
+
+func TestAccCloudflareZone_NameLookup(t *testing.T) {
+
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("data.cloudflare_zone.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareZoneConfigBasic(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareZonesDataSourceID(name),
+					resource.TestCheckResourceAttr(name, "name", "terraform.cfapi.net"),
+					resource.TestCheckResourceAttr(name, "zone_id", testAccCloudflareZoneID),
+					resource.TestCheckResourceAttr(name, "status", "active"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareZoneConfigBasic(rnd string) string {
+	return fmt.Sprintf(`
+data "cloudflare_zone" "%[1]s" {
+  name = "terraform.cfapi.net"
+}
+`, rnd)
+}

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -99,6 +99,7 @@ func Provider() *schema.Provider {
 			"cloudflare_waf_packages":                dataSourceCloudflareWAFPackages(),
 			"cloudflare_waf_rules":                   dataSourceCloudflareWAFRules(),
 			"cloudflare_zones":                       dataSourceCloudflareZones(),
+			"cloudflare_zone":                        dataSourceCloudflareZone(),
 			"cloudflare_zone_dnssec":                 dataSourceCloudflareZoneDNSSEC(),
 		},
 

--- a/website/docs/d/zone.html.md
+++ b/website/docs/d/zone.html.md
@@ -2,18 +2,20 @@
 layout: "cloudflare"
 page_title: "Cloudflare: cloudflare_zone"
 sidebar_current: "docs-cloudflare-datasource-zone"
-description: |- Get information on a Cloudflare Zone.
+description: Get information on a Cloudflare Zone.
 ---
 
 # cloudflare_zone
 
-Use this data source to look up [Zone][1] info. This is the singular alternative to `cloudflare_zones`.
+Use this data source to look up [zone] info. This is the singular alternative
+to `cloudflare_zones`.
+
+~> **Note** Cloudflare zone names **are not unique**. It is possible for multiple
+  accounts to have the same zone created but in different states. If you are
+  using this setup, it is advised to use the `account_id` attribute on this
+  resource or swap to `cloudflare_zones` to further filter the results.
 
 ## Example usage
-
-Given you have the following zones in Cloudflare.
-
-- example.com
 
 ```hcl
 # Look for a single zone that you know exists using an exact match.
@@ -21,16 +23,22 @@ data "cloudflare_zone" "example" {
   name = "example.com"
 }
 
-# you can also lookup by zone_id
+# Look for a zone in a specific account by the zone name.
 data "cloudflare_zone" "example" {
-  zone_id = "<zone_id>"
+  name       = "example.com"
+  account_id = "d41d8cd98f00b204e9800998ecf8427e"
+}
+
+# You can also lookup by zone_id if you prefer.
+data "cloudflare_zone" "example" {
+  zone_id = "0b6d347b01d437a092be84c2edfce72c"
 }
 ```
 
 ### Example usage with other resources
 
-The example below fetches the zone information for example.com and then is referenced in the `cloudflare_record`
-section.
+The example below fetches the zone information for example.com and then is
+referenced in the `cloudflare_record` section.
 
 ```hcl
 data "cloudflare_zone" "example" {
@@ -38,32 +46,29 @@ data "cloudflare_zone" "example" {
 }
 
 resource "cloudflare_record" "example" {
-  zone_id     = cloudflare_zone.example.zone_id # or shorthand cloudflare_zone.example.id
-  name        = "www"
-  value       = "203.0.113.1"
-  type        = "A"
-  proxied     = true
+  zone_id = cloudflare_zone.example.id
+  name    = "www"
+  value   = "203.0.113.1"
+  type    = "A"
+  proxied = true
 }
 ```
 
 ## Argument Reference
 
--> **Note:** It's only required specify **one of** `zone_id` or `name`.
-
-- `zone_id` - (Optional) The zone ID.
-- `name` - (Optional) The name of the zone.
+- `zone_id` - (Optional) The zone ID. Conflicts with `"name"`.
+- `name` - (Optional) The name of the zone. Conflicts with `"zone_id"`.
 
 ## Attributes Reference
 
-- `id` - The zone ID. Same value as `zone_id`.
-- `zone_id` - The zone ID.
+- `id` - The zone ID.
 - `account_id` - The account ID associated with the zone.
 - `name` - The name of the zone.
-- `status` - Status of the zone. Values can be: `active`, `pending`, `initializing`, `moved`, `deleted`,
-  or `deactivated`.
+- `status` - Status of the zone. Values can be: `"active"`, `"pending"`, `"initializing"`, `"moved"`, `"deleted"`,
+  or `"deactivated"`.
 - `paused` - `true` if cloudflare is enabled on the zone, otherwise `false`.
 - `plan` - The name of the plan associated with the zone.
-- `name_servers` - Cloudflare-assigned name servers. This is only populated for zones that use Cloudflare DNS.
+- `name_servers` - Cloudflare assigned name servers. This is only populated for zones that use Cloudflare DNS.
 - `vanity_name_servers` - List of Vanity Nameservers (if set).
 
-[1]: https://api.cloudflare.com/#zone-properties
+[zone]: https://api.cloudflare.com/#zone-properties

--- a/website/docs/d/zone.html.md
+++ b/website/docs/d/zone.html.md
@@ -1,0 +1,69 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_zone"
+sidebar_current: "docs-cloudflare-datasource-zone"
+description: |- Get information on a Cloudflare Zone.
+---
+
+# cloudflare_zone
+
+Use this data source to look up [Zone][1] info. This is the singular alternative to `cloudflare_zones`.
+
+## Example usage
+
+Given you have the following zones in Cloudflare.
+
+- example.com
+
+```hcl
+# Look for a single zone that you know exists using an exact match.
+data "cloudflare_zone" "example" {
+  name = "example.com"
+}
+
+# you can also lookup by zone_id
+data "cloudflare_zone" "example" {
+  zone_id = "<zone_id>"
+}
+```
+
+### Example usage with other resources
+
+The example below fetches the zone information for example.com and then is referenced in the `cloudflare_record`
+section.
+
+```hcl
+data "cloudflare_zone" "example" {
+  name = "example.com"
+}
+
+resource "cloudflare_record" "example" {
+  zone_id     = cloudflare_zone.example.zone_id # or shorthand cloudflare_zone.example.id
+  name        = "www"
+  value       = "203.0.113.1"
+  type        = "A"
+  proxied     = true
+}
+```
+
+## Argument Reference
+
+-> **Note:** It's only required specify **one of** `zone_id` or `name`.
+
+- `zone_id` - (Optional) The zone ID.
+- `name` - (Optional) The name of the zone.
+
+## Attributes Reference
+
+- `id` - The zone ID. Same value as `zone_id`.
+- `zone_id` - The zone ID.
+- `account_id` - The account ID associated with the zone.
+- `name` - The name of the zone.
+- `status` - Status of the zone. Values can be: `active`, `pending`, `initializing`, `moved`, `deleted`,
+  or `deactivated`.
+- `paused` - `true` if cloudflare is enabled on the zone, otherwise `false`.
+- `plan` - The name of the plan associated with the zone.
+- `name_servers` - Cloudflare-assigned name servers. This is only populated for zones that use Cloudflare DNS.
+- `vanity_name_servers` - List of Vanity Nameservers (if set).
+
+[1]: https://api.cloudflare.com/#zone-properties


### PR DESCRIPTION
This commit adds `cloudflare_zone` as a data source. While support for this technically exists by using `cloudflare_zones` and a `lookup`, I think we should explicitly support this approach as well for providing data about zones.

One concern I have is that the same set of fields should be returned when using `cloudflare_zone` or `cloudflare_zones`. Currently, `cloudflare_zones` only returns `id` and `name`. 