### PR TITLE
resource/cloudflare_origin_ca_certificate: ignore requested_validity changes

### DIFF
--- a/.changelog/1214.txt
+++ b/.changelog/1214.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_origin_ca_certificate: ignore `requested_validity` changes due to the value decreasing but still store it
+```

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -56,10 +56,8 @@ func resourceCloudflareOriginCACertificate() *schema.Resource {
 			"requested_validity": {
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IntInSlice([]int{7, 30, 90, 365, 730, 1095, 5475}),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return true
-				},
 			},
 		},
 	}
@@ -83,12 +81,11 @@ func resourceCloudflareOriginCACertificateCreate(d *schema.ResourceData, meta in
 		certInput.CSR = csr.(string)
 	}
 
-	requestValidity, ok := d.GetOk("requested_validity")
-	if ok {
+	if requestValidity, ok := d.GetOk("requested_validity"); ok {
 		certInput.RequestValidity = requestValidity.(int)
 	}
 
-	log.Printf("[INFO] Creating Cloudflare OriginCACertificate: hostnames %v", hostnames)
+	log.Printf("[INFO] Creating Cloudflare OriginCACertificate: %#v", certInput)
 	cert, err := client.CreateOriginCertificate(context.Background(), certInput)
 
 	if err != nil {


### PR DESCRIPTION
In #1078 we shipped a change that would ignore the `requested_validity`
attribute as it is an ever decreasing value that shouldn't trigger a
change. However, digging into this has surfaced [a bug in
`terraform-plugin-sdk`](https://github.com/hashicorp/terraform-plugin-sdk/issues/806) that is preventing the schema from providing
the value to the CRUD method due to the presence of `DiffSuppressFunc`.
Instead of using a `DiffSuppressFunc`, mark the attribute as Optional
and Computed to allow it to be ignored when it decreases.

Fixes the following acceptance test failure too

```
=== RUN   TestAccCloudflareOriginCACertificate_Basic
    resource_cloudflare_origin_ca_certificate_test.go:34: Step 1/2 error: Check failed: Check 6/6 error: cloudflare_origin_ca_certificate.mjrtkutxmm: Attribute 'requested_validity' expected "7", got "5475"
```

Closes #1160
