### PR TITLE
provider: add support for debuggers!

### DIFF
--- a/.changelog/1217.txt
+++ b/.changelog/1217.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: add support for debugging via debuggers (like delve)
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -73,7 +73,7 @@ clean-dev:
 
 build-dev: clean-dev
 	@echo "Building development version ($(dev_version))"
-	go build -o terraform-provider-cloudflare_$(dev_version)
+	go build -gcflags="all=-N -l" -o terraform-provider-cloudflare_$(dev_version)
 
 generate-changelog:
 	@echo "==> Generating changelog..."

--- a/main.go
+++ b/main.go
@@ -1,11 +1,31 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/cloudflare/terraform-provider-cloudflare/cloudflare"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: cloudflare.Provider})
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{
+		ProviderFunc: cloudflare.Provider,
+	}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/cloudflare/cloudflare", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
Now that we are on `terraform-plugin-sdk` v2, we can use real debuggers.