### PR TITLE
resource/cloudflare_record: handle updating for records with `data`

### DIFF
--- a/.changelog/1229.txt
+++ b/.changelog/1229.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_record: handle `Update`s for records with `data` blocks
+```

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -507,7 +507,8 @@ func resourceCloudflareRecordUpdate(d *schema.ResourceData, meta interface{}) er
 	newDataMap := make(map[string]interface{})
 
 	if dataOk {
-		for id, value := range data.(map[string]interface{}) {
+		dataMap := data.([]interface{})[0]
+		for id, value := range dataMap.(map[string]interface{}) {
 			newData, err := transformToCloudflareDNSData(updateRecord.Type, id, value)
 			if err != nil {
 				return err


### PR DESCRIPTION
Fixes the `Update` to respect the `[]interface{}`s for the 3.x data
block.

Closes #1227