### PR TITLE
Adds approval_required flag to access policies

### DIFF
--- a/.changelog/1218.txt
+++ b/.changelog/1218.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_access_policy: add support for approval_required flag
+```

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -75,6 +75,10 @@ func resourceCloudflareAccessPolicy() *schema.Resource {
 				Optional:     true,
 				RequiredWith: []string{"purpose_justification_required"},
 			},
+			"approval_required": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"approval_group": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -178,6 +182,10 @@ func resourceCloudflareAccessPolicyRead(d *schema.ResourceData, meta interface{}
 
 	if accessPolicy.PurposeJustificationPrompt != nil {
 		d.Set("purpose_justification_prompt", accessPolicy.PurposeJustificationPrompt)
+	}
+
+	if accessPolicy.ApprovalRequired != nil {
+		d.Set("approval_required", accessPolicy.ApprovalRequired)
 	}
 
 	if len(accessPolicy.ApprovalGroups) != 0 {
@@ -344,6 +352,9 @@ func appendConditionalAccessPolicyFields(policy cloudflare.AccessPolicy, d *sche
 
 	purposeJustificationPrompt := d.Get("purpose_justification_prompt").(string)
 	policy.PurposeJustificationPrompt = &purposeJustificationPrompt
+
+	approvalRequired := d.Get("approval_required").(bool)
+	policy.ApprovalRequired = &approvalRequired
 
 	approvalGroups := d.Get("approval_group").([]interface{})
 	for _, approvalGroup := range approvalGroups {

--- a/cloudflare/resource_cloudflare_access_policy_test.go
+++ b/cloudflare/resource_cloudflare_access_policy_test.go
@@ -766,6 +766,7 @@ func TestAccCloudflareAccessPolicyApprovalGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "purpose_justification_required", "true"),
 					resource.TestCheckResourceAttr(name, "purpose_justification_prompt", "Why should we let you in?"),
+					resource.TestCheckResourceAttr(name, "approval_required", "true"),
 					resource.TestCheckResourceAttr(name, "approval_group.0.email_addresses.0", "test1@example.com"),
 					resource.TestCheckResourceAttr(name, "approval_group.0.email_addresses.1", "test2@example.com"),
 					resource.TestCheckResourceAttr(name, "approval_group.0.email_addresses.2", "test3@example.com"),
@@ -795,6 +796,7 @@ func testAccessPolicyApprovalGroupConfig(resourceID, zone, accountID string) str
 
       purpose_justification_required = "true"
       purpose_justification_prompt = "Why should we let you in?"
+      approval_required = "true"
 
       include {
         email = ["a@example.com", "b@example.com"]


### PR DESCRIPTION
Adds a approval_required flag to toggle on/off approval_groups influence on the access policy.
Approval groups can still be configured without the flag = false, but will have no effect when access parses the policy.

Builds failing because it depends on an yet unreleased cloudflare-go version
