### PR TITLE
resource/cloudflare_access_group: handle `nil` groupings

### DIFF
--- a/.changelog/1237.txt
+++ b/.changelog/1237.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_access_policy: handle empty `nil` values for building policies
+```

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -394,17 +394,23 @@ func resourceCloudflareAccessGroupImport(d *schema.ResourceData, meta interface{
 func appendConditionalAccessGroupFields(group cloudflare.AccessGroup, d *schema.ResourceData) cloudflare.AccessGroup {
 	exclude := d.Get("exclude").([]interface{})
 	for _, value := range exclude {
-		group.Exclude = BuildAccessGroupCondition(value.(map[string]interface{}))
+		if value != nil {
+			group.Exclude = BuildAccessGroupCondition(value.(map[string]interface{}))
+		}
 	}
 
 	require := d.Get("require").([]interface{})
 	for _, value := range require {
-		group.Require = BuildAccessGroupCondition(value.(map[string]interface{}))
+		if value != nil {
+			group.Require = BuildAccessGroupCondition(value.(map[string]interface{}))
+		}
 	}
 
 	include := d.Get("include").([]interface{})
 	for _, value := range include {
-		group.Include = BuildAccessGroupCondition(value.(map[string]interface{}))
+		if value != nil {
+			group.Include = BuildAccessGroupCondition(value.(map[string]interface{}))
+		}
 	}
 
 	return group


### PR DESCRIPTION
Don't attempt to pass `nil`s to the BuildAccessGroupCondition.

Closes #1142