### PR TITLE
resource/cloudflare_ruleset: don't attempt to update the phase for "custom" rulesets

### DIFF
--- a/.changelog/1245.txt
+++ b/.changelog/1245.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: don't attempt to update "custom" rulesets using the phase entrypoint
+```


### PR DESCRIPTION
After creating the base Ruleset, we usually attempt to update it in place
however Rulesets with a "custom" kind don't need this so we can remove it.

Closes #1242