### PR TITLE
add access groups data source

### DIFF
--- a/cloudflare/data_source_access_groups.go
+++ b/cloudflare/data_source_access_groups.go
@@ -62,9 +62,7 @@ func dataSourceCloudflareAccessGroups() *schema.Resource {
 
 func paginateAllGroups(readAccessGroupHandler func (ctx context.Context, accountID string, pageOpts cloudflare.PaginationOptions) ([]cloudflare.AccessGroup, cloudflare.ResultInfo, error), filter string) ([]cloudflare.AccessGroup, error) {
 	var groups []cloudflare.AccessGroup
-	paginationOptions := cloudflare.PaginationOptions{
-		PerPage: 100,
-	}
+	paginationOptions := cloudflare.PaginationOptions{}
 
 	for {
 		groupPage, resultInfo, err := readAccessGroupHandler(context.Background(), filter, paginationOptions)

--- a/cloudflare/data_source_access_groups.go
+++ b/cloudflare/data_source_access_groups.go
@@ -106,7 +106,6 @@ func dataSourceCloudflareAccessGroupsRead(d *schema.ResourceData, meta interface
 		return nil
 	}
 
-	d.Set("groups", groups)
 	if err != nil {
 		return fmt.Errorf("error setting access groups: %s", err)
 	}
@@ -123,7 +122,10 @@ func dataSourceCloudflareAccessGroupsRead(d *schema.ResourceData, meta interface
 		})
 		groupIds = append(groupIds, g.ID)
 	}
-
+	err = d.Set("groups", groupDetails)
+	if err != nil {
+		return fmt.Errorf("error setting access groups: %s", err)
+	}
 	d.SetId(stringListChecksum(groupIds))
 	return nil
 }

--- a/cloudflare/data_source_access_groups.go
+++ b/cloudflare/data_source_access_groups.go
@@ -60,7 +60,7 @@ func dataSourceCloudflareAccessGroups() *schema.Resource {
 	}
 }
 
-func paginateAllGroups(readAccessGroupHandler func (ctx context.Context, accountID string, pageOpts cloudflare.PaginationOptions) ([]cloudflare.AccessGroup, cloudflare.ResultInfo, error), filter string) ([]cloudflare.AccessGroup, error) {
+func paginateAllGroups(readAccessGroupHandler func(ctx context.Context, accountID string, pageOpts cloudflare.PaginationOptions) ([]cloudflare.AccessGroup, cloudflare.ResultInfo, error), filter string) ([]cloudflare.AccessGroup, error) {
 	var groups []cloudflare.AccessGroup
 	paginationOptions := cloudflare.PaginationOptions{}
 
@@ -88,7 +88,7 @@ func dataSourceCloudflareAccessGroupsRead(d *schema.ResourceData, meta interface
 	accountID := d.Get("account_id").(string)
 
 	var filter string
-	var handler func (ctx context.Context, accountID string, pageOpts cloudflare.PaginationOptions) ([]cloudflare.AccessGroup, cloudflare.ResultInfo, error)
+	var handler func(ctx context.Context, accountID string, pageOpts cloudflare.PaginationOptions) ([]cloudflare.AccessGroup, cloudflare.ResultInfo, error)
 
 	if accountID != "" {
 		filter = accountID
@@ -114,8 +114,8 @@ func dataSourceCloudflareAccessGroupsRead(d *schema.ResourceData, meta interface
 	groupDetails := make([]interface{}, 0)
 	for _, g := range groups {
 		groupDetails = append(groupDetails, map[string]interface{}{
-			"id": g.ID,
-			"name": g.Name,
+			"id":      g.ID,
+			"name":    g.Name,
 			"include": TransformAccessGroupForSchema(g.Include),
 			"exclude": TransformAccessGroupForSchema(g.Exclude),
 			"require": TransformAccessGroupForSchema(g.Require),

--- a/cloudflare/data_source_access_groups.go
+++ b/cloudflare/data_source_access_groups.go
@@ -1,0 +1,131 @@
+package cloudflare
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceCloudflareAccessGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCloudflareAccessGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"zone_id"},
+			},
+			"zone_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"account_id"},
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"require": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     AccessGroupOptionSchemaElement,
+						},
+						"exclude": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     AccessGroupOptionSchemaElement,
+						},
+						"include": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     AccessGroupOptionSchemaElement,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func paginateAllGroups(readAccessGroupHandler func (ctx context.Context, accountID string, pageOpts cloudflare.PaginationOptions) ([]cloudflare.AccessGroup, cloudflare.ResultInfo, error), filter string) ([]cloudflare.AccessGroup, error) {
+	var groups []cloudflare.AccessGroup
+	paginationOptions := cloudflare.PaginationOptions{
+		PerPage: 100,
+	}
+
+	for {
+		groupPage, resultInfo, err := readAccessGroupHandler(context.Background(), filter, paginationOptions)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, g := range groupPage {
+			groups = append(groups, g)
+		}
+		if resultInfo.Page < resultInfo.TotalPages {
+			paginationOptions.Page = resultInfo.Page + 1
+		} else {
+			return groups, nil
+		}
+	}
+}
+
+func dataSourceCloudflareAccessGroupsRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Reading Access Groups")
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+	accountID := d.Get("account_id").(string)
+
+	var filter string
+	var handler func (ctx context.Context, accountID string, pageOpts cloudflare.PaginationOptions) ([]cloudflare.AccessGroup, cloudflare.ResultInfo, error)
+
+	if accountID != "" {
+		filter = accountID
+		handler = client.AccessGroups
+	} else if zoneID != "" {
+		filter = zoneID
+		handler = client.ZoneLevelAccessGroups
+	} else {
+		return errors.New("One of Zone ID or Account ID are required")
+	}
+
+	groups, err := paginateAllGroups(handler, filter)
+
+	if err != nil {
+		return nil
+	}
+
+	d.Set("groups", groups)
+	if err != nil {
+		return fmt.Errorf("error setting access groups: %s", err)
+	}
+
+	groupIds := make([]string, 0)
+	groupDetails := make([]interface{}, 0)
+	for _, g := range groups {
+		groupDetails = append(groupDetails, map[string]interface{}{
+			"id": g.ID,
+			"name": g.Name,
+			"include": TransformAccessGroupForSchema(g.Include),
+			"exclude": TransformAccessGroupForSchema(g.Exclude),
+			"require": TransformAccessGroupForSchema(g.Require),
+		})
+		groupIds = append(groupIds, g.ID)
+	}
+
+	d.SetId(stringListChecksum(groupIds))
+	return nil
+}

--- a/cloudflare/data_source_access_groups_test.go
+++ b/cloudflare/data_source_access_groups_test.go
@@ -1,0 +1,73 @@
+package cloudflare
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccCloudflareAccessGroupsAccountLevel(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("data.cloudflare_access_groups.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareAccessGroupsConfig(rnd, "account_id", accountID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCloudflareAccessGroupsDataSourceId(name),
+					resource.TestCheckResourceAttr(name, "groups.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareAccessGroupsZoneLevel(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("data.cloudflare_access_groups.%s", rnd)
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareAccessGroupsConfig(rnd, "zone_id", zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCloudflareAccessGroupsDataSourceId(name),
+					resource.TestCheckResourceAttr(name, "groups.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareAccessGroupsDataSourceId(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		all := s.RootModule().Resources
+		rs, ok := all[n]
+
+		if !ok {
+			return fmt.Errorf("can't find Account Roles data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Snapshot Account Roles source ID not set")
+		}
+		return nil
+	}
+}
+
+func testAccCloudflareAccessGroupsConfig(name string, accessor string, accessorID string) string {
+	return fmt.Sprintf(`data "cloudflare_access_groups" "%[1]s" {
+		%[2]s = "%[3]s"
+	}`, name, accessor, accessorID)
+}
+

--- a/cloudflare/data_source_access_groups_test.go
+++ b/cloudflare/data_source_access_groups_test.go
@@ -62,11 +62,11 @@ func testAccCloudflareAccessGroupsDataSourceId(n string) resource.TestCheckFunc 
 		rs, ok := all[n]
 
 		if !ok {
-			return fmt.Errorf("can't find Account Roles data source: %s", n)
+			return fmt.Errorf("can't find Access Groups data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("Snapshot Account Roles source ID not set")
+			return fmt.Errorf("Snapshot Access Groups source ID not set")
 		}
 		return nil
 	}

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -92,6 +92,7 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"cloudflare_access_groups":               dataSourceCloudflareAccessGroups(),
 			"cloudflare_account_roles":               dataSourceCloudflareAccountRoles(),
 			"cloudflare_api_token_permission_groups": dataSourceCloudflareApiTokenPermissionGroups(),
 			"cloudflare_ip_ranges":                   dataSourceCloudflareIPRanges(),

--- a/website/docs/d/access_groups.html.md
+++ b/website/docs/d/access_groups.html.md
@@ -12,7 +12,7 @@ Use this data source to look up [Access Groups][1].
 
 ## Example Usage
 
-The example below matches all Access Groups that contain the word `example` and are currently `on`. The matched Access Groups are then returned as output.
+The example below matches all Access Groups that are part of the `zone_id` `12345`.  Access groups can also be looked up by `account_id`. The matched Access Groups are then returned as output.
 
 ```hcl
 data "cloudflare_access_groups" "test" {

--- a/website/docs/d/access_groups.html.md
+++ b/website/docs/d/access_groups.html.md
@@ -1,0 +1,46 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_access_groups"
+sidebar_current: "docs-cloudflare-datasource-access-groups"
+description: |-
+  List available Cloudflare Access Groups.
+---
+
+# cloudflare_access_groups
+
+Use this data source to look up [Access Groups][1].
+
+## Example Usage
+
+The example below matches all Access Groups that contain the word `example` and are currently `on`. The matched Access Groups are then returned as output.
+
+```hcl
+data "cloudflare_access_groups" "test" {
+  zone_id = "12345"
+}
+
+output "access_groups" {
+  value = data.cloudflare_access_groups.test.groups
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+-> **Note:** It's required that an `account_id` or `zone_id` is provided and in most cases using either is fine. However, if you're using a scoped access token, you must provide the argument that matches the token's scope. For example, an access token that is scoped to the "example.com" zone needs to use the `zone_id` argument.
+
+- `zone_id` - (Optional) The ID of the DNS zone in which to search for the Access Groups.  Conflicts with `account_id`.
+- `account_id` - (Optional) The ID of the account in which to search for the Access Groups.  Conflicts with `zone_id`.
+
+## Attributes Reference
+
+- `groups` - An list of Access Groups. Object format:
+
+**groups**
+
+- `id` - The Access Group ID
+* `name` - Friendly name of the Access Group.
+* `require` - A series of access conditions, see [Access Groups](/providers/cloudflare/cloudflare/latest/docs/resources/access_group#conditions).
+* `exclude` - A series of access conditions, see [Access Groups](/providers/cloudflare/cloudflare/latest/docs/resources/access_group#conditions).
+* `include` - A series of access conditions, see [Access Groups](/providers/cloudflare/cloudflare/latest/docs/resources/access_group#conditions).


### PR DESCRIPTION
- Access Groups data source, for either a particular zone or across an entire account
- Tests
- Documentation

I have tested this data source against my own Cloudflare account, for both zone_id and account_id.