### PR TITLE
resource/cloudflare_ruleset: add support for action parameter overrides `enabled` and `action`

### DIFF
--- a/.changelog/1249.txt
+++ b/.changelog/1249.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_ruleset: add support for 'Action' and 'Enabled' action_parameters > overrides attributes
+```

--- a/website/docs/r/ruleset.html.markdown
+++ b/website/docs/r/ruleset.html.markdown
@@ -275,6 +275,7 @@ The following arguments are supported:
 
 * `categories` - (Optional) List of tag-based overrides (refer to the [nested schema](#nestedblock--action-parameters-overrides-categories)).
 * `enabled` - (Optional) Defines if the current ruleset-level override enables or disables the ruleset.
+* `action` - (Optional) Action to perform in the rule-level override. Valid values are `"block"`, `"challenge"`, `"js_challenge"`, `"log"`.
 * `rules` - (Optional) List of rule-based overrides (refer to the [nested schema](#nestedblock--action-parameters-overrides-rules)).
 
 <a id="nestedblock--action-parameters-overrides-categories"></a>


### PR DESCRIPTION
Code changes live in #1249.

Depends on cloudflare/cloudflare-go#723