### PR TITLE
resource/cloudflare_ruleset: be verbose about dashboard created Rulesets

### DIFF
--- a/website/docs/r/ruleset.html.markdown
+++ b/website/docs/r/ruleset.html.markdown
@@ -15,6 +15,8 @@ same syntax used in custom Firewall Rules. Cloudflare uses the Ruleset Engine
 in different products, allowing you to configure several products using the same
 basic syntax.
 
+~> **NOTE:** If you previously configured Rulesets using the dashboard, you first need to delete them ([zone](https://api.cloudflare.com/#zone-rulesets-delete-zone-ruleset), [account](https://api.cloudflare.com/#account-rulesets-delete-account-ruleset) documentation) and clean up the resources before attempting to configure them with Terraform. This is because Terraform will fail to apply if configuration already exists to prevent blindly overwriting changes.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Updates the provider integration to spew out a very specific error
message when Rulesets have been created via the Dashboard and not
cleaned up before attempting to manage them in Terraform.

Includes a documentation update to call this out too.