### PR TITLE
provider: add configuration option to use a specific hostname or base path

### DIFF
--- a/.changelog/1270.txt
+++ b/.changelog/1270.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: add the ability to configure a different hostname and base path for the API client
+```

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -77,3 +77,5 @@ The following arguments are supported:
 * `account_id` - (Optional) Configure API client with this account ID, so calls use the account API rather than the (default) user API.
   This is required for other users in your account to have access to the resources you manage.
   This can also be specified with the `CLOUDFLARE_ACCOUNT_ID` shell environment variable.
+* `api_hostname` - (Optional) Configure the API client to use a specific hostname. Default: "api.cloudflare.com"
+* `api_base_path` - (Optional) Configure the API client to use a specific base path. Default: "/client/v4"


### PR DESCRIPTION
Following on from cloudflare/cloudflare-go#606, this allows the provider
to pass through the ability to override the base URL that the API client
uses for calls.