### PR TITLE
resource/cloudflare_ruleset: allow setting both URI query and path options

### DIFF
--- a/.changelog/1271.txt
+++ b/.changelog/1271.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: allow setting `uri` and `path` action parmeters together in a single rule
+```

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -747,26 +747,25 @@ func buildRulesetRulesFromResource(phase string, r interface{}) ([]cloudflare.Ru
 						}
 
 					case "uri":
+						var uriParameterConfig cloudflare.RulesetRuleActionParametersURI
 						for _, uriValue := range pValue.([]interface{}) {
 							if val, ok := uriValue.(map[string]interface{})["path"]; ok && len(val.([]interface{})) > 0 {
 								uriPathConfig := val.([]interface{})[0].(map[string]interface{})
-								rule.ActionParameters.URI = &cloudflare.RulesetRuleActionParametersURI{
-									Path: &cloudflare.RulesetRuleActionParametersURIPath{
-										Value:      uriPathConfig["value"].(string),
-										Expression: uriPathConfig["expression"].(string),
-									},
+								uriParameterConfig.Path = &cloudflare.RulesetRuleActionParametersURIPath{
+									Value:      uriPathConfig["value"].(string),
+									Expression: uriPathConfig["expression"].(string),
 								}
 							}
 
 							if val, ok := uriValue.(map[string]interface{})["query"]; ok && len(val.([]interface{})) > 0 {
 								uriQueryConfig := val.([]interface{})[0].(map[string]interface{})
-								rule.ActionParameters.URI = &cloudflare.RulesetRuleActionParametersURI{
-									Query: &cloudflare.RulesetRuleActionParametersURIQuery{
-										Value:      uriQueryConfig["value"].(string),
-										Expression: uriQueryConfig["expression"].(string),
-									},
+								uriParameterConfig.Query = &cloudflare.RulesetRuleActionParametersURIQuery{
+									Value:      uriQueryConfig["value"].(string),
+									Expression: uriQueryConfig["expression"].(string),
 								}
 							}
+
+							rule.ActionParameters.URI = &uriParameterConfig
 						}
 
 					case "headers":


### PR DESCRIPTION
Updates the logic to not overwrite the struct but instead append the
fields when they are needed.

Closes #1269