### PR TITLE
test/lint: trim down exceptions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Run tfproviderlint
         uses: bflad/tfproviderlint-github-action@master
         with:
-          args: -R003=false -R011=false -R012=false -S001=false -S002=false -S003=false -S004=false -S005=false -S006=false -S007=false -S008=false -S009=false -S010=false -S011=false -S012=false -S013=false -S014=false -S015=false -S016=false -S017=false -S018=false -S019=false -S020=false -S021=false -S022=false -S023=false -S024=false -S025=false -S026=false -S027=false -S028=false -S029=false -S030=false -S031=false -S032=false -S033=false -S034=false -S035=false -S036=false -S037=false -AT001=false -AT002=false -AT003=false -AT006=false -AT012=false -R013=false ./cloudflare/
+          args: -R003=false -R011=false -R012=false -S006=false -S013=false -S014=false -S020=false -S022=false -S023=false -AT001=false -AT002=false -AT003=false -AT006=false -AT012=false -R013=false ./cloudflare/

--- a/cloudflare/data_source_origin_ca_root_certificate.go
+++ b/cloudflare/data_source_origin_ca_root_certificate.go
@@ -17,7 +17,6 @@ func dataSourceCloudflareOriginCARootCertificate() *schema.Resource {
 			"algorithm": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{"rsa", "ecc"}, true),
 			},
 

--- a/cloudflare/resource_cloudflare_custom_ssl_migrate.go
+++ b/cloudflare/resource_cloudflare_custom_ssl_migrate.go
@@ -18,11 +18,11 @@ func resourceCloudflareCustomSSLV0() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"certificate": {
 							Type:     schema.TypeString,
-							Optional: false,
+							Required: true,
 						},
 						"private_key": {
 							Type:      schema.TypeString,
-							Optional:  false,
+							Required:  true,
 							Sensitive: true,
 						},
 						"bundle_method": {

--- a/cloudflare/resource_cloudflare_static_route.go
+++ b/cloudflare/resource_cloudflare_static_route.go
@@ -46,7 +46,6 @@ func resourceCloudflareStaticRoute() *schema.Resource {
 			"weight": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Required: false,
 				// API does not allow to reset weights when attribute isn't send. To avoid generating unnecessary changes
 				// we will trigger a re-create when weights change
 				ForceNew: true,


### PR DESCRIPTION
I fixed most of these with the 3.x upgrade so we can remove the need to
skip them and instead run them.