### PR TITLE
resource/cloudflare_origin_ca_certificate: reintroduce `DiffSuppressFunc` for `requested_validity` changes

### DIFF
--- a/.changelog/1289.txt
+++ b/.changelog/1289.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_origin_ca_certificate: reintroduce `DiffSuppressFunc` for `requested_validity` changes to handle all schema/SDK combinations
+```

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -58,6 +58,9 @@ func resourceCloudflareOriginCACertificate() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validation.IntInSlice([]int{7, 30, 90, 365, 730, 1095, 5475}),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Re-introduces the `DiffSuppressFunc` to supplement handling the
`requested_validity` countdown.

Closes #1276