### PR TITLE
resource/cloudflare_access_rule: allow IPv6 to be padded or unpadded

### DIFF
--- a/.changelog/1294.txt
+++ b/.changelog/1294.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_access_rule: allow "ip6" to be a padded or unpadded value and compare correctly
+```

--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -258,12 +258,13 @@ func resourceCloudflareAccessRuleImport(d *schema.ResourceData, meta interface{}
 
 func configurationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	switch {
-	case d.Get("configuration.target") == "country" &&
-		k == "configuration.value":
+	case d.Get("configuration.0.target") == "ip6" && k == "configuration.0.value":
+		existingIP := net.ParseIP(old)
+		incomingIP := net.ParseIP(new)
+		return existingIP.Equal(incomingIP)
+	case d.Get("configuration.0.target") == "country" && k == "configuration.0.value":
 		return strings.ToUpper(old) == strings.ToUpper(new)
-	case d.Get("configuration.target") == "asn" &&
-		k == "configuration.value":
-
+	case d.Get("configuration.0.target") == "asn" && k == "configuration.0.value":
 		if !strings.HasPrefix(strings.ToUpper(new), "AS") {
 			new = "AS" + strings.ToUpper(new)
 		}

--- a/cloudflare/resource_cloudflare_access_rule_test.go
+++ b/cloudflare/resource_cloudflare_access_rule_test.go
@@ -7,15 +7,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAccessRuleASN(t *testing.T) {
-	name := "cloudflare_access_rule.test"
+func TestAccCloudflareAccessRule_ASN(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_access_rule." + rnd
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccessRuleAccountConfig("challenge", "this is notes", "asn", "AS112"),
+				Config: testAccessRuleAccountConfig("challenge", "this is notes", "asn", "AS112", rnd),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "notes", "this is notes"),
 					resource.TestCheckResourceAttr(name, "mode", "challenge"),
@@ -25,7 +26,7 @@ func TestAccAccessRuleASN(t *testing.T) {
 			},
 			{
 				// Note: Only notes + mode can be changed in place.
-				Config: testAccessRuleAccountConfig("block", "this is updated notes", "asn", "AS112"),
+				Config: testAccessRuleAccountConfig("block", "this is updated notes", "asn", "AS112", rnd),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "notes", "this is updated notes"),
 					resource.TestCheckResourceAttr(name, "mode", "block"),
@@ -37,15 +38,16 @@ func TestAccAccessRuleASN(t *testing.T) {
 	})
 }
 
-func TestAccAccessRuleIPRange(t *testing.T) {
-	name := "cloudflare_access_rule.test"
+func TestAccCloudflareAccessRule_IPRange(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_access_rule." + rnd
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccessRuleAccountConfig("challenge", "this is notes", "ip_range", "104.16.0.0/24"),
+				Config: testAccessRuleAccountConfig("challenge", "this is notes", "ip_range", "104.16.0.0/24", rnd),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "notes", "this is notes"),
 					resource.TestCheckResourceAttr(name, "mode", "challenge"),
@@ -55,7 +57,7 @@ func TestAccAccessRuleIPRange(t *testing.T) {
 			},
 			{
 				// Note: Only notes + mode can be changed in place.
-				Config: testAccessRuleAccountConfig("block", "this is updated notes", "ip_range", "104.16.0.0/24"),
+				Config: testAccessRuleAccountConfig("block", "this is updated notes", "ip_range", "104.16.0.0/24", rnd),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "notes", "this is updated notes"),
 					resource.TestCheckResourceAttr(name, "mode", "block"),
@@ -67,16 +69,46 @@ func TestAccAccessRuleIPRange(t *testing.T) {
 	})
 }
 
-func testAccessRuleAccountConfig(mode, notes, target, value string) string {
+func TestAccCloudflareAccessRule_IPv6(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_access_rule." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccessRuleAccountConfig("block", "this is notes", "ip6", "2001:0db8::", rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "notes", "this is notes"),
+					resource.TestCheckResourceAttr(name, "mode", "block"),
+					resource.TestCheckResourceAttr(name, "configuration.0.target", "ip6"),
+					resource.TestCheckResourceAttr(name, "configuration.0.value", "2001:0db8:0000:0000:0000:0000:0000:0000"),
+				),
+			},
+			{
+				Config: testAccessRuleAccountConfig("block", "this is notes", "ip6", "2001:0db8:0000:0000:0000:0000:0000:0000", rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "notes", "this is notes"),
+					resource.TestCheckResourceAttr(name, "mode", "block"),
+					resource.TestCheckResourceAttr(name, "configuration.0.target", "ip6"),
+					resource.TestCheckResourceAttr(name, "configuration.0.value", "2001:0db8:0000:0000:0000:0000:0000:0000"),
+				),
+			},
+		},
+	})
+}
+
+func testAccessRuleAccountConfig(mode, notes, target, value, rnd string) string {
 	return fmt.Sprintf(`
-resource "cloudflare_access_rule" "test" {
+resource "cloudflare_access_rule" "%[5]s" {
   notes = "%[2]s"
   mode = "%[1]s"
   configuration {
     target = "%[3]s"
     value = "%[4]s"
   }
-}`, mode, notes, target, value)
+}`, mode, notes, target, value, rnd)
 }
 
 func TestValidateAccessRuleConfigurationIPRange(t *testing.T) {


### PR DESCRIPTION
Updates the `access_rule` configuration to allow passing in a padding or
unpadded value and compare them once fully expanded to determine the
actual diff.

Closes #1282