### PR TITLE
check for nil pointer to GeoRestrictions

### DIFF
--- a/cloudflare/resource_cloudflare_custom_ssl.go
+++ b/cloudflare/resource_cloudflare_custom_ssl.go
@@ -357,7 +357,7 @@ func flattenCustomSSLOptions(sslopt cloudflare.ZoneCustomSSLOptions) map[string]
 		"type":          sslopt.Type,
 	}
 
-	if sslopt.GeoRestrictions.Label != "" && sslopt.GeoRestrictions.Label != "custom" {
+	if sslopt.GeoRestrictions != nil && sslopt.GeoRestrictions.Label != "" && sslopt.GeoRestrictions.Label != "custom" {
 		data["geo_restrictions"] = sslopt.GeoRestrictions.Label
 	}
 


### PR DESCRIPTION
Getting a nil pointer exception here when the payload returned from `GET .../$ZONE_ID/custom_certificates/$CERT_ID` is missing the `geo_restrictions` object. This attempts to fix the issue by checking for a nil pointer before accessing any fields.

[ZoneCustomSSLOptions struct for reference](https://github.com/cloudflare/cloudflare-go/blob/8160849490b166aaf93320c691c57b2d24855cdf/ssl.go#L54)

I don't know why the `GeoRestrictions` field is a pointer `*ZoneCustomSSLGeoRestrictions` instead of just `ZoneCustomSSLGeoRestrictions`. Maybe swapping that for a non-pointer would at least give us an empty struct here so that we could check `sslopt.GeoRestrictions.Label != ""` w/o getting a nil pointer exception. But I guess it would be good to check for nil regardless 🤷‍♂️

possibly related to https://github.com/cloudflare/terraform-provider-cloudflare/issues/1232