### PR TITLE
resource/cloudflare_zone: support setting `type`

### DIFF
--- a/.changelog/1301.txt
+++ b/.changelog/1301.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_zone: support changing `type` values
+```

--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -146,6 +146,13 @@ func resourceCloudflareZoneCreate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
+	if ztype, ok := d.GetOk("type"); ok {
+		_, err := client.ZoneSetType(context.Background(), zone.ID, ztype.(string))
+		if err != nil {
+			return fmt.Errorf("error setting type on zone ID %q: %s", zone.ID, err)
+		}
+	}
+
 	return resourceCloudflareZoneRead(d, meta)
 }
 
@@ -203,7 +210,15 @@ func resourceCloudflareZoneUpdate(d *schema.ResourceData, meta interface{}) erro
 		_, err := client.ZoneSetPaused(context.Background(), zoneID, paused.(bool))
 
 		if err != nil {
-			return fmt.Errorf("error updating zone_id %q: %s", zoneID, err)
+			return fmt.Errorf("error setting paused for zone ID %q: %s", zoneID, err)
+		}
+	}
+
+	if ztype, ok := d.GetOkExists("type"); ok && d.HasChange("type") {
+		_, err := client.ZoneSetType(context.Background(), zoneID, ztype.(string))
+
+		if err != nil {
+			return fmt.Errorf("error setting type for on zone ID %q: %s", zoneID, err)
 		}
 	}
 

--- a/cloudflare/resource_cloudflare_zone_test.go
+++ b/cloudflare/resource_cloudflare_zone_test.go
@@ -2,12 +2,13 @@ package cloudflare
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccCloudflareZoneBasic(t *testing.T) {
+func TestAccCloudflareZone_Basic(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "cloudflare_zone." + rnd
 
@@ -29,7 +30,7 @@ func TestAccCloudflareZoneBasic(t *testing.T) {
 	})
 }
 
-func TestAccCloudflareZoneBasicWithJumpStartEnabled(t *testing.T) {
+func TestAccCloudflareZone_BasicWithJumpStartEnabled(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "cloudflare_zone." + rnd
 
@@ -52,7 +53,7 @@ func TestAccCloudflareZoneBasicWithJumpStartEnabled(t *testing.T) {
 	})
 }
 
-func TestAccCloudflareZoneWithPlan(t *testing.T) {
+func TestAccCloudflareZone_WithPlan(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "cloudflare_zone." + rnd
 
@@ -74,7 +75,7 @@ func TestAccCloudflareZoneWithPlan(t *testing.T) {
 	})
 }
 
-func TestAccCloudflareZonePartialSetup(t *testing.T) {
+func TestAccCloudflareZone_PartialSetup(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "cloudflare_zone." + rnd
 
@@ -95,7 +96,7 @@ func TestAccCloudflareZonePartialSetup(t *testing.T) {
 	})
 }
 
-func TestAccCloudflareZoneFullSetup(t *testing.T) {
+func TestAccCloudflareZone_FullSetup(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "cloudflare_zone." + rnd
 
@@ -194,7 +195,7 @@ func TestAccZonePerformsUnicodeComparison(t *testing.T) {
 	})
 }
 
-func TestAccCloudflareZoneWithEnterprisePlan(t *testing.T) {
+func TestAccCloudflareZone_WithEnterprisePlan(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "cloudflare_zone." + rnd
 
@@ -283,6 +284,27 @@ func TestPlanIDFallsBackToEmptyIfUnknown(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAccCloudflareZone_SetType(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "cloudflare_zone." + rnd
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testZoneConfigWithExplicitFullSetup(rnd, fmt.Sprintf("%s.%s", rnd, zoneName), "true", "false", "enterprise"),
+			},
+			{
+				Config: testZoneConfigWithPartialSetup(rnd, fmt.Sprintf("%s.%s", rnd, zoneName), "true", "false", "enterprise"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "type", "partial"),
+				),
+			},
+		},
+	})
 }
 
 func testZoneConfigWithPartialSetup(resourceID, zoneName, paused, jumpStart, plan string) string {


### PR DESCRIPTION
Updates the `cloudflare_zone` resource to support setting the zone type
when creating and updating the resource.

Fixes #1277