### PR TITLE
Implicitly include cf.colo.id to the ruleset characteristics

### DIFF
--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -823,7 +823,7 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 				for pKey, pValue := range parameter.(map[string]interface{}) {
 					switch pKey {
 					case "characteristics":
-						characteristicKeys := make([]string, 0)
+						characteristicKeys := []string{"cf.colo.id"}
 						for _, v := range pValue.(*schema.Set).List() {
 							characteristicKeys = append(characteristicKeys, v.(string))
 						}


### PR DESCRIPTION
cf.colo.id implicitly included when using the dashboard, but
this is required as ratelimiting counting is processed at colocation level only.