### PR TITLE
fix: `http.uri.path` is `http.request.uri.path`

### DIFF
--- a/website/docs/r/ruleset.html.markdown
+++ b/website/docs/r/ruleset.html.markdown
@@ -105,7 +105,7 @@ resource "cloudflare_ruleset" "transform_uri_rule_path" {
       }
     }
 
-    expression = "(http.host eq \"example.com\" and http.uri.path eq \"/old-path\")"
+    expression = "(http.host eq \"example.com\" and http.request.uri.path eq \"/old-path\")"
     description = "example URI path transform rule"
     enabled = true
   }


### PR DESCRIPTION
Otherwise it yields:
```
Error: error creating ruleset transform rule for _static URI path: HTTP status 400: Filter parsing error (1:15):
regex_replace(http.uri.path, "^/xxx", "/")
              ^^^^^^^^^^^^^ unknown identifier
, '(http.host eq "foo" and starts_with(http.uri.path, "/xxx/"))' is not a valid value for Expression because the expression is invalid: Filter parsing error (1:60):
(http.host eq "fooo" and starts_with(http.uri.path, "/xxx/"))
                                                           ^^^^^^^^^^^^^ unknown identifier
```

cc @varunchandola @juddling