### PR TITLE
resource/cloudflare_teams_list: ignore `list` ordering

### DIFF
--- a/.changelog/1338.txt
+++ b/.changelog/1338.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_teams_list: ignore `items` ordering
+```

--- a/cloudflare/schema_cloudflare_teams_list.go
+++ b/cloudflare/schema_cloudflare_teams_list.go
@@ -25,7 +25,7 @@ func resourceCloudflareTeamsListSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 		"items": {
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,


### PR DESCRIPTION
The `items` come back from the the API are not order dependant so we
should instead use a `TypeSet` for the schema.

Closes #1278