### PR TITLE
Ruleset support for rewriting response headers

### DIFF
--- a/.changelog/1339.txt
+++ b/.changelog/1339.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_ruleset: add support for rewriting HTTP response headers
+```

--- a/cloudflare/resource_cloudflare_ruleset_test.go
+++ b/cloudflare/resource_cloudflare_ruleset_test.go
@@ -728,6 +728,48 @@ func TestAccCloudflareRuleset_TransformationRuleURIQuery(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareRuleset_TransformHTTPResponseHeaders(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetExposedCredentialCheck(rnd, "example exposed credential check", accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "example exposed credential check"),
+					resource.TestCheckResourceAttr(resourceName, "description", "This ruleset includes a rule checking for exposed credentials."),
+					resource.TestCheckResourceAttr(resourceName, "kind", "custom"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_firewall_custom"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "log"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", "http.request.method == \"POST\" && http.request.uri == \"/login.php\""),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "example exposed credential check"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.exposed_credential_check.#", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.exposed_credential_check.0.username_expression", "url_decode(http.request.body.form[\"username\"][0])"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.exposed_credential_check.0.password_expression", "url_decode(http.request.body.form[\"password\"][0])"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudflareRuleset_TransformationRuleURIPathAndQueryCombination(t *testing.T) {
 	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
 	// service does not yet support the API tokens and it results in
@@ -771,7 +813,7 @@ func TestAccCloudflareRuleset_TransformationRuleURIPathAndQueryCombination(t *te
 	})
 }
 
-func TestAccCloudflareRuleset_TransformationRuleHeaders(t *testing.T) {
+func TestAccCloudflareRuleset_TransformationRuleRequestHeaders(t *testing.T) {
 	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
 	// service does not yet support the API tokens and it results in
 	// misleading state error messages.
@@ -793,12 +835,62 @@ func TestAccCloudflareRuleset_TransformationRuleHeaders(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudflareRulesetTransformationRuleHeaders(rnd, "transform rule for headers", zoneID, zoneName),
+				Config: testAccCheckCloudflareRulesetTransformationRuleRequestHeaders(rnd, "transform rule for headers", zoneID, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "transform rule for headers"),
 					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
 					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
 					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_late_transform"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "rewrite"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.#", "3"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.0.name", "example1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.0.value", "my-http-header-value1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.0.operation", "set"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.1.name", "example2"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.1.operation", "set"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.1.expression", "cf.zone.name"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.2.name", "example3"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.headers.2.operation", "remove"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_TransformationRuleResponseHeaders(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetTransformationRuleResponseHeaders(rnd, "transform rule for headers", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "transform rule for headers"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_response_headers_transform"),
 
 					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "rewrite"),
@@ -1512,7 +1604,7 @@ func testAccCheckCloudflareRulesetTransformationRuleURIQuery(rnd, name, zoneID, 
   }`, rnd, name, zoneID, zoneName)
 }
 
-func testAccCheckCloudflareRulesetTransformationRuleHeaders(rnd, name, zoneID, zoneName string) string {
+func testAccCheckCloudflareRulesetTransformationRuleRequestHeaders(rnd, name, zoneID, zoneName string) string {
 	return fmt.Sprintf(`
   resource "cloudflare_ruleset" "%[1]s" {
     zone_id     = "%[3]s"
@@ -1520,6 +1612,43 @@ func testAccCheckCloudflareRulesetTransformationRuleHeaders(rnd, name, zoneID, z
     description = "%[1]s ruleset description"
     kind        = "zone"
     phase       = "http_request_late_transform"
+
+    rules {
+      action = "rewrite"
+      action_parameters {
+        headers {
+          name      = "example1"
+          operation = "set"
+          value     = "my-http-header-value1"
+        }
+
+        headers {
+          name       = "example2"
+          operation  = "set"
+          expression = "cf.zone.name"
+        }
+
+        headers {
+          name      = "example3"
+          operation = "remove"
+        }
+      }
+
+      expression = "true"
+      description = "example header transformation rule"
+      enabled = false
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetTransformationRuleResponseHeaders(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id     = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_response_headers_transform"
 
     rules {
       action = "rewrite"

--- a/website/docs/r/ruleset.html.markdown
+++ b/website/docs/r/ruleset.html.markdown
@@ -205,7 +205,7 @@ The following arguments are supported:
 * `description` - (Required) Brief summary of the ruleset and its intended use.
 * `kind` - (Required) Type of Ruleset to create. Valid values are `"custom"`, `"managed"`, `"root"`, `"schema"` or `"zone"`.
 * `name` - (Required) Name of the ruleset.
-* `phase` - (Required) Point in the request/response lifecycle where the ruleset will be created. Valid values are `"ddos_l4"`, `"ddos_l7"`, `"http_request_firewall_custom"`, `"http_request_firewall_managed"`, `"http_request_late_transform"`, `"http_request_main"`, `"http_request_sanitize"`, `"http_request_transform"`, `"http_response_firewall_managed"`, `"magic_transit"`, or `"http_ratelimit"`.
+* `phase` - (Required) Point in the request/response lifecycle where the ruleset will be created. Valid values are `"ddos_l4"`, `"ddos_l7"`, `"http_request_firewall_custom"`, `"http_request_firewall_managed"`, `"http_request_late_transform"`, `"http_response_headers_transform"`, `"http_request_main"`, `"http_request_sanitize"`, `"http_request_transform"`, `"http_response_firewall_managed"`, `"magic_transit"`, or `"http_ratelimit"`.
 * `rules` - (Required) List of rules to apply to the ruleset (refer to the [nested schema](#nestedblock--rules)).
 * `shareable_entitlement_name` - (Optional) Name of entitlement that is shareable between entities.
 * `zone_id` - (Optional) The ID of the zone where the ruleset is being created. Conflicts with `"account_id"`.


### PR DESCRIPTION
Adds support and documentation for `http_response_headers_transform` phase.

Includes a new sweeper for Rulesets to ensure dangling Rulesets are cleaned up before each run.

Closes #1317