### PR TITLE
Add bookmark to AccessApplication type

### DIFF
--- a/cloudflare/schema_cloudflare_access_application.go
+++ b/cloudflare/schema_cloudflare_access_application.go
@@ -40,7 +40,7 @@ func resourceCloudflareAccessApplicationSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Default:      "self_hosted",
-			ValidateFunc: validation.StringInSlice([]string{"self_hosted", "ssh", "vnc", "file"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"self_hosted", "ssh", "vnc", "file", "bookmark"}, false),
 		},
 		"session_duration": {
 			Type:     schema.TypeString,


### PR DESCRIPTION
#1343 only added the documentation without updating the field validation. 
Fixes #1358.

It is supported by the SDK but [not documented](https://api.cloudflare.com/#access-applications-create-access-application).

When trying to provision some bookmark app with the provider, I get:
```
Error: error updating Access Application for account "xxx": HTTP status 400: access.api.error.invalid_create_app_request (12090)
```

If reproducing the request with curl, I get: 
```
{
    "result": null,
    "success": false,
    "errors": [
        {
            "code": 12090,
            "message": "access.api.error.invalid_create_app_request"
        }
    ],
    "messages": [
        {
            "message": "bookmark application must be updated at the /access/bookmark path"
        }
    ]
}
```