### PR TITLE
Fix cloudflare_api_token's modified_on field

### DIFF
--- a/.changelog/1368.txt
+++ b/.changelog/1368.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_api_token: modified_on is now read correctly
+```

--- a/.golintci.yml
+++ b/.golintci.yml
@@ -1,28 +1,17 @@
 run:
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 1m
-
-  # exit code when at least one issue was found, default is 1
   issues-exit-code: 1
-
-  # include test files or not, default is true
   tests: true
-
-  # default is true. Enables skipping of directories:
-  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   skip-dirs-use-default: true
-
   modules-download-mode: readonly
-
-issues:
-  new: true
 
 linters:
   enable:
     - bodyclose    # ensure HTTP response bodies are successfully closed.
     - contextcheck # check we are passing context an inherited context.
     - gofmt        # checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification.
-    - errname      # checks that sentinel errors are prefixed with the `Err`` and error types are suffixed with the `Error``.
+    - errname      # checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`.
+    - errcheck     # a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases.
     - errorlint    # used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
     - godot        # check if comments end in a period.
     - misspell     # finds commonly misspelled English words in comments.
@@ -30,6 +19,12 @@ linters:
     - tparallel    # detects inappropriate usage of t.Parallel() method in your Go test codes.
     - unparam      # reports unused function parameters.
     - whitespace   # detection of leading and trailing whitespace.
+
+linters-settings:
+  errcheck:
+    exclude-functions:
+      # fine to ignore in errcheck as tfproviderlint covers this
+      - (*github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.ResourceData).Set
 
 output:
   format: colored-line-number

--- a/cloudflare/resource_cloudflare_api_token.go
+++ b/cloudflare/resource_cloudflare_api_token.go
@@ -156,7 +156,7 @@ func resourceCloudflareApiTokenRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("policy", policies)
 	d.Set("status", t.Status)
 	d.Set("issued_on", t.IssuedOn.Format(time.RFC3339Nano))
-	d.Set("modified_on", time.Now().Format(time.RFC3339Nano))
+	d.Set("modified_on", t.ModifiedOn.Format(time.RFC3339Nano))
 
 	var ipIn []string
 	var ipNotIn []string


### PR DESCRIPTION
For some reason this field was always set to `time.Now()` when _reading_, which shows as drift in every Terraform plan:

```hcl
Terraform detected the following changes made outside of Terraform since the
last "terraform apply":

  # cloudflare_api_token.external-dns has changed
  ~ resource "cloudflare_api_token" "external-dns" {
        id          = "[redacted]"
      ~ modified_on = "2021-11-05T09:23:00.921389278Z" -> "2022-01-04T14:35:50.581109737Z"
        name        = "external dns"
        # (3 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```

It's always shown as the exact time of the plan, which is definitely not when every token was last modified!

It looks like the swap happened within the PR adding this resource: https://github.com/cloudflare/terraform-provider-cloudflare/pull/862/commits/02bb4db2805a2c3d740ed7e432f0717af463af0a so as an outsider I don't have an explanation for why `time.Now()` was inserted.