### PR TITLE
resource/cloudflare_ruleset: conditionally set action parameter "version"

### DIFF
--- a/.changelog/1388.txt
+++ b/.changelog/1388.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: conditionally set action parameter "version"
+```

--- a/.golintci.yml
+++ b/.golintci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 1m
+  timeout: 5m
   issues-exit-code: 1
   tests: true
   skip-dirs-use-default: true

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -363,7 +363,9 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 					case "id":
 						rule.ActionParameters.ID = pValue.(string)
 					case "version":
-						rule.ActionParameters.Version = pValue.(string)
+						if rule.ActionParameters.Version != "" {
+							rule.ActionParameters.Version = pValue.(string)
+						}
 					case "ruleset":
 						rule.ActionParameters.Ruleset = pValue.(string)
 					case "rulesets":

--- a/cloudflare/resource_cloudflare_ruleset_test.go
+++ b/cloudflare/resource_cloudflare_ruleset_test.go
@@ -1197,6 +1197,36 @@ func TestAccCloudflareRuleset_ExposedCredentialCheck(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareRuleset_ConditionallySetActionParameterVersion(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareRulesetConditionallySetActionParameterVersion_ExecuteAlone(rnd, accountID, zoneName),
+			},
+			{
+				Config: testAccCloudflareRulesetConditionallySetActionParameterVersion_ExecuteThenSkip(rnd, accountID, zoneName),
+			},
+		},
+	})
+}
+
 func testAccCheckCloudflareRulesetMagicTransitSingle(rnd, name, accountID string) string {
 	return fmt.Sprintf(`
   resource "cloudflare_ruleset" "%[1]s" {
@@ -1989,4 +2019,83 @@ func testAccCheckCloudflareRulesetExposedCredentialCheck(rnd, name, accountID st
     }
   }
 `, rnd, name, accountID)
+}
+
+func testAccCloudflareRulesetConditionallySetActionParameterVersion_ExecuteAlone(rnd, accountID, domain string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    account_id  = "%[2]s"
+    name        = "%[1]s managed WAF"
+    description = "%[1]s managed WAF ruleset description"
+    kind        = "root"
+    phase       = "http_request_firewall_managed"
+
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "4814384a9e5d4991b9815dcfc25d2f1f"
+        overrides {
+          rules {
+            id = "6179ae15870a4bb7b2d480d4843b323c"
+            action = "block"
+            score_threshold = 25
+          }
+          enabled = true
+        }
+        matched_data {
+           public_key = "zpUlcpNtaNiSUN6LL6NiNz8XgIJZWWG3iSZDdPbMszM="
+        }
+      }
+      expression  = "(cf.zone.name eq \"%[3]s\")"
+      description = "Account OWASP %[3]s"
+      enabled     = true
+    }
+  }
+`, rnd, accountID, domain)
+}
+
+func testAccCloudflareRulesetConditionallySetActionParameterVersion_ExecuteThenSkip(rnd, accountID, domain string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    account_id  = "%[2]s"
+    name        = "%[1]s managed WAF"
+    description = "%[1]s managed WAF ruleset description"
+    kind        = "root"
+    phase       = "http_request_firewall_managed"
+
+    rules {
+      action = "skip"
+      action_parameters {
+        rules = {
+          "4814384a9e5d4991b9815dcfc25d2f1f" = "a6be45d4905042b9964ff81dc12e41d2,fa54f3d75ed446e78c22b4ea57b90acf,ec42fac3279943388b6be5ee9182835e,37da7855d2f94f69865365d894a556a4,f2db062052cf453fbe9e93f058ecf7e7,1129dfb383bb42e48466488cf3b37cb1"
+        }
+      }
+      expression = "(cf.zone.name eq \"%[3]s\")"
+      description = "Account skip rules OWASP"
+      enabled = true
+    }
+
+    rules {
+      action = "execute"
+      action_parameters {
+        id = "4814384a9e5d4991b9815dcfc25d2f1f"
+        overrides {
+          rules {
+            id = "6179ae15870a4bb7b2d480d4843b323c"
+            action = "block"
+            score_threshold = 25
+          }
+          enabled = true
+        }
+        matched_data {
+           public_key = "zpUlcpNtaNiSUN6LL6NiNz8XgIJZWWG3iSZDdPbMszM="
+        }
+      }
+      expression  = "(cf.zone.name eq \"%[3]s\")"
+      description = "Account OWASP %[3]s"
+      enabled     = true
+    }
+  }
+`, rnd, accountID, domain)
 }


### PR DESCRIPTION
Updates the action parameter generation process to only set the
"version" value when it is supplied by the end user. This addresses
issues where it was sent unconditionally and prevented some phases from
applying correctly. If the value is set in the configuration, the value
is still sent however, that will be a user configuration error, not a
provider error.

Closes #1309