### PR TITLE
add dns_logs to logpush schema validation

### DIFF
--- a/.changelog/1400.txt
+++ b/.changelog/1400.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_logpush_job: add support for managing`dns_logs`
+```

--- a/cloudflare/schema_cloudflare_logpush_job.go
+++ b/cloudflare/schema_cloudflare_logpush_job.go
@@ -28,7 +28,7 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 		"dataset": {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: validation.StringInSlice([]string{"firewall_events", "http_requests", "spectrum_events", "nel_reports", "audit_logs", "gateway_dns", "gateway_http", "gateway_network"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"firewall_events", "http_requests", "spectrum_events", "nel_reports", "audit_logs", "gateway_dns", "gateway_http", "gateway_network", "dns_logs"}, false),
 		},
 		"logpull_options": {
 			Type:     schema.TypeString,

--- a/website/docs/r/logpush_job.html.markdown
+++ b/website/docs/r/logpush_job.html.markdown
@@ -85,7 +85,7 @@ The following arguments are supported:
 * `destination_conf` - (Required) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included. See [Logpush destination documentation](https://developers.cloudflare.com/logs/reference/logpush-api-configuration#destination).
 * `dataset` - (Required) Which type of dataset resource to use. Available values are
   - [account-scoped](https://developers.cloudflare.com/logs/reference/log-fields/account): `"audit_logs"`, `"gateway_dns"`, `"gateway_http"`, `"gateway_network"`
-  - [zone-scoped](https://developers.cloudflare.com/logs/reference/log-fields/zone): `"firewall_events"`, `"http_requests"`, `"spectrum_events"`, `"nel_reports"`
+  - [zone-scoped](https://developers.cloudflare.com/logs/reference/log-fields/zone): `"firewall_events"`, `"http_requests"`, `"spectrum_events"`, `"nel_reports", "dns_logs"`
 * `account_id` - (Optional) The account ID where the logpush job should be created. Either `account_id` or `zone_id` are required.
 * `zone_id` - (Optional) The zone ID where the logpush job should be created. Either `account_id` or `zone_id` are required.
 * `logpull_options` - (Optional) Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpull options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options).


### PR DESCRIPTION
The dataset `dns_logs` is supported by the Logpush service but not included in the schema validation for the `cloudflare_logpush_job` resource.

I have used this locally and all looks to be working as expected.