### PR TITLE
resource/cloudflare_ruleset: Yet Another tristate bool fix

### DIFF
--- a/.changelog/1405.txt
+++ b/.changelog/1405.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: fix handling of `false` values for category/rule overrides
+```

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -421,6 +421,7 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 						var rules []cloudflare.RulesetRuleActionParametersRules
 
 						for overrideCounter, overrideParamValue := range pValue.([]interface{}) {
+							//nolint:staticcheck
 							if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.overrides.%d.enabled", rulesCounter, overrideCounter)); ok {
 								overrideConfiguration.Enabled = &[]bool{value.(bool)}[0]
 							}
@@ -447,7 +448,8 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 									rData := rule.(map[string]interface{})
 
 									var enabled *bool
-									if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.overrides.%d.rules.%d.enabled", rulesCounter, overrideCounter, ruleOverrideCounter)); ok {
+									//nolint:staticcheck
+									if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.overrides.%d.rules.%d.enabled", rulesCounter, overrideCounter, ruleOverrideCounter)); ok {
 										enabled = &[]bool{value.(bool)}[0]
 									}
 

--- a/cloudflare/resource_cloudflare_ruleset_test.go
+++ b/cloudflare/resource_cloudflare_ruleset_test.go
@@ -475,7 +475,7 @@ func TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithTopSkipAndLastS
 	})
 }
 
-func TestAccCloudflareRuleset_WAFManagedRulesetWithCategoryBasedOverrides(t *testing.T) {
+func TestAccCloudflareRuleset_WAFManagedRulesetWithCategoryAndRuleBasedOverrides(t *testing.T) {
 	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
 	// service does not yet support the API tokens and it results in
 	// misleading state error messages.
@@ -517,6 +517,10 @@ func TestAccCloudflareRuleset_WAFManagedRulesetWithCategoryBasedOverrides(t *tes
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.0.action", "block"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.1.category", "joomla"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.1.action", "block"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.0.id", "e3a567afc347477d9702d9047e97d760"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.0.enabled", "false"),
 				),
 			},
 		},
@@ -1598,6 +1602,11 @@ func testAccCheckCloudflareRulesetManagedWAFWithCategoryBasedOverrides(rnd, name
             action = "block"
             enabled = true
           }
+
+					rules {
+						id = "e3a567afc347477d9702d9047e97d760"
+						enabled = false
+					}
         }
       }
 


### PR DESCRIPTION
Updates the check for whether or not to populate the `enabled` flag on
category/rule based overrides to use the `GetOkExists` method (not
recommended due to undocumented edge cases) to check the existence
before converting the pointer to a value.

Closes #1403