### PR TITLE
make description not a required parameter for cloudflare_ruleset

### DIFF
--- a/.changelog/1412.txt
+++ b/.changelog/1412.txt
@@ -1,3 +1,3 @@
 ```release:enhancement
-cloudflare/schema_cloudflare_ruleset.go: Setting description to Optional to better reflect api docs
+resource/cloudflare_ruleseo: Setting description to `Optional` to better reflect API requirements
 ```

--- a/.changelog/1412.txt
+++ b/.changelog/1412.txt
@@ -1,0 +1,3 @@
+```release:enhancement
+cloudflare/schema_cloudflare_ruleset.go: Setting description to Optional to better reflect api docs
+```

--- a/cloudflare/schema_cloudflare_ruleset.go
+++ b/cloudflare/schema_cloudflare_ruleset.go
@@ -25,7 +25,7 @@ func resourceCloudflareRulesetSchema() map[string]*schema.Schema {
 		},
 		"description": {
 			Type:     schema.TypeString,
-			Required: true,
+			Optional: true,
 		},
 		"kind": {
 			Type:         schema.TypeString,


### PR DESCRIPTION
The API docs (https://api.cloudflare.com/#zone-rulesets-properties) label this as an optional parameter. This change will better reflect the API docs in their current form (at least for this key).

I've also verified that the API call succeeds without description being added.  