### PR TITLE
cloudflare_access_identity_provider import did not include config block

### DIFF
--- a/.changelog/1420.txt
+++ b/.changelog/1420.txt
@@ -1,4 +1,4 @@
 ```release-note:bug
-resource/cloudflare_access_identity_provider: import config block settings
+resource/cloudflare_access_identity_provider: import now includes config block settings
 ```
 

--- a/.changelog/1420.txt
+++ b/.changelog/1420.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+resource/cloudflare_access_identity_provider: import config block settings
+```
+

--- a/cloudflare/resource_cloudflare_access_identity_provider.go
+++ b/cloudflare/resource_cloudflare_access_identity_provider.go
@@ -167,6 +167,11 @@ func resourceCloudflareAccessIdentityProviderImport(d *schema.ResourceData, meta
 
 	log.Printf("[DEBUG] Importing Cloudflare Access Identity Provider: accountID=%s accessIdentityProviderID=%s", accountID, accessIdentityProviderID)
 
+	// create a non-empty config here so Read will import any existing configs
+	m := map[string]interface{}{"support_groups": true}
+	config := []interface{}{m}
+	d.Set("config", config)
+
 	d.Set("account_id", accountID)
 	d.SetId(accessIdentityProviderID)
 


### PR DESCRIPTION
This should close #1419.  When importing, we need a stub config block so that Read will look for an existing one.