### PR TITLE
update validation records/errors for `custom_hostname` and `certificate_pack`

### DIFF
--- a/.changelog/1424.txt
+++ b/.changelog/1424.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/custom_hostname: validation tokens are now an array (`validation_records`) instead of a top level, but the only top level record that was previously here was for cname validation, txt/http/email were entirely missing.
+```
+
+```release-note:enhancement
+resource/custom_hostname: also adds missing `validation_errors`, and `certificate_authority`
+```
+
+```release-note:enhancement
+resource/certificate_pack: adds `validation_errors` and `validation_records` with same format as custom hostnames.
+```

--- a/cloudflare/resource_cloudflare_certificate_pack.go
+++ b/cloudflare/resource_cloudflare_certificate_pack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
@@ -77,6 +78,30 @@ func resourceCloudflareCertificatePackRead(d *schema.ResourceData, meta interfac
 
 	d.Set("type", certificatePack.Type)
 	d.Set("hosts", expandStringListToSet(certificatePack.Hosts))
+
+	if !reflect.ValueOf(certificatePack.ValidationErrors).IsNil() {
+		errors := []map[string]interface{}{}
+		for _, e := range certificatePack.ValidationErrors {
+			errors = append(errors, map[string]interface{}{"message": e.Message})
+		}
+		d.Set("validation_errors", errors)
+	}
+	if !reflect.ValueOf(certificatePack.ValidationRecords).IsNil() {
+		records := []map[string]interface{}{}
+		for _, e := range certificatePack.ValidationRecords {
+			records = append(records,
+				map[string]interface{}{
+					"cname_name":   e.CnameName,
+					"cname_target": e.CnameTarget,
+					"txt_name":     e.TxtName,
+					"txt_value":    e.TxtValue,
+					"http_body":    e.HTTPBody,
+					"http_url":     e.HTTPUrl,
+					"emails":       e.Emails,
+				})
+		}
+		d.Set("validation_records", records)
+	}
 
 	return nil
 }

--- a/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
@@ -31,7 +31,7 @@ func resourceCloudflareCustomHostnameFallbackOriginRead(d *schema.ResourceData, 
 
 	customHostnameFallbackOrigin, err := client.CustomHostnameFallbackOrigin(context.Background(), zoneID)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error reading custom hostname fallback origin %q", zoneID))
+		return fmt.Errorf("error reading custom hostname fallback origin %q: %w", zoneID, err)
 	}
 
 	d.Set("origin", customHostnameFallbackOrigin.Origin)
@@ -46,7 +46,7 @@ func resourceCloudflareCustomHostnameFallbackOriginDelete(d *schema.ResourceData
 
 	err := client.DeleteCustomHostnameFallbackOrigin(context.Background(), zoneID)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete custom hostname fallback origin")
+		return fmt.Errorf("failed to delete custom hostname fallback origin: %w", err)
 	}
 
 	return nil
@@ -64,17 +64,18 @@ func resourceCloudflareCustomHostnameFallbackOriginCreate(d *schema.ResourceData
 	return resource.Retry(d.Timeout(schema.TimeoutDefault), func() *resource.RetryError {
 		_, err := client.UpdateCustomHostnameFallbackOrigin(context.Background(), zoneID, fallbackOrigin)
 		if err != nil {
+			//nolint:errorlint
 			if errors.As(err, &cloudflare.APIRequestError{}) && err.(*cloudflare.APIRequestError).InternalErrorCodeIs(1414) {
 				return resource.RetryableError(fmt.Errorf("expected custom hostname resource to be ready for modification but is still pending"))
 			} else {
-				return resource.NonRetryableError(errors.Wrap(err, "failed to create custom hostname fallback origin"))
+				return resource.NonRetryableError(fmt.Errorf("failed to create custom hostname fallback origin: %w", err))
 			}
 		}
 
 		fallbackHostname, err := client.CustomHostnameFallbackOrigin(context.Background(), zoneID)
 
 		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("failed to fetch custom hostname: %s", err))
+			return resource.NonRetryableError(fmt.Errorf("failed to fetch custom hostname: %w", err))
 		}
 
 		// Address an eventual consistency issue where deleting a fallback hostname
@@ -105,10 +106,11 @@ func resourceCloudflareCustomHostnameFallbackOriginUpdate(d *schema.ResourceData
 	return resource.Retry(d.Timeout(schema.TimeoutDefault), func() *resource.RetryError {
 		_, err := client.UpdateCustomHostnameFallbackOrigin(context.Background(), zoneID, fallbackOrigin)
 		if err != nil {
+			//nolint:errorlint
 			if errors.As(err, &cloudflare.APIRequestError{}) && err.(*cloudflare.APIRequestError).InternalErrorCodeIs(1414) {
 				return resource.RetryableError(fmt.Errorf("expected custom hostname resource to be ready for modification but is still pending"))
 			}
-			return resource.NonRetryableError(errors.Wrap(err, "failed to update custom hostname fallback origin"))
+			return resource.NonRetryableError(fmt.Errorf("failed to update custom hostname fallback origin: %w", err))
 		}
 
 		resourceCloudflareCustomHostnameFallbackOriginRead(d, meta)

--- a/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
@@ -64,10 +64,11 @@ func resourceCloudflareCustomHostnameFallbackOriginCreate(d *schema.ResourceData
 	return resource.Retry(d.Timeout(schema.TimeoutDefault), func() *resource.RetryError {
 		_, err := client.UpdateCustomHostnameFallbackOrigin(context.Background(), zoneID, fallbackOrigin)
 		if err != nil {
-			if err.(*cloudflare.APIRequestError).InternalErrorCodeIs(1414) {
+			if errors.As(err, &cloudflare.APIRequestError{}) && err.(*cloudflare.APIRequestError).InternalErrorCodeIs(1414) {
 				return resource.RetryableError(fmt.Errorf("expected custom hostname resource to be ready for modification but is still pending"))
+			} else {
+				return resource.NonRetryableError(errors.Wrap(err, "failed to create custom hostname fallback origin"))
 			}
-			return resource.NonRetryableError(errors.Wrap(err, "failed to create custom hostname fallback origin"))
 		}
 
 		fallbackHostname, err := client.CustomHostnameFallbackOrigin(context.Background(), zoneID)
@@ -104,7 +105,7 @@ func resourceCloudflareCustomHostnameFallbackOriginUpdate(d *schema.ResourceData
 	return resource.Retry(d.Timeout(schema.TimeoutDefault), func() *resource.RetryError {
 		_, err := client.UpdateCustomHostnameFallbackOrigin(context.Background(), zoneID, fallbackOrigin)
 		if err != nil {
-			if err.(*cloudflare.APIRequestError).InternalErrorCodeIs(1414) {
+			if errors.As(err, &cloudflare.APIRequestError{}) && err.(*cloudflare.APIRequestError).InternalErrorCodeIs(1414) {
 				return resource.RetryableError(fmt.Errorf("expected custom hostname resource to be ready for modification but is still pending"))
 			}
 			return resource.NonRetryableError(errors.Wrap(err, "failed to update custom hostname fallback origin"))

--- a/cloudflare/resource_cloudflare_custom_hostname_test.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_test.go
@@ -197,6 +197,7 @@ func TestAccCloudflareCustomHostname_WithCustomSSLSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.http2", "off"),
 					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.min_tls_version", "1.2"),
 					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.ciphers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.certificate_authority", "digicert"),
 					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.value"),
 					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.type"),
 					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.name"),
@@ -380,8 +381,8 @@ func TestAccCloudflareCustomHostname_Import(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"ssl.#",
 					"ssl.0.certificate_authority",
-					"ssl.0.cname_name",
-					"ssl.0.cname_target",
+					"ssl.0.validation_records",
+					"ssl.0.validation_errors",
 					"ssl.0.custom_certificate",
 					"ssl.0.custom_key",
 					"ssl.0.method",

--- a/cloudflare/schema_cloudflare_certificate_pack.go
+++ b/cloudflare/schema_cloudflare_certificate_pack.go
@@ -41,8 +41,22 @@ func resourceCloudflareCertificatePackSchema() map[string]*schema.Schema {
 		"certificate_authority": {
 			Type:         schema.TypeString,
 			Optional:     true,
+			Computed:     true,
 			ForceNew:     true,
 			ValidateFunc: validation.StringInSlice([]string{"digicert", "lets_encrypt"}, false),
+			Default:      nil,
+		},
+		"validation_records": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Optional: true,
+			Elem:     sslValidationRecordsSchema(),
+		},
+		"validation_errors": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Optional: true,
+			Elem:     sslValidationErrorsSchema(),
 		},
 		"cloudflare_branding": {
 			Type:     schema.TypeBool,

--- a/cloudflare/schema_cloudflare_custom_hostname.go
+++ b/cloudflare/schema_cloudflare_custom_hostname.go
@@ -46,15 +46,19 @@ func resourceCloudflareCustomHostnameSchema() map[string]*schema.Schema {
 					"certificate_authority": {
 						Type:         schema.TypeString,
 						Optional:     true,
+						Computed:     true,
 						ValidateFunc: validation.StringInSlice([]string{"lets_encrypt", "digicert"}, false),
+						Default:      nil,
 					},
-					"cname_target": {
-						Type:     schema.TypeString,
-						Optional: true,
+					"validation_records": {
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem:     sslValidationRecordsSchema(),
 					},
-					"cname_name": {
-						Type:     schema.TypeString,
-						Optional: true,
+					"validation_errors": {
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem:     sslValidationErrorsSchema(),
 					},
 					"wildcard": {
 						Type:     schema.TypeBool,

--- a/cloudflare/schema_cloudflare_ssl.go
+++ b/cloudflare/schema_cloudflare_ssl.go
@@ -1,0 +1,60 @@
+package cloudflare
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+func sslValidationErrorsSchema() *schema.Resource {
+	return &schema.Resource{
+		SchemaVersion: 1,
+		Schema: map[string]*schema.Schema{
+			"message": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+func sslValidationRecordsSchema() *schema.Resource {
+	return &schema.Resource{
+		SchemaVersion: 1,
+		Schema: map[string]*schema.Schema{
+			"cname_target": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"cname_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"txt_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"txt_value": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"http_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"http_body": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"emails": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
```release-note:enhancement
resource/custom_hostname: validation tokens are now an array (`validation_records`) instead of a top level, but the only top level record that was previously here was for cname validation, txt/http/email were entirely missing.
resource/custom_hostname: also adds missing `validation_errors`, and `certificate_authority`
resource/certificate_pack: adds `validation_errors` and `validation_records` with same format as custom hostnames.

```


relies of lib behavior added in https://github.com/cloudflare/cloudflare-go/pull/796