### PR TITLE
feat(rate_limit): add support for managed_challenge

### DIFF
--- a/.changelog/1431.txt
+++ b/.changelog/1431.txt
@@ -1,0 +1,3 @@
+```release:enhancement
+resource/cloudflare_rate_limit: add support for managed_challenge action
+```

--- a/cloudflare/schema_cloudflare_rate_limit.go
+++ b/cloudflare/schema_cloudflare_rate_limit.go
@@ -37,7 +37,7 @@ func resourceCloudflareRateLimitSchema() map[string]*schema.Schema {
 					"mode": {
 						Type:         schema.TypeString,
 						Required:     true,
-						ValidateFunc: validation.StringInSlice([]string{"simulate", "ban", "challenge", "js_challenge"}, true),
+						ValidateFunc: validation.StringInSlice([]string{"simulate", "ban", "challenge", "js_challenge", "managed_challenge"}, true),
 					},
 
 					"timeout": {

--- a/website/docs/r/rate_limit.html.markdown
+++ b/website/docs/r/rate_limit.html.markdown
@@ -93,7 +93,7 @@ The **match.response** block supports:
 
 The **action** block supports:
 
-* `mode` - (Required) The type of action to perform. Allowable values are 'simulate', 'ban', 'challenge' and 'js_challenge'.
+* `mode` - (Required) The type of action to perform. Allowable values are 'simulate', 'ban', 'challenge', 'js_challenge' and 'managed_challenge'.
 * `timeout` - (Optional) The time in seconds as an integer to perform the mitigation action. This field is required if the `mode` is either `simulate` or `ban`. Must be the same or greater than the period (min: 1, max: 86400).
 * `response` - (Optional) Custom content-type and body to return, this overrides the custom error for the zone. This field is not required. Omission will result in default HTML error page. Definition below.
 


### PR DESCRIPTION
Adding support for "managed_challenge" as we need it for old rate limit rules as well

│ Error: expected action.0.mode to be one of [simulate ban challenge js_challenge], got managed_challenge
│ 
│   with module.common.cloudflare_rate_limit.persisted_query_not_found,
│   on ../../modules_v3/common_setup/rate_limit.tf line 279, in resource "cloudflare_rate_limit" "persisted_query_not_found":
│  279:     mode = "managed_challenge"