### PR TITLE
Add docs for zone cache variants

### DIFF
--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -217,6 +217,9 @@
             <li<%= sidebar_current("docs-cloudflare-resource-zone") %>>
               <a href="/docs/providers/cloudflare/r/zone.html">cloudflare_zone</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-zone-cache-variants") %>>
+              <a href="/docs/providers/cloudflare/r/zone_cache_variants.html">cloudflare_zone_cache_variants</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-zone-lockdown") %>>
               <a href="/docs/providers/cloudflare/r/zone_lockdown.html">cloudflare_zone_lockdown</a>
             </li>

--- a/website/docs/r/zone_cache_variants.html.markdown
+++ b/website/docs/r/zone_cache_variants.html.markdown
@@ -3,7 +3,7 @@ layout: "cloudflare"
 page_title: "Cloudflare: cloudflare_zone_cache_variants"
 sidebar_current: "docs-cloudflare-resource-zone-cache-variants"
 description: |-
-  Provides a Cloudflare resource which customizes Cloudflare zone cache variants setting.
+  Provides a resource which customizes Cloudflare zone cache variants setting.
 ---
 
 # cloudflare_zone_cache_variants
@@ -14,7 +14,7 @@ Provides a resource which customizes Cloudflare zone cache variants.
 
 ```hcl
 resource "cloudflare_zone_cache_variants" "example" {
-    zone_id = var.cloudflare_zone_id
+    zone_id = "7df50664b7f90274f4d77cdfee701380"
 
     avif = ["image/avif", "image/webp"]
     bmp = ["image/bmp", "image/webp"]
@@ -34,16 +34,16 @@ resource "cloudflare_zone_cache_variants" "example" {
 
 The following arguments are supported:
 
-- `zone_id` - (Required) The ID of the DNS zone in which to apply the cache variants setting
-- `avif` - (Optional) List of strings with the MIME types of all the variants that should be served for avif
-- `bmp` - (Optional) List of strings with the MIME types of all the variants that should be served for bmp
-- `gif` - (Optional) List of strings with the MIME types of all the variants that should be served for gif
-- `jpeg` - (Optional) List of strings with the MIME types of all the variants that should be served for jpeg
-- `jpg` - (Optional) List of strings with the MIME types of all the variants that should be served for jpg
-- `jpg2` - (Optional) List of strings with the MIME types of all the variants that should be served for jpg2
-- `jp2` - (Optional) List of strings with the MIME types of all the variants that should be served for jp2
-- `png` - (Optional) List of strings with the MIME types of all the variants that should be served for png
-- `tiff` - (Optional) List of strings with the MIME types of all the variants that should be served for tiff
-- `tif` - (Optional) List of strings with the MIME types of all the variants that should be served for tif
-- `webp` - (Optional) List of strings with the MIME types of all the variants that should be served for webp
+* `zone_id` - (Required) The ID of the DNS zone in which to apply the cache variants setting
+* `avif` - (Optional) List of strings with the MIME types of all the variants that should be served for avif
+* `bmp` - (Optional) List of strings with the MIME types of all the variants that should be served for bmp
+* `gif` - (Optional) List of strings with the MIME types of all the variants that should be served for gif
+* `jpeg` - (Optional) List of strings with the MIME types of all the variants that should be served for jpeg
+* `jpg` - (Optional) List of strings with the MIME types of all the variants that should be served for jpg
+* `jpg2` - (Optional) List of strings with the MIME types of all the variants that should be served for jpg2
+* `jp2` - (Optional) List of strings with the MIME types of all the variants that should be served for jp2
+* `png` - (Optional) List of strings with the MIME types of all the variants that should be served for png
+* `tiff` - (Optional) List of strings with the MIME types of all the variants that should be served for tiff
+* `tif` - (Optional) List of strings with the MIME types of all the variants that should be served for tif
+* `webp` - (Optional) List of strings with the MIME types of all the variants that should be served for webp
 

--- a/website/docs/r/zone_cache_variants.html.markdown
+++ b/website/docs/r/zone_cache_variants.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_zone_cache_variants"
+sidebar_current: "docs-cloudflare-resource-zone-cache-variants"
+description: |-
+  Provides a Cloudflare resource which customizes Cloudflare zone cache variants setting.
+---
+
+# cloudflare_zone_cache_variants
+
+Provides a resource which customizes Cloudflare zone cache variants.
+
+## Example Usage
+
+```hcl
+resource "cloudflare_zone_cache_variants" "example" {
+    zone_id = var.cloudflare_zone_id
+
+    avif = ["image/avif", "image/webp"]
+    bmp = ["image/bmp", "image/webp"]
+    gif = ["image/gif", "image/webp"]
+    jpeg = ["image/jpeg", "image/webp"]
+    jpg = ["image/jpg", "image/webp"]
+    jpg2 = ["image/jpg2", "image/webp"]
+    jp2 = ["image/jp2", "image/webp"]
+    png = ["image/png", "image/webp"]
+    tiff = ["image/tiff", "image/webp"]
+    tif = ["image/tif", "image/webp"]
+    webp = ["image/jpeg", "image/webp"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `zone_id` - (Required) The ID of the DNS zone in which to apply the cache variants setting
+- `avif` - (Optional) List of strings with the MIME types of all the variants that should be served for avif
+- `bmp` - (Optional) List of strings with the MIME types of all the variants that should be served for bmp
+- `gif` - (Optional) List of strings with the MIME types of all the variants that should be served for gif
+- `jpeg` - (Optional) List of strings with the MIME types of all the variants that should be served for jpeg
+- `jpg` - (Optional) List of strings with the MIME types of all the variants that should be served for jpg
+- `jpg2` - (Optional) List of strings with the MIME types of all the variants that should be served for jpg2
+- `jp2` - (Optional) List of strings with the MIME types of all the variants that should be served for jp2
+- `png` - (Optional) List of strings with the MIME types of all the variants that should be served for png
+- `tiff` - (Optional) List of strings with the MIME types of all the variants that should be served for tiff
+- `tif` - (Optional) List of strings with the MIME types of all the variants that should be served for tif
+- `webp` - (Optional) List of strings with the MIME types of all the variants that should be served for webp
+


### PR DESCRIPTION
Follow-up of https://github.com/cloudflare/terraform-provider-cloudflare/pull/1444

I'm unsure if that's the proper way of updating the docs shown at https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs . I'm also unsure about how to test those changes 