### PR TITLE
feat: adds support for custom_origin_sni field in cloudflare_custom_hostname

### DIFF
--- a/.changelog/1482.txt
+++ b/.changelog/1482.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_custom_hostname: adds support for custom_origin_sni
+```

--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -37,6 +37,7 @@ func resourceCloudflareCustomHostnameRead(d *schema.ResourceData, meta interface
 
 	d.Set("hostname", customHostname.Hostname)
 	d.Set("custom_origin_server", customHostname.CustomOriginServer)
+	d.Set("custom_origin_sni", customHostname.CustomOriginSNI)
 	var sslConfig []map[string]interface{}
 
 	if !reflect.ValueOf(customHostname.SSL).IsNil() {
@@ -172,6 +173,7 @@ func buildCustomHostname(d *schema.ResourceData) cloudflare.CustomHostname {
 	ch := cloudflare.CustomHostname{
 		Hostname:           d.Get("hostname").(string),
 		CustomOriginServer: d.Get("custom_origin_server").(string),
+		CustomOriginSNI:    d.Get("custom_origin_sni").(string),
 	}
 
 	if _, ok := d.GetOk("ssl"); ok {

--- a/cloudflare/resource_cloudflare_custom_hostname_test.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_test.go
@@ -108,6 +108,7 @@ func TestAccCloudflareCustomHostname_WithCustomOriginServer(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "zone_id", zoneID),
 					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("%s.%s", rnd, domain)),
 					resource.TestCheckResourceAttr(resourceName, "custom_origin_server", fmt.Sprintf("origin.%s.terraform.cfapi.net", rnd)),
+					resource.TestCheckResourceAttr(resourceName, "custom_origin_sni", fmt.Sprintf("origin.%s.terraform.cfapi.net", rnd)),
 					resource.TestCheckResourceAttr(resourceName, "ssl.0.method", "txt"),
 					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.value"),
 					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.type"),
@@ -126,6 +127,7 @@ resource "cloudflare_custom_hostname" "%[2]s" {
   zone_id = "%[1]s"
   hostname = "%[2]s.%[3]s"
   custom_origin_server = "origin.%[2]s.terraform.cfapi.net"
+	custom_origin_sni = "origin.%[2]s.terraform.cfapi.net"
   ssl {
     method = "txt"
   }

--- a/cloudflare/schema_cloudflare_custom_hostname.go
+++ b/cloudflare/schema_cloudflare_custom_hostname.go
@@ -24,7 +24,7 @@ func resourceCloudflareCustomHostnameSchema() map[string]*schema.Schema {
 		},
 		"custom_origin_sni": {
 			Type:     schema.TypeString,
-			Computed: true,
+			Optional: true,
 		},
 		"ssl": {
 			Type:     schema.TypeList,

--- a/cloudflare/schema_cloudflare_custom_hostname.go
+++ b/cloudflare/schema_cloudflare_custom_hostname.go
@@ -22,6 +22,10 @@ func resourceCloudflareCustomHostnameSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"custom_origin_sni": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 		"ssl": {
 			Type:     schema.TypeList,
 			Optional: true,

--- a/website/docs/r/custom_hostname.html.markdown
+++ b/website/docs/r/custom_hostname.html.markdown
@@ -29,6 +29,7 @@ The following arguments are supported:
 * `zone_id` - (Required) The DNS zone ID where the custom hostname should be assigned.
 * `hostname` - (Required) Hostname you intend to request a certificate for.
 * `custom_origin_server` - (Optional) The custom origin server used for certificates.
+* `custom_origin_sni` - (Optional) The [custom origin SNI](https://developers.cloudflare.com/ssl/ssl-for-saas/hostname-specific-behavior/custom-origin) used for certificates.
 * `ssl` - (Required) SSL configuration of the certificate. See further notes below.
 
 **ssl** block supports:


### PR DESCRIPTION
Adds missing custom_origin_sni field in cloudflare_custom_hostname resource. It's an update from this PR https://github.com/cloudflare/cloudflare-go/pull/732/files.

https://developers.cloudflare.com/ssl/ssl-for-saas/hostname-specific-behavior/custom-origin