### PR TITLE
resource/cloudflare_ruleset: fix ruleset category overrides in DDoS L7 phase by allowing the provider to omit the `enabled` flag, as required by Cloudflare's API

### DIFF
--- a/.changelog/1492.txt
+++ b/.changelog/1492.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+resource/cloudflare_ruleset: fix category overrides for ddos_l7 phase
+```
+

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -460,12 +460,19 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 
 							// Category based overrides
 							if val, ok := overrideParamValue.(map[string]interface{})["categories"]; ok {
-								for _, category := range val.([]interface{}) {
+								for categoryOverrideCounter, category := range val.([]interface{}) {
 									cData := category.(map[string]interface{})
+
+									var enabled *bool
+									//nolint:staticcheck
+									if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.overrides.%d.categories.%d.enabled", rulesCounter, overrideCounter, categoryOverrideCounter)); ok {
+										enabled = &[]bool{value.(bool)}[0]
+									}
+
 									categories = append(categories, cloudflare.RulesetRuleActionParametersCategories{
 										Category: cData["category"].(string),
 										Action:   cData["action"].(string),
-										Enabled:  cData["enabled"].(bool),
+										Enabled:  enabled,
 									})
 								}
 							}

--- a/cloudflare/resource_cloudflare_ruleset_migrate.go
+++ b/cloudflare/resource_cloudflare_ruleset_migrate.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"context"
+	"log"
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -341,6 +342,13 @@ func resourceCloudflareRulesetSchemaV0() *schema.Resource {
 }
 
 func resourceCloudflareRulesetStateUpgradeV0ToV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	// Broadly intercept the panic generated from our inability to perform the upgrade.
+	defer func() {
+		if err := recover(); err != nil {
+			log.Printf("[DEBUG] Unable to perform resourceCloudflareRulesetStateUpgradeV0ToV1")
+		}
+	}()
+
 	rawState["ratelimit"].([]map[string]interface{})[0]["counting_expression"] = rawState["ratelimit"].([]map[string]interface{})[0]["mitigation_expression"]
 	delete(rawState["ratelimit"].([]map[string]interface{})[0], "mitigation_expression")
 

--- a/cloudflare/resource_cloudflare_ruleset_test.go
+++ b/cloudflare/resource_cloudflare_ruleset_test.go
@@ -1165,6 +1165,9 @@ func TestAccCloudflareRuleset_ActionParametersHTTPDDoSOverride(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.id", "4d21379b4f9f4bb088e0729962c8b3cf"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.0.id", "fdfdac75430c4c47a959592f0aa5e68a"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.rules.0.sensitivity_level", "low"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.0.category", "unusual-requests"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.overrides.0.categories.0.action", "challenge"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", "true"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "override HTTP DDoS ruleset rule"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.enabled", "true"),
@@ -2099,6 +2102,10 @@ func testAccCheckCloudflareRulesetActionParametersHTTPDDosOverride(rnd, name, zo
             id = "fdfdac75430c4c47a959592f0aa5e68a" # requests with odd HTTP headers or URI path
             sensitivity_level = "low"
           }
+          categories {
+		    category = "unusual-requests"
+		    action = "challenge"
+		  }
         }
       }
       expression = "true"


### PR DESCRIPTION
In the DDoS L7 phase, category overrides do not support the `enabled` flag which must therefore be omitted. This is pretty closely related to https://github.com/cloudflare/terraform-provider-cloudflare/pull/1405. 

### Terraform example

```
resource "cloudflare_ruleset" "example" {
  zone_id     = cloudflare_zone.example.id
  name        = "zone_managed_ddos"
  description = "Zone-level Cloudflare DDoS Managed Rulesets"
  kind        = "zone"
  phase       = "ddos_l7"

  // DDoS L7 ruleset
  rules {
    action      = "execute"
    description = "Override DDoS L7 Ruleset"
    expression  = "true"
    enabled     = true

    action_parameters {
      id = "4d21379b4f9f4bb088e0729962c8b3cf"

      overrides {
        // Enable all unusual request rules
        categories {
          category = "unusual-requests"
          action   = "challenge"
        }
```

### API Request (sample) & error before this PR

```
                        "categories": [
                          {
                            "action": "challenge",
                            "category": "unusual-requests",
                            "enabled": false
                          },
                          {
                            "action": "challenge",
                            "category": "botnets",
                            "enabled": false
                          }
                        ],
```

Leading to the following `400 Bad Request` error returned by the Cloudflare API (doubled, because two categories):

```
    DDoS L7 overrides cannot use the enabled field, DDoS L7 overrides cannot use the enabled field
    DDoS L7 overrides cannot use the enabled field, DDoS L7 overrides cannot use the enabled field
```

### API Request (sample) after this PR

```
     "categories": [
      {
       "category": "unusual-requests",
       "action": "challenge"
      },
      {
       "category": "botnets",
       "action": "challenge"
      }
     ],
```
 
### Notes

- This PR requires the following cloudflare-go schema: https://github.com/cloudflare/cloudflare-go/pull/824
- This PR also includes a second commit to fix a panic encountered in resourceCloudflareRulesetStateUpgradeV0ToV1 during testing