### PR TITLE
resource/cloudflare_record: no need to pass the entire `Update` method

### DIFF
--- a/.changelog/1496.txt
+++ b/.changelog/1496.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_record: no need to pass the resourceCloudflareRecordUpdate to the NonRetryable handler
+```

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -144,7 +144,11 @@ func resourceCloudflareRecordCreate(d *schema.ResourceData, meta interface{}) er
 					// for Terraform to operate on it, we need an anchor.
 					d.SetId(rs[0].ID)
 
-					return resource.NonRetryableError(resourceCloudflareRecordUpdate(d, meta))
+					if updateErr := resourceCloudflareRecordUpdate(d, meta); updateErr != nil {
+						return resource.NonRetryableError(updateErr)
+					}
+
+					return nil
 				}
 
 				return resource.RetryableError(fmt.Errorf("expected DNS record to not already be present but already exists"))


### PR DESCRIPTION
Splits the `NonRetryableError` handler to prevent everything falling
into the condition.