### PR TITLE
resource/cloudflare_ruleset: don't attempt to upgrade ratelimit if it isn't set

### DIFF
--- a/.changelog/1501.txt
+++ b/.changelog/1501.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: don't attempt to upgrade ratelimit if it isn't set
+```

--- a/cloudflare/resource_cloudflare_ruleset_migrate.go
+++ b/cloudflare/resource_cloudflare_ruleset_migrate.go
@@ -341,6 +341,10 @@ func resourceCloudflareRulesetSchemaV0() *schema.Resource {
 }
 
 func resourceCloudflareRulesetStateUpgradeV0ToV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if rawState["ratelimit"] == nil {
+		return rawState, nil
+	}
+
 	rawState["ratelimit"].([]map[string]interface{})[0]["counting_expression"] = rawState["ratelimit"].([]map[string]interface{})[0]["mitigation_expression"]
 	delete(rawState["ratelimit"].([]map[string]interface{})[0], "mitigation_expression")
 


### PR DESCRIPTION
Fixes #1499