### PR TITLE
Use requested_validity from API response

### DIFF
--- a/.changelog/1502.txt
+++ b/.changelog/1502.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/cloudflare_origin_ca_certificate: `requested_validity` is no longer calculated (to be the amount of days until the certificate expires) but is now the amount of days the certificate was requested for.
+```

--- a/.changelog/1502.txt
+++ b/.changelog/1502.txt
@@ -1,3 +1,3 @@
-```release-note:breaking-change
-resource/cloudflare_origin_ca_certificate: `requested_validity` is no longer calculated (to be the amount of days until the certificate expires) but is now the amount of days the certificate was requested for.
+```release-note:note
+resource/cloudflare_origin_ca_certificate: `requested_validity` no longer decrements until the `expires_on` value but is now the amount of days the certificate was requested for.
 ```

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -6,7 +6,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"log"
-	"math"
 	"strings"
 	"time"
 
@@ -92,19 +91,7 @@ func resourceCloudflareOriginCACertificateRead(d *schema.ResourceData, meta inte
 	d.Set("expires_on", cert.ExpiresOn.Format(time.RFC3339))
 	d.Set("hostnames", hostnames)
 	d.Set("request_type", cert.RequestType)
-
-	// lazy approach to extracting the date from a known timestamp in order to
-	// `time.Parse` it correctly. Here we are getting the certificate expiry and
-	// calculating the validity as the API doesn't return it yet it is present in
-	// the schema.
-	date := strings.Split(cert.ExpiresOn.Format(time.RFC3339), "T")
-	certDate, _ := time.Parse("2006-01-02", date[0])
-	now := time.Now()
-	duration := certDate.Sub(now)
-	var validityDays int
-	validityDays = int(math.Ceil(duration.Hours() / 24))
-
-	d.Set("requested_validity", validityDays)
+	d.Set("requested_validity", cert.RequestValidity)
 
 	return nil
 }

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -93,7 +93,12 @@ func resourceCloudflareOriginCACertificateRead(d *schema.ResourceData, meta inte
 	d.Set("hostnames", hostnames)
 	d.Set("request_type", cert.RequestType)
 
-	x509Cert, err := x509.ParseCertificate([]byte(cert.Certificate))
+	certBlock, _ := pem.Decode([]byte(cert.Certificate))
+	if certBlock == nil {
+		return fmt.Errorf("error decoding OriginCACertificate %q: %s", certID, err)
+	}
+
+	x509Cert, err := x509.ParseCertificate(certBlock.Bytes)
 	if err != nil {
 		return fmt.Errorf("error parsing OriginCACertificate %q: %s", certID, err)
 	}

--- a/cloudflare/schema_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/schema_cloudflare_origin_ca_certificate.go
@@ -39,9 +39,6 @@ func resourceCloudflareOriginCACertificateSchema() map[string]*schema.Schema {
 			Optional:     true,
 			Computed:     true,
 			ValidateFunc: validation.IntInSlice([]int{7, 30, 90, 365, 730, 1095, 5475}),
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				return true
-			},
 		},
 	}
 }


### PR DESCRIPTION
Instead of trying and failing to calculate the requested validity of the certificate we can use the returned validity.
It looks like `requested_validity` was being used in 2 ways.
The first one was to request the certificate for a time period and the second to indicate the amount of day the certificate is still valid.

The calculation is no longer done and could be seen as a BC break but since the current setup is causing issue like #1448, #1276 and #1031. I expect that this is acceptable.

Related API docs: https://api.cloudflare.com/#origin-ca-get-certificate