### PR TITLE
[resource/device_posture_integration] Remove extra id parameters

### DIFF
--- a/.changelog/1504.txt
+++ b/.changelog/1504.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_device_posture_integration: remove superfluous `id` from schema
+```

--- a/cloudflare/schema_cloudflare_device_posture_integration.go
+++ b/cloudflare/schema_cloudflare_device_posture_integration.go
@@ -11,10 +11,6 @@ func resourceCloudflareDevicePostureIntegrationSchema() map[string]*schema.Schem
 			Type:     schema.TypeString,
 			Required: true,
 		},
-		"id": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
 		"name": {
 			Type:     schema.TypeString,
 			Required: true,


### PR DESCRIPTION
the terraform-plugin-sdk adds the "id" to the schema when d.SetID is
used. therefore, there is no need to have this extra parameter in
the schema.

The use of this extra id is causing the pulumi schema to pull a
duplicate argument

```
sdk/python/pulumi_cloudflare/device_posture_integration.py:377: error: Duplicate argument "id" in function definition
```