### PR TITLE
Fix unexpected crashes when using `cloudflare_notification_policy` with a `filters` attribute

### DIFF
--- a/.changelog/1520.txt
+++ b/.changelog/1520.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_notification_policy: Fix unexpected crashes when using cloudflare_notification_policy with a filters attribute
+```

--- a/cloudflare/resource_cloudflare_notification_policy.go
+++ b/cloudflare/resource_cloudflare_notification_policy.go
@@ -55,17 +55,22 @@ func resourceCloudflareNotificationPolicyRead(d *schema.ResourceData, meta inter
 	d.Set("enabled", policy.Result.Enabled)
 	d.Set("alert_type", policy.Result.AlertType)
 	d.Set("description", policy.Result.Description)
-	d.Set("filters", policy.Result.Filters)
 	d.Set("conditions", policy.Result.Conditions)
 	d.Set("created", policy.Result.Created.Format(time.RFC3339))
 	d.Set("modified", policy.Result.Modified.Format(time.RFC3339))
 
+	if err := d.Set("filters", policy.Result.Filters); err != nil {
+		return fmt.Errorf("failed to set filters: %s", err)
+	}
+
 	if err := d.Set("email_integration", setNotificationMechanisms(policy.Result.Mechanisms["email"])); err != nil {
 		return fmt.Errorf("failed to set email integration: %s", err)
 	}
+
 	if err := d.Set("pagerduty_integration", setNotificationMechanisms(policy.Result.Mechanisms["pagerduty"])); err != nil {
 		return fmt.Errorf("failed to set pagerduty integration: %s", err)
 	}
+
 	if err := d.Set("webhooks_integration", setNotificationMechanisms(policy.Result.Mechanisms["webhooks"])); err != nil {
 		return fmt.Errorf("failed to set webhooks integration: %s", err)
 	}

--- a/cloudflare/resource_cloudflare_notification_policy.go
+++ b/cloudflare/resource_cloudflare_notification_policy.go
@@ -155,7 +155,7 @@ func buildNotificationPolicy(d *schema.ResourceData) cloudflare.NotificationPoli
 	}
 
 	if filters, ok := d.GetOk("filters"); ok {
-		notificationPolicy.Filters = filters.(map[string][]string)
+		notificationPolicy.Filters = filters.([]interface{})[0].(map[string][]string)
 	}
 
 	if conditions, ok := d.GetOk("conditions"); ok {

--- a/cloudflare/resource_cloudflare_notification_policy_test.go
+++ b/cloudflare/resource_cloudflare_notification_policy_test.go
@@ -84,3 +84,103 @@ func testCheckCloudflareNotificationPolicyUpdated(resName, policyName, policyDes
     }
   }`, resName, policyName, policyDesc, accountID)
 }
+
+func TestAccCloudflareNotificationPolicyWithFiltersAttribute(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the notification
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := generateRandomResourceName()
+	resourceName := "cloudflare_notification_policy." + rnd
+	updatedPolicyName := "updated Advanced Security Events Alert from terraform provider"
+	updatedPolicyDesc := "updated description"
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckAccount(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testCheckCloudflareNotificationPolicyWithFiltersAttribute(rnd, accountID, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "test Advanced Security Events Alert from terraform provider"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "alert_type", "clickhouse_alert_fw_ent_anomaly"),
+					resource.TestCheckResourceAttr(resourceName, "account_id", accountID),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.services.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.services.0", "waf"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.zones.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.zones.0", zoneID),
+				),
+			},
+			{
+				Config: testCheckCloudflareNotificationPolicyWithFiltersAttributeUpdated(rnd, updatedPolicyName, updatedPolicyDesc, accountID, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", updatedPolicyName),
+					resource.TestCheckResourceAttr(resourceName, "description", updatedPolicyDesc),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "alert_type", "clickhouse_alert_fw_ent_anomaly"),
+					resource.TestCheckResourceAttr(resourceName, "account_id", accountID),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.services.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.services.0", "waf"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.services.1", "firewallrules"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.zones.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.zones.0", zoneID),
+				),
+			},
+		},
+	})
+}
+
+func testCheckCloudflareNotificationPolicyWithFiltersAttribute(name, accountID, zoneID string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_notification_policy" "%[1]s" {
+    name        = "test Advanced Security Events Alert from terraform provider"
+    account_id  = "%[2]s"
+    description = "test description"
+    enabled     =  true
+    alert_type  = "clickhouse_alert_fw_ent_anomaly"
+    email_integration {
+      name =  ""
+      id   =  "test@example.com"
+    }
+    filters {
+      services = [
+        "waf",
+      ]
+      zones = ["%[3]s"]
+    }
+  }`, name, accountID, zoneID)
+}
+
+func testCheckCloudflareNotificationPolicyWithFiltersAttributeUpdated(resName, policyName, policyDesc, accountID, zoneID string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_notification_policy" "%[1]s" {
+    name        = "%[2]s"
+    account_id  = "%[4]s"
+    description = "%[3]s"
+    enabled     =  true
+    alert_type  = "clickhouse_alert_fw_ent_anomaly"
+    email_integration {
+      name =  ""
+      id   =  "test@example.com"
+    }
+    filters {
+      services = [
+        "waf",
+        "firewallrules",
+      ]
+      zones = ["%[5]s"]
+    }
+  }`, resName, policyName, policyDesc, accountID, zoneID)
+}

--- a/cloudflare/resource_cloudflare_notification_policy_test.go
+++ b/cloudflare/resource_cloudflare_notification_policy_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccCloudflareNotificationPolicy(t *testing.T) {
+func TestAccCloudflareNotificationPolicy_Basic(t *testing.T) {
 	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the notification
 	// service does not yet support the API tokens and it results in
 	// misleading state error messages.
@@ -85,7 +85,7 @@ func testCheckCloudflareNotificationPolicyUpdated(resName, policyName, policyDes
   }`, resName, policyName, policyDesc, accountID)
 }
 
-func TestAccCloudflareNotificationPolicyWithFiltersAttribute(t *testing.T) {
+func TestAccCloudflareNotificationPolicy_WithFiltersAttribute(t *testing.T) {
 	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the notification
 	// service does not yet support the API tokens and it results in
 	// misleading state error messages.

--- a/cloudflare/schema_cloudflare_notification_policy.go
+++ b/cloudflare/schema_cloudflare_notification_policy.go
@@ -25,20 +25,20 @@ func resourceCloudflareNotificationPolicySchema() map[string]*schema.Schema {
 			Required: true,
 		},
 		"filters": {
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			MaxItems: 1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"zones": {
-						Type: schema.TypeList,
+						Type: schema.TypeSet,
 						Elem: &schema.Schema{
 							Type: schema.TypeString,
 						},
 						Optional: true,
 					},
 					"services": {
-						Type: schema.TypeList,
+						Type: schema.TypeSet,
 						Elem: &schema.Schema{
 							Type: schema.TypeString,
 						},

--- a/cloudflare/schema_cloudflare_notification_policy.go
+++ b/cloudflare/schema_cloudflare_notification_policy.go
@@ -25,11 +25,26 @@ func resourceCloudflareNotificationPolicySchema() map[string]*schema.Schema {
 			Required: true,
 		},
 		"filters": {
-			Type:     schema.TypeMap,
+			Type:     schema.TypeList,
 			Optional: true,
-			Elem: &schema.Schema{
-				Type: schema.TypeList,
-				Elem: schema.TypeString,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"zones": {
+						Type: schema.TypeList,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+						Optional: true,
+					},
+					"services": {
+						Type: schema.TypeList,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+						Optional: true,
+					},
+				},
 			},
 		},
 		"created": {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/1189

# Background
https://github.com/cloudflare/terraform-provider-cloudflare/issues/1189

When running `terraform plan` for `cloudflare_notification_policy` with a `filters` attribute,  I encountered the same issue with the following stack trace.

```
Stack trace from the terraform-provider-cloudflare_v3.8.0 plugin:

panic: Unknown validation type: 6

goroutine 90 [running]:
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.validateMapValues({0xd27c94, 0x7}, 0xc000390c30, 0xc00034db80, {0xc000390a60, 0x1, 0x1})
github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/schema.go:1912 +0x969
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.validateMap(0xc2f5e0, {0xd27c94, 0x7}, {0xc2f5e0, 0xc000545290}, 0x8bdbac, 0xc0003d52e8, {0xc000390a60, 0x1, 0x1})
github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/schema.go:1819 +0x271
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.validateType(0xc0003908e0, {0xd27c94, 0x7f496a}, {0xc2f5e0, 0xc000545290}, 0xc00034db80, 0xc1d4a0, {0xc000390a60, 0x1, 0x1})
github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/schema.go:2111 +0x185
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.validate(0xc4edc0, {0xd27c94, 0x7}, 0xc00034db80, 0x0, {0xc000390a60, 0x1, 0x1})
github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/schema.go:1534 +0x71a
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.validateObject(0xc000545680, {0x0, 0xc00047d2a8}, 0xcffce0, 0xc000390000, {0x13d7568, 0xc2f5e0, 0xc0005451d0})
github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/schema.go:1970 +0x585
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.Validate(...)
github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/schema.go:649
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Validate(0xc0003397a0, 0xc000318480)
github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/resource.go:542 +0x4d
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Provider).ValidateResource(0xe56d80, {0xc0003a74c0, 0x1e}, 0xc0005451d0)
github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/provider.go:254 +0xf2
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ValidateResourceTypeConfig(0xc00000c138, {0xc0003fef40, 0xd25dbf}, 0xc00047d1d0)
github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/grpc_provider.go:230 +0x126
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ValidateResourceTypeConfig(0xc00007e880, {0xe56680, 0xc00050b260}, 0xc0003fed80)
github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/tf5server/server.go:503 +0x2e2
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ValidateResourceTypeConfig_Handler({0xcf6a20, 0xc00007e880}, {0xe56680, 0xc00050b260}, 0xc0000a9980, 0x0)
github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:272 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0002988c0, {0xe64ea8, 0xc0001a6480}, 0xc000561d40, 0xc000399530, 0x13982b0, 0x0)
google.golang.org/grpc@v1.40.0/server.go:1297 +0xccf
google.golang.org/grpc.(*Server).handleStream(0xc0002988c0, {0xe64ea8, 0xc0001a6480}, 0xc000561d40, 0x0)
google.golang.org/grpc@v1.40.0/server.go:1626 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
google.golang.org/grpc@v1.40.0/server.go:941 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
google.golang.org/grpc@v1.40.0/server.go:939 +0x294
```

Currently, TypeMap doesn't support non-primitive type values.
ref : https://github.com/hashicorp/terraform-plugin-sdk/issues/62

When using non-primitive values with TypeMap, terraform crashes at runtime with a following error message.

```
panic: Unknown validation type: 6
```


This error is originated at
https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.11.0/helper/schema/schema.go#L2017
Only TypeBool, TypeInt, TypeFloat and TypeString are supported.

This is why terraform crashes.

So, in this change, use TypeList with new custom resource to store non-primitive values.

# NOTE
I also couldn't find any documentation about a filter parameters. ( https://github.com/cloudflare/terraform-provider-cloudflare/issues/1406 )

Therefore, currently this change doesn't support all possible filters. (now supports `zones` and `services` filters only)

Could you help me to support all possible filters, Cloudflare staffs?