### PR TITLE
add healthcheck notification deprecation

### DIFF
--- a/.changelog/1529.txt
+++ b/.changelog/1529.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-resource/cloudflare_healthcheck: notification_suspended and notification_email_addresses attributes are being deprecated in favor of cloudflare_notification_policy resource.
+resource/cloudflare_healthcheck: `notification_suspended` and `notification_email_addresses` attributes are being deprecated in favour of `cloudflare_notification_policy` resource instead.
 ```

--- a/.changelog/1529.txt
+++ b/.changelog/1529.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/cloudflare_healthcheck: notification_suspended and notification_email_addresses attributes are being deprecated in favor of cloudflare_notification_policy resource.
+```

--- a/cloudflare/schema_cloudflare_healthcheck.go
+++ b/cloudflare/schema_cloudflare_healthcheck.go
@@ -129,7 +129,7 @@ func resourceCloudflareHealthcheckSchema() map[string]*schema.Schema {
 			Type:       schema.TypeBool,
 			Optional:   true,
 			Default:    false,
-			Deprecated: "deprecated in favor of using `cloudflare_notification_policy` instead.",
+			Deprecated: "Use `cloudflare_notification_policy` instead.",
 		},
 		"notification_email_addresses": {
 			Type:     schema.TypeList,
@@ -137,7 +137,7 @@ func resourceCloudflareHealthcheckSchema() map[string]*schema.Schema {
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
-			Deprecated: "deprecated in favor of using `cloudflare_notification_policy` instead.",
+			Deprecated: "Use `cloudflare_notification_policy` instead.",
 		},
 		"created_on": {
 			Type:     schema.TypeString,

--- a/cloudflare/schema_cloudflare_healthcheck.go
+++ b/cloudflare/schema_cloudflare_healthcheck.go
@@ -126,9 +126,10 @@ func resourceCloudflareHealthcheckSchema() map[string]*schema.Schema {
 			},
 		},
 		"notification_suspended": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
+			Type:       schema.TypeBool,
+			Optional:   true,
+			Default:    false,
+			Deprecated: "deprecated in favor of using `cloudflare_notification_policy` instead.",
 		},
 		"notification_email_addresses": {
 			Type:     schema.TypeList,
@@ -136,6 +137,7 @@ func resourceCloudflareHealthcheckSchema() map[string]*schema.Schema {
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
+			Deprecated: "deprecated in favor of using `cloudflare_notification_policy` instead.",
 		},
 		"created_on": {
 			Type:     schema.TypeString,

--- a/website/docs/r/healthcheck.html.markdown
+++ b/website/docs/r/healthcheck.html.markdown
@@ -92,8 +92,8 @@ The following arguments are supported:
 * `address` - (Required) The hostname or IP address of the origin server to run health checks on.
 * `suspended` - (Optional) If suspended, no health checks are sent to the origin. Valid values: `true` or `false` (Default: `false`).
 * `check_regions` - (Optional) A list of regions from which to run health checks. If not set Cloudflare will pick a default region. Valid values: `WNAM`, `ENAM`, `WEU`, `EEU`, `NSAM`, `SSAM`, `OC`, `ME`, `NAF`, `SAF`, `IN`, `SEAS`, `NEAS`, `ALL_REGIONS`.
-* `notification_suspended` - (Optional) Whether the notifications are suspended or not. Useful for maintenance periods. Valid values: `true` or `false` (Default: `false`).
-* `notification_email_addresses` - (Optional) A list of email addresses we want to send the notifications to.
+* `notification_suspended` - (Optional) Whether the notifications are suspended or not. Useful for maintenance periods. Valid values: `true` or `false` (Default: `false`). *Deprecated, use `cloudflare_notification_policy` instead.*
+* `notification_email_addresses` - (Optional) A list of email addresses we want to send the notifications to. *Deprecated, use `cloudflare_notification_policy` instead.*
 * `type` - (Required) The protocol to use for the health check. Valid values: `HTTP`, `HTTPS`, `TCP`.
 * `port` - (Optional) Port number to connect to for the health check.  Valid values are in the range `0-65535` (Default: `80`).
 * `timeout` - (Optional) The timeout (in seconds) before marking the health check as failed. (Default: `5`)


### PR DESCRIPTION
Add deprecation notice to healthcheck `notification` related properties. 

Deprecated in favor of using new cloudflare notification policy.
https://blog.cloudflare.com/get-updates-on-the-health-of-your-origin-where-you-need-them/