### PR TITLE
fix: detect zone dnssec as enabled when in pending status

### DIFF
--- a/.changelog/1530.txt
+++ b/.changelog/1530.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_zone_dnssec: don't try to enable DNSSEC when state is "pending"
+```

--- a/cloudflare/resource_cloudflare_zone_dnssec.go
+++ b/cloudflare/resource_cloudflare_zone_dnssec.go
@@ -14,6 +14,7 @@ import (
 // The supported status for a Zone DNSSEC setting
 const (
 	DNSSECStatusActive   = "active"
+	DNSSECStatusPending  = "pending"
 	DNSSECStatusDisabled = "disabled"
 )
 
@@ -41,7 +42,7 @@ func resourceCloudflareZoneDNSSECCreate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err)
 	}
-	if currentDNSSEC.Status != DNSSECStatusActive {
+	if currentDNSSEC.Status != DNSSECStatusActive && currentDNSSEC.Status != DNSSECStatusPending {
 		_, err := client.UpdateZoneDNSSEC(context.Background(), zoneID, cloudflare.ZoneDNSSECUpdateOptions{Status: DNSSECStatusActive})
 
 		if err != nil {


### PR DESCRIPTION
Related to #1486

This PR does not fully fix that issue because it addresses two different errors and I think one of them is a bug either in the Cloudflare API or the Go client: https://github.com/cloudflare/terraform-provider-cloudflare/issues/1486#issuecomment-1079902813.

With this change, zones with DNSSEC in `pending` state (when the DS record has not been added or detected yet) won't throw a `DNSSEC is already enabled` error. The code expected the `state` value of the DNSSEC API request was only one of `active` or `disabled`, but the `pending` state also represents an enabled DNSSEC, only that is not fully configured yet.