### PR TITLE
Adding IP type support for cloudflare teams list

### DIFF
--- a/.changelog/1550.txt
+++ b/.changelog/1550.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_teams_list: Add support for IP type
+```

--- a/cloudflare/schema_cloudflare_teams_list.go
+++ b/cloudflare/schema_cloudflare_teams_list.go
@@ -18,7 +18,7 @@ func resourceCloudflareTeamsListSchema() map[string]*schema.Schema {
 		"type": {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: validation.StringInSlice([]string{"SERIAL", "URL", "DOMAIN", "EMAIL"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"IP", "SERIAL", "URL", "DOMAIN", "EMAIL"}, false),
 		},
 		"description": {
 			Type:     schema.TypeString,

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -15,8 +15,8 @@ import (
 	_ "github.com/bflad/tfproviderlint/cmd/tfproviderlintx"
 	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "github.com/google/go-github/github"
 	_ "github.com/hashicorp/go-changelog/cmd/changelog-build"
 	_ "github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs"
-	_ "github.com/google/go-github/github"
 	_ "golang.org/x/oauth2"
 )

--- a/website/docs/r/teams_list.html.markdown
+++ b/website/docs/r/teams_list.html.markdown
@@ -28,7 +28,7 @@ The following arguments are supported:
 
 * `account_id` - (Required) The account to which the teams list should be added.
 * `name` - (Required) Name of the teams list.
-* `type` - (Required) The teams list type. Valid values are `SERIAL`, `URL`, `DOMAIN`, and `EMAIL`.
+* `type` - (Required) The teams list type. Valid values are `IP`, `SERIAL`, `URL`, `DOMAIN`, and `EMAIL`.
 * `items` - (Required) The items of the teams list.
 * `description` - (Optional) The description of the teams list.
 


### PR DESCRIPTION
This PR adds IP type support to cloudflare teams list.

I checked the cloudflare-go repo and could not find any validation performed on a type of a list.

Even though API docs does not mention IP type:
![Screenshot from 2022-04-06 12-54-00](https://user-images.githubusercontent.com/6863458/161915565-7502eb58-b940-4dc3-881d-4148859c2411.png)

By looking at the response from GET '/lists' i was able verify that IP is actually supported: 
![Screenshot from 2022-04-06 17-08-14](https://user-images.githubusercontent.com/6863458/161916063-b77e3e36-5981-4423-83ba-eb7cef13f685.png)

I also tried to test it locally using terraform.
So far so good.

Please let me know if there is anything i am missing.
As our team would like to have that juicy feature available via terraform