### PR TITLE
Redeploy cloudflare_ruleset

### DIFF
--- a/.changelog/1554.txt
+++ b/.changelog/1554.txt
@@ -1,0 +1,3 @@
+```release:enhancement
+resource/cloudflare_ruleset: Setting description to `Optional` to better reflect API requirements
+```


### PR DESCRIPTION
I think a typo in the CHANGELOG for https://github.com/cloudflare/terraform-provider-cloudflare/pull/1412/files
Didn't deploy that change. I might be wrong but it's worth a shot.
