### PR TITLE
Allow import for cloudflare_zone_settings_override

### DIFF
--- a/.changelog/1570.txt
+++ b/.changelog/1570.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_zone_settings_override: Add option to import resource
+```

--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -23,6 +23,9 @@ func resourceCloudflareZoneSettingsOverride() *schema.Resource {
 		Read:   resourceCloudflareZoneSettingsOverrideRead,
 		Update: resourceCloudflareZoneSettingsOverrideUpdate,
 		Delete: resourceCloudflareZoneSettingsOverrideDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 	}
 }
 

--- a/website/docs/r/zone_settings_override.html.markdown
+++ b/website/docs/r/zone_settings_override.html.markdown
@@ -155,3 +155,15 @@ The following attributes are exported:
 * `readonly_settings` - Which of the current `settings` are not able to be set by the user. Which settings these are is determined by plan level and user permissions.
 * `zone_status`. A full zone implies that DNS is hosted with Cloudflare. A partial zone is typically a partner-hosted zone or a CNAME setup.
 * `zone_type`. Status of the zone. Valid values: active, pending, initializing, moved, deleted, deactivated.
+
+## Import
+
+Zone settings override resource can be imported using a zone ID, e.g.
+
+```
+$ terraform import cloudflare_zone_settings_override.example d41d8cd98f00b204e9800998ecf8427e
+```
+
+where:
+
+* `d41d8cd98f00b204e9800998ecf8427e` - zone ID, as returned from [API](https://api.cloudflare.com/#zone-list-zones)


### PR DESCRIPTION
This is a simple, backwards-compatible change that just adds the capability to do `terraform import` for `cloudflare_zone_settings_override`.