### PR TITLE
docs(certificate_pack): hosts must include zone name

### DIFF
--- a/website/docs/r/certificate_pack.html.markdown
+++ b/website/docs/r/certificate_pack.html.markdown
@@ -60,8 +60,8 @@ The following arguments are supported:
 * `type` - (Required) Certificate pack configuration type.
   Allowed values: `"custom"`, `"dedicated_custom"`, `"advanced"`.
 * `hosts` - (Required) List of hostnames to provision the certificate pack for.
-  Note: If using Let's Encrypt, you cannot use individual subdomains and only a
-  wildcard for subdomain is available.
+  The zone name must be included as a host. Note: If using Let's Encrypt, you
+  cannot use individual subdomains and only a wildcard for subdomain is available.
 * `validation_method` - (Optional based on `type`) Which validation method to
   use in order to prove domain ownership. Allowed values: `"txt"`, `"http"`, `"email"`.
 * `validity_days` - (Optional based on `type`) How long the certificate is valid


### PR DESCRIPTION
Add a sentence to the `hosts` argument reference indicating that the
`certificate_packs` order must include the zone name (apex) in the
list of hostnames for the certificate. [API docs reference.](https://api.cloudflare.com/#certificate-packs-order-advanced-certificate-manager-certificate-pack)

> Note: I have not included a `release-note` as per the [Changelog Process](https://github.com/cloudflare/terraform-provider-cloudflare/blob/master/docs/changelog-process.md#changes-that-should-not-have-a-changelog-entry).