### PR TITLE
cloudflare_tunnel_route: read by filtering list

### DIFF
--- a/.changelog/1581.txt
+++ b/.changelog/1581.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cloudflare_tunnel_routes: Fix reads matching routers with larger CIDRs
+```


### PR DESCRIPTION
The `GetTunnelRouteForIP` SDK function will return the first route that
either exactly matches the specified IP or larger CIDR. If routes exist
for both `10.0.0.0/8` and `10.0.0.0/24`, and the latter is accidentally
deleted, the SDK function will start returning the former route.

This changeset resolves this issue by providing filters to the
`ListTunnelRoutes` such that the network subset and superset are both
the specific CIDR being managed. The API returns 1 result if there is an
exact match, and 0 results otherwise.

Bug: K8S-4828