### PR TITLE
resource/cloudflare_zone: update plan identifier for professional rate plans

### DIFF
--- a/.changelog/1583.txt
+++ b/.changelog/1583.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_zone: update plan identifier for professional rate plans
+```

--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -37,7 +37,7 @@ var ratePlans = map[string]subscriptionData{
 		Description: "Free Website",
 	},
 	planIDPro: {
-		Name:        "CF_PRO",
+		Name:        "CF_PRO_20_20",
 		ID:          planIDPro,
 		Description: "Pro Website",
 	},


### PR DESCRIPTION
Looks like this has been wrong for a while. Updating to allow
professional signups.

Closes #1576