### PR TITLE
cloudflare_teams_list: add IP list type

### DIFF
--- a/.changelog/1587.txt
+++ b/.changelog/1587.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_teams_list: add IP list type
+```

--- a/cloudflare/schema_cloudflare_teams_list.go
+++ b/cloudflare/schema_cloudflare_teams_list.go
@@ -18,7 +18,7 @@ func resourceCloudflareTeamsListSchema() map[string]*schema.Schema {
 		"type": {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: validation.StringInSlice([]string{"SERIAL", "URL", "DOMAIN", "EMAIL"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"SERIAL", "URL", "DOMAIN", "EMAIL", "IP"}, false),
 		},
 		"description": {
 			Type:     schema.TypeString,


### PR DESCRIPTION
The dashboard allows creating Gateway lists of the "IP" type, but the
schema here rejects attempts to define resources using it.

Bug: K8S-4829