### PR TITLE
fix(#1578): allow `github` access groups to be created without a list of `teams`

### DIFF
--- a/.changelog/1589.txt
+++ b/.changelog/1589.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_access_group: allow github access groups to be created without a list of teams
+```


### PR DESCRIPTION
Previously, the contents of the `github` block were not serialized to input JSON being sent to the Cloudflare API unless there was at least one team specified, even though the teams field is optional.

This commit changes the behavior of the `github` block to create `include`, `require` and `exclude` blocks with github organizations without specifying a list of teams.

Testing was done on my personal Cloudflare Zero Trust account. Running `terraform apply` twice still results in "detected" changes even though they have been applied. I think this is related to issue #1553.

Closes #1578 