### PR TITLE
Swap to `Context` everywhere and `diag` support

### DIFF
--- a/.changelog/1592.txt
+++ b/.changelog/1592.txt
@@ -1,0 +1,3 @@
+```release-note:note
+provider: internally swapped to using `diag.Diagnostics` for CRUD return types and using `context.Context` passed in from the provider itself instead of instantiating our own in each operation
+```

--- a/cloudflare/config.go
+++ b/cloudflare/config.go
@@ -26,7 +26,7 @@ func (c *Config) Client() (*cloudflare.API, error) {
 		client, err = cloudflare.New(c.APIKey, c.Email, c.Options...)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("Error creating new Cloudflare client: %s", err)
+		return nil, fmt.Errorf("Error creating new Cloudflare client: %w", err)
 	}
 
 	if c.APIUserServiceKey != "" {

--- a/cloudflare/data_source_access_identity_provider.go
+++ b/cloudflare/data_source_access_identity_provider.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceCloudflareAccessIdentityProvider() *schema.Resource {
 	return &schema.Resource{
-		Schema: dataSourceCloudflareAccessIdentityProviderSchema(),
-		Read:   dataSourceCloudflareAccessIdentityProviderRead,
+		Schema:      dataSourceCloudflareAccessIdentityProviderSchema(),
+		ReadContext: dataSourceCloudflareAccessIdentityProviderRead,
 	}
 }
 

--- a/cloudflare/data_source_access_identity_provider.go
+++ b/cloudflare/data_source_access_identity_provider.go
@@ -31,11 +31,11 @@ func dataSourceCloudflareAccessIdentityProviderRead(ctx context.Context, d *sche
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing Access Identity Providers: %s", err)
+		return diag.FromErr(fmt.Errorf("error listing Access Identity Providers: %s", err))
 	}
 
 	if len(providers) == 0 {
-		return fmt.Errorf("no Access Identity Providers found")
+		return diag.FromErr(fmt.Errorf("no Access Identity Providers found"))
 	}
 
 	var accessIdentityProvider cloudflare.AccessIdentityProvider
@@ -47,7 +47,7 @@ func dataSourceCloudflareAccessIdentityProviderRead(ctx context.Context, d *sche
 	}
 
 	if accessIdentityProvider.ID == "" {
-		return fmt.Errorf("no Access Identity Provider matching name %q", name)
+		return diag.FromErr(fmt.Errorf("no Access Identity Provider matching name %q", name))
 	}
 
 	d.SetId(accessIdentityProvider.ID)

--- a/cloudflare/data_source_access_identity_provider.go
+++ b/cloudflare/data_source_access_identity_provider.go
@@ -15,12 +15,12 @@ func dataSourceCloudflareAccessIdentityProvider() *schema.Resource {
 	}
 }
 
-func dataSourceCloudflareAccessIdentityProviderRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceCloudflareAccessIdentityProviderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	identifier, err := initIdentifier(d)
 	name := d.Get("name").(string)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var providers []cloudflare.AccessIdentityProvider

--- a/cloudflare/data_source_access_identity_provider.go
+++ b/cloudflare/data_source_access_identity_provider.go
@@ -26,9 +26,9 @@ func dataSourceCloudflareAccessIdentityProviderRead(ctx context.Context, d *sche
 
 	var providers []cloudflare.AccessIdentityProvider
 	if identifier.Type == AccountType {
-		providers, err = client.AccessIdentityProviders(context.Background(), identifier.Value)
+		providers, err = client.AccessIdentityProviders(ctx, identifier.Value)
 	} else {
-		providers, err = client.ZoneLevelAccessIdentityProviders(context.Background(), identifier.Value)
+		providers, err = client.ZoneLevelAccessIdentityProviders(ctx, identifier.Value)
 	}
 
 	if err != nil {

--- a/cloudflare/data_source_access_identity_provider.go
+++ b/cloudflare/data_source_access_identity_provider.go
@@ -32,7 +32,7 @@ func dataSourceCloudflareAccessIdentityProviderRead(ctx context.Context, d *sche
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error listing Access Identity Providers: %s", err))
+		return diag.FromErr(fmt.Errorf("error listing Access Identity Providers: %w", err))
 	}
 
 	if len(providers) == 0 {

--- a/cloudflare/data_source_account_roles.go
+++ b/cloudflare/data_source_account_roles.go
@@ -43,7 +43,7 @@ func dataSourceCloudflareAccountRoles() *schema.Resource {
 	}
 }
 
-func dataSourceCloudflareAccountRolesRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceCloudflareAccountRolesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 

--- a/cloudflare/data_source_account_roles.go
+++ b/cloudflare/data_source_account_roles.go
@@ -50,7 +50,7 @@ func dataSourceCloudflareAccountRolesRead(ctx context.Context, d *schema.Resourc
 	log.Printf("[DEBUG] Reading Account Roles")
 	roles, err := client.AccountRoles(context.Background(), accountID)
 	if err != nil {
-		return fmt.Errorf("error listing Account Roles: %s", err)
+		return diag.FromErr(fmt.Errorf("error listing Account Roles: %s", err))
 	}
 
 	roleIds := make([]string, 0)
@@ -67,7 +67,7 @@ func dataSourceCloudflareAccountRolesRead(ctx context.Context, d *schema.Resourc
 
 	err = d.Set("roles", roleDetails)
 	if err != nil {
-		return fmt.Errorf("error setting roles: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting roles: %s", err))
 	}
 
 	d.SetId(stringListChecksum(roleIds))

--- a/cloudflare/data_source_account_roles.go
+++ b/cloudflare/data_source_account_roles.go
@@ -49,7 +49,7 @@ func dataSourceCloudflareAccountRolesRead(ctx context.Context, d *schema.Resourc
 	accountID := d.Get("account_id").(string)
 
 	log.Printf("[DEBUG] Reading Account Roles")
-	roles, err := client.AccountRoles(context.Background(), accountID)
+	roles, err := client.AccountRoles(ctx, accountID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error listing Account Roles: %s", err))
 	}

--- a/cloudflare/data_source_account_roles.go
+++ b/cloudflare/data_source_account_roles.go
@@ -6,12 +6,13 @@ import (
 	"log"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceCloudflareAccountRoles() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceCloudflareAccountRolesRead,
+		ReadContext: dataSourceCloudflareAccountRolesRead,
 
 		Schema: map[string]*schema.Schema{
 			"account_id": {

--- a/cloudflare/data_source_account_roles.go
+++ b/cloudflare/data_source_account_roles.go
@@ -51,7 +51,7 @@ func dataSourceCloudflareAccountRolesRead(ctx context.Context, d *schema.Resourc
 	log.Printf("[DEBUG] Reading Account Roles")
 	roles, err := client.AccountRoles(ctx, accountID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error listing Account Roles: %s", err))
+		return diag.FromErr(fmt.Errorf("error listing Account Roles: %w", err))
 	}
 
 	roleIds := make([]string, 0)
@@ -68,7 +68,7 @@ func dataSourceCloudflareAccountRolesRead(ctx context.Context, d *schema.Resourc
 
 	err = d.Set("roles", roleDetails)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error setting roles: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting roles: %w", err))
 	}
 
 	d.SetId(stringListChecksum(roleIds))

--- a/cloudflare/data_source_api_token_permission_groups.go
+++ b/cloudflare/data_source_api_token_permission_groups.go
@@ -6,12 +6,13 @@ import (
 	"log"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceCloudflareApiTokenPermissionGroups() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceCloudflareApiTokenPermissionGroupsRead,
+		ReadContext: dataSourceCloudflareApiTokenPermissionGroupsRead,
 
 		Schema: map[string]*schema.Schema{
 			"permissions": {

--- a/cloudflare/data_source_api_token_permission_groups.go
+++ b/cloudflare/data_source_api_token_permission_groups.go
@@ -22,7 +22,7 @@ func dataSourceCloudflareApiTokenPermissionGroups() *schema.Resource {
 	}
 }
 
-func dataSourceCloudflareApiTokenPermissionGroupsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceCloudflareApiTokenPermissionGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] Reading API Token Permission Groups")
 	client := meta.(*cloudflare.API)
 

--- a/cloudflare/data_source_api_token_permission_groups.go
+++ b/cloudflare/data_source_api_token_permission_groups.go
@@ -28,7 +28,7 @@ func dataSourceCloudflareApiTokenPermissionGroupsRead(ctx context.Context, d *sc
 
 	permissions, err := client.ListAPITokensPermissionGroups(context.Background())
 	if err != nil {
-		return fmt.Errorf("error listing API Token Permission Groups: %s", err)
+		return diag.FromErr(fmt.Errorf("error listing API Token Permission Groups: %s", err))
 	}
 
 	permissionDetails := make(map[string]interface{}, 0)
@@ -40,7 +40,7 @@ func dataSourceCloudflareApiTokenPermissionGroupsRead(ctx context.Context, d *sc
 
 	err = d.Set("permissions", permissionDetails)
 	if err != nil {
-		return fmt.Errorf("error setting API Token Permission Groups: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting API Token Permission Groups: %s", err))
 	}
 
 	d.SetId(stringListChecksum(ids))

--- a/cloudflare/data_source_api_token_permission_groups.go
+++ b/cloudflare/data_source_api_token_permission_groups.go
@@ -29,7 +29,7 @@ func dataSourceCloudflareApiTokenPermissionGroupsRead(ctx context.Context, d *sc
 
 	permissions, err := client.ListAPITokensPermissionGroups(context.Background())
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error listing API Token Permission Groups: %s", err))
+		return diag.FromErr(fmt.Errorf("error listing API Token Permission Groups: %w", err))
 	}
 
 	permissionDetails := make(map[string]interface{}, 0)
@@ -41,7 +41,7 @@ func dataSourceCloudflareApiTokenPermissionGroupsRead(ctx context.Context, d *sc
 
 	err = d.Set("permissions", permissionDetails)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error setting API Token Permission Groups: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting API Token Permission Groups: %w", err))
 	}
 
 	d.SetId(stringListChecksum(ids))

--- a/cloudflare/data_source_devices.go
+++ b/cloudflare/data_source_devices.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceCloudflareDevices() *schema.Resource {
 	return &schema.Resource{
-		Schema: resoureceCloudflareDevicesSchema(),
-		Read:   dataResourceCloudflareDevicesRead,
+		Schema:      resoureceCloudflareDevicesSchema(),
+		ReadContext: dataResourceCloudflareDevicesRead,
 	}
 }
 

--- a/cloudflare/data_source_devices.go
+++ b/cloudflare/data_source_devices.go
@@ -23,7 +23,7 @@ func dataResourceCloudflareDevicesRead(ctx context.Context, d *schema.ResourceDa
 	devices, err := client.ListTeamsDevices(context.Background(), accountID)
 
 	if err != nil {
-		return fmt.Errorf("error finding devices in account %q: %w", accountID, err)
+		return diag.FromErr(fmt.Errorf("error finding devices in account %q: %w", accountID, err))
 	}
 
 	deviceDetails := make([]interface{}, 0)
@@ -48,7 +48,7 @@ func dataResourceCloudflareDevicesRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if err = d.Set("devices", deviceDetails); err != nil {
-		return fmt.Errorf("error setting device details: %w", err)
+		return diag.FromErr(fmt.Errorf("error setting device details: %w", err))
 	}
 
 	return nil

--- a/cloudflare/data_source_devices.go
+++ b/cloudflare/data_source_devices.go
@@ -21,7 +21,7 @@ func dataResourceCloudflareDevicesRead(ctx context.Context, d *schema.ResourceDa
 	accountID := d.Get("account_id").(string)
 	d.SetId(accountID)
 
-	devices, err := client.ListTeamsDevices(context.Background(), accountID)
+	devices, err := client.ListTeamsDevices(ctx, accountID)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error finding devices in account %q: %w", accountID, err))

--- a/cloudflare/data_source_devices.go
+++ b/cloudflare/data_source_devices.go
@@ -15,7 +15,7 @@ func dataSourceCloudflareDevices() *schema.Resource {
 	}
 }
 
-func dataResourceCloudflareDevicesRead(d *schema.ResourceData, meta interface{}) error {
+func dataResourceCloudflareDevicesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	d.SetId(accountID)

--- a/cloudflare/data_source_ip_ranges.go
+++ b/cloudflare/data_source_ip_ranges.go
@@ -1,12 +1,14 @@
 package cloudflare
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -17,7 +19,7 @@ const (
 
 func dataSourceCloudflareIPRanges() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceCloudflareIPRangesRead,
+		ReadContext: dataSourceCloudflareIPRangesRead,
 
 		Schema: map[string]*schema.Schema{
 			"cidr_blocks": {

--- a/cloudflare/data_source_ip_ranges.go
+++ b/cloudflare/data_source_ip_ranges.go
@@ -49,7 +49,7 @@ func dataSourceCloudflareIPRanges() *schema.Resource {
 	}
 }
 
-func dataSourceCloudflareIPRangesRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceCloudflareIPRangesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	ranges, err := cloudflare.IPs()
 	if err != nil {
 		return fmt.Errorf("failed to fetch Cloudflare IP ranges: %s", err)

--- a/cloudflare/data_source_ip_ranges.go
+++ b/cloudflare/data_source_ip_ranges.go
@@ -52,7 +52,7 @@ func dataSourceCloudflareIPRanges() *schema.Resource {
 func dataSourceCloudflareIPRangesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	ranges, err := cloudflare.IPs()
 	if err != nil {
-		return fmt.Errorf("failed to fetch Cloudflare IP ranges: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to fetch Cloudflare IP ranges: %s", err))
 	}
 
 	IPv4s := ranges.IPv4CIDRs
@@ -72,23 +72,23 @@ func dataSourceCloudflareIPRangesRead(ctx context.Context, d *schema.ResourceDat
 	d.SetId(strconv.Itoa(hashCodeString(strings.Join(all, "|"))))
 
 	if err := d.Set("cidr_blocks", all); err != nil {
-		return fmt.Errorf("error setting all cidr blocks: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting all cidr blocks: %s", err))
 	}
 
 	if err := d.Set("ipv4_cidr_blocks", IPv4s); err != nil {
-		return fmt.Errorf("error setting ipv4 cidr blocks: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting ipv4 cidr blocks: %s", err))
 	}
 
 	if err := d.Set("ipv6_cidr_blocks", IPv6s); err != nil {
-		return fmt.Errorf("error setting ipv6 cidr blocks: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting ipv6 cidr blocks: %s", err))
 	}
 
 	if err := d.Set("china_ipv4_cidr_blocks", chinaIPv4s); err != nil {
-		return fmt.Errorf("error setting china ipv4 cidr blocks: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting china ipv4 cidr blocks: %s", err))
 	}
 
 	if err := d.Set("china_ipv6_cidr_blocks", chinaIPv6s); err != nil {
-		return fmt.Errorf("error setting china ipv6 cidr blocks: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting china ipv6 cidr blocks: %s", err))
 	}
 
 	return nil

--- a/cloudflare/data_source_ip_ranges.go
+++ b/cloudflare/data_source_ip_ranges.go
@@ -54,7 +54,7 @@ func dataSourceCloudflareIPRanges() *schema.Resource {
 func dataSourceCloudflareIPRangesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	ranges, err := cloudflare.IPs()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to fetch Cloudflare IP ranges: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to fetch Cloudflare IP ranges: %w", err))
 	}
 
 	IPv4s := ranges.IPv4CIDRs
@@ -74,23 +74,23 @@ func dataSourceCloudflareIPRangesRead(ctx context.Context, d *schema.ResourceDat
 	d.SetId(strconv.Itoa(hashCodeString(strings.Join(all, "|"))))
 
 	if err := d.Set("cidr_blocks", all); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting all cidr blocks: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting all cidr blocks: %w", err))
 	}
 
 	if err := d.Set("ipv4_cidr_blocks", IPv4s); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting ipv4 cidr blocks: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting ipv4 cidr blocks: %w", err))
 	}
 
 	if err := d.Set("ipv6_cidr_blocks", IPv6s); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting ipv6 cidr blocks: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting ipv6 cidr blocks: %w", err))
 	}
 
 	if err := d.Set("china_ipv4_cidr_blocks", chinaIPv4s); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting china ipv4 cidr blocks: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting china ipv4 cidr blocks: %w", err))
 	}
 
 	if err := d.Set("china_ipv6_cidr_blocks", chinaIPv6s); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting china ipv6 cidr blocks: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting china ipv6 cidr blocks: %w", err))
 	}
 
 	return nil

--- a/cloudflare/data_source_ip_ranges_test.go
+++ b/cloudflare/data_source_ip_ranges_test.go
@@ -16,7 +16,7 @@ func TestAccCloudflareIPRanges(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCloudflareIPRangesConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudflareIPRanges("data.cloudflare_ip_ranges.some"),

--- a/cloudflare/data_source_ip_ranges_test.go
+++ b/cloudflare/data_source_ip_ranges_test.go
@@ -47,15 +47,13 @@ func testAccCloudflareIPRanges(n string) resource.TestCheckFunc {
 		var cidrBlocks sort.StringSlice = make([]string, cidrBlockSize)
 
 		for i := range make([]string, cidrBlockSize) {
-
 			block := a[fmt.Sprintf("cidr_blocks.%d", i)]
 
 			if _, _, err := net.ParseCIDR(block); err != nil {
-				return fmt.Errorf("malformed CIDR block %s: %s", block, err)
+				return fmt.Errorf("malformed CIDR block %s: %w", block, err)
 			}
 
 			cidrBlocks[i] = block
-
 		}
 
 		if !sort.IsSorted(cidrBlocks) {

--- a/cloudflare/data_source_origin_ca_root_certificate.go
+++ b/cloudflare/data_source_origin_ca_root_certificate.go
@@ -28,7 +28,7 @@ func dataSourceCloudflareOriginCARootCertificate() *schema.Resource {
 	}
 }
 
-func dataSourceCloudflareOriginCARootCertificateRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceCloudflareOriginCARootCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	algorithm := strings.ToLower(fmt.Sprintf("%s", d.Get("algorithm")))
 	certBytes, err := cloudflare.OriginCARootCertificate(algorithm)
 	if err != nil {

--- a/cloudflare/data_source_origin_ca_root_certificate.go
+++ b/cloudflare/data_source_origin_ca_root_certificate.go
@@ -34,7 +34,7 @@ func dataSourceCloudflareOriginCARootCertificateRead(ctx context.Context, d *sch
 	algorithm := strings.ToLower(fmt.Sprintf("%s", d.Get("algorithm")))
 	certBytes, err := cloudflare.OriginCARootCertificate(algorithm)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to fetch Cloudflare Origin CA root %s certificate: %s", algorithm, err))
+		return diag.FromErr(fmt.Errorf("failed to fetch Cloudflare Origin CA root %s certificate: %w", algorithm, err))
 	}
 
 	cert := string(certBytes[:])
@@ -42,7 +42,7 @@ func dataSourceCloudflareOriginCARootCertificateRead(ctx context.Context, d *sch
 	d.SetId(stringChecksum(cert))
 
 	if err := d.Set("cert_pem", cert); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting cert_pem: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting cert_pem: %w", err))
 	}
 
 	return nil

--- a/cloudflare/data_source_origin_ca_root_certificate.go
+++ b/cloudflare/data_source_origin_ca_root_certificate.go
@@ -1,17 +1,19 @@
 package cloudflare
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataSourceCloudflareOriginCARootCertificate() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceCloudflareOriginCARootCertificateRead,
+		ReadContext: dataSourceCloudflareOriginCARootCertificateRead,
 
 		Schema: map[string]*schema.Schema{
 			"algorithm": {

--- a/cloudflare/data_source_origin_ca_root_certificate.go
+++ b/cloudflare/data_source_origin_ca_root_certificate.go
@@ -32,7 +32,7 @@ func dataSourceCloudflareOriginCARootCertificateRead(ctx context.Context, d *sch
 	algorithm := strings.ToLower(fmt.Sprintf("%s", d.Get("algorithm")))
 	certBytes, err := cloudflare.OriginCARootCertificate(algorithm)
 	if err != nil {
-		return fmt.Errorf("failed to fetch Cloudflare Origin CA root %s certificate: %s", algorithm, err)
+		return diag.FromErr(fmt.Errorf("failed to fetch Cloudflare Origin CA root %s certificate: %s", algorithm, err))
 	}
 
 	cert := string(certBytes[:])
@@ -40,7 +40,7 @@ func dataSourceCloudflareOriginCARootCertificateRead(ctx context.Context, d *sch
 	d.SetId(stringChecksum(cert))
 
 	if err := d.Set("cert_pem", cert); err != nil {
-		return fmt.Errorf("error setting cert_pem: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting cert_pem: %s", err))
 	}
 
 	return nil

--- a/cloudflare/data_source_waf_groups.go
+++ b/cloudflare/data_source_waf_groups.go
@@ -85,14 +85,14 @@ func dataSourceCloudflareWAFGroups() *schema.Resource {
 	}
 }
 
-func dataSourceCloudflareWAFGroupsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceCloudflareWAFGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
 	// Prepare the filters to be applied to the search
 	filter, err := expandFilterWAFGroups(d.Get("filter"))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// If no package ID is given, we will consider all for the zone
@@ -103,7 +103,7 @@ func dataSourceCloudflareWAFGroupsRead(d *schema.ResourceData, meta interface{})
 		log.Printf("[DEBUG] Reading WAF Packages")
 		pkgList, err = client.ListWAFPackages(context.Background(), zoneID)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	} else {
 		pkgList = append(pkgList, cloudflare.WAFPackage{ID: packageID})
@@ -115,7 +115,7 @@ func dataSourceCloudflareWAFGroupsRead(d *schema.ResourceData, meta interface{})
 	for _, pkg := range pkgList {
 		groupList, err := client.ListWAFGroups(context.Background(), zoneID, pkg.ID)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 
 		for _, group := range groupList {

--- a/cloudflare/data_source_waf_groups.go
+++ b/cloudflare/data_source_waf_groups.go
@@ -142,7 +142,7 @@ func dataSourceCloudflareWAFGroupsRead(ctx context.Context, d *schema.ResourceDa
 
 	err = d.Set("groups", groupDetails)
 	if err != nil {
-		return fmt.Errorf("error setting WAF groups: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting WAF groups: %s", err))
 	}
 
 	d.SetId(stringListChecksum(groupIds))

--- a/cloudflare/data_source_waf_groups.go
+++ b/cloudflare/data_source_waf_groups.go
@@ -7,13 +7,14 @@ import (
 	"regexp"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataSourceCloudflareWAFGroups() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceCloudflareWAFGroupsRead,
+		ReadContext: dataSourceCloudflareWAFGroupsRead,
 
 		Schema: map[string]*schema.Schema{
 			"zone_id": {

--- a/cloudflare/data_source_waf_groups.go
+++ b/cloudflare/data_source_waf_groups.go
@@ -143,7 +143,7 @@ func dataSourceCloudflareWAFGroupsRead(ctx context.Context, d *schema.ResourceDa
 
 	err = d.Set("groups", groupDetails)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error setting WAF groups: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting WAF groups: %w", err))
 	}
 
 	d.SetId(stringListChecksum(groupIds))

--- a/cloudflare/data_source_waf_groups.go
+++ b/cloudflare/data_source_waf_groups.go
@@ -102,7 +102,7 @@ func dataSourceCloudflareWAFGroupsRead(ctx context.Context, d *schema.ResourceDa
 	if packageID == "" {
 		var err error
 		log.Printf("[DEBUG] Reading WAF Packages")
-		pkgList, err = client.ListWAFPackages(context.Background(), zoneID)
+		pkgList, err = client.ListWAFPackages(ctx, zoneID)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -114,7 +114,7 @@ func dataSourceCloudflareWAFGroupsRead(ctx context.Context, d *schema.ResourceDa
 	groupIds := make([]string, 0)
 	groupDetails := make([]interface{}, 0)
 	for _, pkg := range pkgList {
-		groupList, err := client.ListWAFGroups(context.Background(), zoneID, pkg.ID)
+		groupList, err := client.ListWAFGroups(ctx, zoneID, pkg.ID)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/cloudflare/data_source_waf_packages.go
+++ b/cloudflare/data_source_waf_packages.go
@@ -133,7 +133,7 @@ func dataSourceCloudflareWAFPackagesRead(ctx context.Context, d *schema.Resource
 
 	err = d.Set("packages", packageDetails)
 	if err != nil {
-		return fmt.Errorf("error setting WAF packages: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting WAF packages: %s", err))
 	}
 
 	d.SetId(stringListChecksum(packageIds))

--- a/cloudflare/data_source_waf_packages.go
+++ b/cloudflare/data_source_waf_packages.go
@@ -7,13 +7,14 @@ import (
 	"regexp"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataSourceCloudflareWAFPackages() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceCloudflareWAFPackagesRead,
+		ReadContext: dataSourceCloudflareWAFPackagesRead,
 
 		Schema: map[string]*schema.Schema{
 			"zone_id": {

--- a/cloudflare/data_source_waf_packages.go
+++ b/cloudflare/data_source_waf_packages.go
@@ -134,7 +134,7 @@ func dataSourceCloudflareWAFPackagesRead(ctx context.Context, d *schema.Resource
 
 	err = d.Set("packages", packageDetails)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error setting WAF packages: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting WAF packages: %w", err))
 	}
 
 	d.SetId(stringListChecksum(packageIds))

--- a/cloudflare/data_source_waf_packages.go
+++ b/cloudflare/data_source_waf_packages.go
@@ -99,7 +99,7 @@ func dataSourceCloudflareWAFPackagesRead(ctx context.Context, d *schema.Resource
 	log.Printf("[DEBUG] Reading WAF Packages")
 	packageIds := make([]string, 0)
 	packageDetails := make([]interface{}, 0)
-	pkgList, err := client.ListWAFPackages(context.Background(), zoneID)
+	pkgList, err := client.ListWAFPackages(ctx, zoneID)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/cloudflare/data_source_waf_packages.go
+++ b/cloudflare/data_source_waf_packages.go
@@ -85,14 +85,14 @@ func dataSourceCloudflareWAFPackages() *schema.Resource {
 	}
 }
 
-func dataSourceCloudflareWAFPackagesRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceCloudflareWAFPackagesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
 	// Prepare the filters to be applied to the search
 	filter, err := expandFilterWAFPackages(d.Get("filter"))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[DEBUG] Reading WAF Packages")
@@ -100,7 +100,7 @@ func dataSourceCloudflareWAFPackagesRead(d *schema.ResourceData, meta interface{
 	packageDetails := make([]interface{}, 0)
 	pkgList, err := client.ListWAFPackages(context.Background(), zoneID)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	for _, pkg := range pkgList {

--- a/cloudflare/data_source_waf_rules.go
+++ b/cloudflare/data_source_waf_rules.go
@@ -98,14 +98,14 @@ func dataSourceCloudflareWAFRules() *schema.Resource {
 	}
 }
 
-func dataSourceCloudflareWAFRulesRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceCloudflareWAFRulesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
 	// Prepare the filters to be applied to the search
 	filter, err := expandFilterWAFRules(d.Get("filter"))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// If no package ID is given, we will consider all for the zone
@@ -116,7 +116,7 @@ func dataSourceCloudflareWAFRulesRead(d *schema.ResourceData, meta interface{}) 
 		log.Printf("[DEBUG] Reading WAF Packages")
 		pkgList, err = client.ListWAFPackages(context.Background(), zoneID)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	} else {
 		pkgList = append(pkgList, cloudflare.WAFPackage{ID: packageID})
@@ -128,7 +128,7 @@ func dataSourceCloudflareWAFRulesRead(d *schema.ResourceData, meta interface{}) 
 	for _, pkg := range pkgList {
 		ruleList, err := client.ListWAFRules(context.Background(), zoneID, pkg.ID)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 
 		foundGroup := false

--- a/cloudflare/data_source_waf_rules.go
+++ b/cloudflare/data_source_waf_rules.go
@@ -7,12 +7,13 @@ import (
 	"regexp"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceCloudflareWAFRules() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceCloudflareWAFRulesRead,
+		ReadContext: dataSourceCloudflareWAFRulesRead,
 
 		Schema: map[string]*schema.Schema{
 			"zone_id": {

--- a/cloudflare/data_source_waf_rules.go
+++ b/cloudflare/data_source_waf_rules.go
@@ -175,7 +175,7 @@ func dataSourceCloudflareWAFRulesRead(ctx context.Context, d *schema.ResourceDat
 
 	err = d.Set("rules", ruleDetails)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error setting WAF rules: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting WAF rules: %w", err))
 	}
 
 	d.SetId(stringListChecksum(ruleIds))

--- a/cloudflare/data_source_waf_rules.go
+++ b/cloudflare/data_source_waf_rules.go
@@ -174,7 +174,7 @@ func dataSourceCloudflareWAFRulesRead(ctx context.Context, d *schema.ResourceDat
 
 	err = d.Set("rules", ruleDetails)
 	if err != nil {
-		return fmt.Errorf("error setting WAF rules: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting WAF rules: %s", err))
 	}
 
 	d.SetId(stringListChecksum(ruleIds))

--- a/cloudflare/data_source_waf_rules.go
+++ b/cloudflare/data_source_waf_rules.go
@@ -115,7 +115,7 @@ func dataSourceCloudflareWAFRulesRead(ctx context.Context, d *schema.ResourceDat
 	if packageID == "" {
 		var err error
 		log.Printf("[DEBUG] Reading WAF Packages")
-		pkgList, err = client.ListWAFPackages(context.Background(), zoneID)
+		pkgList, err = client.ListWAFPackages(ctx, zoneID)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -127,7 +127,7 @@ func dataSourceCloudflareWAFRulesRead(ctx context.Context, d *schema.ResourceDat
 	ruleIds := make([]string, 0)
 	ruleDetails := make([]interface{}, 0)
 	for _, pkg := range pkgList {
-		ruleList, err := client.ListWAFRules(context.Background(), zoneID, pkg.ID)
+		ruleList, err := client.ListWAFRules(ctx, zoneID, pkg.ID)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/cloudflare/data_source_zone.go
+++ b/cloudflare/data_source_zone.go
@@ -6,12 +6,13 @@ import (
 	"log"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceCloudflareZone() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceCloudflareZoneRead,
+		ReadContext: dataSourceCloudflareZoneRead,
 
 		Schema: map[string]*schema.Schema{
 			"zone_id": {

--- a/cloudflare/data_source_zone.go
+++ b/cloudflare/data_source_zone.go
@@ -72,7 +72,7 @@ func dataSourceCloudflareZoneRead(ctx context.Context, d *schema.ResourceData, m
 	var zone cloudflare.Zone
 	if name != "" && zoneID == "" {
 		zoneFilter := cloudflare.WithZoneFilters(name, accountID, "")
-		zonesResp, err := client.ListZonesContext(context.Background(), zoneFilter)
+		zonesResp, err := client.ListZonesContext(ctx, zoneFilter)
 
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error listing zones: %s", err))
@@ -89,7 +89,7 @@ func dataSourceCloudflareZoneRead(ctx context.Context, d *schema.ResourceData, m
 		zone = zonesResp.Result[0]
 	} else {
 		var err error
-		zone, err = client.ZoneDetails(context.Background(), zoneID)
+		zone, err = client.ZoneDetails(ctx, zoneID)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error getting zone details: %s", err))
 		}

--- a/cloudflare/data_source_zone.go
+++ b/cloudflare/data_source_zone.go
@@ -74,15 +74,15 @@ func dataSourceCloudflareZoneRead(ctx context.Context, d *schema.ResourceData, m
 		zonesResp, err := client.ListZonesContext(context.Background(), zoneFilter)
 
 		if err != nil {
-			return fmt.Errorf("error listing zones: %s", err)
+			return diag.FromErr(fmt.Errorf("error listing zones: %s", err))
 		}
 
 		if zonesResp.Total > 1 {
-			return fmt.Errorf("more than one zone was returned; consider adding the `account_id` to the existing resource or use the `cloudflare_zones` data source with filtering to target the zone more specifically")
+			return diag.FromErr(fmt.Errorf("more than one zone was returned; consider adding the `account_id` to the existing resource or use the `cloudflare_zones` data source with filtering to target the zone more specifically"))
 		}
 
 		if zonesResp.Total == 0 {
-			return fmt.Errorf("no zone found")
+			return diag.FromErr(fmt.Errorf("no zone found"))
 		}
 
 		zone = zonesResp.Result[0]
@@ -90,7 +90,7 @@ func dataSourceCloudflareZoneRead(ctx context.Context, d *schema.ResourceData, m
 		var err error
 		zone, err = client.ZoneDetails(context.Background(), zoneID)
 		if err != nil {
-			return fmt.Errorf("error getting zone details: %s", err)
+			return diag.FromErr(fmt.Errorf("error getting zone details: %s", err))
 		}
 	}
 
@@ -103,11 +103,11 @@ func dataSourceCloudflareZoneRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("plan", zone.Plan.Name)
 
 	if err := d.Set("name_servers", zone.NameServers); err != nil {
-		return fmt.Errorf("failed to set name_servers attribute: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to set name_servers attribute: %s", err))
 	}
 
 	if err := d.Set("vanity_name_servers", zone.VanityNS); err != nil {
-		return fmt.Errorf("failed to set vanity_name_servers attribute: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to set vanity_name_servers attribute: %s", err))
 	}
 
 	return nil

--- a/cloudflare/data_source_zone.go
+++ b/cloudflare/data_source_zone.go
@@ -75,7 +75,7 @@ func dataSourceCloudflareZoneRead(ctx context.Context, d *schema.ResourceData, m
 		zonesResp, err := client.ListZonesContext(ctx, zoneFilter)
 
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error listing zones: %s", err))
+			return diag.FromErr(fmt.Errorf("error listing zones: %w", err))
 		}
 
 		if zonesResp.Total > 1 {
@@ -91,7 +91,7 @@ func dataSourceCloudflareZoneRead(ctx context.Context, d *schema.ResourceData, m
 		var err error
 		zone, err = client.ZoneDetails(ctx, zoneID)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error getting zone details: %s", err))
+			return diag.FromErr(fmt.Errorf("error getting zone details: %w", err))
 		}
 	}
 
@@ -104,11 +104,11 @@ func dataSourceCloudflareZoneRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("plan", zone.Plan.Name)
 
 	if err := d.Set("name_servers", zone.NameServers); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set name_servers attribute: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to set name_servers attribute: %w", err))
 	}
 
 	if err := d.Set("vanity_name_servers", zone.VanityNS); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set vanity_name_servers attribute: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to set vanity_name_servers attribute: %w", err))
 	}
 
 	return nil

--- a/cloudflare/data_source_zone.go
+++ b/cloudflare/data_source_zone.go
@@ -61,7 +61,7 @@ func dataSourceCloudflareZone() *schema.Resource {
 	}
 }
 
-func dataSourceCloudflareZoneRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceCloudflareZoneRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] Reading Zones")
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)

--- a/cloudflare/data_source_zone_dnssec.go
+++ b/cloudflare/data_source_zone_dnssec.go
@@ -71,7 +71,7 @@ func dataSourceCloudflareZoneDNSSECRead(ctx context.Context, d *schema.ResourceD
 
 	dnssec, err := client.ZoneDNSSECSetting(context.Background(), zoneID)
 	if err != nil {
-		return fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err))
 	}
 
 	d.Set("zone_id", zoneID)

--- a/cloudflare/data_source_zone_dnssec.go
+++ b/cloudflare/data_source_zone_dnssec.go
@@ -72,7 +72,7 @@ func dataSourceCloudflareZoneDNSSECRead(ctx context.Context, d *schema.ResourceD
 
 	dnssec, err := client.ZoneDNSSECSetting(ctx, zoneID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err))
+		return diag.FromErr(fmt.Errorf("error finding Zone DNSSEC %q: %w", zoneID, err))
 	}
 
 	d.Set("zone_id", zoneID)

--- a/cloudflare/data_source_zone_dnssec.go
+++ b/cloudflare/data_source_zone_dnssec.go
@@ -70,7 +70,7 @@ func dataSourceCloudflareZoneDNSSECRead(ctx context.Context, d *schema.ResourceD
 
 	log.Printf("[DEBUG] Reading Zone DNSSEC %s", zoneID)
 
-	dnssec, err := client.ZoneDNSSECSetting(context.Background(), zoneID)
+	dnssec, err := client.ZoneDNSSECSetting(ctx, zoneID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err))
 	}

--- a/cloudflare/data_source_zone_dnssec.go
+++ b/cloudflare/data_source_zone_dnssec.go
@@ -6,12 +6,13 @@ import (
 	"log"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceCloudflareZoneDNSSEC() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceCloudflareZoneDNSSECRead,
+		ReadContext: dataSourceCloudflareZoneDNSSECRead,
 
 		Schema: map[string]*schema.Schema{
 			"zone_id": {

--- a/cloudflare/data_source_zone_dnssec.go
+++ b/cloudflare/data_source_zone_dnssec.go
@@ -62,7 +62,7 @@ func dataSourceCloudflareZoneDNSSEC() *schema.Resource {
 	}
 }
 
-func dataSourceCloudflareZoneDNSSECRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceCloudflareZoneDNSSECRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	zoneID := d.Get("zone_id").(string)

--- a/cloudflare/data_source_zone_test.go
+++ b/cloudflare/data_source_zone_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAccCloudflareZone_PreventZoneIdAndNameConflicts(t *testing.T) {
-
 	t.Parallel()
 	rnd := generateRandomResourceName()
 	resource.Test(t, resource.TestCase{
@@ -34,7 +33,6 @@ data "cloudflare_zone" "%[1]s" {
 }
 
 func TestAccCloudflareZone_NameLookup(t *testing.T) {
-
 	t.Parallel()
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("data.cloudflare_zone.%s", rnd)

--- a/cloudflare/data_source_zones.go
+++ b/cloudflare/data_source_zones.go
@@ -92,7 +92,7 @@ func dataSourceCloudflareZonesRead(ctx context.Context, d *schema.ResourceData, 
 		filter.status,
 	)
 
-	zones, err := client.ListZonesContext(context.Background(), zoneFilter)
+	zones, err := client.ListZonesContext(ctx, zoneFilter)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error listing Zone: %s", err))
 	}

--- a/cloudflare/data_source_zones.go
+++ b/cloudflare/data_source_zones.go
@@ -72,12 +72,12 @@ func dataSourceCloudflareZones() *schema.Resource {
 	}
 }
 
-func dataSourceCloudflareZonesRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceCloudflareZonesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] Reading Zones")
 	client := meta.(*cloudflare.API)
 	filter, err := expandFilter(d.Get("filter"))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	zoneLookupValue := filter.name

--- a/cloudflare/data_source_zones.go
+++ b/cloudflare/data_source_zones.go
@@ -7,13 +7,14 @@ import (
 	"regexp"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataSourceCloudflareZones() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceCloudflareZonesRead,
+		ReadContext: dataSourceCloudflareZonesRead,
 
 		Schema: map[string]*schema.Schema{
 			"filter": {

--- a/cloudflare/data_source_zones.go
+++ b/cloudflare/data_source_zones.go
@@ -94,7 +94,7 @@ func dataSourceCloudflareZonesRead(ctx context.Context, d *schema.ResourceData, 
 
 	zones, err := client.ListZonesContext(ctx, zoneFilter)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error listing Zone: %s", err))
+		return diag.FromErr(fmt.Errorf("error listing Zone: %w", err))
 	}
 
 	zoneIds := make([]string, 0)
@@ -119,7 +119,7 @@ func dataSourceCloudflareZonesRead(ctx context.Context, d *schema.ResourceData, 
 
 	err = d.Set("zones", zoneDetails)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error setting zones: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting zones: %w", err))
 	}
 
 	d.SetId(stringListChecksum(zoneIds))

--- a/cloudflare/data_source_zones.go
+++ b/cloudflare/data_source_zones.go
@@ -93,7 +93,7 @@ func dataSourceCloudflareZonesRead(ctx context.Context, d *schema.ResourceData, 
 
 	zones, err := client.ListZonesContext(context.Background(), zoneFilter)
 	if err != nil {
-		return fmt.Errorf("error listing Zone: %s", err)
+		return diag.FromErr(fmt.Errorf("error listing Zone: %s", err))
 	}
 
 	zoneIds := make([]string, 0)
@@ -118,7 +118,7 @@ func dataSourceCloudflareZonesRead(ctx context.Context, d *schema.ResourceData, 
 
 	err = d.Set("zones", zoneDetails)
 	if err != nil {
-		return fmt.Errorf("error setting zones: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting zones: %s", err))
 	}
 
 	d.SetId(stringListChecksum(zoneIds))

--- a/cloudflare/data_source_zones_test.go
+++ b/cloudflare/data_source_zones_test.go
@@ -61,7 +61,6 @@ func testSweepCloudflareZones(r string) error {
 }
 
 func TestAccCloudflareZonesMatchName(t *testing.T) {
-
 	t.Parallel()
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("data.cloudflare_zones.%s", rnd)

--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareAccessApplication() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareAccessApplicationSchema(),
+		Schema:        resourceCloudflareAccessApplicationSchema(),
 		CreateContext: resourceCloudflareAccessApplicationCreate,
-		ReadContext: resourceCloudflareAccessApplicationRead,
+		ReadContext:   resourceCloudflareAccessApplicationRead,
 		UpdateContext: resourceCloudflareAccessApplicationUpdate,
 		DeleteContext: resourceCloudflareAccessApplicationDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareAccessApplicationImport,
+			StateContext: resourceCloudflareAccessApplicationImport,
 		},
 	}
 }
@@ -81,7 +82,7 @@ func resourceCloudflareAccessApplicationCreate(ctx context.Context, d *schema.Re
 
 	d.SetId(accessApplication.ID)
 
-	return resourceCloudflareAccessApplicationRead(d, meta)
+	return resourceCloudflareAccessApplicationRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -190,7 +191,7 @@ func resourceCloudflareAccessApplicationUpdate(ctx context.Context, d *schema.Re
 		return diag.FromErr(fmt.Errorf("failed to find Access Application ID in update response; resource was empty"))
 	}
 
-	return resourceCloudflareAccessApplicationRead(d, meta)
+	return resourceCloudflareAccessApplicationRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessApplicationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -213,12 +214,12 @@ func resourceCloudflareAccessApplicationDelete(ctx context.Context, d *schema.Re
 		return diag.FromErr(fmt.Errorf("error deleting Access Application for %s %q: %s", identifier.Type, identifier.Value, err))
 	}
 
-	resourceCloudflareAccessApplicationRead(d, meta)
+	resourceCloudflareAccessApplicationRead(ctx, d, meta)
 
 	return nil
 }
 
-func resourceCloudflareAccessApplicationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareAccessApplicationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -232,7 +233,7 @@ func resourceCloudflareAccessApplicationImport(d *schema.ResourceData, meta inte
 	d.Set("account_id", accountID)
 	d.SetId(accessApplicationID)
 
-	resourceCloudflareAccessApplicationRead(d, meta)
+	resourceCloudflareAccessApplicationRead(context.TODO(), d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -76,7 +76,7 @@ func resourceCloudflareAccessApplicationCreate(ctx context.Context, d *schema.Re
 		accessApplication, err = client.CreateZoneLevelAccessApplication(context.Background(), identifier.Value, newAccessApplication)
 	}
 	if err != nil {
-		return fmt.Errorf("error creating Access Application for %s %q: %s", identifier.Type, identifier.Value, err)
+		return diag.FromErr(fmt.Errorf("error creating Access Application for %s %q: %s", identifier.Type, identifier.Value, err))
 	}
 
 	d.SetId(accessApplication.ID)
@@ -105,7 +105,7 @@ func resourceCloudflareAccessApplicationRead(ctx context.Context, d *schema.Reso
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Access Application %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Access Application %q: %s", d.Id(), err))
 	}
 
 	d.Set("name", accessApplication.Name)
@@ -127,7 +127,7 @@ func resourceCloudflareAccessApplicationRead(ctx context.Context, d *schema.Reso
 
 	corsConfig := convertCORSStructToSchema(d, accessApplication.CorsHeaders)
 	if corsConfigErr := d.Set("cors_headers", corsConfig); corsConfigErr != nil {
-		return fmt.Errorf("error setting Access Application CORS header configuration: %s", corsConfigErr)
+		return diag.FromErr(fmt.Errorf("error setting Access Application CORS header configuration: %s", corsConfigErr))
 	}
 
 	return nil
@@ -183,11 +183,11 @@ func resourceCloudflareAccessApplicationUpdate(ctx context.Context, d *schema.Re
 		accessApplication, err = client.UpdateZoneLevelAccessApplication(context.Background(), identifier.Value, updatedAccessApplication)
 	}
 	if err != nil {
-		return fmt.Errorf("error updating Access Application for %s %q: %s", identifier.Type, identifier.Value, err)
+		return diag.FromErr(fmt.Errorf("error updating Access Application for %s %q: %s", identifier.Type, identifier.Value, err))
 	}
 
 	if accessApplication.ID == "" {
-		return fmt.Errorf("failed to find Access Application ID in update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find Access Application ID in update response; resource was empty"))
 	}
 
 	return resourceCloudflareAccessApplicationRead(d, meta)
@@ -210,7 +210,7 @@ func resourceCloudflareAccessApplicationDelete(ctx context.Context, d *schema.Re
 		err = client.DeleteZoneLevelAccessApplication(context.Background(), identifier.Value, appID)
 	}
 	if err != nil {
-		return fmt.Errorf("error deleting Access Application for %s %q: %s", identifier.Type, identifier.Value, err)
+		return diag.FromErr(fmt.Errorf("error deleting Access Application for %s %q: %s", identifier.Type, identifier.Value, err))
 	}
 
 	resourceCloudflareAccessApplicationRead(d, meta)

--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareAccessApplication() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareAccessApplicationSchema(),
-		Create: resourceCloudflareAccessApplicationCreate,
-		Read:   resourceCloudflareAccessApplicationRead,
-		Update: resourceCloudflareAccessApplicationUpdate,
-		Delete: resourceCloudflareAccessApplicationDelete,
+		CreateContext: resourceCloudflareAccessApplicationCreate,
+		ReadContext: resourceCloudflareAccessApplicationRead,
+		UpdateContext: resourceCloudflareAccessApplicationUpdate,
+		DeleteContext: resourceCloudflareAccessApplicationDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareAccessApplicationImport,
 		},

--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -72,9 +72,9 @@ func resourceCloudflareAccessApplicationCreate(ctx context.Context, d *schema.Re
 
 	var accessApplication cloudflare.AccessApplication
 	if identifier.Type == AccountType {
-		accessApplication, err = client.CreateAccessApplication(context.Background(), identifier.Value, newAccessApplication)
+		accessApplication, err = client.CreateAccessApplication(ctx, identifier.Value, newAccessApplication)
 	} else {
-		accessApplication, err = client.CreateZoneLevelAccessApplication(context.Background(), identifier.Value, newAccessApplication)
+		accessApplication, err = client.CreateZoneLevelAccessApplication(ctx, identifier.Value, newAccessApplication)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Access Application for %s %q: %s", identifier.Type, identifier.Value, err))
@@ -95,9 +95,9 @@ func resourceCloudflareAccessApplicationRead(ctx context.Context, d *schema.Reso
 
 	var accessApplication cloudflare.AccessApplication
 	if identifier.Type == AccountType {
-		accessApplication, err = client.AccessApplication(context.Background(), identifier.Value, d.Id())
+		accessApplication, err = client.AccessApplication(ctx, identifier.Value, d.Id())
 	} else {
-		accessApplication, err = client.ZoneLevelAccessApplication(context.Background(), identifier.Value, d.Id())
+		accessApplication, err = client.ZoneLevelAccessApplication(ctx, identifier.Value, d.Id())
 	}
 
 	if err != nil {
@@ -179,9 +179,9 @@ func resourceCloudflareAccessApplicationUpdate(ctx context.Context, d *schema.Re
 
 	var accessApplication cloudflare.AccessApplication
 	if identifier.Type == AccountType {
-		accessApplication, err = client.UpdateAccessApplication(context.Background(), identifier.Value, updatedAccessApplication)
+		accessApplication, err = client.UpdateAccessApplication(ctx, identifier.Value, updatedAccessApplication)
 	} else {
-		accessApplication, err = client.UpdateZoneLevelAccessApplication(context.Background(), identifier.Value, updatedAccessApplication)
+		accessApplication, err = client.UpdateZoneLevelAccessApplication(ctx, identifier.Value, updatedAccessApplication)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Access Application for %s %q: %s", identifier.Type, identifier.Value, err))
@@ -206,9 +206,9 @@ func resourceCloudflareAccessApplicationDelete(ctx context.Context, d *schema.Re
 	}
 
 	if identifier.Type == AccountType {
-		err = client.DeleteAccessApplication(context.Background(), identifier.Value, appID)
+		err = client.DeleteAccessApplication(ctx, identifier.Value, appID)
 	} else {
-		err = client.DeleteZoneLevelAccessApplication(context.Background(), identifier.Value, appID)
+		err = client.DeleteZoneLevelAccessApplication(ctx, identifier.Value, appID)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Access Application for %s %q: %s", identifier.Type, identifier.Value, err))

--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -23,7 +23,7 @@ func resourceCloudflareAccessApplication() *schema.Resource {
 	}
 }
 
-func resourceCloudflareAccessApplicationCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	allowedIDPList := expandInterfaceToStringList(d.Get("allowed_idps"))
@@ -57,7 +57,7 @@ func resourceCloudflareAccessApplicationCreate(d *schema.ResourceData, meta inte
 	if _, ok := d.GetOk("cors_headers"); ok {
 		CORSConfig, err := convertCORSSchemaToStruct(d)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		newAccessApplication.CorsHeaders = CORSConfig
 	}
@@ -66,7 +66,7 @@ func resourceCloudflareAccessApplicationCreate(d *schema.ResourceData, meta inte
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessApplication cloudflare.AccessApplication
@@ -84,12 +84,12 @@ func resourceCloudflareAccessApplicationCreate(d *schema.ResourceData, meta inte
 	return resourceCloudflareAccessApplicationRead(d, meta)
 }
 
-func resourceCloudflareAccessApplicationRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessApplication cloudflare.AccessApplication
@@ -133,7 +133,7 @@ func resourceCloudflareAccessApplicationRead(d *schema.ResourceData, meta interf
 	return nil
 }
 
-func resourceCloudflareAccessApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	allowedIDPList := expandInterfaceToStringList(d.Get("allowed_idps"))
@@ -164,7 +164,7 @@ func resourceCloudflareAccessApplicationUpdate(d *schema.ResourceData, meta inte
 	if _, ok := d.GetOk("cors_headers"); ok {
 		CORSConfig, err := convertCORSSchemaToStruct(d)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		updatedAccessApplication.CorsHeaders = CORSConfig
 	}
@@ -173,7 +173,7 @@ func resourceCloudflareAccessApplicationUpdate(d *schema.ResourceData, meta inte
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessApplication cloudflare.AccessApplication
@@ -193,7 +193,7 @@ func resourceCloudflareAccessApplicationUpdate(d *schema.ResourceData, meta inte
 	return resourceCloudflareAccessApplicationRead(d, meta)
 }
 
-func resourceCloudflareAccessApplicationDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessApplicationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	appID := d.Id()
 
@@ -201,7 +201,7 @@ func resourceCloudflareAccessApplicationDelete(d *schema.ResourceData, meta inte
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if identifier.Type == AccountType {

--- a/cloudflare/resource_cloudflare_access_bookmark.go
+++ b/cloudflare/resource_cloudflare_access_bookmark.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareAccessBookmark() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareAccessBookmarkSchema(),
+		Schema:        resourceCloudflareAccessBookmarkSchema(),
 		CreateContext: resourceCloudflareAccessBookmarkCreate,
-		ReadContext: resourceCloudflareAccessBookmarkRead,
+		ReadContext:   resourceCloudflareAccessBookmarkRead,
 		UpdateContext: resourceCloudflareAccessBookmarkUpdate,
 		DeleteContext: resourceCloudflareAccessBookmarkDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareAccessBookmarkImport,
+			StateContext: resourceCloudflareAccessBookmarkImport,
 		},
 	}
 }
@@ -52,7 +53,7 @@ func resourceCloudflareAccessBookmarkCreate(ctx context.Context, d *schema.Resou
 
 	d.SetId(accessBookmark.ID)
 
-	return resourceCloudflareAccessBookmarkRead(d, meta)
+	return resourceCloudflareAccessBookmarkRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessBookmarkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -119,7 +120,7 @@ func resourceCloudflareAccessBookmarkUpdate(ctx context.Context, d *schema.Resou
 		return diag.FromErr(fmt.Errorf("failed to find Access Bookmark ID in update response; resource was empty"))
 	}
 
-	return resourceCloudflareAccessBookmarkRead(d, meta)
+	return resourceCloudflareAccessBookmarkRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessBookmarkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -142,12 +143,12 @@ func resourceCloudflareAccessBookmarkDelete(ctx context.Context, d *schema.Resou
 		return diag.FromErr(fmt.Errorf("error deleting Access Bookmark for %s %q: %s", identifier.Type, identifier.Value, err))
 	}
 
-	resourceCloudflareAccessBookmarkRead(d, meta)
+	resourceCloudflareAccessBookmarkRead(ctx, d, meta)
 
 	return nil
 }
 
-func resourceCloudflareAccessBookmarkImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareAccessBookmarkImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -161,7 +162,7 @@ func resourceCloudflareAccessBookmarkImport(d *schema.ResourceData, meta interfa
 	d.Set("account_id", accountID)
 	d.SetId(accessBookmarkID)
 
-	resourceCloudflareAccessBookmarkRead(d, meta)
+	resourceCloudflareAccessBookmarkRead(context.TODO(), d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_bookmark.go
+++ b/cloudflare/resource_cloudflare_access_bookmark.go
@@ -47,7 +47,7 @@ func resourceCloudflareAccessBookmarkCreate(ctx context.Context, d *schema.Resou
 		accessBookmark, err = client.CreateZoneLevelAccessBookmark(context.Background(), identifier.Value, newAccessBookmark)
 	}
 	if err != nil {
-		return fmt.Errorf("error creating Access Bookmark for %s %q: %s", identifier.Type, identifier.Value, err)
+		return diag.FromErr(fmt.Errorf("error creating Access Bookmark for %s %q: %s", identifier.Type, identifier.Value, err))
 	}
 
 	d.SetId(accessBookmark.ID)
@@ -76,7 +76,7 @@ func resourceCloudflareAccessBookmarkRead(ctx context.Context, d *schema.Resourc
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Access Bookmark %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Access Bookmark %q: %s", d.Id(), err))
 	}
 
 	d.Set("name", accessBookmark.Name)
@@ -112,11 +112,11 @@ func resourceCloudflareAccessBookmarkUpdate(ctx context.Context, d *schema.Resou
 		accessBookmark, err = client.UpdateZoneLevelAccessBookmark(context.Background(), identifier.Value, updatedAccessBookmark)
 	}
 	if err != nil {
-		return fmt.Errorf("error updating Access Bookmark for %s %q: %s", identifier.Type, identifier.Value, err)
+		return diag.FromErr(fmt.Errorf("error updating Access Bookmark for %s %q: %s", identifier.Type, identifier.Value, err))
 	}
 
 	if accessBookmark.ID == "" {
-		return fmt.Errorf("failed to find Access Bookmark ID in update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find Access Bookmark ID in update response; resource was empty"))
 	}
 
 	return resourceCloudflareAccessBookmarkRead(d, meta)
@@ -139,7 +139,7 @@ func resourceCloudflareAccessBookmarkDelete(ctx context.Context, d *schema.Resou
 		err = client.DeleteZoneLevelAccessBookmark(context.Background(), identifier.Value, bookmarkID)
 	}
 	if err != nil {
-		return fmt.Errorf("error deleting Access Bookmark for %s %q: %s", identifier.Type, identifier.Value, err)
+		return diag.FromErr(fmt.Errorf("error deleting Access Bookmark for %s %q: %s", identifier.Type, identifier.Value, err))
 	}
 
 	resourceCloudflareAccessBookmarkRead(d, meta)

--- a/cloudflare/resource_cloudflare_access_bookmark.go
+++ b/cloudflare/resource_cloudflare_access_bookmark.go
@@ -23,7 +23,7 @@ func resourceCloudflareAccessBookmark() *schema.Resource {
 	}
 }
 
-func resourceCloudflareAccessBookmarkCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessBookmarkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	newAccessBookmark := cloudflare.AccessBookmark{
@@ -37,7 +37,7 @@ func resourceCloudflareAccessBookmarkCreate(d *schema.ResourceData, meta interfa
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessBookmark cloudflare.AccessBookmark
@@ -55,12 +55,12 @@ func resourceCloudflareAccessBookmarkCreate(d *schema.ResourceData, meta interfa
 	return resourceCloudflareAccessBookmarkRead(d, meta)
 }
 
-func resourceCloudflareAccessBookmarkRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessBookmarkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessBookmark cloudflare.AccessBookmark
@@ -87,7 +87,7 @@ func resourceCloudflareAccessBookmarkRead(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func resourceCloudflareAccessBookmarkUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessBookmarkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	updatedAccessBookmark := cloudflare.AccessBookmark{
@@ -102,7 +102,7 @@ func resourceCloudflareAccessBookmarkUpdate(d *schema.ResourceData, meta interfa
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessBookmark cloudflare.AccessBookmark
@@ -122,7 +122,7 @@ func resourceCloudflareAccessBookmarkUpdate(d *schema.ResourceData, meta interfa
 	return resourceCloudflareAccessBookmarkRead(d, meta)
 }
 
-func resourceCloudflareAccessBookmarkDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessBookmarkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	bookmarkID := d.Id()
 
@@ -130,7 +130,7 @@ func resourceCloudflareAccessBookmarkDelete(d *schema.ResourceData, meta interfa
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if identifier.Type == AccountType {

--- a/cloudflare/resource_cloudflare_access_bookmark.go
+++ b/cloudflare/resource_cloudflare_access_bookmark.go
@@ -43,9 +43,9 @@ func resourceCloudflareAccessBookmarkCreate(ctx context.Context, d *schema.Resou
 
 	var accessBookmark cloudflare.AccessBookmark
 	if identifier.Type == AccountType {
-		accessBookmark, err = client.CreateAccessBookmark(context.Background(), identifier.Value, newAccessBookmark)
+		accessBookmark, err = client.CreateAccessBookmark(ctx, identifier.Value, newAccessBookmark)
 	} else {
-		accessBookmark, err = client.CreateZoneLevelAccessBookmark(context.Background(), identifier.Value, newAccessBookmark)
+		accessBookmark, err = client.CreateZoneLevelAccessBookmark(ctx, identifier.Value, newAccessBookmark)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Access Bookmark for %s %q: %s", identifier.Type, identifier.Value, err))
@@ -66,9 +66,9 @@ func resourceCloudflareAccessBookmarkRead(ctx context.Context, d *schema.Resourc
 
 	var accessBookmark cloudflare.AccessBookmark
 	if identifier.Type == AccountType {
-		accessBookmark, err = client.AccessBookmark(context.Background(), identifier.Value, d.Id())
+		accessBookmark, err = client.AccessBookmark(ctx, identifier.Value, d.Id())
 	} else {
-		accessBookmark, err = client.ZoneLevelAccessBookmark(context.Background(), identifier.Value, d.Id())
+		accessBookmark, err = client.ZoneLevelAccessBookmark(ctx, identifier.Value, d.Id())
 	}
 
 	if err != nil {
@@ -108,9 +108,9 @@ func resourceCloudflareAccessBookmarkUpdate(ctx context.Context, d *schema.Resou
 
 	var accessBookmark cloudflare.AccessBookmark
 	if identifier.Type == AccountType {
-		accessBookmark, err = client.UpdateAccessBookmark(context.Background(), identifier.Value, updatedAccessBookmark)
+		accessBookmark, err = client.UpdateAccessBookmark(ctx, identifier.Value, updatedAccessBookmark)
 	} else {
-		accessBookmark, err = client.UpdateZoneLevelAccessBookmark(context.Background(), identifier.Value, updatedAccessBookmark)
+		accessBookmark, err = client.UpdateZoneLevelAccessBookmark(ctx, identifier.Value, updatedAccessBookmark)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Access Bookmark for %s %q: %s", identifier.Type, identifier.Value, err))
@@ -135,9 +135,9 @@ func resourceCloudflareAccessBookmarkDelete(ctx context.Context, d *schema.Resou
 	}
 
 	if identifier.Type == AccountType {
-		err = client.DeleteAccessBookmark(context.Background(), identifier.Value, bookmarkID)
+		err = client.DeleteAccessBookmark(ctx, identifier.Value, bookmarkID)
 	} else {
-		err = client.DeleteZoneLevelAccessBookmark(context.Background(), identifier.Value, bookmarkID)
+		err = client.DeleteZoneLevelAccessBookmark(ctx, identifier.Value, bookmarkID)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Access Bookmark for %s %q: %s", identifier.Type, identifier.Value, err))

--- a/cloudflare/resource_cloudflare_access_bookmark.go
+++ b/cloudflare/resource_cloudflare_access_bookmark.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareAccessBookmark() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareAccessBookmarkSchema(),
-		Create: resourceCloudflareAccessBookmarkCreate,
-		Read:   resourceCloudflareAccessBookmarkRead,
-		Update: resourceCloudflareAccessBookmarkUpdate,
-		Delete: resourceCloudflareAccessBookmarkDelete,
+		CreateContext: resourceCloudflareAccessBookmarkCreate,
+		ReadContext: resourceCloudflareAccessBookmarkRead,
+		UpdateContext: resourceCloudflareAccessBookmarkUpdate,
+		DeleteContext: resourceCloudflareAccessBookmarkDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareAccessBookmarkImport,
 		},

--- a/cloudflare/resource_cloudflare_access_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_access_ca_certificate.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareAccessCACertificate() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareAccessCACertificateSchema(),
-		Create: resourceCloudflareAccessCACertificateCreate,
-		Read:   resourceCloudflareAccessCACertificateRead,
-		Update: resourceCloudflareAccessCACertificateUpdate,
-		Delete: resourceCloudflareAccessCACertificateDelete,
+		CreateContext: resourceCloudflareAccessCACertificateCreate,
+		ReadContext: resourceCloudflareAccessCACertificateRead,
+		UpdateContext: resourceCloudflareAccessCACertificateUpdate,
+		DeleteContext: resourceCloudflareAccessCACertificateDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareAccessCACertificateImport,
 		},

--- a/cloudflare/resource_cloudflare_access_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_access_ca_certificate.go
@@ -38,7 +38,7 @@ func resourceCloudflareAccessCACertificateCreate(ctx context.Context, d *schema.
 		accessCACert, err = client.CreateZoneLevelAccessCACertificate(context.Background(), identifier.Value, d.Get("application_id").(string))
 	}
 	if err != nil {
-		return fmt.Errorf("error creating Access CA Certificate for %s %q: %s", identifier.Type, identifier.Value, err)
+		return diag.FromErr(fmt.Errorf("error creating Access CA Certificate for %s %q: %s", identifier.Type, identifier.Value, err))
 	}
 
 	d.SetId(accessCACert.ID)
@@ -67,7 +67,7 @@ func resourceCloudflareAccessCACertificateRead(ctx context.Context, d *schema.Re
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Access CA Certificate %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Access CA Certificate %q: %s", d.Id(), err))
 	}
 
 	d.Set("aud", accessCACert.Aud)

--- a/cloudflare/resource_cloudflare_access_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_access_ca_certificate.go
@@ -34,9 +34,9 @@ func resourceCloudflareAccessCACertificateCreate(ctx context.Context, d *schema.
 
 	var accessCACert cloudflare.AccessCACertificate
 	if identifier.Type == AccountType {
-		accessCACert, err = client.CreateAccessCACertificate(context.Background(), identifier.Value, d.Get("application_id").(string))
+		accessCACert, err = client.CreateAccessCACertificate(ctx, identifier.Value, d.Get("application_id").(string))
 	} else {
-		accessCACert, err = client.CreateZoneLevelAccessCACertificate(context.Background(), identifier.Value, d.Get("application_id").(string))
+		accessCACert, err = client.CreateZoneLevelAccessCACertificate(ctx, identifier.Value, d.Get("application_id").(string))
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Access CA Certificate for %s %q: %s", identifier.Type, identifier.Value, err))
@@ -57,9 +57,9 @@ func resourceCloudflareAccessCACertificateRead(ctx context.Context, d *schema.Re
 
 	var accessCACert cloudflare.AccessCACertificate
 	if identifier.Type == AccountType {
-		accessCACert, err = client.AccessCACertificate(context.Background(), identifier.Value, applicationID)
+		accessCACert, err = client.AccessCACertificate(ctx, identifier.Value, applicationID)
 	} else {
-		accessCACert, err = client.ZoneLevelAccessCACertificate(context.Background(), identifier.Value, applicationID)
+		accessCACert, err = client.ZoneLevelAccessCACertificate(ctx, identifier.Value, applicationID)
 	}
 
 	if err != nil {
@@ -93,9 +93,9 @@ func resourceCloudflareAccessCACertificateDelete(ctx context.Context, d *schema.
 	}
 
 	if identifier.Type == AccountType {
-		err = client.DeleteAccessCACertificate(context.Background(), identifier.Value, applicationID)
+		err = client.DeleteAccessCACertificate(ctx, identifier.Value, applicationID)
 	} else {
-		err = client.DeleteZoneLevelAccessCACertificate(context.Background(), identifier.Value, applicationID)
+		err = client.DeleteZoneLevelAccessCACertificate(ctx, identifier.Value, applicationID)
 	}
 
 	if err != nil {

--- a/cloudflare/resource_cloudflare_access_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_access_ca_certificate.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareAccessCACertificate() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareAccessCACertificateSchema(),
+		Schema:        resourceCloudflareAccessCACertificateSchema(),
 		CreateContext: resourceCloudflareAccessCACertificateCreate,
-		ReadContext: resourceCloudflareAccessCACertificateRead,
+		ReadContext:   resourceCloudflareAccessCACertificateRead,
 		UpdateContext: resourceCloudflareAccessCACertificateUpdate,
 		DeleteContext: resourceCloudflareAccessCACertificateDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareAccessCACertificateImport,
+			StateContext: resourceCloudflareAccessCACertificateImport,
 		},
 	}
 }
@@ -43,7 +44,7 @@ func resourceCloudflareAccessCACertificateCreate(ctx context.Context, d *schema.
 
 	d.SetId(accessCACert.ID)
 
-	return resourceCloudflareAccessCACertificateRead(d, meta)
+	return resourceCloudflareAccessCACertificateRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessCACertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -106,7 +107,7 @@ func resourceCloudflareAccessCACertificateDelete(ctx context.Context, d *schema.
 	return nil
 }
 
-func resourceCloudflareAccessCACertificateImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareAccessCACertificateImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 3)
 
 	if len(attributes) != 3 {
@@ -125,7 +126,7 @@ func resourceCloudflareAccessCACertificateImport(d *schema.ResourceData, meta in
 	d.Set(fmt.Sprintf("%s_id", identifierType), identifierID)
 	d.SetId(accessCACertificateID)
 
-	resourceCloudflareAccessCACertificateRead(d, meta)
+	resourceCloudflareAccessCACertificateRead(context.TODO(), d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_access_ca_certificate.go
@@ -23,12 +23,12 @@ func resourceCloudflareAccessCACertificate() *schema.Resource {
 	}
 }
 
-func resourceCloudflareAccessCACertificateCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessCACertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessCACert cloudflare.AccessCACertificate
@@ -46,12 +46,12 @@ func resourceCloudflareAccessCACertificateCreate(d *schema.ResourceData, meta in
 	return resourceCloudflareAccessCACertificateRead(d, meta)
 }
 
-func resourceCloudflareAccessCACertificateRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessCACertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	applicationID := d.Get("application_id").(string)
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessCACert cloudflare.AccessCACertificate
@@ -76,11 +76,11 @@ func resourceCloudflareAccessCACertificateRead(d *schema.ResourceData, meta inte
 	return nil
 }
 
-func resourceCloudflareAccessCACertificateUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessCACertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceCloudflareAccessCACertificateDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessCACertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	applicationID := d.Get("application_id").(string)
 
@@ -88,7 +88,7 @@ func resourceCloudflareAccessCACertificateDelete(d *schema.ResourceData, meta in
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if identifier.Type == AccountType {
@@ -98,7 +98,7 @@ func resourceCloudflareAccessCACertificateDelete(d *schema.ResourceData, meta in
 	}
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId("")

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareAccessGroup() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareAccessGroupSchema(),
-		Create: resourceCloudflareAccessGroupCreate,
-		Read:   resourceCloudflareAccessGroupRead,
-		Update: resourceCloudflareAccessGroupUpdate,
-		Delete: resourceCloudflareAccessGroupDelete,
+		CreateContext: resourceCloudflareAccessGroupCreate,
+		ReadContext: resourceCloudflareAccessGroupRead,
+		UpdateContext: resourceCloudflareAccessGroupUpdate,
+		DeleteContext: resourceCloudflareAccessGroupDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareAccessGroupImport,
 		},

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -44,21 +44,21 @@ func resourceCloudflareAccessGroupRead(ctx context.Context, d *schema.ResourceDa
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Access Group %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Access Group %q: %s", d.Id(), err))
 	}
 
 	d.Set("name", accessGroup.Name)
 
 	if err := d.Set("require", TransformAccessGroupForSchema(accessGroup.Require)); err != nil {
-		return fmt.Errorf("failed to set require attribute: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to set require attribute: %s", err))
 	}
 
 	if err := d.Set("exclude", TransformAccessGroupForSchema(accessGroup.Exclude)); err != nil {
-		return fmt.Errorf("failed to set exclude attribute: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to set exclude attribute: %s", err))
 	}
 
 	if err := d.Set("include", TransformAccessGroupForSchema(accessGroup.Include)); err != nil {
-		return fmt.Errorf("failed to set include attribute: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to set include attribute: %s", err))
 	}
 
 	return nil
@@ -86,7 +86,7 @@ func resourceCloudflareAccessGroupCreate(ctx context.Context, d *schema.Resource
 		accessGroup, err = client.CreateZoneLevelAccessGroup(context.Background(), identifier.Value, newAccessGroup)
 	}
 	if err != nil {
-		return fmt.Errorf("error creating Access Group for ID %q: %s", accessGroup.ID, err)
+		return diag.FromErr(fmt.Errorf("error creating Access Group for ID %q: %s", accessGroup.ID, err))
 	}
 
 	d.SetId(accessGroup.ID)
@@ -116,11 +116,11 @@ func resourceCloudflareAccessGroupUpdate(ctx context.Context, d *schema.Resource
 		accessGroup, err = client.UpdateZoneLevelAccessGroup(context.Background(), identifier.Value, updatedAccessGroup)
 	}
 	if err != nil {
-		return fmt.Errorf("error updating Access Group for ID %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error updating Access Group for ID %q: %s", d.Id(), err))
 	}
 
 	if accessGroup.ID == "" {
-		return fmt.Errorf("failed to find Access Group ID in update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find Access Group ID in update response; resource was empty"))
 	}
 
 	return resourceCloudflareAccessGroupRead(d, meta)
@@ -142,7 +142,7 @@ func resourceCloudflareAccessGroupDelete(ctx context.Context, d *schema.Resource
 		err = client.DeleteZoneLevelAccessGroup(context.Background(), identifier.Value, d.Id())
 	}
 	if err != nil {
-		return fmt.Errorf("error deleting Access Group for ID %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error deleting Access Group for ID %q: %s", d.Id(), err))
 	}
 
 	resourceCloudflareAccessGroupRead(d, meta)

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -45,21 +45,21 @@ func resourceCloudflareAccessGroupRead(ctx context.Context, d *schema.ResourceDa
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding Access Group %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding Access Group %q: %w", d.Id(), err))
 	}
 
 	d.Set("name", accessGroup.Name)
 
 	if err := d.Set("require", TransformAccessGroupForSchema(accessGroup.Require)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set require attribute: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to set require attribute: %w", err))
 	}
 
 	if err := d.Set("exclude", TransformAccessGroupForSchema(accessGroup.Exclude)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set exclude attribute: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to set exclude attribute: %w", err))
 	}
 
 	if err := d.Set("include", TransformAccessGroupForSchema(accessGroup.Include)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set include attribute: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to set include attribute: %w", err))
 	}
 
 	return nil
@@ -87,7 +87,7 @@ func resourceCloudflareAccessGroupCreate(ctx context.Context, d *schema.Resource
 		accessGroup, err = client.CreateZoneLevelAccessGroup(ctx, identifier.Value, newAccessGroup)
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Access Group for ID %q: %s", accessGroup.ID, err))
+		return diag.FromErr(fmt.Errorf("error creating Access Group for ID %q: %w", accessGroup.ID, err))
 	}
 
 	d.SetId(accessGroup.ID)
@@ -117,7 +117,7 @@ func resourceCloudflareAccessGroupUpdate(ctx context.Context, d *schema.Resource
 		accessGroup, err = client.UpdateZoneLevelAccessGroup(ctx, identifier.Value, updatedAccessGroup)
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Access Group for ID %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error updating Access Group for ID %q: %w", d.Id(), err))
 	}
 
 	if accessGroup.ID == "" {
@@ -143,7 +143,7 @@ func resourceCloudflareAccessGroupDelete(ctx context.Context, d *schema.Resource
 		err = client.DeleteZoneLevelAccessGroup(ctx, identifier.Value, d.Id())
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Access Group for ID %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error deleting Access Group for ID %q: %w", d.Id(), err))
 	}
 
 	resourceCloudflareAccessGroupRead(ctx, d, meta)
@@ -165,7 +165,7 @@ func resourceCloudflareAccessGroupImport(ctx context.Context, d *schema.Resource
 	d.Set("account_id", accountID)
 	d.SetId(accessGroupID)
 
-	resourceCloudflareAccessGroupRead(context.TODO(), d, meta)
+	resourceCloudflareAccessGroupRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareAccessGroup() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareAccessGroupSchema(),
+		Schema:        resourceCloudflareAccessGroupSchema(),
 		CreateContext: resourceCloudflareAccessGroupCreate,
-		ReadContext: resourceCloudflareAccessGroupRead,
+		ReadContext:   resourceCloudflareAccessGroupRead,
 		UpdateContext: resourceCloudflareAccessGroupUpdate,
 		DeleteContext: resourceCloudflareAccessGroupDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareAccessGroupImport,
+			StateContext: resourceCloudflareAccessGroupImport,
 		},
 	}
 }
@@ -90,7 +91,7 @@ func resourceCloudflareAccessGroupCreate(ctx context.Context, d *schema.Resource
 	}
 
 	d.SetId(accessGroup.ID)
-	return resourceCloudflareAccessGroupRead(d, meta)
+	return resourceCloudflareAccessGroupRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -123,7 +124,7 @@ func resourceCloudflareAccessGroupUpdate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(fmt.Errorf("failed to find Access Group ID in update response; resource was empty"))
 	}
 
-	return resourceCloudflareAccessGroupRead(d, meta)
+	return resourceCloudflareAccessGroupRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -145,12 +146,12 @@ func resourceCloudflareAccessGroupDelete(ctx context.Context, d *schema.Resource
 		return diag.FromErr(fmt.Errorf("error deleting Access Group for ID %q: %s", d.Id(), err))
 	}
 
-	resourceCloudflareAccessGroupRead(d, meta)
+	resourceCloudflareAccessGroupRead(ctx, d, meta)
 
 	return nil
 }
 
-func resourceCloudflareAccessGroupImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareAccessGroupImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -164,7 +165,7 @@ func resourceCloudflareAccessGroupImport(d *schema.ResourceData, meta interface{
 	d.Set("account_id", accountID)
 	d.SetId(accessGroupID)
 
-	resourceCloudflareAccessGroupRead(d, meta)
+	resourceCloudflareAccessGroupRead(context.TODO(), d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -34,9 +34,9 @@ func resourceCloudflareAccessGroupRead(ctx context.Context, d *schema.ResourceDa
 
 	var accessGroup cloudflare.AccessGroup
 	if identifier.Type == AccountType {
-		accessGroup, err = client.AccessGroup(context.Background(), identifier.Value, d.Id())
+		accessGroup, err = client.AccessGroup(ctx, identifier.Value, d.Id())
 	} else {
-		accessGroup, err = client.ZoneLevelAccessGroup(context.Background(), identifier.Value, d.Id())
+		accessGroup, err = client.ZoneLevelAccessGroup(ctx, identifier.Value, d.Id())
 	}
 
 	if err != nil {
@@ -82,9 +82,9 @@ func resourceCloudflareAccessGroupCreate(ctx context.Context, d *schema.Resource
 
 	var accessGroup cloudflare.AccessGroup
 	if identifier.Type == AccountType {
-		accessGroup, err = client.CreateAccessGroup(context.Background(), identifier.Value, newAccessGroup)
+		accessGroup, err = client.CreateAccessGroup(ctx, identifier.Value, newAccessGroup)
 	} else {
-		accessGroup, err = client.CreateZoneLevelAccessGroup(context.Background(), identifier.Value, newAccessGroup)
+		accessGroup, err = client.CreateZoneLevelAccessGroup(ctx, identifier.Value, newAccessGroup)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Access Group for ID %q: %s", accessGroup.ID, err))
@@ -112,9 +112,9 @@ func resourceCloudflareAccessGroupUpdate(ctx context.Context, d *schema.Resource
 
 	var accessGroup cloudflare.AccessGroup
 	if identifier.Type == AccountType {
-		accessGroup, err = client.UpdateAccessGroup(context.Background(), identifier.Value, updatedAccessGroup)
+		accessGroup, err = client.UpdateAccessGroup(ctx, identifier.Value, updatedAccessGroup)
 	} else {
-		accessGroup, err = client.UpdateZoneLevelAccessGroup(context.Background(), identifier.Value, updatedAccessGroup)
+		accessGroup, err = client.UpdateZoneLevelAccessGroup(ctx, identifier.Value, updatedAccessGroup)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Access Group for ID %q: %s", d.Id(), err))
@@ -138,9 +138,9 @@ func resourceCloudflareAccessGroupDelete(ctx context.Context, d *schema.Resource
 	}
 
 	if identifier.Type == AccountType {
-		err = client.DeleteAccessGroup(context.Background(), identifier.Value, d.Id())
+		err = client.DeleteAccessGroup(ctx, identifier.Value, d.Id())
 	} else {
-		err = client.DeleteZoneLevelAccessGroup(context.Background(), identifier.Value, d.Id())
+		err = client.DeleteZoneLevelAccessGroup(ctx, identifier.Value, d.Id())
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Access Group for ID %q: %s", d.Id(), err))

--- a/cloudflare/resource_cloudflare_access_group.go
+++ b/cloudflare/resource_cloudflare_access_group.go
@@ -23,12 +23,12 @@ func resourceCloudflareAccessGroup() *schema.Resource {
 	}
 }
 
-func resourceCloudflareAccessGroupRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessGroup cloudflare.AccessGroup
@@ -64,7 +64,7 @@ func resourceCloudflareAccessGroupRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceCloudflareAccessGroupCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	newAccessGroup := cloudflare.AccessGroup{
 		Name: d.Get("name").(string),
@@ -76,7 +76,7 @@ func resourceCloudflareAccessGroupCreate(d *schema.ResourceData, meta interface{
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessGroup cloudflare.AccessGroup
@@ -93,7 +93,7 @@ func resourceCloudflareAccessGroupCreate(d *schema.ResourceData, meta interface{
 	return resourceCloudflareAccessGroupRead(d, meta)
 }
 
-func resourceCloudflareAccessGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	updatedAccessGroup := cloudflare.AccessGroup{
 		Name: d.Get("name").(string),
@@ -106,7 +106,7 @@ func resourceCloudflareAccessGroupUpdate(d *schema.ResourceData, meta interface{
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessGroup cloudflare.AccessGroup
@@ -126,14 +126,14 @@ func resourceCloudflareAccessGroupUpdate(d *schema.ResourceData, meta interface{
 	return resourceCloudflareAccessGroupRead(d, meta)
 }
 
-func resourceCloudflareAccessGroupDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	log.Printf("[DEBUG] Deleting Cloudflare Access Group using ID: %s", d.Id())
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if identifier.Type == AccountType {

--- a/cloudflare/resource_cloudflare_access_identity_provider.go
+++ b/cloudflare/resource_cloudflare_access_identity_provider.go
@@ -46,7 +46,7 @@ func resourceCloudflareAccessIdentityProviderRead(ctx context.Context, d *schema
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("unable to find Access Identity Provider %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("unable to find Access Identity Provider %q: %w", d.Id(), err))
 	}
 
 	d.SetId(accessIdentityProvider.ID)
@@ -55,7 +55,7 @@ func resourceCloudflareAccessIdentityProviderRead(ctx context.Context, d *schema
 
 	config := convertStructToSchema(d, accessIdentityProvider.Config)
 	if configErr := d.Set("config", config); configErr != nil {
-		return diag.FromErr(fmt.Errorf("error setting Access Identity Provider configuration: %s", configErr))
+		return diag.FromErr(fmt.Errorf("error setting Access Identity Provider configuration: %w", configErr))
 	}
 
 	return nil
@@ -86,7 +86,7 @@ func resourceCloudflareAccessIdentityProviderCreate(ctx context.Context, d *sche
 		accessIdentityProvider, err = client.CreateZoneLevelAccessIdentityProvider(ctx, identifier.Value, identityProvider)
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Access Identity Provider for ID %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error creating Access Identity Provider for ID %q: %w", d.Id(), err))
 	}
 
 	d.SetId(accessIdentityProvider.ID)
@@ -99,7 +99,7 @@ func resourceCloudflareAccessIdentityProviderUpdate(ctx context.Context, d *sche
 
 	IDPConfig, conversionErr := convertSchemaToStruct(d)
 	if conversionErr != nil {
-		return diag.FromErr(fmt.Errorf("failed to convert schema into struct: %s", conversionErr))
+		return diag.FromErr(fmt.Errorf("failed to convert schema into struct: %w", conversionErr))
 	}
 
 	log.Printf("[DEBUG] updatedConfig: %+v", IDPConfig)
@@ -123,7 +123,7 @@ func resourceCloudflareAccessIdentityProviderUpdate(ctx context.Context, d *sche
 		accessIdentityProvider, err = client.UpdateZoneLevelAccessIdentityProvider(ctx, identifier.Value, d.Id(), updatedAccessIdentityProvider)
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Access Identity Provider for ID %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error updating Access Identity Provider for ID %q: %w", d.Id(), err))
 	}
 
 	if accessIdentityProvider.ID == "" {
@@ -149,7 +149,7 @@ func resourceCloudflareAccessIdentityProviderDelete(ctx context.Context, d *sche
 		_, err = client.DeleteZoneLevelAccessIdentityProvider(ctx, identifier.Value, d.Id())
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Access Identity Provider for ID %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error deleting Access Identity Provider for ID %q: %w", d.Id(), err))
 	}
 
 	d.SetId("")
@@ -171,7 +171,7 @@ func resourceCloudflareAccessIdentityProviderImport(ctx context.Context, d *sche
 	d.Set("account_id", accountID)
 	d.SetId(accessIdentityProviderID)
 
-	resourceCloudflareAccessIdentityProviderRead(context.TODO(), d, meta)
+	resourceCloudflareAccessIdentityProviderRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_identity_provider.go
+++ b/cloudflare/resource_cloudflare_access_identity_provider.go
@@ -45,7 +45,7 @@ func resourceCloudflareAccessIdentityProviderRead(ctx context.Context, d *schema
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("unable to find Access Identity Provider %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("unable to find Access Identity Provider %q: %s", d.Id(), err))
 	}
 
 	d.SetId(accessIdentityProvider.ID)
@@ -54,7 +54,7 @@ func resourceCloudflareAccessIdentityProviderRead(ctx context.Context, d *schema
 
 	config := convertStructToSchema(d, accessIdentityProvider.Config)
 	if configErr := d.Set("config", config); configErr != nil {
-		return fmt.Errorf("error setting Access Identity Provider configuration: %s", configErr)
+		return diag.FromErr(fmt.Errorf("error setting Access Identity Provider configuration: %s", configErr))
 	}
 
 	return nil
@@ -85,7 +85,7 @@ func resourceCloudflareAccessIdentityProviderCreate(ctx context.Context, d *sche
 		accessIdentityProvider, err = client.CreateZoneLevelAccessIdentityProvider(context.Background(), identifier.Value, identityProvider)
 	}
 	if err != nil {
-		return fmt.Errorf("error creating Access Identity Provider for ID %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error creating Access Identity Provider for ID %q: %s", d.Id(), err))
 	}
 
 	d.SetId(accessIdentityProvider.ID)
@@ -98,7 +98,7 @@ func resourceCloudflareAccessIdentityProviderUpdate(ctx context.Context, d *sche
 
 	IDPConfig, conversionErr := convertSchemaToStruct(d)
 	if conversionErr != nil {
-		return fmt.Errorf("failed to convert schema into struct: %s", conversionErr)
+		return diag.FromErr(fmt.Errorf("failed to convert schema into struct: %s", conversionErr))
 	}
 
 	log.Printf("[DEBUG] updatedConfig: %+v", IDPConfig)
@@ -122,11 +122,11 @@ func resourceCloudflareAccessIdentityProviderUpdate(ctx context.Context, d *sche
 		accessIdentityProvider, err = client.UpdateZoneLevelAccessIdentityProvider(context.Background(), identifier.Value, d.Id(), updatedAccessIdentityProvider)
 	}
 	if err != nil {
-		return fmt.Errorf("error updating Access Identity Provider for ID %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error updating Access Identity Provider for ID %q: %s", d.Id(), err))
 	}
 
 	if accessIdentityProvider.ID == "" {
-		return fmt.Errorf("failed to find Access Identity Provider ID in update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find Access Identity Provider ID in update response; resource was empty"))
 	}
 
 	return resourceCloudflareAccessIdentityProviderRead(d, meta)
@@ -148,7 +148,7 @@ func resourceCloudflareAccessIdentityProviderDelete(ctx context.Context, d *sche
 		_, err = client.DeleteZoneLevelAccessIdentityProvider(context.Background(), identifier.Value, d.Id())
 	}
 	if err != nil {
-		return fmt.Errorf("error deleting Access Identity Provider for ID %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error deleting Access Identity Provider for ID %q: %s", d.Id(), err))
 	}
 
 	d.SetId("")

--- a/cloudflare/resource_cloudflare_access_identity_provider.go
+++ b/cloudflare/resource_cloudflare_access_identity_provider.go
@@ -36,9 +36,9 @@ func resourceCloudflareAccessIdentityProviderRead(ctx context.Context, d *schema
 
 	var accessIdentityProvider cloudflare.AccessIdentityProvider
 	if identifier.Type == AccountType {
-		accessIdentityProvider, err = client.AccessIdentityProviderDetails(context.Background(), identifier.Value, d.Id())
+		accessIdentityProvider, err = client.AccessIdentityProviderDetails(ctx, identifier.Value, d.Id())
 	} else {
-		accessIdentityProvider, err = client.ZoneLevelAccessIdentityProviderDetails(context.Background(), identifier.Value, d.Id())
+		accessIdentityProvider, err = client.ZoneLevelAccessIdentityProviderDetails(ctx, identifier.Value, d.Id())
 	}
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
@@ -81,9 +81,9 @@ func resourceCloudflareAccessIdentityProviderCreate(ctx context.Context, d *sche
 
 	var accessIdentityProvider cloudflare.AccessIdentityProvider
 	if identifier.Type == AccountType {
-		accessIdentityProvider, err = client.CreateAccessIdentityProvider(context.Background(), identifier.Value, identityProvider)
+		accessIdentityProvider, err = client.CreateAccessIdentityProvider(ctx, identifier.Value, identityProvider)
 	} else {
-		accessIdentityProvider, err = client.CreateZoneLevelAccessIdentityProvider(context.Background(), identifier.Value, identityProvider)
+		accessIdentityProvider, err = client.CreateZoneLevelAccessIdentityProvider(ctx, identifier.Value, identityProvider)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Access Identity Provider for ID %q: %s", d.Id(), err))
@@ -118,9 +118,9 @@ func resourceCloudflareAccessIdentityProviderUpdate(ctx context.Context, d *sche
 
 	var accessIdentityProvider cloudflare.AccessIdentityProvider
 	if identifier.Type == AccountType {
-		accessIdentityProvider, err = client.UpdateAccessIdentityProvider(context.Background(), identifier.Value, d.Id(), updatedAccessIdentityProvider)
+		accessIdentityProvider, err = client.UpdateAccessIdentityProvider(ctx, identifier.Value, d.Id(), updatedAccessIdentityProvider)
 	} else {
-		accessIdentityProvider, err = client.UpdateZoneLevelAccessIdentityProvider(context.Background(), identifier.Value, d.Id(), updatedAccessIdentityProvider)
+		accessIdentityProvider, err = client.UpdateZoneLevelAccessIdentityProvider(ctx, identifier.Value, d.Id(), updatedAccessIdentityProvider)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Access Identity Provider for ID %q: %s", d.Id(), err))
@@ -144,9 +144,9 @@ func resourceCloudflareAccessIdentityProviderDelete(ctx context.Context, d *sche
 	}
 
 	if identifier.Type == AccountType {
-		_, err = client.DeleteAccessIdentityProvider(context.Background(), identifier.Value, d.Id())
+		_, err = client.DeleteAccessIdentityProvider(ctx, identifier.Value, d.Id())
 	} else {
-		_, err = client.DeleteZoneLevelAccessIdentityProvider(context.Background(), identifier.Value, d.Id())
+		_, err = client.DeleteZoneLevelAccessIdentityProvider(ctx, identifier.Value, d.Id())
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Access Identity Provider for ID %q: %s", d.Id(), err))

--- a/cloudflare/resource_cloudflare_access_identity_provider.go
+++ b/cloudflare/resource_cloudflare_access_identity_provider.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -14,13 +15,13 @@ const CONCEALED_STRING = "**********************************"
 
 func resourceCloudflareAccessIdentityProvider() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareAccessIdentityProviderSchema(),
+		Schema:        resourceCloudflareAccessIdentityProviderSchema(),
 		CreateContext: resourceCloudflareAccessIdentityProviderCreate,
-		ReadContext: resourceCloudflareAccessIdentityProviderRead,
+		ReadContext:   resourceCloudflareAccessIdentityProviderRead,
 		UpdateContext: resourceCloudflareAccessIdentityProviderUpdate,
 		DeleteContext: resourceCloudflareAccessIdentityProviderDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareAccessIdentityProviderImport,
+			StateContext: resourceCloudflareAccessIdentityProviderImport,
 		},
 	}
 }
@@ -90,7 +91,7 @@ func resourceCloudflareAccessIdentityProviderCreate(ctx context.Context, d *sche
 
 	d.SetId(accessIdentityProvider.ID)
 
-	return resourceCloudflareAccessIdentityProviderRead(d, meta)
+	return resourceCloudflareAccessIdentityProviderRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessIdentityProviderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -129,7 +130,7 @@ func resourceCloudflareAccessIdentityProviderUpdate(ctx context.Context, d *sche
 		return diag.FromErr(fmt.Errorf("failed to find Access Identity Provider ID in update response; resource was empty"))
 	}
 
-	return resourceCloudflareAccessIdentityProviderRead(d, meta)
+	return resourceCloudflareAccessIdentityProviderRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessIdentityProviderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -156,7 +157,7 @@ func resourceCloudflareAccessIdentityProviderDelete(ctx context.Context, d *sche
 	return nil
 }
 
-func resourceCloudflareAccessIdentityProviderImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareAccessIdentityProviderImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -170,7 +171,7 @@ func resourceCloudflareAccessIdentityProviderImport(d *schema.ResourceData, meta
 	d.Set("account_id", accountID)
 	d.SetId(accessIdentityProviderID)
 
-	resourceCloudflareAccessIdentityProviderRead(d, meta)
+	resourceCloudflareAccessIdentityProviderRead(context.TODO(), d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_identity_provider.go
+++ b/cloudflare/resource_cloudflare_access_identity_provider.go
@@ -25,12 +25,12 @@ func resourceCloudflareAccessIdentityProvider() *schema.Resource {
 	}
 }
 
-func resourceCloudflareAccessIdentityProviderRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessIdentityProviderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessIdentityProvider cloudflare.AccessIdentityProvider
@@ -60,7 +60,7 @@ func resourceCloudflareAccessIdentityProviderRead(d *schema.ResourceData, meta i
 	return nil
 }
 
-func resourceCloudflareAccessIdentityProviderCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessIdentityProviderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	IDPConfig, _ := convertSchemaToStruct(d)
@@ -75,7 +75,7 @@ func resourceCloudflareAccessIdentityProviderCreate(d *schema.ResourceData, meta
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessIdentityProvider cloudflare.AccessIdentityProvider
@@ -93,7 +93,7 @@ func resourceCloudflareAccessIdentityProviderCreate(d *schema.ResourceData, meta
 	return resourceCloudflareAccessIdentityProviderRead(d, meta)
 }
 
-func resourceCloudflareAccessIdentityProviderUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessIdentityProviderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	IDPConfig, conversionErr := convertSchemaToStruct(d)
@@ -112,7 +112,7 @@ func resourceCloudflareAccessIdentityProviderUpdate(d *schema.ResourceData, meta
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessIdentityProvider cloudflare.AccessIdentityProvider
@@ -132,14 +132,14 @@ func resourceCloudflareAccessIdentityProviderUpdate(d *schema.ResourceData, meta
 	return resourceCloudflareAccessIdentityProviderRead(d, meta)
 }
 
-func resourceCloudflareAccessIdentityProviderDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessIdentityProviderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	log.Printf("[DEBUG] Deleting Cloudflare Access Identity Provider using ID: %s", d.Id())
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if identifier.Type == AccountType {

--- a/cloudflare/resource_cloudflare_access_identity_provider.go
+++ b/cloudflare/resource_cloudflare_access_identity_provider.go
@@ -15,10 +15,10 @@ const CONCEALED_STRING = "**********************************"
 func resourceCloudflareAccessIdentityProvider() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareAccessIdentityProviderSchema(),
-		Create: resourceCloudflareAccessIdentityProviderCreate,
-		Read:   resourceCloudflareAccessIdentityProviderRead,
-		Update: resourceCloudflareAccessIdentityProviderUpdate,
-		Delete: resourceCloudflareAccessIdentityProviderDelete,
+		CreateContext: resourceCloudflareAccessIdentityProviderCreate,
+		ReadContext: resourceCloudflareAccessIdentityProviderRead,
+		UpdateContext: resourceCloudflareAccessIdentityProviderUpdate,
+		DeleteContext: resourceCloudflareAccessIdentityProviderDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareAccessIdentityProviderImport,
 		},

--- a/cloudflare/resource_cloudflare_access_keys_configuration.go
+++ b/cloudflare/resource_cloudflare_access_keys_configuration.go
@@ -37,7 +37,7 @@ func resourceCloudflareAccessKeysConfigurationRead(ctx context.Context, d *schem
 				return nil
 			}
 		}
-		return fmt.Errorf("error finding Access Keys Configuration %s: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error finding Access Keys Configuration %s: %s", accountID, err))
 	}
 
 	d.SetId(accountID)
@@ -67,7 +67,7 @@ func resourceCloudflareAccessKeysConfigurationUpdate(ctx context.Context, d *sch
 
 	_, err := client.UpdateAccessKeysConfig(context.Background(), accountID, keysConfigUpdateReq)
 	if err != nil {
-		return fmt.Errorf("error updating Access Keys Configuration for account %s: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error updating Access Keys Configuration for account %s: %s", accountID, err))
 	}
 
 	return resourceCloudflareAccessKeysConfigurationRead(d, meta)

--- a/cloudflare/resource_cloudflare_access_keys_configuration.go
+++ b/cloudflare/resource_cloudflare_access_keys_configuration.go
@@ -23,7 +23,7 @@ func resourceCloudflareAccessKeysConfiguration() *schema.Resource {
 	}
 }
 
-func resourceCloudflareAccessKeysConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessKeysConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -46,7 +46,7 @@ func resourceCloudflareAccessKeysConfigurationRead(d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceCloudflareAccessKeysConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessKeysConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// keys configuration share the same lifetime as an organization, so creating is a no-op, unless
 	// key_rotation_interval_days was explicitly passed, in which case we need to update its value.
 
@@ -57,7 +57,7 @@ func resourceCloudflareAccessKeysConfigurationCreate(d *schema.ResourceData, met
 	return resourceCloudflareAccessKeysConfigurationUpdate(d, meta)
 }
 
-func resourceCloudflareAccessKeysConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessKeysConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -73,7 +73,7 @@ func resourceCloudflareAccessKeysConfigurationUpdate(d *schema.ResourceData, met
 	return resourceCloudflareAccessKeysConfigurationRead(d, meta)
 }
 
-func resourceCloudflareKeysConfigurationDelete(_ *schema.ResourceData, _ interface{}) error {
+func resourceCloudflareKeysConfigurationDelete(ctx context.Context, _ *schema.ResourceData, _ interface{}) error {
 	// keys configuration share the same lifetime as an organization, and can not be
 	// explicitly deleted by the user. so this is a no-op.
 	return nil

--- a/cloudflare/resource_cloudflare_access_keys_configuration.go
+++ b/cloudflare/resource_cloudflare_access_keys_configuration.go
@@ -38,7 +38,7 @@ func resourceCloudflareAccessKeysConfigurationRead(ctx context.Context, d *schem
 				return nil
 			}
 		}
-		return diag.FromErr(fmt.Errorf("error finding Access Keys Configuration %s: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error finding Access Keys Configuration %s: %w", accountID, err))
 	}
 
 	d.SetId(accountID)
@@ -68,7 +68,7 @@ func resourceCloudflareAccessKeysConfigurationUpdate(ctx context.Context, d *sch
 
 	_, err := client.UpdateAccessKeysConfig(ctx, accountID, keysConfigUpdateReq)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Access Keys Configuration for account %s: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error updating Access Keys Configuration for account %s: %w", accountID, err))
 	}
 
 	return resourceCloudflareAccessKeysConfigurationRead(ctx, d, meta)
@@ -86,6 +86,6 @@ func resourceCloudflareKeysConfigurationImport(ctx context.Context, d *schema.Re
 	d.SetId(accountID)
 	d.Set("account_id", accountID)
 
-	resourceCloudflareAccessKeysConfigurationRead(context.TODO(), d, meta)
+	resourceCloudflareAccessKeysConfigurationRead(ctx, d, meta)
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_keys_configuration.go
+++ b/cloudflare/resource_cloudflare_access_keys_configuration.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareAccessKeysConfiguration() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareAccessKeysConfigurationSchema(),
-		Read:   resourceCloudflareAccessKeysConfigurationRead,
-		Create: resourceCloudflareAccessKeysConfigurationCreate,
-		Update: resourceCloudflareAccessKeysConfigurationUpdate,
-		Delete: resourceCloudflareKeysConfigurationDelete,
+		ReadContext: resourceCloudflareAccessKeysConfigurationRead,
+		CreateContext: resourceCloudflareAccessKeysConfigurationCreate,
+		UpdateContext: resourceCloudflareAccessKeysConfigurationUpdate,
+		DeleteContext: resourceCloudflareKeysConfigurationDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareKeysConfigurationImport,
 		},

--- a/cloudflare/resource_cloudflare_access_keys_configuration.go
+++ b/cloudflare/resource_cloudflare_access_keys_configuration.go
@@ -28,7 +28,7 @@ func resourceCloudflareAccessKeysConfigurationRead(ctx context.Context, d *schem
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	keysConfig, err := client.AccessKeysConfig(context.Background(), accountID)
+	keysConfig, err := client.AccessKeysConfig(ctx, accountID)
 	if err != nil {
 		var requestError *cloudflare.RequestError
 		if errors.As(err, &requestError) {
@@ -66,7 +66,7 @@ func resourceCloudflareAccessKeysConfigurationUpdate(ctx context.Context, d *sch
 		KeyRotationIntervalDays: d.Get("key_rotation_interval_days").(int),
 	}
 
-	_, err := client.UpdateAccessKeysConfig(context.Background(), accountID, keysConfigUpdateReq)
+	_, err := client.UpdateAccessKeysConfig(ctx, accountID, keysConfigUpdateReq)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Access Keys Configuration for account %s: %s", accountID, err))
 	}

--- a/cloudflare/resource_cloudflare_access_mutual_tls_certificate.go
+++ b/cloudflare/resource_cloudflare_access_mutual_tls_certificate.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareAccessMutualTLSCertificate() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareAccessMutualTLSCertificateSchema(),
-		Create: resourceCloudflareAccessMutualTLSCertificateCreate,
-		Read:   resourceCloudflareAccessMutualTLSCertificateRead,
-		Update: resourceCloudflareAccessMutualTLSCertificateUpdate,
-		Delete: resourceCloudflareAccessMutualTLSCertificateDelete,
+		CreateContext: resourceCloudflareAccessMutualTLSCertificateCreate,
+		ReadContext: resourceCloudflareAccessMutualTLSCertificateRead,
+		UpdateContext: resourceCloudflareAccessMutualTLSCertificateUpdate,
+		DeleteContext: resourceCloudflareAccessMutualTLSCertificateDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareAccessMutualTLSCertificateImport,
 		},

--- a/cloudflare/resource_cloudflare_access_mutual_tls_certificate.go
+++ b/cloudflare/resource_cloudflare_access_mutual_tls_certificate.go
@@ -48,7 +48,7 @@ func resourceCloudflareAccessMutualTLSCertificateCreate(ctx context.Context, d *
 		accessMutualTLSCert, err = client.CreateZoneAccessMutualTLSCertificate(ctx, identifier.Value, newAccessMutualTLSCertificate)
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Access Mutual TLS Certificate for %s %q: %s", identifier.Type, identifier.Value, err))
+		return diag.FromErr(fmt.Errorf("error creating Access Mutual TLS Certificate for %s %q: %w", identifier.Type, identifier.Value, err))
 	}
 
 	d.SetId(accessMutualTLSCert.ID)
@@ -77,7 +77,7 @@ func resourceCloudflareAccessMutualTLSCertificateRead(ctx context.Context, d *sc
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding Access Mutual TLS Certificate %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding Access Mutual TLS Certificate %q: %w", d.Id(), err))
 	}
 
 	d.Set("name", accessMutualTLSCert.Name)
@@ -109,14 +109,13 @@ func resourceCloudflareAccessMutualTLSCertificateUpdate(ctx context.Context, d *
 		_, err = client.UpdateZoneAccessMutualTLSCertificate(ctx, identifier.Value, d.Id(), updatedAccessMutualTLSCert)
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Access Mutual TLS Certificate for %s %q: %s", identifier.Type, identifier.Value, err))
+		return diag.FromErr(fmt.Errorf("error updating Access Mutual TLS Certificate for %s %q: %w", identifier.Type, identifier.Value, err))
 	}
 
 	return resourceCloudflareAccessMutualTLSCertificateRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessMutualTLSCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	client := meta.(*cloudflare.API)
 	certID := d.Id()
 
@@ -143,7 +142,7 @@ func resourceCloudflareAccessMutualTLSCertificateDelete(ctx context.Context, d *
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Access Mutual TLS Certificate for %s %q: %s", identifier.Type, identifier.Value, err))
+		return diag.FromErr(fmt.Errorf("error updating Access Mutual TLS Certificate for %s %q: %w", identifier.Type, identifier.Value, err))
 	}
 
 	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
@@ -157,7 +156,7 @@ func resourceCloudflareAccessMutualTLSCertificateDelete(ctx context.Context, d *
 			if strings.Contains(err.Error(), "access.api.error.certificate_has_active_associations") {
 				return resource.RetryableError(fmt.Errorf("certificate associations are not yet removed"))
 			} else {
-				return resource.NonRetryableError(fmt.Errorf("error deleting Access Mutual TLS Certificate for %s %q: %s", identifier.Type, identifier.Value, err))
+				return resource.NonRetryableError(fmt.Errorf("error deleting Access Mutual TLS Certificate for %s %q: %w", identifier.Type, identifier.Value, err))
 			}
 		}
 
@@ -171,7 +170,6 @@ func resourceCloudflareAccessMutualTLSCertificateDelete(ctx context.Context, d *
 	}
 
 	return nil
-
 }
 
 func resourceCloudflareAccessMutualTLSCertificateImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
@@ -193,7 +191,7 @@ func resourceCloudflareAccessMutualTLSCertificateImport(ctx context.Context, d *
 	d.Set(fmt.Sprintf("%s_id", identifierType), identifierID)
 	d.SetId(accessMutualTLSCertificateID)
 
-	resourceCloudflareAccessMutualTLSCertificateRead(context.TODO(), d, meta)
+	resourceCloudflareAccessMutualTLSCertificateRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_mutual_tls_certificate.go
+++ b/cloudflare/resource_cloudflare_access_mutual_tls_certificate.go
@@ -43,9 +43,9 @@ func resourceCloudflareAccessMutualTLSCertificateCreate(ctx context.Context, d *
 
 	var accessMutualTLSCert cloudflare.AccessMutualTLSCertificate
 	if identifier.Type == AccountType {
-		accessMutualTLSCert, err = client.CreateAccessMutualTLSCertificate(context.Background(), identifier.Value, newAccessMutualTLSCertificate)
+		accessMutualTLSCert, err = client.CreateAccessMutualTLSCertificate(ctx, identifier.Value, newAccessMutualTLSCertificate)
 	} else {
-		accessMutualTLSCert, err = client.CreateZoneAccessMutualTLSCertificate(context.Background(), identifier.Value, newAccessMutualTLSCertificate)
+		accessMutualTLSCert, err = client.CreateZoneAccessMutualTLSCertificate(ctx, identifier.Value, newAccessMutualTLSCertificate)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Access Mutual TLS Certificate for %s %q: %s", identifier.Type, identifier.Value, err))
@@ -66,9 +66,9 @@ func resourceCloudflareAccessMutualTLSCertificateRead(ctx context.Context, d *sc
 
 	var accessMutualTLSCert cloudflare.AccessMutualTLSCertificate
 	if identifier.Type == AccountType {
-		accessMutualTLSCert, err = client.AccessMutualTLSCertificate(context.Background(), identifier.Value, d.Id())
+		accessMutualTLSCert, err = client.AccessMutualTLSCertificate(ctx, identifier.Value, d.Id())
 	} else {
-		accessMutualTLSCert, err = client.ZoneAccessMutualTLSCertificate(context.Background(), identifier.Value, d.Id())
+		accessMutualTLSCert, err = client.ZoneAccessMutualTLSCertificate(ctx, identifier.Value, d.Id())
 	}
 
 	if err != nil {
@@ -104,9 +104,9 @@ func resourceCloudflareAccessMutualTLSCertificateUpdate(ctx context.Context, d *
 	}
 
 	if identifier.Type == AccountType {
-		_, err = client.UpdateAccessMutualTLSCertificate(context.Background(), identifier.Value, d.Id(), updatedAccessMutualTLSCert)
+		_, err = client.UpdateAccessMutualTLSCertificate(ctx, identifier.Value, d.Id(), updatedAccessMutualTLSCert)
 	} else {
-		_, err = client.UpdateZoneAccessMutualTLSCertificate(context.Background(), identifier.Value, d.Id(), updatedAccessMutualTLSCert)
+		_, err = client.UpdateZoneAccessMutualTLSCertificate(ctx, identifier.Value, d.Id(), updatedAccessMutualTLSCert)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Access Mutual TLS Certificate for %s %q: %s", identifier.Type, identifier.Value, err))
@@ -137,9 +137,9 @@ func resourceCloudflareAccessMutualTLSCertificateDelete(ctx context.Context, d *
 	}
 
 	if identifier.Type == AccountType {
-		_, err = client.UpdateAccessMutualTLSCertificate(context.Background(), identifier.Value, d.Id(), deletedCertificate)
+		_, err = client.UpdateAccessMutualTLSCertificate(ctx, identifier.Value, d.Id(), deletedCertificate)
 	} else {
-		_, err = client.UpdateZoneAccessMutualTLSCertificate(context.Background(), identifier.Value, d.Id(), deletedCertificate)
+		_, err = client.UpdateZoneAccessMutualTLSCertificate(ctx, identifier.Value, d.Id(), deletedCertificate)
 	}
 
 	if err != nil {
@@ -148,9 +148,9 @@ func resourceCloudflareAccessMutualTLSCertificateDelete(ctx context.Context, d *
 
 	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		if identifier.Type == AccountType {
-			err = client.DeleteAccessMutualTLSCertificate(context.Background(), identifier.Value, certID)
+			err = client.DeleteAccessMutualTLSCertificate(ctx, identifier.Value, certID)
 		} else {
-			err = client.DeleteZoneAccessMutualTLSCertificate(context.Background(), identifier.Value, certID)
+			err = client.DeleteZoneAccessMutualTLSCertificate(ctx, identifier.Value, certID)
 		}
 
 		if err != nil {

--- a/cloudflare/resource_cloudflare_access_mutual_tls_certificate.go
+++ b/cloudflare/resource_cloudflare_access_mutual_tls_certificate.go
@@ -47,7 +47,7 @@ func resourceCloudflareAccessMutualTLSCertificateCreate(ctx context.Context, d *
 		accessMutualTLSCert, err = client.CreateZoneAccessMutualTLSCertificate(context.Background(), identifier.Value, newAccessMutualTLSCertificate)
 	}
 	if err != nil {
-		return fmt.Errorf("error creating Access Mutual TLS Certificate for %s %q: %s", identifier.Type, identifier.Value, err)
+		return diag.FromErr(fmt.Errorf("error creating Access Mutual TLS Certificate for %s %q: %s", identifier.Type, identifier.Value, err))
 	}
 
 	d.SetId(accessMutualTLSCert.ID)
@@ -76,7 +76,7 @@ func resourceCloudflareAccessMutualTLSCertificateRead(ctx context.Context, d *sc
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Access Mutual TLS Certificate %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Access Mutual TLS Certificate %q: %s", d.Id(), err))
 	}
 
 	d.Set("name", accessMutualTLSCert.Name)
@@ -108,7 +108,7 @@ func resourceCloudflareAccessMutualTLSCertificateUpdate(ctx context.Context, d *
 		_, err = client.UpdateZoneAccessMutualTLSCertificate(context.Background(), identifier.Value, d.Id(), updatedAccessMutualTLSCert)
 	}
 	if err != nil {
-		return fmt.Errorf("error updating Access Mutual TLS Certificate for %s %q: %s", identifier.Type, identifier.Value, err)
+		return diag.FromErr(fmt.Errorf("error updating Access Mutual TLS Certificate for %s %q: %s", identifier.Type, identifier.Value, err))
 	}
 
 	return resourceCloudflareAccessMutualTLSCertificateRead(d, meta)
@@ -142,7 +142,7 @@ func resourceCloudflareAccessMutualTLSCertificateDelete(ctx context.Context, d *
 	}
 
 	if err != nil {
-		return fmt.Errorf("error updating Access Mutual TLS Certificate for %s %q: %s", identifier.Type, identifier.Value, err)
+		return diag.FromErr(fmt.Errorf("error updating Access Mutual TLS Certificate for %s %q: %s", identifier.Type, identifier.Value, err))
 	}
 
 	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {

--- a/cloudflare/resource_cloudflare_access_mutual_tls_certificate.go
+++ b/cloudflare/resource_cloudflare_access_mutual_tls_certificate.go
@@ -24,7 +24,7 @@ func resourceCloudflareAccessMutualTLSCertificate() *schema.Resource {
 	}
 }
 
-func resourceCloudflareAccessMutualTLSCertificateCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessMutualTLSCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	newAccessMutualTLSCertificate := cloudflare.AccessMutualTLSCertificate{
@@ -37,7 +37,7 @@ func resourceCloudflareAccessMutualTLSCertificateCreate(d *schema.ResourceData, 
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessMutualTLSCert cloudflare.AccessMutualTLSCertificate
@@ -55,12 +55,12 @@ func resourceCloudflareAccessMutualTLSCertificateCreate(d *schema.ResourceData, 
 	return resourceCloudflareAccessMutualTLSCertificateRead(d, meta)
 }
 
-func resourceCloudflareAccessMutualTLSCertificateRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessMutualTLSCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessMutualTLSCert cloudflare.AccessMutualTLSCertificate
@@ -86,7 +86,7 @@ func resourceCloudflareAccessMutualTLSCertificateRead(d *schema.ResourceData, me
 	return nil
 }
 
-func resourceCloudflareAccessMutualTLSCertificateUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessMutualTLSCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	updatedAccessMutualTLSCert := cloudflare.AccessMutualTLSCertificate{
@@ -99,7 +99,7 @@ func resourceCloudflareAccessMutualTLSCertificateUpdate(d *schema.ResourceData, 
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if identifier.Type == AccountType {
@@ -114,7 +114,7 @@ func resourceCloudflareAccessMutualTLSCertificateUpdate(d *schema.ResourceData, 
 	return resourceCloudflareAccessMutualTLSCertificateRead(d, meta)
 }
 
-func resourceCloudflareAccessMutualTLSCertificateDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessMutualTLSCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	client := meta.(*cloudflare.API)
 	certID := d.Id()
@@ -123,7 +123,7 @@ func resourceCloudflareAccessMutualTLSCertificateDelete(d *schema.ResourceData, 
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// To actually delete the certificate, it cannot have any hostnames associated

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -62,9 +62,9 @@ func resourceCloudflareAccessPolicyRead(ctx context.Context, d *schema.ResourceD
 
 	var accessPolicy cloudflare.AccessPolicy
 	if identifier.Type == AccountType {
-		accessPolicy, err = client.AccessPolicy(context.Background(), identifier.Value, appID, d.Id())
+		accessPolicy, err = client.AccessPolicy(ctx, identifier.Value, appID, d.Id())
 	} else {
-		accessPolicy, err = client.ZoneLevelAccessPolicy(context.Background(), identifier.Value, appID, d.Id())
+		accessPolicy, err = client.ZoneLevelAccessPolicy(ctx, identifier.Value, appID, d.Id())
 	}
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
@@ -136,9 +136,9 @@ func resourceCloudflareAccessPolicyCreate(ctx context.Context, d *schema.Resourc
 
 	var accessPolicy cloudflare.AccessPolicy
 	if identifier.Type == AccountType {
-		accessPolicy, err = client.CreateAccessPolicy(context.Background(), identifier.Value, appID, newAccessPolicy)
+		accessPolicy, err = client.CreateAccessPolicy(ctx, identifier.Value, appID, newAccessPolicy)
 	} else {
-		accessPolicy, err = client.CreateZoneLevelAccessPolicy(context.Background(), identifier.Value, appID, newAccessPolicy)
+		accessPolicy, err = client.CreateZoneLevelAccessPolicy(ctx, identifier.Value, appID, newAccessPolicy)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Access Policy for ID %q: %s", accessPolicy.ID, err))
@@ -170,9 +170,9 @@ func resourceCloudflareAccessPolicyUpdate(ctx context.Context, d *schema.Resourc
 
 	var accessPolicy cloudflare.AccessPolicy
 	if identifier.Type == AccountType {
-		accessPolicy, err = client.UpdateAccessPolicy(context.Background(), identifier.Value, appID, updatedAccessPolicy)
+		accessPolicy, err = client.UpdateAccessPolicy(ctx, identifier.Value, appID, updatedAccessPolicy)
 	} else {
-		accessPolicy, err = client.UpdateZoneLevelAccessPolicy(context.Background(), identifier.Value, appID, updatedAccessPolicy)
+		accessPolicy, err = client.UpdateZoneLevelAccessPolicy(ctx, identifier.Value, appID, updatedAccessPolicy)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Access Policy for ID %q: %s", d.Id(), err))
@@ -197,9 +197,9 @@ func resourceCloudflareAccessPolicyDelete(ctx context.Context, d *schema.Resourc
 	}
 
 	if identifier.Type == AccountType {
-		err = client.DeleteAccessPolicy(context.Background(), identifier.Value, appID, d.Id())
+		err = client.DeleteAccessPolicy(ctx, identifier.Value, appID, d.Id())
 	} else {
-		err = client.DeleteZoneLevelAccessPolicy(context.Background(), identifier.Value, appID, d.Id())
+		err = client.DeleteZoneLevelAccessPolicy(ctx, identifier.Value, appID, d.Id())
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Access Policy for ID %q: %s", d.Id(), err))

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -50,13 +50,13 @@ func schemaAccessPolicyApprovalGroupToAPI(data map[string]interface{}) cloudflar
 	return approvalGroup
 }
 
-func resourceCloudflareAccessPolicyRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	appID := d.Get("application_id").(string)
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessPolicy cloudflare.AccessPolicy
@@ -115,7 +115,7 @@ func resourceCloudflareAccessPolicyRead(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceCloudflareAccessPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	appID := d.Get("application_id").(string)
 	newAccessPolicy := cloudflare.AccessPolicy{
@@ -130,7 +130,7 @@ func resourceCloudflareAccessPolicyCreate(d *schema.ResourceData, meta interface
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessPolicy cloudflare.AccessPolicy
@@ -148,7 +148,7 @@ func resourceCloudflareAccessPolicyCreate(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func resourceCloudflareAccessPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	appID := d.Get("application_id").(string)
 	updatedAccessPolicy := cloudflare.AccessPolicy{
@@ -164,7 +164,7 @@ func resourceCloudflareAccessPolicyUpdate(d *schema.ResourceData, meta interface
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var accessPolicy cloudflare.AccessPolicy
@@ -184,7 +184,7 @@ func resourceCloudflareAccessPolicyUpdate(d *schema.ResourceData, meta interface
 	return resourceCloudflareAccessPolicyRead(d, meta)
 }
 
-func resourceCloudflareAccessPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	appID := d.Get("application_id").(string)
 
@@ -192,7 +192,7 @@ func resourceCloudflareAccessPolicyDelete(d *schema.ResourceData, meta interface
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if identifier.Type == AccountType {

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -72,7 +72,7 @@ func resourceCloudflareAccessPolicyRead(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding Access Policy %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding Access Policy %q: %w", d.Id(), err))
 	}
 
 	d.Set("name", accessPolicy.Name)
@@ -80,15 +80,15 @@ func resourceCloudflareAccessPolicyRead(ctx context.Context, d *schema.ResourceD
 	d.Set("precedence", accessPolicy.Precedence)
 
 	if err := d.Set("require", TransformAccessGroupForSchema(accessPolicy.Require)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set require attribute: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to set require attribute: %w", err))
 	}
 
 	if err := d.Set("exclude", TransformAccessGroupForSchema(accessPolicy.Exclude)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set exclude attribute: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to set exclude attribute: %w", err))
 	}
 
 	if err := d.Set("include", TransformAccessGroupForSchema(accessPolicy.Include)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set include attribute: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to set include attribute: %w", err))
 	}
 
 	if accessPolicy.PurposeJustificationRequired != nil {
@@ -109,7 +109,7 @@ func resourceCloudflareAccessPolicyRead(ctx context.Context, d *schema.ResourceD
 			approvalGroups = append(approvalGroups, apiAccessPolicyApprovalGroupToSchema(apiApprovalGroup))
 		}
 		if err := d.Set("approval_group", approvalGroups); err != nil {
-			return diag.FromErr(fmt.Errorf("failed to set approval_group attribute: %s", err))
+			return diag.FromErr(fmt.Errorf("failed to set approval_group attribute: %w", err))
 		}
 	}
 
@@ -141,7 +141,7 @@ func resourceCloudflareAccessPolicyCreate(ctx context.Context, d *schema.Resourc
 		accessPolicy, err = client.CreateZoneLevelAccessPolicy(ctx, identifier.Value, appID, newAccessPolicy)
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Access Policy for ID %q: %s", accessPolicy.ID, err))
+		return diag.FromErr(fmt.Errorf("error creating Access Policy for ID %q: %w", accessPolicy.ID, err))
 	}
 
 	d.SetId(accessPolicy.ID)
@@ -175,7 +175,7 @@ func resourceCloudflareAccessPolicyUpdate(ctx context.Context, d *schema.Resourc
 		accessPolicy, err = client.UpdateZoneLevelAccessPolicy(ctx, identifier.Value, appID, updatedAccessPolicy)
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Access Policy for ID %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error updating Access Policy for ID %q: %w", d.Id(), err))
 	}
 
 	if accessPolicy.ID == "" {
@@ -202,7 +202,7 @@ func resourceCloudflareAccessPolicyDelete(ctx context.Context, d *schema.Resourc
 		err = client.DeleteZoneLevelAccessPolicy(ctx, identifier.Value, appID, d.Id())
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Access Policy for ID %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error deleting Access Policy for ID %q: %w", d.Id(), err))
 	}
 
 	resourceCloudflareAccessPolicyRead(ctx, d, meta)
@@ -231,7 +231,7 @@ func resourceCloudflareAccessPolicyImport(ctx context.Context, d *schema.Resourc
 	d.Set("application_id", accessAppID)
 	d.SetId(accessPolicyID)
 
-	resourceCloudflareAccessPolicyRead(context.TODO(), d, meta)
+	resourceCloudflareAccessPolicyRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareAccessPolicy() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareAccessPolicySchema(),
+		Schema:        resourceCloudflareAccessPolicySchema(),
 		CreateContext: resourceCloudflareAccessPolicyCreate,
-		ReadContext: resourceCloudflareAccessPolicyRead,
+		ReadContext:   resourceCloudflareAccessPolicyRead,
 		UpdateContext: resourceCloudflareAccessPolicyUpdate,
 		DeleteContext: resourceCloudflareAccessPolicyDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareAccessPolicyImport,
+			StateContext: resourceCloudflareAccessPolicyImport,
 		},
 	}
 }
@@ -181,7 +182,7 @@ func resourceCloudflareAccessPolicyUpdate(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(fmt.Errorf("failed to find Access Policy ID in update response; resource was empty"))
 	}
 
-	return resourceCloudflareAccessPolicyRead(d, meta)
+	return resourceCloudflareAccessPolicyRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -204,12 +205,12 @@ func resourceCloudflareAccessPolicyDelete(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(fmt.Errorf("error deleting Access Policy for ID %q: %s", d.Id(), err))
 	}
 
-	resourceCloudflareAccessPolicyRead(d, meta)
+	resourceCloudflareAccessPolicyRead(ctx, d, meta)
 
 	return nil
 }
 
-func resourceCloudflareAccessPolicyImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareAccessPolicyImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 4)
 
 	if len(attributes) != 4 {
@@ -230,7 +231,7 @@ func resourceCloudflareAccessPolicyImport(d *schema.ResourceData, meta interface
 	d.Set("application_id", accessAppID)
 	d.SetId(accessPolicyID)
 
-	resourceCloudflareAccessPolicyRead(d, meta)
+	resourceCloudflareAccessPolicyRead(context.TODO(), d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -71,7 +71,7 @@ func resourceCloudflareAccessPolicyRead(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Access Policy %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Access Policy %q: %s", d.Id(), err))
 	}
 
 	d.Set("name", accessPolicy.Name)
@@ -79,15 +79,15 @@ func resourceCloudflareAccessPolicyRead(ctx context.Context, d *schema.ResourceD
 	d.Set("precedence", accessPolicy.Precedence)
 
 	if err := d.Set("require", TransformAccessGroupForSchema(accessPolicy.Require)); err != nil {
-		return fmt.Errorf("failed to set require attribute: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to set require attribute: %s", err))
 	}
 
 	if err := d.Set("exclude", TransformAccessGroupForSchema(accessPolicy.Exclude)); err != nil {
-		return fmt.Errorf("failed to set exclude attribute: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to set exclude attribute: %s", err))
 	}
 
 	if err := d.Set("include", TransformAccessGroupForSchema(accessPolicy.Include)); err != nil {
-		return fmt.Errorf("failed to set include attribute: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to set include attribute: %s", err))
 	}
 
 	if accessPolicy.PurposeJustificationRequired != nil {
@@ -108,7 +108,7 @@ func resourceCloudflareAccessPolicyRead(ctx context.Context, d *schema.ResourceD
 			approvalGroups = append(approvalGroups, apiAccessPolicyApprovalGroupToSchema(apiApprovalGroup))
 		}
 		if err := d.Set("approval_group", approvalGroups); err != nil {
-			return fmt.Errorf("failed to set approval_group attribute: %s", err)
+			return diag.FromErr(fmt.Errorf("failed to set approval_group attribute: %s", err))
 		}
 	}
 
@@ -140,7 +140,7 @@ func resourceCloudflareAccessPolicyCreate(ctx context.Context, d *schema.Resourc
 		accessPolicy, err = client.CreateZoneLevelAccessPolicy(context.Background(), identifier.Value, appID, newAccessPolicy)
 	}
 	if err != nil {
-		return fmt.Errorf("error creating Access Policy for ID %q: %s", accessPolicy.ID, err)
+		return diag.FromErr(fmt.Errorf("error creating Access Policy for ID %q: %s", accessPolicy.ID, err))
 	}
 
 	d.SetId(accessPolicy.ID)
@@ -174,11 +174,11 @@ func resourceCloudflareAccessPolicyUpdate(ctx context.Context, d *schema.Resourc
 		accessPolicy, err = client.UpdateZoneLevelAccessPolicy(context.Background(), identifier.Value, appID, updatedAccessPolicy)
 	}
 	if err != nil {
-		return fmt.Errorf("error updating Access Policy for ID %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error updating Access Policy for ID %q: %s", d.Id(), err))
 	}
 
 	if accessPolicy.ID == "" {
-		return fmt.Errorf("failed to find Access Policy ID in update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find Access Policy ID in update response; resource was empty"))
 	}
 
 	return resourceCloudflareAccessPolicyRead(d, meta)
@@ -201,7 +201,7 @@ func resourceCloudflareAccessPolicyDelete(ctx context.Context, d *schema.Resourc
 		err = client.DeleteZoneLevelAccessPolicy(context.Background(), identifier.Value, appID, d.Id())
 	}
 	if err != nil {
-		return fmt.Errorf("error deleting Access Policy for ID %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error deleting Access Policy for ID %q: %s", d.Id(), err))
 	}
 
 	resourceCloudflareAccessPolicyRead(d, meta)

--- a/cloudflare/resource_cloudflare_access_policy.go
+++ b/cloudflare/resource_cloudflare_access_policy.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareAccessPolicy() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareAccessPolicySchema(),
-		Create: resourceCloudflareAccessPolicyCreate,
-		Read:   resourceCloudflareAccessPolicyRead,
-		Update: resourceCloudflareAccessPolicyUpdate,
-		Delete: resourceCloudflareAccessPolicyDelete,
+		CreateContext: resourceCloudflareAccessPolicyCreate,
+		ReadContext: resourceCloudflareAccessPolicyRead,
+		UpdateContext: resourceCloudflareAccessPolicyUpdate,
+		DeleteContext: resourceCloudflareAccessPolicyDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareAccessPolicyImport,
 		},

--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -67,7 +67,7 @@ func resourceCloudflareAccessRuleCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to create access rule: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to create access rule: %w", err))
 	}
 
 	if r.Result.ID == "" {
@@ -105,7 +105,7 @@ func resourceCloudflareAccessRuleRead(ctx context.Context, d *schema.ResourceDat
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding access rule %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding access rule %q: %w", d.Id(), err))
 	}
 
 	log.Printf("[DEBUG] Cloudflare Access Rule read configuration: %#v", accessRuleResponse)
@@ -158,7 +158,7 @@ func resourceCloudflareAccessRuleUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update Access Rule: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to update Access Rule: %w", err))
 	}
 
 	return resourceCloudflareAccessRuleRead(ctx, d, meta)
@@ -183,7 +183,7 @@ func resourceCloudflareAccessRuleDelete(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Access Rule: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Access Rule: %w", err))
 	}
 
 	return nil
@@ -214,7 +214,7 @@ func resourceCloudflareAccessRuleImport(ctx context.Context, d *schema.ResourceD
 		d.Set("zone_id", accessRuleTypeIdentifier)
 	}
 
-	resourceCloudflareAccessRuleRead(context.TODO(), d, meta)
+	resourceCloudflareAccessRuleRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }
@@ -256,7 +256,7 @@ func validateAccessRuleConfiguration(v interface{}, k string) (warnings []string
 func validateAccessRuleConfigurationIPRange(v string) (warnings []string, errors []error) {
 	ip, ipNet, err := net.ParseCIDR(v)
 	if err != nil {
-		errors = append(errors, fmt.Errorf("failed to parse value as CIDR: %v", err))
+		errors = append(errors, fmt.Errorf("failed to parse value as CIDR: %w", err))
 		return warnings, errors
 	}
 

--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -58,12 +58,12 @@ func resourceCloudflareAccessRuleCreate(ctx context.Context, d *schema.ResourceD
 
 	if zoneID == "" {
 		if client.AccountID != "" {
-			r, err = client.CreateAccountAccessRule(context.Background(), client.AccountID, newRule)
+			r, err = client.CreateAccountAccessRule(ctx, client.AccountID, newRule)
 		} else {
-			r, err = client.CreateUserAccessRule(context.Background(), newRule)
+			r, err = client.CreateUserAccessRule(ctx, newRule)
 		}
 	} else {
-		r, err = client.CreateZoneAccessRule(context.Background(), zoneID, newRule)
+		r, err = client.CreateZoneAccessRule(ctx, zoneID, newRule)
 	}
 
 	if err != nil {
@@ -88,12 +88,12 @@ func resourceCloudflareAccessRuleRead(ctx context.Context, d *schema.ResourceDat
 
 	if zoneID == "" {
 		if client.AccountID != "" {
-			accessRuleResponse, err = client.AccountAccessRule(context.Background(), client.AccountID, d.Id())
+			accessRuleResponse, err = client.AccountAccessRule(ctx, client.AccountID, d.Id())
 		} else {
-			accessRuleResponse, err = client.UserAccessRule(context.Background(), d.Id())
+			accessRuleResponse, err = client.UserAccessRule(ctx, d.Id())
 		}
 	} else {
-		accessRuleResponse, err = client.ZoneAccessRule(context.Background(), zoneID, d.Id())
+		accessRuleResponse, err = client.ZoneAccessRule(ctx, zoneID, d.Id())
 	}
 
 	log.Printf("[DEBUG] accessRuleResponse: %#v", accessRuleResponse)
@@ -149,12 +149,12 @@ func resourceCloudflareAccessRuleUpdate(ctx context.Context, d *schema.ResourceD
 
 	if zoneID == "" {
 		if client.AccountID != "" {
-			_, err = client.UpdateAccountAccessRule(context.Background(), client.AccountID, d.Id(), updatedRule)
+			_, err = client.UpdateAccountAccessRule(ctx, client.AccountID, d.Id(), updatedRule)
 		} else {
-			_, err = client.UpdateUserAccessRule(context.Background(), d.Id(), updatedRule)
+			_, err = client.UpdateUserAccessRule(ctx, d.Id(), updatedRule)
 		}
 	} else {
-		_, err = client.UpdateZoneAccessRule(context.Background(), zoneID, d.Id(), updatedRule)
+		_, err = client.UpdateZoneAccessRule(ctx, zoneID, d.Id(), updatedRule)
 	}
 
 	if err != nil {
@@ -174,12 +174,12 @@ func resourceCloudflareAccessRuleDelete(ctx context.Context, d *schema.ResourceD
 
 	if zoneID == "" {
 		if client.AccountID != "" {
-			_, err = client.DeleteAccountAccessRule(context.Background(), client.AccountID, d.Id())
+			_, err = client.DeleteAccountAccessRule(ctx, client.AccountID, d.Id())
 		} else {
-			_, err = client.DeleteUserAccessRule(context.Background(), d.Id())
+			_, err = client.DeleteUserAccessRule(ctx, d.Id())
 		}
 	} else {
-		_, err = client.DeleteZoneAccessRule(context.Background(), zoneID, d.Id())
+		_, err = client.DeleteZoneAccessRule(ctx, zoneID, d.Id())
 	}
 
 	if err != nil {

--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -66,11 +66,11 @@ func resourceCloudflareAccessRuleCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to create access rule: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to create access rule: %s", err))
 	}
 
 	if r.Result.ID == "" {
-		return fmt.Errorf("Failed to find access rule in Create response; ID was empty")
+		return diag.FromErr(fmt.Errorf("Failed to find access rule in Create response; ID was empty"))
 	}
 
 	d.SetId(r.Result.ID)
@@ -104,7 +104,7 @@ func resourceCloudflareAccessRuleRead(ctx context.Context, d *schema.ResourceDat
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding access rule %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding access rule %q: %s", d.Id(), err))
 	}
 
 	log.Printf("[DEBUG] Cloudflare Access Rule read configuration: %#v", accessRuleResponse)
@@ -157,7 +157,7 @@ func resourceCloudflareAccessRuleUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to update Access Rule: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to update Access Rule: %s", err))
 	}
 
 	return resourceCloudflareAccessRuleRead(d, meta)
@@ -182,7 +182,7 @@ func resourceCloudflareAccessRuleDelete(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Cloudflare Access Rule: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Access Rule: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareAccessRule() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareAccessRuleSchema(),
-		Create: resourceCloudflareAccessRuleCreate,
-		Read:   resourceCloudflareAccessRuleRead,
-		Update: resourceCloudflareAccessRuleUpdate,
-		Delete: resourceCloudflareAccessRuleDelete,
+		CreateContext: resourceCloudflareAccessRuleCreate,
+		ReadContext: resourceCloudflareAccessRuleRead,
+		UpdateContext: resourceCloudflareAccessRuleUpdate,
+		DeleteContext: resourceCloudflareAccessRuleDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareAccessRuleImport,
 		},

--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -8,18 +8,19 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareAccessRule() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareAccessRuleSchema(),
+		Schema:        resourceCloudflareAccessRuleSchema(),
 		CreateContext: resourceCloudflareAccessRuleCreate,
-		ReadContext: resourceCloudflareAccessRuleRead,
+		ReadContext:   resourceCloudflareAccessRuleRead,
 		UpdateContext: resourceCloudflareAccessRuleUpdate,
 		DeleteContext: resourceCloudflareAccessRuleDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareAccessRuleImport,
+			StateContext: resourceCloudflareAccessRuleImport,
 		},
 
 		SchemaVersion: 1,
@@ -75,7 +76,7 @@ func resourceCloudflareAccessRuleCreate(ctx context.Context, d *schema.ResourceD
 
 	d.SetId(r.Result.ID)
 
-	return resourceCloudflareAccessRuleRead(d, meta)
+	return resourceCloudflareAccessRuleRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -160,7 +161,7 @@ func resourceCloudflareAccessRuleUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(fmt.Errorf("failed to update Access Rule: %s", err))
 	}
 
-	return resourceCloudflareAccessRuleRead(d, meta)
+	return resourceCloudflareAccessRuleRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -188,7 +189,7 @@ func resourceCloudflareAccessRuleDelete(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func resourceCloudflareAccessRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareAccessRuleImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*cloudflare.API)
 	attributes := strings.Split(d.Id(), "/")
 
@@ -213,7 +214,7 @@ func resourceCloudflareAccessRuleImport(d *schema.ResourceData, meta interface{}
 		d.Set("zone_id", accessRuleTypeIdentifier)
 	}
 
-	resourceCloudflareAccessRuleRead(d, meta)
+	resourceCloudflareAccessRuleRead(context.TODO(), d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_rule.go
+++ b/cloudflare/resource_cloudflare_access_rule.go
@@ -34,7 +34,7 @@ func resourceCloudflareAccessRule() *schema.Resource {
 	}
 }
 
-func resourceCloudflareAccessRuleCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -78,7 +78,7 @@ func resourceCloudflareAccessRuleCreate(d *schema.ResourceData, meta interface{}
 	return resourceCloudflareAccessRuleRead(d, meta)
 }
 
-func resourceCloudflareAccessRuleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -125,7 +125,7 @@ func resourceCloudflareAccessRuleRead(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceCloudflareAccessRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -163,7 +163,7 @@ func resourceCloudflareAccessRuleUpdate(d *schema.ResourceData, meta interface{}
 	return resourceCloudflareAccessRuleRead(d, meta)
 }
 
-func resourceCloudflareAccessRuleDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 

--- a/cloudflare/resource_cloudflare_access_service_tokens.go
+++ b/cloudflare/resource_cloudflare_access_service_tokens.go
@@ -60,9 +60,9 @@ func resourceCloudflareAccessServiceTokenRead(ctx context.Context, d *schema.Res
 	// when we have a match.
 	var serviceTokens []cloudflare.AccessServiceToken
 	if identifier.Type == AccountType {
-		serviceTokens, _, err = client.AccessServiceTokens(context.Background(), identifier.Value)
+		serviceTokens, _, err = client.AccessServiceTokens(ctx, identifier.Value)
 	} else {
-		serviceTokens, _, err = client.ZoneLevelAccessServiceTokens(context.Background(), identifier.Value)
+		serviceTokens, _, err = client.ZoneLevelAccessServiceTokens(ctx, identifier.Value)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error fetching access service tokens: %s", err))
@@ -89,9 +89,9 @@ func resourceCloudflareAccessServiceTokenCreate(ctx context.Context, d *schema.R
 
 	var serviceToken cloudflare.AccessServiceTokenCreateResponse
 	if identifier.Type == AccountType {
-		serviceToken, err = client.CreateAccessServiceToken(context.Background(), identifier.Value, tokenName)
+		serviceToken, err = client.CreateAccessServiceToken(ctx, identifier.Value, tokenName)
 	} else {
-		serviceToken, err = client.CreateZoneLevelAccessServiceToken(context.Background(), identifier.Value, tokenName)
+		serviceToken, err = client.CreateZoneLevelAccessServiceToken(ctx, identifier.Value, tokenName)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating access service token: %s", err))
@@ -119,9 +119,9 @@ func resourceCloudflareAccessServiceTokenUpdate(ctx context.Context, d *schema.R
 
 	var serviceToken cloudflare.AccessServiceTokenUpdateResponse
 	if identifier.Type == AccountType {
-		serviceToken, err = client.UpdateAccessServiceToken(context.Background(), identifier.Value, d.Id(), tokenName)
+		serviceToken, err = client.UpdateAccessServiceToken(ctx, identifier.Value, d.Id(), tokenName)
 	} else {
-		serviceToken, err = client.UpdateZoneLevelAccessServiceToken(context.Background(), identifier.Value, d.Id(), tokenName)
+		serviceToken, err = client.UpdateZoneLevelAccessServiceToken(ctx, identifier.Value, d.Id(), tokenName)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating access service token: %s", err))
@@ -141,9 +141,9 @@ func resourceCloudflareAccessServiceTokenDelete(ctx context.Context, d *schema.R
 	}
 
 	if identifier.Type == AccountType {
-		_, err = client.DeleteAccessServiceToken(context.Background(), identifier.Value, d.Id())
+		_, err = client.DeleteAccessServiceToken(ctx, identifier.Value, d.Id())
 	} else {
-		_, err = client.DeleteZoneLevelAccessServiceToken(context.Background(), identifier.Value, d.Id())
+		_, err = client.DeleteZoneLevelAccessServiceToken(ctx, identifier.Value, d.Id())
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting access service token: %s", err))

--- a/cloudflare/resource_cloudflare_access_service_tokens.go
+++ b/cloudflare/resource_cloudflare_access_service_tokens.go
@@ -46,12 +46,12 @@ func resourceCloudflareAccessServiceTokenExpireDiff(ctx context.Context, d *sche
 	return false
 }
 
-func resourceCloudflareAccessServiceTokenRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessServiceTokenRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// The Cloudflare API doesn't support fetching a single service token
@@ -77,13 +77,13 @@ func resourceCloudflareAccessServiceTokenRead(d *schema.ResourceData, meta inter
 	return nil
 }
 
-func resourceCloudflareAccessServiceTokenCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessServiceTokenCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	tokenName := d.Get("name").(string)
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var serviceToken cloudflare.AccessServiceTokenCreateResponse
@@ -107,13 +107,13 @@ func resourceCloudflareAccessServiceTokenCreate(d *schema.ResourceData, meta int
 	return nil
 }
 
-func resourceCloudflareAccessServiceTokenUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessServiceTokenUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	tokenName := d.Get("name").(string)
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var serviceToken cloudflare.AccessServiceTokenUpdateResponse
@@ -131,12 +131,12 @@ func resourceCloudflareAccessServiceTokenUpdate(d *schema.ResourceData, meta int
 	return resourceCloudflareAccessServiceTokenRead(d, meta)
 }
 
-func resourceCloudflareAccessServiceTokenDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccessServiceTokenDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if identifier.Type == AccountType {

--- a/cloudflare/resource_cloudflare_access_service_tokens.go
+++ b/cloudflare/resource_cloudflare_access_service_tokens.go
@@ -65,7 +65,7 @@ func resourceCloudflareAccessServiceTokenRead(ctx context.Context, d *schema.Res
 		serviceTokens, _, err = client.ZoneLevelAccessServiceTokens(ctx, identifier.Value)
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error fetching access service tokens: %s", err))
+		return diag.FromErr(fmt.Errorf("error fetching access service tokens: %w", err))
 	}
 	for _, token := range serviceTokens {
 		if token.ID == d.Id() {
@@ -94,7 +94,7 @@ func resourceCloudflareAccessServiceTokenCreate(ctx context.Context, d *schema.R
 		serviceToken, err = client.CreateZoneLevelAccessServiceToken(ctx, identifier.Value, tokenName)
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating access service token: %s", err))
+		return diag.FromErr(fmt.Errorf("error creating access service token: %w", err))
 	}
 
 	d.SetId(serviceToken.ID)
@@ -124,7 +124,7 @@ func resourceCloudflareAccessServiceTokenUpdate(ctx context.Context, d *schema.R
 		serviceToken, err = client.UpdateZoneLevelAccessServiceToken(ctx, identifier.Value, d.Id(), tokenName)
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating access service token: %s", err))
+		return diag.FromErr(fmt.Errorf("error updating access service token: %w", err))
 	}
 
 	d.Set("name", serviceToken.Name)
@@ -146,7 +146,7 @@ func resourceCloudflareAccessServiceTokenDelete(ctx context.Context, d *schema.R
 		_, err = client.DeleteZoneLevelAccessServiceToken(ctx, identifier.Value, d.Id())
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting access service token: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting access service token: %w", err))
 	}
 
 	d.SetId("")

--- a/cloudflare/resource_cloudflare_access_service_tokens.go
+++ b/cloudflare/resource_cloudflare_access_service_tokens.go
@@ -7,19 +7,20 @@ import (
 	"time"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareAccessServiceToken() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareAccessServiceTokenSchema(),
+		Schema:        resourceCloudflareAccessServiceTokenSchema(),
 		CreateContext: resourceCloudflareAccessServiceTokenCreate,
-		ReadContext: resourceCloudflareAccessServiceTokenRead,
+		ReadContext:   resourceCloudflareAccessServiceTokenRead,
 		UpdateContext: resourceCloudflareAccessServiceTokenUpdate,
 		DeleteContext: resourceCloudflareAccessServiceTokenDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareAccessServiceTokenImport,
+			StateContext: resourceCloudflareAccessServiceTokenImport,
 		},
 
 		CustomizeDiff: customdiff.ComputedIf("expires_at", resourceCloudflareAccessServiceTokenExpireDiff),
@@ -102,7 +103,7 @@ func resourceCloudflareAccessServiceTokenCreate(ctx context.Context, d *schema.R
 	d.Set("client_secret", serviceToken.ClientSecret)
 	d.Set("expires_at", serviceToken.ExpiresAt.Format(time.RFC3339))
 
-	resourceCloudflareAccessServiceTokenRead(d, meta)
+	resourceCloudflareAccessServiceTokenRead(ctx, d, meta)
 
 	return nil
 }
@@ -128,7 +129,7 @@ func resourceCloudflareAccessServiceTokenUpdate(ctx context.Context, d *schema.R
 
 	d.Set("name", serviceToken.Name)
 
-	return resourceCloudflareAccessServiceTokenRead(d, meta)
+	return resourceCloudflareAccessServiceTokenRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccessServiceTokenDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -153,7 +154,7 @@ func resourceCloudflareAccessServiceTokenDelete(ctx context.Context, d *schema.R
 	return nil
 }
 
-func resourceCloudflareAccessServiceTokenImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareAccessServiceTokenImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -163,7 +164,7 @@ func resourceCloudflareAccessServiceTokenImport(d *schema.ResourceData, meta int
 	d.Set("account_id", attributes[0])
 	d.SetId(attributes[1])
 
-	resourceCloudflareAccessServiceTokenRead(d, meta)
+	resourceCloudflareAccessServiceTokenRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_access_service_tokens.go
+++ b/cloudflare/resource_cloudflare_access_service_tokens.go
@@ -64,7 +64,7 @@ func resourceCloudflareAccessServiceTokenRead(ctx context.Context, d *schema.Res
 		serviceTokens, _, err = client.ZoneLevelAccessServiceTokens(context.Background(), identifier.Value)
 	}
 	if err != nil {
-		return fmt.Errorf("error fetching access service tokens: %s", err)
+		return diag.FromErr(fmt.Errorf("error fetching access service tokens: %s", err))
 	}
 	for _, token := range serviceTokens {
 		if token.ID == d.Id() {
@@ -93,7 +93,7 @@ func resourceCloudflareAccessServiceTokenCreate(ctx context.Context, d *schema.R
 		serviceToken, err = client.CreateZoneLevelAccessServiceToken(context.Background(), identifier.Value, tokenName)
 	}
 	if err != nil {
-		return fmt.Errorf("error creating access service token: %s", err)
+		return diag.FromErr(fmt.Errorf("error creating access service token: %s", err))
 	}
 
 	d.SetId(serviceToken.ID)
@@ -123,7 +123,7 @@ func resourceCloudflareAccessServiceTokenUpdate(ctx context.Context, d *schema.R
 		serviceToken, err = client.UpdateZoneLevelAccessServiceToken(context.Background(), identifier.Value, d.Id(), tokenName)
 	}
 	if err != nil {
-		return fmt.Errorf("error updating access service token: %s", err)
+		return diag.FromErr(fmt.Errorf("error updating access service token: %s", err))
 	}
 
 	d.Set("name", serviceToken.Name)
@@ -145,7 +145,7 @@ func resourceCloudflareAccessServiceTokenDelete(ctx context.Context, d *schema.R
 		_, err = client.DeleteZoneLevelAccessServiceToken(context.Background(), identifier.Value, d.Id())
 	}
 	if err != nil {
-		return fmt.Errorf("error deleting access service token: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting access service token: %s", err))
 	}
 
 	d.SetId("")

--- a/cloudflare/resource_cloudflare_access_service_tokens.go
+++ b/cloudflare/resource_cloudflare_access_service_tokens.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareAccessServiceToken() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareAccessServiceTokenSchema(),
-		Create: resourceCloudflareAccessServiceTokenCreate,
-		Read:   resourceCloudflareAccessServiceTokenRead,
-		Update: resourceCloudflareAccessServiceTokenUpdate,
-		Delete: resourceCloudflareAccessServiceTokenDelete,
+		CreateContext: resourceCloudflareAccessServiceTokenCreate,
+		ReadContext: resourceCloudflareAccessServiceTokenRead,
+		UpdateContext: resourceCloudflareAccessServiceTokenUpdate,
+		DeleteContext: resourceCloudflareAccessServiceTokenDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareAccessServiceTokenImport,
 		},

--- a/cloudflare/resource_cloudflare_account_member.go
+++ b/cloudflare/resource_cloudflare_account_member.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareAccountMember() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareAccountMemberSchema(),
-		Create: resourceCloudflareAccountMemberCreate,
-		Read:   resourceCloudflareAccountMemberRead,
-		Update: resourceCloudflareAccountMemberUpdate,
-		Delete: resourceCloudflareAccountMemberDelete,
+		CreateContext: resourceCloudflareAccountMemberCreate,
+		ReadContext: resourceCloudflareAccountMemberRead,
+		UpdateContext: resourceCloudflareAccountMemberUpdate,
+		DeleteContext: resourceCloudflareAccountMemberDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareAccountMemberImport,
 		},

--- a/cloudflare/resource_cloudflare_account_member.go
+++ b/cloudflare/resource_cloudflare_account_member.go
@@ -27,7 +27,7 @@ func resourceCloudflareAccountMember() *schema.Resource {
 func resourceCloudflareAccountMemberRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
-	member, err := client.AccountMember(context.Background(), client.AccountID, d.Id())
+	member, err := client.AccountMember(ctx, client.AccountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "Member not found") ||
 			strings.Contains(err.Error(), "HTTP status 404") {
@@ -55,7 +55,7 @@ func resourceCloudflareAccountMemberDelete(ctx context.Context, d *schema.Resour
 
 	log.Printf("[INFO] Deleting Cloudflare account member ID: %s", d.Id())
 
-	err := client.DeleteAccountMember(context.Background(), client.AccountID, d.Id())
+	err := client.DeleteAccountMember(ctx, client.AccountID, d.Id())
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Cloudflare account member: %s", err))
 	}
@@ -74,7 +74,7 @@ func resourceCloudflareAccountMemberCreate(ctx context.Context, d *schema.Resour
 		accountMemberRoleIDs = append(accountMemberRoleIDs, roleID.(string))
 	}
 
-	r, err := client.CreateAccountMember(context.Background(), client.AccountID, memberEmailAddress, accountMemberRoleIDs)
+	r, err := client.CreateAccountMember(ctx, client.AccountID, memberEmailAddress, accountMemberRoleIDs)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Cloudflare account member: %s", err))
@@ -95,12 +95,12 @@ func resourceCloudflareAccountMemberUpdate(ctx context.Context, d *schema.Resour
 	memberRoles := d.Get("role_ids").(*schema.Set).List()
 
 	for _, r := range memberRoles {
-		accountRole, _ := client.AccountRole(context.Background(), client.AccountID, r.(string))
+		accountRole, _ := client.AccountRole(ctx, client.AccountID, r.(string))
 		accountRoles = append(accountRoles, accountRole)
 	}
 
 	updatedAccountMember := cloudflare.AccountMember{Roles: accountRoles}
-	_, err := client.UpdateAccountMember(context.Background(), client.AccountID, d.Id(), updatedAccountMember)
+	_, err := client.UpdateAccountMember(ctx, client.AccountID, d.Id(), updatedAccountMember)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to update Cloudflare account member: %s", err))
 	}
@@ -122,7 +122,7 @@ func resourceCloudflareAccountMemberImport(ctx context.Context, d *schema.Resour
 		return nil, fmt.Errorf("invalid id %q specified, should be in format \"accountID/accountMemberID\" for import", d.Id())
 	}
 
-	member, err := client.AccountMember(context.Background(), accountID, accountMemberID)
+	member, err := client.AccountMember(ctx, accountID, accountMemberID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find account member with ID %q: %q", accountMemberID, err)
 	}

--- a/cloudflare/resource_cloudflare_account_member.go
+++ b/cloudflare/resource_cloudflare_account_member.go
@@ -56,7 +56,7 @@ func resourceCloudflareAccountMemberDelete(ctx context.Context, d *schema.Resour
 
 	err := client.DeleteAccountMember(context.Background(), client.AccountID, d.Id())
 	if err != nil {
-		return fmt.Errorf("error deleting Cloudflare account member: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare account member: %s", err))
 	}
 
 	return nil
@@ -76,11 +76,11 @@ func resourceCloudflareAccountMemberCreate(ctx context.Context, d *schema.Resour
 	r, err := client.CreateAccountMember(context.Background(), client.AccountID, memberEmailAddress, accountMemberRoleIDs)
 
 	if err != nil {
-		return fmt.Errorf("error creating Cloudflare account member: %s", err)
+		return diag.FromErr(fmt.Errorf("error creating Cloudflare account member: %s", err))
 	}
 
 	if r.ID == "" {
-		return fmt.Errorf("failed to find ID in create response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find ID in create response; resource was empty"))
 	}
 
 	d.SetId(r.ID)
@@ -101,7 +101,7 @@ func resourceCloudflareAccountMemberUpdate(ctx context.Context, d *schema.Resour
 	updatedAccountMember := cloudflare.AccountMember{Roles: accountRoles}
 	_, err := client.UpdateAccountMember(context.Background(), client.AccountID, d.Id(), updatedAccountMember)
 	if err != nil {
-		return fmt.Errorf("failed to update Cloudflare account member: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to update Cloudflare account member: %s", err))
 	}
 
 	return resourceCloudflareAccountMemberRead(d, meta)

--- a/cloudflare/resource_cloudflare_account_member.go
+++ b/cloudflare/resource_cloudflare_account_member.go
@@ -57,7 +57,7 @@ func resourceCloudflareAccountMemberDelete(ctx context.Context, d *schema.Resour
 
 	err := client.DeleteAccountMember(ctx, client.AccountID, d.Id())
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare account member: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare account member: %w", err))
 	}
 
 	return nil
@@ -77,7 +77,7 @@ func resourceCloudflareAccountMemberCreate(ctx context.Context, d *schema.Resour
 	r, err := client.CreateAccountMember(ctx, client.AccountID, memberEmailAddress, accountMemberRoleIDs)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Cloudflare account member: %s", err))
+		return diag.FromErr(fmt.Errorf("error creating Cloudflare account member: %w", err))
 	}
 
 	if r.ID == "" {
@@ -102,7 +102,7 @@ func resourceCloudflareAccountMemberUpdate(ctx context.Context, d *schema.Resour
 	updatedAccountMember := cloudflare.AccountMember{Roles: accountRoles}
 	_, err := client.UpdateAccountMember(ctx, client.AccountID, d.Id(), updatedAccountMember)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update Cloudflare account member: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to update Cloudflare account member: %w", err))
 	}
 
 	return resourceCloudflareAccountMemberRead(ctx, d, meta)
@@ -124,7 +124,7 @@ func resourceCloudflareAccountMemberImport(ctx context.Context, d *schema.Resour
 
 	member, err := client.AccountMember(ctx, accountID, accountMemberID)
 	if err != nil {
-		return nil, fmt.Errorf("unable to find account member with ID %q: %q", accountMemberID, err)
+		return nil, fmt.Errorf("unable to find account member with ID %q: %w", accountMemberID, err)
 	}
 
 	log.Printf("[INFO] Found account member: %s", member.User.Email)

--- a/cloudflare/resource_cloudflare_account_member.go
+++ b/cloudflare/resource_cloudflare_account_member.go
@@ -23,7 +23,7 @@ func resourceCloudflareAccountMember() *schema.Resource {
 	}
 }
 
-func resourceCloudflareAccountMemberRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccountMemberRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	member, err := client.AccountMember(context.Background(), client.AccountID, d.Id())
@@ -34,7 +34,7 @@ func resourceCloudflareAccountMemberRead(d *schema.ResourceData, meta interface{
 			d.SetId("")
 			return nil
 		}
-		return err
+		return diag.FromErr(err)
 	}
 
 	var memberIDs []string
@@ -49,7 +49,7 @@ func resourceCloudflareAccountMemberRead(d *schema.ResourceData, meta interface{
 	return nil
 }
 
-func resourceCloudflareAccountMemberDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccountMemberDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	log.Printf("[INFO] Deleting Cloudflare account member ID: %s", d.Id())
@@ -62,7 +62,7 @@ func resourceCloudflareAccountMemberDelete(d *schema.ResourceData, meta interfac
 	return nil
 }
 
-func resourceCloudflareAccountMemberCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccountMemberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	memberEmailAddress := d.Get("email_address").(string)
 	requestedMemberRoles := d.Get("role_ids").(*schema.Set).List()
 
@@ -88,7 +88,7 @@ func resourceCloudflareAccountMemberCreate(d *schema.ResourceData, meta interfac
 	return resourceCloudflareAccountMemberRead(d, meta)
 }
 
-func resourceCloudflareAccountMemberUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAccountMemberUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountRoles := []cloudflare.AccountRole{}
 	memberRoles := d.Get("role_ids").(*schema.Set).List()

--- a/cloudflare/resource_cloudflare_account_member.go
+++ b/cloudflare/resource_cloudflare_account_member.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareAccountMember() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareAccountMemberSchema(),
+		Schema:        resourceCloudflareAccountMemberSchema(),
 		CreateContext: resourceCloudflareAccountMemberCreate,
-		ReadContext: resourceCloudflareAccountMemberRead,
+		ReadContext:   resourceCloudflareAccountMemberRead,
 		UpdateContext: resourceCloudflareAccountMemberUpdate,
 		DeleteContext: resourceCloudflareAccountMemberDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareAccountMemberImport,
+			StateContext: resourceCloudflareAccountMemberImport,
 		},
 	}
 }
@@ -85,7 +86,7 @@ func resourceCloudflareAccountMemberCreate(ctx context.Context, d *schema.Resour
 
 	d.SetId(r.ID)
 
-	return resourceCloudflareAccountMemberRead(d, meta)
+	return resourceCloudflareAccountMemberRead(ctx, d, meta)
 }
 
 func resourceCloudflareAccountMemberUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -104,10 +105,10 @@ func resourceCloudflareAccountMemberUpdate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(fmt.Errorf("failed to update Cloudflare account member: %s", err))
 	}
 
-	return resourceCloudflareAccountMemberRead(d, meta)
+	return resourceCloudflareAccountMemberRead(ctx, d, meta)
 }
 
-func resourceCloudflareAccountMemberImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareAccountMemberImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*cloudflare.API)
 
 	// split the id so we can lookup the account member

--- a/cloudflare/resource_cloudflare_api_token.go
+++ b/cloudflare/resource_cloudflare_api_token.go
@@ -16,10 +16,10 @@ func resourceCloudflareApiToken() *schema.Resource {
 
 	return &schema.Resource{
 		Schema: resourceCloudflareApiTokenSchema(),
-		Create: resourceCloudflareApiTokenCreate,
-		Read:   resourceCloudflareApiTokenRead,
-		Update: resourceCloudflareApiTokenUpdate,
-		Delete: resourceCloudflareApiTokenDelete,
+		CreateContext: resourceCloudflareApiTokenCreate,
+		ReadContext: resourceCloudflareApiTokenRead,
+		UpdateContext: resourceCloudflareApiTokenUpdate,
+		DeleteContext: resourceCloudflareApiTokenDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/cloudflare/resource_cloudflare_api_token.go
+++ b/cloudflare/resource_cloudflare_api_token.go
@@ -68,7 +68,7 @@ func resourceCloudflareApiTokenCreate(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[INFO] Creating Cloudflare API Token: name %s", name)
 
 	t := buildAPIToken(d)
-	t, err := client.CreateAPIToken(context.Background(), t)
+	t, err := client.CreateAPIToken(ctx, t)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Cloudflare API Token %q: %s", name, err))
 	}
@@ -123,7 +123,7 @@ func resourceCloudflareApiTokenRead(ctx context.Context, d *schema.ResourceData,
 	client := meta.(*cloudflare.API)
 	tokenID := d.Id()
 
-	t, err := client.GetAPIToken(context.Background(), tokenID)
+	t, err := client.GetAPIToken(ctx, tokenID)
 
 	log.Printf("[DEBUG] Cloudflare API Token: %+v", t)
 
@@ -189,7 +189,7 @@ func resourceCloudflareApiTokenUpdate(ctx context.Context, d *schema.ResourceDat
 
 	log.Printf("[INFO] Updating Cloudflare API Token: name %s", name)
 
-	t, err := client.UpdateAPIToken(context.Background(), tokenID, t)
+	t, err := client.UpdateAPIToken(ctx, tokenID, t)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Cloudflare API Token %q: %s", name, err))
 	}
@@ -203,7 +203,7 @@ func resourceCloudflareApiTokenDelete(ctx context.Context, d *schema.ResourceDat
 
 	log.Printf("[INFO] Deleting Cloudflare API Token: id %s", tokenID)
 
-	err := client.DeleteAPIToken(context.Background(), tokenID)
+	err := client.DeleteAPIToken(ctx, tokenID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Cloudflare API Token: %s", err))
 	}

--- a/cloudflare/resource_cloudflare_api_token.go
+++ b/cloudflare/resource_cloudflare_api_token.go
@@ -14,7 +14,6 @@ import (
 )
 
 func resourceCloudflareApiToken() *schema.Resource {
-
 	return &schema.Resource{
 		Schema:        resourceCloudflareApiTokenSchema(),
 		CreateContext: resourceCloudflareApiTokenCreate,
@@ -70,7 +69,7 @@ func resourceCloudflareApiTokenCreate(ctx context.Context, d *schema.ResourceDat
 	t := buildAPIToken(d)
 	t, err := client.CreateAPIToken(ctx, t)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Cloudflare API Token %q: %s", name, err))
+		return diag.FromErr(fmt.Errorf("error creating Cloudflare API Token %q: %w", name, err))
 	}
 
 	d.SetId(t.ID)
@@ -133,7 +132,7 @@ func resourceCloudflareApiTokenRead(ctx context.Context, d *schema.ResourceData,
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding Cloudflare API Token %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding Cloudflare API Token %q: %w", d.Id(), err))
 	}
 
 	policies := []map[string]interface{}{}
@@ -191,7 +190,7 @@ func resourceCloudflareApiTokenUpdate(ctx context.Context, d *schema.ResourceDat
 
 	t, err := client.UpdateAPIToken(ctx, tokenID, t)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Cloudflare API Token %q: %s", name, err))
+		return diag.FromErr(fmt.Errorf("error updating Cloudflare API Token %q: %w", name, err))
 	}
 
 	return resourceCloudflareApiTokenRead(ctx, d, meta)
@@ -205,7 +204,7 @@ func resourceCloudflareApiTokenDelete(ctx context.Context, d *schema.ResourceDat
 
 	err := client.DeleteAPIToken(ctx, tokenID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare API Token: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare API Token: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_api_token.go
+++ b/cloudflare/resource_cloudflare_api_token.go
@@ -59,7 +59,7 @@ func buildAPIToken(d *schema.ResourceData) cloudflare.APIToken {
 	return token
 }
 
-func resourceCloudflareApiTokenCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareApiTokenCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	name := d.Get("name").(string)
@@ -118,7 +118,7 @@ func resourceDataToApiTokenPolices(d *schema.ResourceData) []cloudflare.APIToken
 	return cfPolicies
 }
 
-func resourceCloudflareApiTokenRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareApiTokenRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	tokenID := d.Id()
 
@@ -178,7 +178,7 @@ func resourceCloudflareApiTokenRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceCloudflareApiTokenUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareApiTokenUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	name := d.Get("name").(string)
@@ -196,7 +196,7 @@ func resourceCloudflareApiTokenUpdate(d *schema.ResourceData, meta interface{}) 
 	return resourceCloudflareApiTokenRead(d, meta)
 }
 
-func resourceCloudflareApiTokenDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareApiTokenDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	tokenID := d.Id()
 

--- a/cloudflare/resource_cloudflare_api_token.go
+++ b/cloudflare/resource_cloudflare_api_token.go
@@ -9,19 +9,20 @@ import (
 	"time"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareApiToken() *schema.Resource {
 
 	return &schema.Resource{
-		Schema: resourceCloudflareApiTokenSchema(),
+		Schema:        resourceCloudflareApiTokenSchema(),
 		CreateContext: resourceCloudflareApiTokenCreate,
-		ReadContext: resourceCloudflareApiTokenRead,
+		ReadContext:   resourceCloudflareApiTokenRead,
 		UpdateContext: resourceCloudflareApiTokenUpdate,
 		DeleteContext: resourceCloudflareApiTokenDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }
@@ -76,7 +77,7 @@ func resourceCloudflareApiTokenCreate(ctx context.Context, d *schema.ResourceDat
 	d.Set("status", t.Status)
 	d.Set("value", t.Value)
 
-	return resourceCloudflareApiTokenRead(d, meta)
+	return resourceCloudflareApiTokenRead(ctx, d, meta)
 }
 
 func resourceDataToApiTokenPolices(d *schema.ResourceData) []cloudflare.APITokenPolicies {
@@ -193,7 +194,7 @@ func resourceCloudflareApiTokenUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(fmt.Errorf("error updating Cloudflare API Token %q: %s", name, err))
 	}
 
-	return resourceCloudflareApiTokenRead(d, meta)
+	return resourceCloudflareApiTokenRead(ctx, d, meta)
 }
 
 func resourceCloudflareApiTokenDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/cloudflare/resource_cloudflare_api_token.go
+++ b/cloudflare/resource_cloudflare_api_token.go
@@ -69,7 +69,7 @@ func resourceCloudflareApiTokenCreate(ctx context.Context, d *schema.ResourceDat
 	t := buildAPIToken(d)
 	t, err := client.CreateAPIToken(context.Background(), t)
 	if err != nil {
-		return fmt.Errorf("error creating Cloudflare API Token %q: %s", name, err)
+		return diag.FromErr(fmt.Errorf("error creating Cloudflare API Token %q: %s", name, err))
 	}
 
 	d.SetId(t.ID)
@@ -132,7 +132,7 @@ func resourceCloudflareApiTokenRead(ctx context.Context, d *schema.ResourceData,
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Cloudflare API Token %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Cloudflare API Token %q: %s", d.Id(), err))
 	}
 
 	policies := []map[string]interface{}{}
@@ -190,7 +190,7 @@ func resourceCloudflareApiTokenUpdate(ctx context.Context, d *schema.ResourceDat
 
 	t, err := client.UpdateAPIToken(context.Background(), tokenID, t)
 	if err != nil {
-		return fmt.Errorf("error updating Cloudflare API Token %q: %s", name, err)
+		return diag.FromErr(fmt.Errorf("error updating Cloudflare API Token %q: %s", name, err))
 	}
 
 	return resourceCloudflareApiTokenRead(d, meta)
@@ -204,7 +204,7 @@ func resourceCloudflareApiTokenDelete(ctx context.Context, d *schema.ResourceDat
 
 	err := client.DeleteAPIToken(context.Background(), tokenID)
 	if err != nil {
-		return fmt.Errorf("error deleting Cloudflare API Token: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare API Token: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_argo.go
+++ b/cloudflare/resource_cloudflare_argo.go
@@ -37,7 +37,7 @@ func resourceCloudflareArgoRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("zone_id", zoneID)
 
 	if tieredCaching != "" {
-		tieredCaching, err := client.ArgoTieredCaching(context.Background(), zoneID)
+		tieredCaching, err := client.ArgoTieredCaching(ctx, zoneID)
 		if err != nil {
 			return diag.FromErr(errors.Wrap(err, "failed to get tiered caching setting"))
 		}
@@ -46,7 +46,7 @@ func resourceCloudflareArgoRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if smartRouting != "" {
-		smartRouting, err := client.ArgoSmartRouting(context.Background(), zoneID)
+		smartRouting, err := client.ArgoSmartRouting(ctx, zoneID)
 		if err != nil {
 			return diag.FromErr(errors.Wrap(err, "failed to get smart routing setting"))
 		}
@@ -64,7 +64,7 @@ func resourceCloudflareArgoUpdate(ctx context.Context, d *schema.ResourceData, m
 	smartRouting := d.Get("smart_routing").(string)
 
 	if smartRouting != "" {
-		argoSmartRouting, err := client.UpdateArgoSmartRouting(context.Background(), zoneID, smartRouting)
+		argoSmartRouting, err := client.UpdateArgoSmartRouting(ctx, zoneID, smartRouting)
 		if err != nil {
 			return diag.FromErr(errors.Wrap(err, "failed to update smart routing setting"))
 		}
@@ -72,7 +72,7 @@ func resourceCloudflareArgoUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if tieredCaching != "" {
-		argoTieredCaching, err := client.UpdateArgoTieredCaching(context.Background(), zoneID, tieredCaching)
+		argoTieredCaching, err := client.UpdateArgoTieredCaching(ctx, zoneID, tieredCaching)
 		if err != nil {
 			return diag.FromErr(errors.Wrap(err, "failed to update tiered caching setting"))
 		}
@@ -88,12 +88,12 @@ func resourceCloudflareArgoDelete(ctx context.Context, d *schema.ResourceData, m
 
 	log.Printf("[DEBUG] Resetting Argo values to 'off'")
 
-	_, smartRoutingErr := client.UpdateArgoSmartRouting(context.Background(), zoneID, "off")
+	_, smartRoutingErr := client.UpdateArgoSmartRouting(ctx, zoneID, "off")
 	if smartRoutingErr != nil {
 		return diag.FromErr(errors.Wrap(smartRoutingErr, "failed to update smart routing setting"))
 	}
 
-	_, tieredCachingErr := client.UpdateArgoTieredCaching(context.Background(), zoneID, "off")
+	_, tieredCachingErr := client.UpdateArgoTieredCaching(ctx, zoneID, "off")
 	if tieredCachingErr != nil {
 		return diag.FromErr(errors.Wrap(tieredCachingErr, "failed to update tiered caching setting"))
 	}

--- a/cloudflare/resource_cloudflare_argo.go
+++ b/cloudflare/resource_cloudflare_argo.go
@@ -23,7 +23,7 @@ func resourceCloudflareArgo() *schema.Resource {
 	}
 }
 
-func resourceCloudflareArgoRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareArgoRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	tieredCaching := d.Get("tiered_caching").(string)
@@ -38,7 +38,7 @@ func resourceCloudflareArgoRead(d *schema.ResourceData, meta interface{}) error 
 	if tieredCaching != "" {
 		tieredCaching, err := client.ArgoTieredCaching(context.Background(), zoneID)
 		if err != nil {
-			return errors.Wrap(err, "failed to get tiered caching setting")
+			return err.Wrap(err, "failed to get tiered caching setting")
 		}
 
 		d.Set("tiered_caching", tieredCaching.Value)
@@ -47,7 +47,7 @@ func resourceCloudflareArgoRead(d *schema.ResourceData, meta interface{}) error 
 	if smartRouting != "" {
 		smartRouting, err := client.ArgoSmartRouting(context.Background(), zoneID)
 		if err != nil {
-			return errors.Wrap(err, "failed to get smart routing setting")
+			return err.Wrap(err, "failed to get smart routing setting")
 		}
 
 		d.Set("smart_routing", smartRouting.Value)
@@ -56,7 +56,7 @@ func resourceCloudflareArgoRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceCloudflareArgoUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareArgoUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	tieredCaching := d.Get("tiered_caching").(string)
@@ -65,7 +65,7 @@ func resourceCloudflareArgoUpdate(d *schema.ResourceData, meta interface{}) erro
 	if smartRouting != "" {
 		argoSmartRouting, err := client.UpdateArgoSmartRouting(context.Background(), zoneID, smartRouting)
 		if err != nil {
-			return errors.Wrap(err, "failed to update smart routing setting")
+			return err.Wrap(err, "failed to update smart routing setting")
 		}
 		log.Printf("[DEBUG] Argo Smart Routing set to: %s", argoSmartRouting.Value)
 	}
@@ -73,7 +73,7 @@ func resourceCloudflareArgoUpdate(d *schema.ResourceData, meta interface{}) erro
 	if tieredCaching != "" {
 		argoTieredCaching, err := client.UpdateArgoTieredCaching(context.Background(), zoneID, tieredCaching)
 		if err != nil {
-			return errors.Wrap(err, "failed to update tiered caching setting")
+			return err.Wrap(err, "failed to update tiered caching setting")
 		}
 		log.Printf("[DEBUG] Argo Tiered Caching set to: %s", argoTieredCaching.Value)
 	}
@@ -81,7 +81,7 @@ func resourceCloudflareArgoUpdate(d *schema.ResourceData, meta interface{}) erro
 	return resourceCloudflareArgoRead(d, meta)
 }
 
-func resourceCloudflareArgoDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareArgoDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -89,12 +89,12 @@ func resourceCloudflareArgoDelete(d *schema.ResourceData, meta interface{}) erro
 
 	_, smartRoutingErr := client.UpdateArgoSmartRouting(context.Background(), zoneID, "off")
 	if smartRoutingErr != nil {
-		return errors.Wrap(smartRoutingErr, "failed to update smart routing setting")
+		return err.Wrap(smartRoutingErr, "failed to update smart routing setting")
 	}
 
 	_, tieredCachingErr := client.UpdateArgoTieredCaching(context.Background(), zoneID, "off")
 	if tieredCachingErr != nil {
-		return errors.Wrap(tieredCachingErr, "failed to update tiered caching setting")
+		return err.Wrap(tieredCachingErr, "failed to update tiered caching setting")
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_argo.go
+++ b/cloudflare/resource_cloudflare_argo.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareArgo() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareArgoSchema(),
-		Create: resourceCloudflareArgoUpdate,
-		Read:   resourceCloudflareArgoRead,
-		Update: resourceCloudflareArgoUpdate,
-		Delete: resourceCloudflareArgoDelete,
+		CreateContext: resourceCloudflareArgoUpdate,
+		ReadContext: resourceCloudflareArgoRead,
+		UpdateContext: resourceCloudflareArgoUpdate,
+		DeleteContext: resourceCloudflareArgoDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareArgoImport,
 		},

--- a/cloudflare/resource_cloudflare_argo_tunnel.go
+++ b/cloudflare/resource_cloudflare_argo_tunnel.go
@@ -46,7 +46,7 @@ func resourceCloudflareArgoTunnelRead(ctx context.Context, d *schema.ResourceDat
 
 	tunnel, err := client.ArgoTunnel(context.Background(), accID, d.Id())
 	if err != nil {
-		return fmt.Errorf("failed to fetch Argo Tunnel: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to fetch Argo Tunnel: %w", err))
 	}
 
 	d.Set("cname", fmt.Sprintf("%s.%s", tunnel.ID, argoTunnelCNAME))

--- a/cloudflare/resource_cloudflare_argo_tunnel.go
+++ b/cloudflare/resource_cloudflare_argo_tunnel.go
@@ -24,7 +24,7 @@ func resourceCloudflareArgoTunnel() *schema.Resource {
 	}
 }
 
-func resourceCloudflareArgoTunnelCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareArgoTunnelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accID := d.Get("account_id").(string)
 	name := d.Get("name").(string)
@@ -32,7 +32,7 @@ func resourceCloudflareArgoTunnelCreate(d *schema.ResourceData, meta interface{}
 
 	tunnel, err := client.CreateArgoTunnel(context.Background(), accID, name, secret)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to create Argo Tunnel"))
+		return err.Wrap(err, fmt.Sprintf("failed to create Argo Tunnel"))
 	}
 
 	d.SetId(tunnel.ID)
@@ -40,7 +40,7 @@ func resourceCloudflareArgoTunnelCreate(d *schema.ResourceData, meta interface{}
 	return resourceCloudflareArgoTunnelRead(d, meta)
 }
 
-func resourceCloudflareArgoTunnelRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareArgoTunnelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accID := d.Get("account_id").(string)
 
@@ -54,18 +54,18 @@ func resourceCloudflareArgoTunnelRead(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceCloudflareArgoTunnelDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareArgoTunnelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accID := d.Get("account_id").(string)
 
 	cleanupErr := client.CleanupArgoTunnelConnections(context.Background(), accID, d.Id())
 	if cleanupErr != nil {
-		return errors.Wrap(cleanupErr, fmt.Sprintf("failed to clean up Argo Tunnel connections"))
+		return err.Wrap(cleanupErr, fmt.Sprintf("failed to clean up Argo Tunnel connections"))
 	}
 
 	deleteErr := client.DeleteArgoTunnel(context.Background(), accID, d.Id())
 	if deleteErr != nil {
-		return errors.Wrap(deleteErr, fmt.Sprintf("failed to delete Argo Tunnel"))
+		return err.Wrap(deleteErr, fmt.Sprintf("failed to delete Argo Tunnel"))
 	}
 
 	d.SetId("")

--- a/cloudflare/resource_cloudflare_argo_tunnel.go
+++ b/cloudflare/resource_cloudflare_argo_tunnel.go
@@ -31,7 +31,7 @@ func resourceCloudflareArgoTunnelCreate(ctx context.Context, d *schema.ResourceD
 	name := d.Get("name").(string)
 	secret := d.Get("secret").(string)
 
-	tunnel, err := client.CreateArgoTunnel(context.Background(), accID, name, secret)
+	tunnel, err := client.CreateArgoTunnel(ctx, accID, name, secret)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("failed to create Argo Tunnel")))
 	}
@@ -45,7 +45,7 @@ func resourceCloudflareArgoTunnelRead(ctx context.Context, d *schema.ResourceDat
 	client := meta.(*cloudflare.API)
 	accID := d.Get("account_id").(string)
 
-	tunnel, err := client.ArgoTunnel(context.Background(), accID, d.Id())
+	tunnel, err := client.ArgoTunnel(ctx, accID, d.Id())
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to fetch Argo Tunnel: %w", err))
 	}
@@ -59,12 +59,12 @@ func resourceCloudflareArgoTunnelDelete(ctx context.Context, d *schema.ResourceD
 	client := meta.(*cloudflare.API)
 	accID := d.Get("account_id").(string)
 
-	cleanupErr := client.CleanupArgoTunnelConnections(context.Background(), accID, d.Id())
+	cleanupErr := client.CleanupArgoTunnelConnections(ctx, accID, d.Id())
 	if cleanupErr != nil {
 		return diag.FromErr(errors.Wrap(cleanupErr, fmt.Sprintf("failed to clean up Argo Tunnel connections")))
 	}
 
-	deleteErr := client.DeleteArgoTunnel(context.Background(), accID, d.Id())
+	deleteErr := client.DeleteArgoTunnel(ctx, accID, d.Id())
 	if deleteErr != nil {
 		return diag.FromErr(errors.Wrap(deleteErr, fmt.Sprintf("failed to delete Argo Tunnel")))
 	}
@@ -84,7 +84,7 @@ func resourceCloudflareArgoTunnelImport(ctx context.Context, d *schema.ResourceD
 
 	accID, tunnelID := attributes[0], attributes[1]
 
-	tunnel, err := client.ArgoTunnel(context.Background(), accID, tunnelID)
+	tunnel, err := client.ArgoTunnel(ctx, accID, tunnelID)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch Argo Tunnel %s", tunnelID))
 	}

--- a/cloudflare/resource_cloudflare_argo_tunnel.go
+++ b/cloudflare/resource_cloudflare_argo_tunnel.go
@@ -15,9 +15,9 @@ const argoTunnelCNAME = "cfargotunnel.com"
 func resourceCloudflareArgoTunnel() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareArgoTunnelSchema(),
-		Create: resourceCloudflareArgoTunnelCreate,
-		Read:   resourceCloudflareArgoTunnelRead,
-		Delete: resourceCloudflareArgoTunnelDelete,
+		CreateContext: resourceCloudflareArgoTunnelCreate,
+		ReadContext: resourceCloudflareArgoTunnelRead,
+		DeleteContext: resourceCloudflareArgoTunnelDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareArgoTunnelImport,
 		},

--- a/cloudflare/resource_cloudflare_argo_tunnel_test.go
+++ b/cloudflare/resource_cloudflare_argo_tunnel_test.go
@@ -72,7 +72,6 @@ func testAccCheckCloudflareArgoTunnelDestroy(s *terraform.State) error {
 		if tunnel.DeletedAt == nil {
 			return fmt.Errorf("argo tunnel with ID %s still exists", tunnel.ID)
 		}
-
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls.go
@@ -40,7 +40,7 @@ func resourceCloudflareAuthenticatedOriginPullsCreate(ctx context.Context, d *sc
 		}}
 		_, err := client.EditPerHostnameAuthenticatedOriginPullsConfig(context.Background(), zoneID, conf)
 		if err != nil {
-			return fmt.Errorf("error creating Per-Hostname Authenticated Origin Pulls resource on zone %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error creating Per-Hostname Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
 		}
 		checksum = stringChecksum(fmt.Sprintf("PerHostnameAOP/%s/%s/%s", zoneID, hostname, aopCert))
 
@@ -48,7 +48,7 @@ func resourceCloudflareAuthenticatedOriginPullsCreate(ctx context.Context, d *sc
 		// Per Zone AOP
 		_, err := client.SetPerZoneAuthenticatedOriginPullsStatus(context.Background(), zoneID, isEnabled.(bool))
 		if err != nil {
-			return fmt.Errorf("error creating Per-Zone Authenticated Origin Pulls resource on zone %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error creating Per-Zone Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
 		}
 		checksum = stringChecksum(fmt.Sprintf("PerZoneAOP/%s/%s", zoneID, aopCert))
 
@@ -56,7 +56,7 @@ func resourceCloudflareAuthenticatedOriginPullsCreate(ctx context.Context, d *sc
 		// Global AOP
 		_, err := client.SetAuthenticatedOriginPullsStatus(context.Background(), zoneID, isEnabled.(bool))
 		if err != nil {
-			return fmt.Errorf("error creating Global Authenticated Origin Pulls resource on zone %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error creating Global Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
 		}
 		checksum = stringChecksum(fmt.Sprintf("GlobalAOP/%s/", zoneID))
 	}
@@ -115,19 +115,19 @@ func resourceCloudflareAuthenticatedOriginPullsDelete(ctx context.Context, d *sc
 		}}
 		_, err := client.EditPerHostnameAuthenticatedOriginPullsConfig(context.Background(), zoneID, conf)
 		if err != nil {
-			return fmt.Errorf("error disabling Per-Hostname Authenticated Origin Pulls resource on zone %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error disabling Per-Hostname Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
 		}
 	} else if aopCert != "" {
 		// Per Zone AOP
 		_, err := client.SetPerZoneAuthenticatedOriginPullsStatus(context.Background(), zoneID, false)
 		if err != nil {
-			return fmt.Errorf("error disabling Per-Zone Authenticated Origin Pulls resource on zone %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error disabling Per-Zone Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
 		}
 	} else {
 		// Global AOP
 		_, err := client.SetAuthenticatedOriginPullsStatus(context.Background(), zoneID, false)
 		if err != nil {
-			return fmt.Errorf("error disabling Global Authenticated Origin Pulls resource on zone %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error disabling Global Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
 		}
 	}
 	return nil

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls.go
@@ -23,7 +23,7 @@ func resourceCloudflareAuthenticatedOriginPulls() *schema.Resource {
 	}
 }
 
-func resourceCloudflareAuthenticatedOriginPullsCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAuthenticatedOriginPullsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	hostname := d.Get("hostname").(string)
@@ -65,7 +65,7 @@ func resourceCloudflareAuthenticatedOriginPullsCreate(d *schema.ResourceData, me
 	return resourceCloudflareAuthenticatedOriginPullsRead(d, meta)
 }
 
-func resourceCloudflareAuthenticatedOriginPullsRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAuthenticatedOriginPullsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	hostname := d.Get("hostname").(string)
@@ -75,21 +75,21 @@ func resourceCloudflareAuthenticatedOriginPullsRead(d *schema.ResourceData, meta
 		// Per Hostname AOP
 		res, err := client.GetPerHostnameAuthenticatedOriginPullsConfig(context.Background(), zoneID, hostname)
 		if err != nil {
-			return errors.Wrap(err, "failed to get Per-Hostname Authenticated Origin Pulls setting")
+			return err.Wrap(err, "failed to get Per-Hostname Authenticated Origin Pulls setting")
 		}
 		d.Set("enabled", res.Enabled)
 	} else if aopCert != "" {
 		// Per Zone AOP
 		res, err := client.GetPerZoneAuthenticatedOriginPullsStatus(context.Background(), zoneID)
 		if err != nil {
-			return errors.Wrap(err, "failed to get Per-Zone Authenticated Origin Pulls setting")
+			return err.Wrap(err, "failed to get Per-Zone Authenticated Origin Pulls setting")
 		}
 		d.Set("enabled", res.Enabled)
 	} else {
 		// Global AOP
 		res, err := client.GetAuthenticatedOriginPullsStatus(context.Background(), zoneID)
 		if err != nil {
-			return errors.Wrap(err, "failed to get Global Authenticated Origin Pulls setting")
+			return err.Wrap(err, "failed to get Global Authenticated Origin Pulls setting")
 		}
 		if res.Value == "on" {
 			d.Set("enabled", true)
@@ -100,7 +100,7 @@ func resourceCloudflareAuthenticatedOriginPullsRead(d *schema.ResourceData, meta
 	return nil
 }
 
-func resourceCloudflareAuthenticatedOriginPullsDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAuthenticatedOriginPullsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	hostname := d.Get("hostname").(string)

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls.go
@@ -41,7 +41,7 @@ func resourceCloudflareAuthenticatedOriginPullsCreate(ctx context.Context, d *sc
 		}}
 		_, err := client.EditPerHostnameAuthenticatedOriginPullsConfig(ctx, zoneID, conf)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error creating Per-Hostname Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error creating Per-Hostname Authenticated Origin Pulls resource on zone %q: %w", zoneID, err))
 		}
 		checksum = stringChecksum(fmt.Sprintf("PerHostnameAOP/%s/%s/%s", zoneID, hostname, aopCert))
 
@@ -49,7 +49,7 @@ func resourceCloudflareAuthenticatedOriginPullsCreate(ctx context.Context, d *sc
 		// Per Zone AOP
 		_, err := client.SetPerZoneAuthenticatedOriginPullsStatus(ctx, zoneID, isEnabled.(bool))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error creating Per-Zone Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error creating Per-Zone Authenticated Origin Pulls resource on zone %q: %w", zoneID, err))
 		}
 		checksum = stringChecksum(fmt.Sprintf("PerZoneAOP/%s/%s", zoneID, aopCert))
 
@@ -57,7 +57,7 @@ func resourceCloudflareAuthenticatedOriginPullsCreate(ctx context.Context, d *sc
 		// Global AOP
 		_, err := client.SetAuthenticatedOriginPullsStatus(ctx, zoneID, isEnabled.(bool))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error creating Global Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error creating Global Authenticated Origin Pulls resource on zone %q: %w", zoneID, err))
 		}
 		checksum = stringChecksum(fmt.Sprintf("GlobalAOP/%s/", zoneID))
 	}
@@ -116,19 +116,19 @@ func resourceCloudflareAuthenticatedOriginPullsDelete(ctx context.Context, d *sc
 		}}
 		_, err := client.EditPerHostnameAuthenticatedOriginPullsConfig(ctx, zoneID, conf)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error disabling Per-Hostname Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error disabling Per-Hostname Authenticated Origin Pulls resource on zone %q: %w", zoneID, err))
 		}
 	} else if aopCert != "" {
 		// Per Zone AOP
 		_, err := client.SetPerZoneAuthenticatedOriginPullsStatus(ctx, zoneID, false)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error disabling Per-Zone Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error disabling Per-Zone Authenticated Origin Pulls resource on zone %q: %w", zoneID, err))
 		}
 	} else {
 		// Global AOP
 		_, err := client.SetAuthenticatedOriginPullsStatus(ctx, zoneID, false)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error disabling Global Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error disabling Global Authenticated Origin Pulls resource on zone %q: %w", zoneID, err))
 		}
 	}
 	return nil

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareAuthenticatedOriginPulls() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareAuthenticatedOriginPullsSchema(),
-		Create: resourceCloudflareAuthenticatedOriginPullsCreate,
-		Read:   resourceCloudflareAuthenticatedOriginPullsRead,
-		Update: resourceCloudflareAuthenticatedOriginPullsCreate,
-		Delete: resourceCloudflareAuthenticatedOriginPullsDelete,
+		CreateContext: resourceCloudflareAuthenticatedOriginPullsCreate,
+		ReadContext: resourceCloudflareAuthenticatedOriginPullsRead,
+		UpdateContext: resourceCloudflareAuthenticatedOriginPullsCreate,
+		DeleteContext: resourceCloudflareAuthenticatedOriginPullsDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareAuthenticatedOriginPullsImport,
 		},

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls.go
@@ -39,7 +39,7 @@ func resourceCloudflareAuthenticatedOriginPullsCreate(ctx context.Context, d *sc
 			Hostname: hostname,
 			Enabled:  isEnabled.(bool),
 		}}
-		_, err := client.EditPerHostnameAuthenticatedOriginPullsConfig(context.Background(), zoneID, conf)
+		_, err := client.EditPerHostnameAuthenticatedOriginPullsConfig(ctx, zoneID, conf)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error creating Per-Hostname Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
 		}
@@ -47,7 +47,7 @@ func resourceCloudflareAuthenticatedOriginPullsCreate(ctx context.Context, d *sc
 
 	case aopCert != "":
 		// Per Zone AOP
-		_, err := client.SetPerZoneAuthenticatedOriginPullsStatus(context.Background(), zoneID, isEnabled.(bool))
+		_, err := client.SetPerZoneAuthenticatedOriginPullsStatus(ctx, zoneID, isEnabled.(bool))
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error creating Per-Zone Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
 		}
@@ -55,7 +55,7 @@ func resourceCloudflareAuthenticatedOriginPullsCreate(ctx context.Context, d *sc
 
 	default:
 		// Global AOP
-		_, err := client.SetAuthenticatedOriginPullsStatus(context.Background(), zoneID, isEnabled.(bool))
+		_, err := client.SetAuthenticatedOriginPullsStatus(ctx, zoneID, isEnabled.(bool))
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error creating Global Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
 		}
@@ -74,21 +74,21 @@ func resourceCloudflareAuthenticatedOriginPullsRead(ctx context.Context, d *sche
 
 	if hostname != "" && aopCert != "" {
 		// Per Hostname AOP
-		res, err := client.GetPerHostnameAuthenticatedOriginPullsConfig(context.Background(), zoneID, hostname)
+		res, err := client.GetPerHostnameAuthenticatedOriginPullsConfig(ctx, zoneID, hostname)
 		if err != nil {
 			return diag.FromErr(errors.Wrap(err, "failed to get Per-Hostname Authenticated Origin Pulls setting"))
 		}
 		d.Set("enabled", res.Enabled)
 	} else if aopCert != "" {
 		// Per Zone AOP
-		res, err := client.GetPerZoneAuthenticatedOriginPullsStatus(context.Background(), zoneID)
+		res, err := client.GetPerZoneAuthenticatedOriginPullsStatus(ctx, zoneID)
 		if err != nil {
 			return diag.FromErr(errors.Wrap(err, "failed to get Per-Zone Authenticated Origin Pulls setting"))
 		}
 		d.Set("enabled", res.Enabled)
 	} else {
 		// Global AOP
-		res, err := client.GetAuthenticatedOriginPullsStatus(context.Background(), zoneID)
+		res, err := client.GetAuthenticatedOriginPullsStatus(ctx, zoneID)
 		if err != nil {
 			return diag.FromErr(errors.Wrap(err, "failed to get Global Authenticated Origin Pulls setting"))
 		}
@@ -114,19 +114,19 @@ func resourceCloudflareAuthenticatedOriginPullsDelete(ctx context.Context, d *sc
 			Hostname: hostname,
 			Enabled:  false,
 		}}
-		_, err := client.EditPerHostnameAuthenticatedOriginPullsConfig(context.Background(), zoneID, conf)
+		_, err := client.EditPerHostnameAuthenticatedOriginPullsConfig(ctx, zoneID, conf)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error disabling Per-Hostname Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
 		}
 	} else if aopCert != "" {
 		// Per Zone AOP
-		_, err := client.SetPerZoneAuthenticatedOriginPullsStatus(context.Background(), zoneID, false)
+		_, err := client.SetPerZoneAuthenticatedOriginPullsStatus(ctx, zoneID, false)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error disabling Per-Zone Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
 		}
 	} else {
 		// Global AOP
-		_, err := client.SetAuthenticatedOriginPullsStatus(context.Background(), zoneID, false)
+		_, err := client.SetAuthenticatedOriginPullsStatus(ctx, zoneID, false)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error disabling Global Authenticated Origin Pulls resource on zone %q: %s", zoneID, err))
 		}

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
@@ -29,7 +29,7 @@ func resourceCloudflareAuthenticatedOriginPullsCertificate() *schema.Resource {
 	}
 }
 
-func resourceCloudflareAuthenticatedOriginPullsCertificateCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAuthenticatedOriginPullsCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -86,7 +86,7 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateCreate(d *schema.Resou
 	return nil
 }
 
-func resourceCloudflareAuthenticatedOriginPullsCertificateRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAuthenticatedOriginPullsCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	certID := d.Id()
@@ -127,7 +127,7 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateRead(d *schema.Resourc
 	return nil
 }
 
-func resourceCloudflareAuthenticatedOriginPullsCertificateDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareAuthenticatedOriginPullsCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	certID := d.Id()

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
@@ -15,9 +15,9 @@ import (
 func resourceCloudflareAuthenticatedOriginPullsCertificate() *schema.Resource {
 	return &schema.Resource{
 		// You cannot edit AOP certificates, rather, only upload new ones.
-		Create: resourceCloudflareAuthenticatedOriginPullsCertificateCreate,
-		Read:   resourceCloudflareAuthenticatedOriginPullsCertificateRead,
-		Delete: resourceCloudflareAuthenticatedOriginPullsCertificateDelete,
+		CreateContext: resourceCloudflareAuthenticatedOriginPullsCertificateCreate,
+		ReadContext: resourceCloudflareAuthenticatedOriginPullsCertificateRead,
+		DeleteContext: resourceCloudflareAuthenticatedOriginPullsCertificateDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareAuthenticatedOriginPullsCertificateImport,
 		},

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
@@ -42,14 +42,14 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateCreate(ctx context.Con
 		}
 		record, err := client.UploadPerZoneAuthenticatedOriginPullsCertificate(ctx, zoneID, perZoneAOPCert)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error uploading Per-Zone AOP certificate on zone %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error uploading Per-Zone AOP certificate on zone %q: %w", zoneID, err))
 		}
 		d.SetId(record.ID)
 
 		perZoneRetryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			resp, err := client.GetPerZoneAuthenticatedOriginPullsCertificateDetails(ctx, zoneID, record.ID)
 			if err != nil {
-				return resource.NonRetryableError(fmt.Errorf("error reading Per Zone AOP certificate details: %s", err))
+				return resource.NonRetryableError(fmt.Errorf("error reading Per Zone AOP certificate details: %w", err))
 			}
 
 			if resp.Status != "active" {
@@ -73,14 +73,14 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateCreate(ctx context.Con
 		}
 		record, err := client.UploadPerHostnameAuthenticatedOriginPullsCertificate(ctx, zoneID, perHostnameAOPCert)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error uploading Per-Hostname AOP certificate on zone %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error uploading Per-Hostname AOP certificate on zone %q: %w", zoneID, err))
 		}
 		d.SetId(record.ID)
 
 		perHostnameRetryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			resp, err := client.GetPerHostnameAuthenticatedOriginPullsCertificate(ctx, zoneID, record.ID)
 			if err != nil {
-				return resource.NonRetryableError(fmt.Errorf("error reading Per Hostname AOP certificate details: %s", err))
+				return resource.NonRetryableError(fmt.Errorf("error reading Per Hostname AOP certificate details: %w", err))
 			}
 
 			if resp.Status != "active" {
@@ -114,7 +114,7 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateRead(ctx context.Conte
 				d.SetId("")
 				return nil
 			}
-			return diag.FromErr(fmt.Errorf("error finding Per-Zone Authenticated Origin Pull certificate %q: %s", d.Id(), err))
+			return diag.FromErr(fmt.Errorf("error finding Per-Zone Authenticated Origin Pull certificate %q: %w", d.Id(), err))
 		}
 		d.Set("issuer", record.Issuer)
 		d.Set("signature", record.Signature)
@@ -129,7 +129,7 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateRead(ctx context.Conte
 				d.SetId("")
 				return nil
 			}
-			return diag.FromErr(fmt.Errorf("error finding Per-Hostname Authenticated Origin Pull certificate %q: %s", d.Id(), err))
+			return diag.FromErr(fmt.Errorf("error finding Per-Hostname Authenticated Origin Pull certificate %q: %w", d.Id(), err))
 		}
 		d.Set("issuer", record.Issuer)
 		d.Set("signature", record.Signature)
@@ -150,12 +150,12 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateDelete(ctx context.Con
 	case aopType == "per-zone":
 		_, err := client.DeletePerZoneAuthenticatedOriginPullsCertificate(ctx, zoneID, certID)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error deleting Per-Zone AOP certificate on zone %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error deleting Per-Zone AOP certificate on zone %q: %w", zoneID, err))
 		}
 	case aopType == "per-hostname":
 		_, err := client.DeletePerHostnameAuthenticatedOriginPullsCertificate(ctx, zoneID, certID)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error deleting Per-Hostname AOP certificate on zone %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error deleting Per-Hostname AOP certificate on zone %q: %w", zoneID, err))
 		}
 	}
 	return nil

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
@@ -40,14 +40,14 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateCreate(ctx context.Con
 			Certificate: d.Get("certificate").(string),
 			PrivateKey:  d.Get("private_key").(string),
 		}
-		record, err := client.UploadPerZoneAuthenticatedOriginPullsCertificate(context.Background(), zoneID, perZoneAOPCert)
+		record, err := client.UploadPerZoneAuthenticatedOriginPullsCertificate(ctx, zoneID, perZoneAOPCert)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error uploading Per-Zone AOP certificate on zone %q: %s", zoneID, err))
 		}
 		d.SetId(record.ID)
 
 		perZoneRetryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-			resp, err := client.GetPerZoneAuthenticatedOriginPullsCertificateDetails(context.Background(), zoneID, record.ID)
+			resp, err := client.GetPerZoneAuthenticatedOriginPullsCertificateDetails(ctx, zoneID, record.ID)
 			if err != nil {
 				return resource.NonRetryableError(fmt.Errorf("error reading Per Zone AOP certificate details: %s", err))
 			}
@@ -71,14 +71,14 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateCreate(ctx context.Con
 			Certificate: d.Get("certificate").(string),
 			PrivateKey:  d.Get("private_key").(string),
 		}
-		record, err := client.UploadPerHostnameAuthenticatedOriginPullsCertificate(context.Background(), zoneID, perHostnameAOPCert)
+		record, err := client.UploadPerHostnameAuthenticatedOriginPullsCertificate(ctx, zoneID, perHostnameAOPCert)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error uploading Per-Hostname AOP certificate on zone %q: %s", zoneID, err))
 		}
 		d.SetId(record.ID)
 
 		perHostnameRetryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-			resp, err := client.GetPerHostnameAuthenticatedOriginPullsCertificate(context.Background(), zoneID, record.ID)
+			resp, err := client.GetPerHostnameAuthenticatedOriginPullsCertificate(ctx, zoneID, record.ID)
 			if err != nil {
 				return resource.NonRetryableError(fmt.Errorf("error reading Per Hostname AOP certificate details: %s", err))
 			}
@@ -107,7 +107,7 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateRead(ctx context.Conte
 
 	switch aopType, ok := d.GetOk("type"); ok {
 	case aopType == "per-zone":
-		record, err := client.GetPerZoneAuthenticatedOriginPullsCertificateDetails(context.Background(), zoneID, certID)
+		record, err := client.GetPerZoneAuthenticatedOriginPullsCertificateDetails(ctx, zoneID, certID)
 		if err != nil {
 			if strings.Contains(err.Error(), "HTTP status 404") {
 				log.Printf("[INFO] Per-Zone Authenticated Origin Pull certificate %s no longer exists", d.Id())
@@ -122,7 +122,7 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateRead(ctx context.Conte
 		d.Set("status", record.Status)
 		d.Set("uploaded_on", record.UploadedOn.Format(time.RFC3339Nano))
 	case aopType == "per-hostname":
-		record, err := client.GetPerHostnameAuthenticatedOriginPullsCertificate(context.Background(), zoneID, certID)
+		record, err := client.GetPerHostnameAuthenticatedOriginPullsCertificate(ctx, zoneID, certID)
 		if err != nil {
 			if strings.Contains(err.Error(), "HTTP status 404") {
 				log.Printf("[INFO] Per-Hostname Authenticated Origin Pull certificate %s no longer exists", d.Id())
@@ -148,12 +148,12 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateDelete(ctx context.Con
 
 	switch aopType, ok := d.GetOk("type"); ok {
 	case aopType == "per-zone":
-		_, err := client.DeletePerZoneAuthenticatedOriginPullsCertificate(context.Background(), zoneID, certID)
+		_, err := client.DeletePerZoneAuthenticatedOriginPullsCertificate(ctx, zoneID, certID)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error deleting Per-Zone AOP certificate on zone %q: %s", zoneID, err))
 		}
 	case aopType == "per-hostname":
-		_, err := client.DeletePerHostnameAuthenticatedOriginPullsCertificate(context.Background(), zoneID, certID)
+		_, err := client.DeletePerHostnameAuthenticatedOriginPullsCertificate(ctx, zoneID, certID)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error deleting Per-Hostname AOP certificate on zone %q: %s", zoneID, err))
 		}

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate.go
@@ -41,7 +41,7 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateCreate(ctx context.Con
 		}
 		record, err := client.UploadPerZoneAuthenticatedOriginPullsCertificate(context.Background(), zoneID, perZoneAOPCert)
 		if err != nil {
-			return fmt.Errorf("error uploading Per-Zone AOP certificate on zone %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error uploading Per-Zone AOP certificate on zone %q: %s", zoneID, err))
 		}
 		d.SetId(record.ID)
 
@@ -65,7 +65,7 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateCreate(ctx context.Con
 		}
 		record, err := client.UploadPerHostnameAuthenticatedOriginPullsCertificate(context.Background(), zoneID, perHostnameAOPCert)
 		if err != nil {
-			return fmt.Errorf("error uploading Per-Hostname AOP certificate on zone %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error uploading Per-Hostname AOP certificate on zone %q: %s", zoneID, err))
 		}
 		d.SetId(record.ID)
 
@@ -100,7 +100,7 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateRead(ctx context.Conte
 				d.SetId("")
 				return nil
 			}
-			return fmt.Errorf("error finding Per-Zone Authenticated Origin Pull certificate %q: %s", d.Id(), err)
+			return diag.FromErr(fmt.Errorf("error finding Per-Zone Authenticated Origin Pull certificate %q: %s", d.Id(), err))
 		}
 		d.Set("issuer", record.Issuer)
 		d.Set("signature", record.Signature)
@@ -115,7 +115,7 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateRead(ctx context.Conte
 				d.SetId("")
 				return nil
 			}
-			return fmt.Errorf("error finding Per-Hostname Authenticated Origin Pull certificate %q: %s", d.Id(), err)
+			return diag.FromErr(fmt.Errorf("error finding Per-Hostname Authenticated Origin Pull certificate %q: %s", d.Id(), err))
 		}
 		d.Set("issuer", record.Issuer)
 		d.Set("signature", record.Signature)
@@ -136,12 +136,12 @@ func resourceCloudflareAuthenticatedOriginPullsCertificateDelete(ctx context.Con
 	case aopType == "per-zone":
 		_, err := client.DeletePerZoneAuthenticatedOriginPullsCertificate(context.Background(), zoneID, certID)
 		if err != nil {
-			return fmt.Errorf("error deleting Per-Zone AOP certificate on zone %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error deleting Per-Zone AOP certificate on zone %q: %s", zoneID, err))
 		}
 	case aopType == "per-hostname":
 		_, err := client.DeletePerHostnameAuthenticatedOriginPullsCertificate(context.Background(), zoneID, certID)
 		if err != nil {
-			return fmt.Errorf("error deleting Per-Hostname AOP certificate on zone %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error deleting Per-Hostname AOP certificate on zone %q: %s", zoneID, err))
 		}
 	}
 	return nil

--- a/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate_test.go
+++ b/cloudflare/resource_cloudflare_authenticated_origin_pulls_certificate_test.go
@@ -160,12 +160,12 @@ func testAccCheckCloudflareAuthenticatedOriginPullsCertificateDestroy(s *terrafo
 		if rs.Primary.Attributes["type"] == "per-zone" {
 			_, err := client.DeletePerZoneAuthenticatedOriginPullsCertificate(context.Background(), rs.Primary.Attributes["zone_id"], rs.Primary.ID)
 			if err == nil {
-				return fmt.Errorf("error deleting Per-Zone AOP certificate on zone %q: %s", zoneID, err)
+				return fmt.Errorf("error deleting Per-Zone AOP certificate on zone %q: %w", zoneID, err)
 			}
 		} else if rs.Primary.Attributes["type"] == "per-hostname" {
 			_, err := client.DeletePerZoneAuthenticatedOriginPullsCertificate(context.Background(), rs.Primary.Attributes["zone_id"], rs.Primary.ID)
 			if err == nil {
-				return fmt.Errorf("error deleting Per-Zone AOP certificate on zone %q: %s", zoneID, err)
+				return fmt.Errorf("error deleting Per-Zone AOP certificate on zone %q: %w", zoneID, err)
 			}
 		}
 	}

--- a/cloudflare/resource_cloudflare_byo_ip_prefix.go
+++ b/cloudflare/resource_cloudflare_byo_ip_prefix.go
@@ -12,10 +12,10 @@ import (
 func resourceCloudflareBYOIPPrefix() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareBYOIPPrefixSchema(),
-		Create: resourceCloudflareBYOIPPrefixCreate,
-		Read:   resourceCloudflareBYOIPPrefixRead,
-		Update: resourceCloudflareBYOIPPrefixUpdate,
-		Delete: resourceCloudflareBYOIPPrefixDelete,
+		CreateContext: resourceCloudflareBYOIPPrefixCreate,
+		ReadContext: resourceCloudflareBYOIPPrefixRead,
+		UpdateContext: resourceCloudflareBYOIPPrefixUpdate,
+		DeleteContext: resourceCloudflareBYOIPPrefixDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareBYOIPPrefixImport,
 		},

--- a/cloudflare/resource_cloudflare_byo_ip_prefix.go
+++ b/cloudflare/resource_cloudflare_byo_ip_prefix.go
@@ -22,12 +22,12 @@ func resourceCloudflareBYOIPPrefix() *schema.Resource {
 	}
 }
 
-func resourceCloudflareBYOIPPrefixCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareBYOIPPrefixCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	prefixID := d.Get("prefix_id")
 	d.SetId(prefixID.(string))
 
 	if err := resourceCloudflareBYOIPPrefixUpdate(d, meta); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	return resourceCloudflareBYOIPPrefixRead(d, meta)
@@ -42,20 +42,20 @@ func resourceCloudflareBYOIPPrefixImport(d *schema.ResourceData, meta interface{
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceCloudflareBYOIPPrefixRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareBYOIPPrefixRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
 	prefix, err := client.GetPrefix(context.Background(), accountID, d.Id())
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error reading IP prefix information for %q", d.Id()))
+		return err.Wrap(err, fmt.Sprintf("error reading IP prefix information for %q", d.Id()))
 	}
 
 	d.Set("description", prefix.Description)
 
 	advertisementStatus, err := client.GetAdvertisementStatus(context.Background(), accountID, d.Id())
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error reading advertisement status of IP prefix for %q", d.Id()))
+		return err.Wrap(err, fmt.Sprintf("error reading advertisement status of IP prefix for %q", d.Id()))
 	}
 
 	d.Set("advertisement", stringFromBool(advertisementStatus.Advertised))
@@ -63,19 +63,19 @@ func resourceCloudflareBYOIPPrefixRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceCloudflareBYOIPPrefixUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareBYOIPPrefixUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
 	if _, ok := d.GetOk("description"); ok && d.HasChange("description") {
 		if _, err := client.UpdatePrefixDescription(context.Background(), accountID, d.Id(), d.Get("description").(string)); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("cannot update prefix description for %q", d.Id()))
+			return err.Wrap(err, fmt.Sprintf("cannot update prefix description for %q", d.Id()))
 		}
 	}
 
 	if _, ok := d.GetOk("advertisement"); ok && d.HasChange("advertisement") {
 		if _, err := client.UpdateAdvertisementStatus(context.Background(), accountID, d.Id(), boolFromString(d.Get("advertisement").(string))); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("cannot update prefix advertisement status for %q", d.Id()))
+			return err.Wrap(err, fmt.Sprintf("cannot update prefix advertisement status for %q", d.Id()))
 		}
 	}
 
@@ -83,6 +83,6 @@ func resourceCloudflareBYOIPPrefixUpdate(d *schema.ResourceData, meta interface{
 }
 
 // Deletion of prefixes is not really supported, so we keep this as a dummy
-func resourceCloudflareBYOIPPrefixDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareBYOIPPrefixDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }

--- a/cloudflare/resource_cloudflare_byo_ip_prefix.go
+++ b/cloudflare/resource_cloudflare_byo_ip_prefix.go
@@ -5,19 +5,20 @@ import (
 	"fmt"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 )
 
 func resourceCloudflareBYOIPPrefix() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareBYOIPPrefixSchema(),
+		Schema:        resourceCloudflareBYOIPPrefixSchema(),
 		CreateContext: resourceCloudflareBYOIPPrefixCreate,
-		ReadContext: resourceCloudflareBYOIPPrefixRead,
+		ReadContext:   resourceCloudflareBYOIPPrefixRead,
 		UpdateContext: resourceCloudflareBYOIPPrefixUpdate,
 		DeleteContext: resourceCloudflareBYOIPPrefixDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareBYOIPPrefixImport,
+			StateContext: resourceCloudflareBYOIPPrefixImport,
 		},
 	}
 }
@@ -26,18 +27,18 @@ func resourceCloudflareBYOIPPrefixCreate(ctx context.Context, d *schema.Resource
 	prefixID := d.Get("prefix_id")
 	d.SetId(prefixID.(string))
 
-	if err := resourceCloudflareBYOIPPrefixUpdate(d, meta); err != nil {
-		return diag.FromErr(err)
+	if err := resourceCloudflareBYOIPPrefixUpdate(ctx, d, meta); err != nil {
+		return err
 	}
 
-	return resourceCloudflareBYOIPPrefixRead(d, meta)
+	return resourceCloudflareBYOIPPrefixRead(ctx, d, meta)
 }
 
-func resourceCloudflareBYOIPPrefixImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareBYOIPPrefixImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	prefixID := d.Id()
 	d.Set("prefix_id", prefixID)
 
-	resourceCloudflareBYOIPPrefixRead(d, meta)
+	resourceCloudflareBYOIPPrefixRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }
@@ -48,14 +49,14 @@ func resourceCloudflareBYOIPPrefixRead(ctx context.Context, d *schema.ResourceDa
 
 	prefix, err := client.GetPrefix(context.Background(), accountID, d.Id())
 	if err != nil {
-		return err.Wrap(err, fmt.Sprintf("error reading IP prefix information for %q", d.Id()))
+		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error reading IP prefix information for %q", d.Id())))
 	}
 
 	d.Set("description", prefix.Description)
 
 	advertisementStatus, err := client.GetAdvertisementStatus(context.Background(), accountID, d.Id())
 	if err != nil {
-		return err.Wrap(err, fmt.Sprintf("error reading advertisement status of IP prefix for %q", d.Id()))
+		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error reading advertisement status of IP prefix for %q", d.Id())))
 	}
 
 	d.Set("advertisement", stringFromBool(advertisementStatus.Advertised))
@@ -69,13 +70,13 @@ func resourceCloudflareBYOIPPrefixUpdate(ctx context.Context, d *schema.Resource
 
 	if _, ok := d.GetOk("description"); ok && d.HasChange("description") {
 		if _, err := client.UpdatePrefixDescription(context.Background(), accountID, d.Id(), d.Get("description").(string)); err != nil {
-			return err.Wrap(err, fmt.Sprintf("cannot update prefix description for %q", d.Id()))
+			return diag.FromErr(errors.Wrap(err, fmt.Sprintf("cannot update prefix description for %q", d.Id())))
 		}
 	}
 
 	if _, ok := d.GetOk("advertisement"); ok && d.HasChange("advertisement") {
 		if _, err := client.UpdateAdvertisementStatus(context.Background(), accountID, d.Id(), boolFromString(d.Get("advertisement").(string))); err != nil {
-			return err.Wrap(err, fmt.Sprintf("cannot update prefix advertisement status for %q", d.Id()))
+			return diag.FromErr(errors.Wrap(err, fmt.Sprintf("cannot update prefix advertisement status for %q", d.Id())))
 		}
 	}
 

--- a/cloudflare/resource_cloudflare_byo_ip_prefix.go
+++ b/cloudflare/resource_cloudflare_byo_ip_prefix.go
@@ -47,14 +47,14 @@ func resourceCloudflareBYOIPPrefixRead(ctx context.Context, d *schema.ResourceDa
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	prefix, err := client.GetPrefix(context.Background(), accountID, d.Id())
+	prefix, err := client.GetPrefix(ctx, accountID, d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error reading IP prefix information for %q", d.Id())))
 	}
 
 	d.Set("description", prefix.Description)
 
-	advertisementStatus, err := client.GetAdvertisementStatus(context.Background(), accountID, d.Id())
+	advertisementStatus, err := client.GetAdvertisementStatus(ctx, accountID, d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error reading advertisement status of IP prefix for %q", d.Id())))
 	}
@@ -69,13 +69,13 @@ func resourceCloudflareBYOIPPrefixUpdate(ctx context.Context, d *schema.Resource
 	accountID := d.Get("account_id").(string)
 
 	if _, ok := d.GetOk("description"); ok && d.HasChange("description") {
-		if _, err := client.UpdatePrefixDescription(context.Background(), accountID, d.Id(), d.Get("description").(string)); err != nil {
+		if _, err := client.UpdatePrefixDescription(ctx, accountID, d.Id(), d.Get("description").(string)); err != nil {
 			return diag.FromErr(errors.Wrap(err, fmt.Sprintf("cannot update prefix description for %q", d.Id())))
 		}
 	}
 
 	if _, ok := d.GetOk("advertisement"); ok && d.HasChange("advertisement") {
-		if _, err := client.UpdateAdvertisementStatus(context.Background(), accountID, d.Id(), boolFromString(d.Get("advertisement").(string))); err != nil {
+		if _, err := client.UpdateAdvertisementStatus(ctx, accountID, d.Id(), boolFromString(d.Get("advertisement").(string))); err != nil {
 			return diag.FromErr(errors.Wrap(err, fmt.Sprintf("cannot update prefix advertisement status for %q", d.Id())))
 		}
 	}

--- a/cloudflare/resource_cloudflare_certificate_pack.go
+++ b/cloudflare/resource_cloudflare_certificate_pack.go
@@ -17,9 +17,9 @@ import (
 func resourceCloudflareCertificatePack() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareCertificatePackSchema(),
-		Create: resourceCloudflareCertificatePackCreate,
-		Read:   resourceCloudflareCertificatePackRead,
-		Delete: resourceCloudflareCertificatePackDelete,
+		CreateContext: resourceCloudflareCertificatePackCreate,
+		ReadContext: resourceCloudflareCertificatePackRead,
+		DeleteContext: resourceCloudflareCertificatePackDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareCertificatePackImport,
 		},

--- a/cloudflare/resource_cloudflare_certificate_pack.go
+++ b/cloudflare/resource_cloudflare_certificate_pack.go
@@ -26,7 +26,7 @@ func resourceCloudflareCertificatePack() *schema.Resource {
 	}
 }
 
-func resourceCloudflareCertificatePackCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCertificatePackCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	certificatePackType := d.Get("type").(string)
@@ -49,7 +49,7 @@ func resourceCloudflareCertificatePackCreate(d *schema.ResourceData, meta interf
 		}
 		certPackResponse, err := client.CreateAdvancedCertificatePack(context.Background(), zoneID, cert)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("failed to create certificate pack: %s", err))
+			return err.Wrap(err, fmt.Sprintf("failed to create certificate pack: %s", err))
 		}
 		certificatePackID = certPackResponse.ID
 	} else {
@@ -59,7 +59,7 @@ func resourceCloudflareCertificatePackCreate(d *schema.ResourceData, meta interf
 		}
 		certPackResponse, err := client.CreateCertificatePack(context.Background(), zoneID, cert)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("failed to create certificate pack: %s", err))
+			return err.Wrap(err, fmt.Sprintf("failed to create certificate pack: %s", err))
 		}
 		certificatePackID = certPackResponse.ID
 	}
@@ -82,7 +82,7 @@ func resourceCloudflareCertificatePackCreate(d *schema.ResourceData, meta interf
 		})
 
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
@@ -91,13 +91,13 @@ func resourceCloudflareCertificatePackCreate(d *schema.ResourceData, meta interf
 	return resourceCloudflareCertificatePackRead(d, meta)
 }
 
-func resourceCloudflareCertificatePackRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCertificatePackRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
 	certificatePack, err := client.CertificatePack(context.Background(), zoneID, d.Id())
 	if err != nil {
-		return errors.Wrap(err, "failed to fetch certificate pack")
+		return err.Wrap(err, "failed to fetch certificate pack")
 	}
 
 	d.Set("type", certificatePack.Type)
@@ -130,13 +130,13 @@ func resourceCloudflareCertificatePackRead(d *schema.ResourceData, meta interfac
 	return nil
 }
 
-func resourceCloudflareCertificatePackDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCertificatePackDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
 	err := client.DeleteCertificatePack(context.Background(), zoneID, d.Id())
 	if err != nil {
-		return errors.Wrap(err, "failed to delete certificate pack")
+		return err.Wrap(err, "failed to delete certificate pack")
 	}
 
 	resourceCloudflareCertificatePackRead(d, meta)

--- a/cloudflare/resource_cloudflare_certificate_pack.go
+++ b/cloudflare/resource_cloudflare_certificate_pack.go
@@ -48,7 +48,7 @@ func resourceCloudflareCertificatePackCreate(ctx context.Context, d *schema.Reso
 			CertificateAuthority: ca,
 			CloudflareBranding:   cloudflareBranding,
 		}
-		certPackResponse, err := client.CreateAdvancedCertificatePack(context.Background(), zoneID, cert)
+		certPackResponse, err := client.CreateAdvancedCertificatePack(ctx, zoneID, cert)
 		if err != nil {
 			return diag.FromErr(errors.Wrap(err, fmt.Sprintf("failed to create certificate pack: %s", err)))
 		}
@@ -58,7 +58,7 @@ func resourceCloudflareCertificatePackCreate(ctx context.Context, d *schema.Reso
 			Type:  certificatePackType,
 			Hosts: expandInterfaceToStringList(certificateHostSet.List()),
 		}
-		certPackResponse, err := client.CreateCertificatePack(context.Background(), zoneID, cert)
+		certPackResponse, err := client.CreateCertificatePack(ctx, zoneID, cert)
 		if err != nil {
 			return diag.FromErr(errors.Wrap(err, fmt.Sprintf("failed to create certificate pack: %s", err)))
 		}
@@ -66,8 +66,8 @@ func resourceCloudflareCertificatePackCreate(ctx context.Context, d *schema.Reso
 	}
 
 	if d.Get("wait_for_active_status").(bool) {
-		err := resource.Retry(d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
-			certificatePack, err := client.CertificatePack(context.Background(), zoneID, certificatePackID)
+		err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
+			certificatePack, err := client.CertificatePack(ctx, zoneID, certificatePackID)
 			if err != nil {
 				return resource.NonRetryableError(errors.Wrap(err, "failed to fetch certificate pack"))
 			}
@@ -96,7 +96,7 @@ func resourceCloudflareCertificatePackRead(ctx context.Context, d *schema.Resour
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	certificatePack, err := client.CertificatePack(context.Background(), zoneID, d.Id())
+	certificatePack, err := client.CertificatePack(ctx, zoneID, d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "failed to fetch certificate pack"))
 	}
@@ -135,7 +135,7 @@ func resourceCloudflareCertificatePackDelete(ctx context.Context, d *schema.Reso
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	err := client.DeleteCertificatePack(context.Background(), zoneID, d.Id())
+	err := client.DeleteCertificatePack(ctx, zoneID, d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "failed to delete certificate pack"))
 	}

--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -84,7 +84,7 @@ func resourceCloudflareCustomHostnameRead(ctx context.Context, d *schema.Resourc
 	}
 
 	if err := d.Set("ssl", sslConfig); err != nil {
-		return fmt.Errorf("failed to set ssl")
+		return diag.FromErr(fmt.Errorf("failed to set ssl"))
 	}
 
 	ownershipVerificationCfg := map[string]interface{}{
@@ -93,7 +93,7 @@ func resourceCloudflareCustomHostnameRead(ctx context.Context, d *schema.Resourc
 		"name":  customHostname.OwnershipVerification.Name,
 	}
 	if err := d.Set("ownership_verification", ownershipVerificationCfg); err != nil {
-		return fmt.Errorf("failed to set ownership_verification: %v", err)
+		return diag.FromErr(fmt.Errorf("failed to set ownership_verification: %v", err))
 	}
 
 	ownershipVerificationHTTPCfg := map[string]interface{}{
@@ -101,7 +101,7 @@ func resourceCloudflareCustomHostnameRead(ctx context.Context, d *schema.Resourc
 		"http_url":  customHostname.OwnershipVerificationHTTP.HTTPUrl,
 	}
 	if err := d.Set("ownership_verification_http", ownershipVerificationHTTPCfg); err != nil {
-		return fmt.Errorf("failed to set ownership_verification_http: %v", err)
+		return diag.FromErr(fmt.Errorf("failed to set ownership_verification_http: %v", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -15,10 +15,10 @@ import (
 func resourceCloudflareCustomHostname() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareCustomHostnameSchema(),
-		Create: resourceCloudflareCustomHostnameCreate,
-		Read:   resourceCloudflareCustomHostnameRead,
-		Update: resourceCloudflareCustomHostnameUpdate,
-		Delete: resourceCloudflareCustomHostnameDelete,
+		CreateContext: resourceCloudflareCustomHostnameCreate,
+		ReadContext: resourceCloudflareCustomHostnameRead,
+		UpdateContext: resourceCloudflareCustomHostnameUpdate,
+		DeleteContext: resourceCloudflareCustomHostnameDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareCustomHostnameImport,
 		},

--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -25,14 +25,14 @@ func resourceCloudflareCustomHostname() *schema.Resource {
 	}
 }
 
-func resourceCloudflareCustomHostnameRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomHostnameRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	hostnameID := d.Id()
 
 	customHostname, err := client.CustomHostname(context.Background(), zoneID, hostnameID)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error reading custom hostname %q", hostnameID))
+		return err.Wrap(err, fmt.Sprintf("error reading custom hostname %q", hostnameID))
 	}
 
 	d.Set("hostname", customHostname.Hostname)
@@ -107,20 +107,20 @@ func resourceCloudflareCustomHostnameRead(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func resourceCloudflareCustomHostnameDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomHostnameDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	hostnameID := d.Id()
 
 	err := client.DeleteCustomHostname(context.Background(), zoneID, hostnameID)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete custom hostname certificate")
+		return err.Wrap(err, "failed to delete custom hostname certificate")
 	}
 
 	return nil
 }
 
-func resourceCloudflareCustomHostnameCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomHostnameCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -128,7 +128,7 @@ func resourceCloudflareCustomHostnameCreate(d *schema.ResourceData, meta interfa
 
 	newCertificate, err := client.CreateCustomHostname(context.Background(), zoneID, certificate)
 	if err != nil {
-		return errors.Wrap(err, "failed to create custom hostname certificate")
+		return err.Wrap(err, "failed to create custom hostname certificate")
 	}
 
 	d.SetId(newCertificate.Result.ID)
@@ -136,7 +136,7 @@ func resourceCloudflareCustomHostnameCreate(d *schema.ResourceData, meta interfa
 	return resourceCloudflareCustomHostnameRead(d, meta)
 }
 
-func resourceCloudflareCustomHostnameUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomHostnameUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	hostnameID := d.Id()
@@ -144,7 +144,7 @@ func resourceCloudflareCustomHostnameUpdate(d *schema.ResourceData, meta interfa
 
 	_, err := client.UpdateCustomHostname(context.Background(), zoneID, hostnameID, certificate)
 	if err != nil {
-		return errors.Wrap(err, "failed to update custom hostname certificate")
+		return err.Wrap(err, "failed to update custom hostname certificate")
 	}
 
 	return resourceCloudflareCustomHostnameRead(d, meta)

--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -94,7 +94,7 @@ func resourceCloudflareCustomHostnameRead(ctx context.Context, d *schema.Resourc
 		"name":  customHostname.OwnershipVerification.Name,
 	}
 	if err := d.Set("ownership_verification", ownershipVerificationCfg); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set ownership_verification: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to set ownership_verification: %w", err))
 	}
 
 	ownershipVerificationHTTPCfg := map[string]interface{}{
@@ -102,7 +102,7 @@ func resourceCloudflareCustomHostnameRead(ctx context.Context, d *schema.Resourc
 		"http_url":  customHostname.OwnershipVerificationHTTP.HTTPUrl,
 	}
 	if err := d.Set("ownership_verification_http", ownershipVerificationHTTPCfg); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set ownership_verification_http: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to set ownership_verification_http: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -31,7 +31,7 @@ func resourceCloudflareCustomHostnameRead(ctx context.Context, d *schema.Resourc
 	zoneID := d.Get("zone_id").(string)
 	hostnameID := d.Id()
 
-	customHostname, err := client.CustomHostname(context.Background(), zoneID, hostnameID)
+	customHostname, err := client.CustomHostname(ctx, zoneID, hostnameID)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error reading custom hostname %q", hostnameID)))
 	}
@@ -113,7 +113,7 @@ func resourceCloudflareCustomHostnameDelete(ctx context.Context, d *schema.Resou
 	zoneID := d.Get("zone_id").(string)
 	hostnameID := d.Id()
 
-	err := client.DeleteCustomHostname(context.Background(), zoneID, hostnameID)
+	err := client.DeleteCustomHostname(ctx, zoneID, hostnameID)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "failed to delete custom hostname certificate"))
 	}
@@ -127,7 +127,7 @@ func resourceCloudflareCustomHostnameCreate(ctx context.Context, d *schema.Resou
 
 	certificate := buildCustomHostname(d)
 
-	newCertificate, err := client.CreateCustomHostname(context.Background(), zoneID, certificate)
+	newCertificate, err := client.CreateCustomHostname(ctx, zoneID, certificate)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "failed to create custom hostname certificate"))
 	}
@@ -143,7 +143,7 @@ func resourceCloudflareCustomHostnameUpdate(ctx context.Context, d *schema.Resou
 	hostnameID := d.Id()
 	certificate := buildCustomHostname(d)
 
-	_, err := client.UpdateCustomHostname(context.Background(), zoneID, hostnameID, certificate)
+	_, err := client.UpdateCustomHostname(ctx, zoneID, hostnameID, certificate)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "failed to update custom hostname certificate"))
 	}

--- a/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
@@ -15,10 +15,10 @@ import (
 func resourceCloudflareCustomHostnameFallbackOrigin() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareCustomHostnameFallbackOriginSchema(),
-		Create: resourceCloudflareCustomHostnameFallbackOriginCreate,
-		Read:   resourceCloudflareCustomHostnameFallbackOriginRead,
-		Update: resourceCloudflareCustomHostnameFallbackOriginUpdate,
-		Delete: resourceCloudflareCustomHostnameFallbackOriginDelete,
+		CreateContext: resourceCloudflareCustomHostnameFallbackOriginCreate,
+		ReadContext: resourceCloudflareCustomHostnameFallbackOriginRead,
+		UpdateContext: resourceCloudflareCustomHostnameFallbackOriginUpdate,
+		DeleteContext: resourceCloudflareCustomHostnameFallbackOriginDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareCustomHostnameFallbackOriginImport,
 		},

--- a/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
@@ -31,7 +31,7 @@ func resourceCloudflareCustomHostnameFallbackOriginRead(ctx context.Context, d *
 
 	customHostnameFallbackOrigin, err := client.CustomHostnameFallbackOrigin(context.Background(), zoneID)
 	if err != nil {
-		return fmt.Errorf("error reading custom hostname fallback origin %q: %w", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error reading custom hostname fallback origin %q: %w", zoneID, err))
 	}
 
 	d.Set("origin", customHostnameFallbackOrigin.Origin)
@@ -46,7 +46,7 @@ func resourceCloudflareCustomHostnameFallbackOriginDelete(ctx context.Context, d
 
 	err := client.DeleteCustomHostnameFallbackOrigin(context.Background(), zoneID)
 	if err != nil {
-		return fmt.Errorf("failed to delete custom hostname fallback origin: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to delete custom hostname fallback origin: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
@@ -25,7 +25,7 @@ func resourceCloudflareCustomHostnameFallbackOrigin() *schema.Resource {
 	}
 }
 
-func resourceCloudflareCustomHostnameFallbackOriginRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomHostnameFallbackOriginRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -40,7 +40,7 @@ func resourceCloudflareCustomHostnameFallbackOriginRead(d *schema.ResourceData, 
 	return nil
 }
 
-func resourceCloudflareCustomHostnameFallbackOriginDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomHostnameFallbackOriginDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -52,7 +52,7 @@ func resourceCloudflareCustomHostnameFallbackOriginDelete(d *schema.ResourceData
 	return nil
 }
 
-func resourceCloudflareCustomHostnameFallbackOriginCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomHostnameFallbackOriginCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	origin := d.Get("origin").(string)
@@ -94,7 +94,7 @@ func resourceCloudflareCustomHostnameFallbackOriginCreate(d *schema.ResourceData
 
 }
 
-func resourceCloudflareCustomHostnameFallbackOriginUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomHostnameFallbackOriginUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	origin := d.Get("origin").(string)

--- a/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
@@ -98,7 +98,6 @@ func resourceCloudflareCustomHostnameFallbackOriginCreate(ctx context.Context, d
 	}
 
 	return nil
-
 }
 
 func resourceCloudflareCustomHostnameFallbackOriginUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_fallback_origin.go
@@ -30,7 +30,7 @@ func resourceCloudflareCustomHostnameFallbackOriginRead(ctx context.Context, d *
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	customHostnameFallbackOrigin, err := client.CustomHostnameFallbackOrigin(context.Background(), zoneID)
+	customHostnameFallbackOrigin, err := client.CustomHostnameFallbackOrigin(ctx, zoneID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error reading custom hostname fallback origin %q: %w", zoneID, err))
 	}
@@ -45,7 +45,7 @@ func resourceCloudflareCustomHostnameFallbackOriginDelete(ctx context.Context, d
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	err := client.DeleteCustomHostnameFallbackOrigin(context.Background(), zoneID)
+	err := client.DeleteCustomHostnameFallbackOrigin(ctx, zoneID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to delete custom hostname fallback origin: %w", err))
 	}
@@ -63,7 +63,7 @@ func resourceCloudflareCustomHostnameFallbackOriginCreate(ctx context.Context, d
 	}
 
 	retry := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDefault), func() *resource.RetryError {
-		_, err := client.UpdateCustomHostnameFallbackOrigin(context.Background(), zoneID, fallbackOrigin)
+		_, err := client.UpdateCustomHostnameFallbackOrigin(ctx, zoneID, fallbackOrigin)
 		if err != nil {
 			var requestError *cloudflare.RequestError
 			if errors.As(err, &requestError) && sliceContainsInt(requestError.ErrorCodes(), 1414) {
@@ -73,7 +73,7 @@ func resourceCloudflareCustomHostnameFallbackOriginCreate(ctx context.Context, d
 			}
 		}
 
-		fallbackHostname, err := client.CustomHostnameFallbackOrigin(context.Background(), zoneID)
+		fallbackHostname, err := client.CustomHostnameFallbackOrigin(ctx, zoneID)
 
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("failed to fetch custom hostname: %w", err))
@@ -111,7 +111,7 @@ func resourceCloudflareCustomHostnameFallbackOriginUpdate(ctx context.Context, d
 	}
 
 	retry := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDefault), func() *resource.RetryError {
-		_, err := client.UpdateCustomHostnameFallbackOrigin(context.Background(), zoneID, fallbackOrigin)
+		_, err := client.UpdateCustomHostnameFallbackOrigin(ctx, zoneID, fallbackOrigin)
 		if err != nil {
 			var requestError *cloudflare.RequestError
 			if errors.As(err, &requestError) && sliceContainsInt(requestError.ErrorCodes(), 1414) {

--- a/cloudflare/resource_cloudflare_custom_pages.go
+++ b/cloudflare/resource_cloudflare_custom_pages.go
@@ -48,7 +48,7 @@ func resourceCloudflareCustomPagesRead(ctx context.Context, d *schema.ResourceDa
 		identifier = zoneID
 	}
 
-	page, err := client.CustomPage(context.Background(), &pageOptions, pageType)
+	page, err := client.CustomPage(ctx, &pageOptions, pageType)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -89,7 +89,7 @@ func resourceCloudflareCustomPagesUpdate(ctx context.Context, d *schema.Resource
 		URL:   d.Get("url").(string),
 		State: "customized",
 	}
-	_, err := client.UpdateCustomPage(context.Background(), &pageOptions, pageType, customPageParameters)
+	_, err := client.UpdateCustomPage(ctx, &pageOptions, pageType, customPageParameters)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("failed to update '%s' custom page", pageType)))
 	}
@@ -114,7 +114,7 @@ func resourceCloudflareCustomPagesDelete(ctx context.Context, d *schema.Resource
 		URL:   nil,
 		State: "default",
 	}
-	_, err := client.UpdateCustomPage(context.Background(), &pageOptions, pageType, customPageParameters)
+	_, err := client.UpdateCustomPage(ctx, &pageOptions, pageType, customPageParameters)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("failed to update '%s' custom page", pageType)))
 	}

--- a/cloudflare/resource_cloudflare_custom_pages.go
+++ b/cloudflare/resource_cloudflare_custom_pages.go
@@ -31,7 +31,7 @@ func resourceCloudflareCustomPagesRead(ctx context.Context, d *schema.ResourceDa
 	pageType := d.Get("type").(string)
 
 	if accountID == "" && zoneID == "" {
-		return fmt.Errorf("either `account_id` or `zone_id` must be set")
+		return diag.FromErr(fmt.Errorf("either `account_id` or `zone_id` must be set"))
 	}
 
 	var (

--- a/cloudflare/resource_cloudflare_custom_pages.go
+++ b/cloudflare/resource_cloudflare_custom_pages.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareCustomPages() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareCustomPagesSchema(),
-		Create: resourceCloudflareCustomPagesUpdate,
-		Read:   resourceCloudflareCustomPagesRead,
-		Update: resourceCloudflareCustomPagesUpdate,
-		Delete: resourceCloudflareCustomPagesDelete,
+		CreateContext: resourceCloudflareCustomPagesUpdate,
+		ReadContext: resourceCloudflareCustomPagesRead,
+		UpdateContext: resourceCloudflareCustomPagesUpdate,
+		DeleteContext: resourceCloudflareCustomPagesDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareCustomPagesImport,
 		},

--- a/cloudflare/resource_cloudflare_custom_pages.go
+++ b/cloudflare/resource_cloudflare_custom_pages.go
@@ -24,7 +24,7 @@ func resourceCloudflareCustomPages() *schema.Resource {
 	}
 }
 
-func resourceCloudflareCustomPagesRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomPagesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	accountID := d.Get("account_id").(string)
@@ -49,7 +49,7 @@ func resourceCloudflareCustomPagesRead(d *schema.ResourceData, meta interface{})
 
 	page, err := client.CustomPage(context.Background(), &pageOptions, pageType)
 	if err != nil {
-		return errors.New(err.Error())
+		return diag.FromErr(err)ors.New(err.Error())
 	}
 
 	// If the `page.State` comes back as "default", it's safe to assume we
@@ -71,7 +71,7 @@ func resourceCloudflareCustomPagesRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceCloudflareCustomPagesUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomPagesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	zoneID := d.Get("zone_id").(string)
@@ -90,13 +90,13 @@ func resourceCloudflareCustomPagesUpdate(d *schema.ResourceData, meta interface{
 	}
 	_, err := client.UpdateCustomPage(context.Background(), &pageOptions, pageType, customPageParameters)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to update '%s' custom page", pageType))
+		return err.Wrap(err, fmt.Sprintf("failed to update '%s' custom page", pageType))
 	}
 
 	return resourceCloudflareCustomPagesRead(d, meta)
 }
 
-func resourceCloudflareCustomPagesDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomPagesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	zoneID := d.Get("zone_id").(string)
@@ -115,7 +115,7 @@ func resourceCloudflareCustomPagesDelete(d *schema.ResourceData, meta interface{
 	}
 	_, err := client.UpdateCustomPage(context.Background(), &pageOptions, pageType, customPageParameters)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to update '%s' custom page", pageType))
+		return err.Wrap(err, fmt.Sprintf("failed to update '%s' custom page", pageType))
 	}
 
 	return resourceCloudflareCustomPagesRead(d, meta)

--- a/cloudflare/resource_cloudflare_custom_ssl.go
+++ b/cloudflare/resource_cloudflare_custom_ssl.go
@@ -17,10 +17,10 @@ import (
 
 func resourceCloudflareCustomSsl() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudflareCustomSslCreate,
-		Read:   resourceCloudflareCustomSslRead,
-		Update: resourceCloudflareCustomSslUpdate,
-		Delete: resourceCloudflareCustomSslDelete,
+		CreateContext: resourceCloudflareCustomSslCreate,
+		ReadContext: resourceCloudflareCustomSslRead,
+		UpdateContext: resourceCloudflareCustomSslUpdate,
+		DeleteContext: resourceCloudflareCustomSslDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareCustomSslImport,
 		},

--- a/cloudflare/resource_cloudflare_custom_ssl.go
+++ b/cloudflare/resource_cloudflare_custom_ssl.go
@@ -39,7 +39,7 @@ func resourceCloudflareCustomSsl() *schema.Resource {
 	}
 }
 
-func resourceCloudflareCustomSslCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomSslCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	log.Printf("[DEBUG] zone ID: %s", zoneID)
@@ -74,7 +74,7 @@ func resourceCloudflareCustomSslCreate(d *schema.ResourceData, meta interface{})
 	})
 }
 
-func resourceCloudflareCustomSslUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomSslUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	certID := d.Id()
@@ -122,7 +122,7 @@ func resourceCloudflareCustomSslUpdate(d *schema.ResourceData, meta interface{})
 	return resourceCloudflareCustomSslRead(d, meta)
 }
 
-func resourceCloudflareCustomSslRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomSslRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	certID := d.Id()
@@ -156,7 +156,7 @@ func resourceCloudflareCustomSslRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceCloudflareCustomSslDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareCustomSslDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	certID := d.Id()

--- a/cloudflare/resource_cloudflare_custom_ssl.go
+++ b/cloudflare/resource_cloudflare_custom_ssl.go
@@ -45,16 +45,16 @@ func resourceCloudflareCustomSslCreate(ctx context.Context, d *schema.ResourceDa
 	log.Printf("[DEBUG] zone ID: %s", zoneID)
 	zcso, err := expandToZoneCustomSSLOptions(d)
 	if err != nil {
-		return fmt.Errorf("failed to create custom ssl cert: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to create custom ssl cert: %s", err))
 	}
 
 	res, err := client.CreateSSL(context.Background(), zoneID, zcso)
 	if err != nil {
-		return fmt.Errorf("failed to create custom ssl cert: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to create custom ssl cert: %s", err))
 	}
 
 	if res.ID == "" {
-		return fmt.Errorf("failed to find custom ssl in Create response: id was empty")
+		return diag.FromErr(fmt.Errorf("failed to find custom ssl in Create response: id was empty"))
 	}
 
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
@@ -87,7 +87,7 @@ func resourceCloudflareCustomSslUpdate(ctx context.Context, d *schema.ResourceDa
 	if d.HasChange("custom_ssl_options") {
 		zcso, err := expandToZoneCustomSSLOptions(d)
 		if err != nil {
-			return fmt.Errorf("failed to update custom ssl cert: %s", err)
+			return diag.FromErr(fmt.Errorf("failed to update custom ssl cert: %s", err))
 		}
 
 		res, uErr := client.UpdateSSL(context.Background(), zoneID, certID, zcso)
@@ -116,7 +116,7 @@ func resourceCloudflareCustomSslUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if updateErr && reprioritizeErr {
-		return fmt.Errorf("failed to update and reprioritize custom ssl cert: %s, %s", uErr, reErr)
+		return diag.FromErr(fmt.Errorf("failed to update and reprioritize custom ssl cert: %s, %s", uErr, reErr))
 	}
 
 	return resourceCloudflareCustomSslRead(d, meta)
@@ -146,7 +146,7 @@ func resourceCloudflareCustomSslRead(ctx context.Context, d *schema.ResourceData
 	d.Set("issuer", record.Issuer)
 	d.Set("signature", record.Signature)
 	if err := d.Set("custom_ssl_options", []interface{}{customSslOpts}); err != nil {
-		return fmt.Errorf("[WARN] Error reading custom ssl opts %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("[WARN] Error reading custom ssl opts %q: %s", d.Id(), err))
 	}
 	d.Set("status", record.Status)
 	d.Set("uploaded_on", record.UploadedOn.Format(time.RFC3339Nano))

--- a/cloudflare/resource_cloudflare_custom_ssl.go
+++ b/cloudflare/resource_cloudflare_custom_ssl.go
@@ -49,7 +49,7 @@ func resourceCloudflareCustomSslCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(fmt.Errorf("failed to create custom ssl cert: %s", err))
 	}
 
-	res, err := client.CreateSSL(context.Background(), zoneID, zcso)
+	res, err := client.CreateSSL(ctx, zoneID, zcso)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to create custom ssl cert: %s", err))
 	}
@@ -59,7 +59,7 @@ func resourceCloudflareCustomSslCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	retry := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		cert, err := client.SSLDetails(context.Background(), zoneID, res.ID)
+		cert, err := client.SSLDetails(ctx, zoneID, res.ID)
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("failed to fetch custom ssl cert: %s", err))
 		}
@@ -97,7 +97,7 @@ func resourceCloudflareCustomSslUpdate(ctx context.Context, d *schema.ResourceDa
 			return diag.FromErr(fmt.Errorf("failed to update custom ssl cert: %s", err))
 		}
 
-		res, uErr := client.UpdateSSL(context.Background(), zoneID, certID, zcso)
+		res, uErr := client.UpdateSSL(ctx, zoneID, certID, zcso)
 		if uErr != nil {
 			log.Printf("[DEBUG] Failed to update custom ssl cert: %s", uErr)
 			updateErr = true
@@ -113,7 +113,7 @@ func resourceCloudflareCustomSslUpdate(ctx context.Context, d *schema.ResourceDa
 			log.Printf("Failed to update custom ssl cert: %s", err)
 		}
 
-		resList, reErr := client.ReprioritizeSSL(context.Background(), zoneID, zcsp)
+		resList, reErr := client.ReprioritizeSSL(ctx, zoneID, zcsp)
 		if err != nil {
 			log.Printf("Failed to update / reprioritize custom ssl cert: %s", reErr)
 			reprioritizeErr = true
@@ -135,7 +135,7 @@ func resourceCloudflareCustomSslRead(ctx context.Context, d *schema.ResourceData
 	certID := d.Id()
 
 	// update all possible schema attributes with fields from api response
-	record, err := client.SSLDetails(context.Background(), zoneID, certID)
+	record, err := client.SSLDetails(ctx, zoneID, certID)
 	if err != nil {
 		log.Printf("[WARN] Removing record from state because it's not found in API")
 		d.SetId("")
@@ -170,7 +170,7 @@ func resourceCloudflareCustomSslDelete(ctx context.Context, d *schema.ResourceDa
 
 	log.Printf("[DEBUG] Deleting SSL cert %s for zone %s", certID, zoneID)
 
-	err := client.DeleteSSL(context.Background(), zoneID, certID)
+	err := client.DeleteSSL(ctx, zoneID, certID)
 	if err != nil {
 		errors.Wrap(err, "failed to delete custom ssl cert setting")
 	}

--- a/cloudflare/resource_cloudflare_device_policy.go
+++ b/cloudflare/resource_cloudflare_device_policy.go
@@ -12,10 +12,10 @@ import (
 func resourceCloudflareDevicePolicyCertificates() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareDevicePolicyCertificatesSchema(),
-		Create: resourceCloudflareDevicePolicyCertificateUpdate,
-		Read:   resourceCloudflareDevicePolicyCertificateRead,
-		Update: resourceCloudflareDevicePolicyCertificateUpdate,
-		Delete: resourceCloudflareDevicePolicyCertificateDelete,
+		CreateContext: resourceCloudflareDevicePolicyCertificateUpdate,
+		ReadContext: resourceCloudflareDevicePolicyCertificateRead,
+		UpdateContext: resourceCloudflareDevicePolicyCertificateUpdate,
+		DeleteContext: resourceCloudflareDevicePolicyCertificateDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareDevicePolicyCertificateImport,
 		},

--- a/cloudflare/resource_cloudflare_device_policy.go
+++ b/cloudflare/resource_cloudflare_device_policy.go
@@ -30,7 +30,7 @@ func resourceCloudflareDevicePolicyCertificateUpdate(ctx context.Context, d *sch
 
 	log.Printf("[DEBUG] Updating Cloudflare device policy certificate: zoneID=%s enabled=%t", zoneID, enabled)
 
-	_, err := client.UpdateDeviceClientCertificatesZone(context.Background(), zoneID, enabled)
+	_, err := client.UpdateDeviceClientCertificatesZone(ctx, zoneID, enabled)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Cloudflare device policy certificate %q: %w", zoneID, err))
 	}
@@ -43,7 +43,7 @@ func resourceCloudflareDevicePolicyCertificateRead(ctx context.Context, d *schem
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	enabled, err := client.GetDeviceClientCertificatesZone(context.Background(), zoneID)
+	enabled, err := client.GetDeviceClientCertificatesZone(ctx, zoneID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error reading device policy certificate setting %q: %w", zoneID, err))
 	}

--- a/cloudflare/resource_cloudflare_device_policy.go
+++ b/cloudflare/resource_cloudflare_device_policy.go
@@ -31,7 +31,7 @@ func resourceCloudflareDevicePolicyCertificateUpdate(ctx context.Context, d *sch
 
 	_, err := client.UpdateDeviceClientCertificatesZone(context.Background(), zoneID, enabled)
 	if err != nil {
-		return fmt.Errorf("error updating Cloudflare device policy certificate %q: %w", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error updating Cloudflare device policy certificate %q: %w", zoneID, err))
 	}
 
 	d.SetId(zoneID)
@@ -44,7 +44,7 @@ func resourceCloudflareDevicePolicyCertificateRead(ctx context.Context, d *schem
 
 	enabled, err := client.GetDeviceClientCertificatesZone(context.Background(), zoneID)
 	if err != nil {
-		return fmt.Errorf("error reading device policy certificate setting %q: %w", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error reading device policy certificate setting %q: %w", zoneID, err))
 	}
 
 	d.SetId(zoneID)

--- a/cloudflare/resource_cloudflare_device_policy.go
+++ b/cloudflare/resource_cloudflare_device_policy.go
@@ -22,7 +22,7 @@ func resourceCloudflareDevicePolicyCertificates() *schema.Resource {
 	}
 }
 
-func resourceCloudflareDevicePolicyCertificateUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareDevicePolicyCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	enabled := d.Get("enabled").(bool)
@@ -38,7 +38,7 @@ func resourceCloudflareDevicePolicyCertificateUpdate(d *schema.ResourceData, met
 	return nil
 }
 
-func resourceCloudflareDevicePolicyCertificateRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareDevicePolicyCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -63,6 +63,6 @@ func resourceCloudflareDevicePolicyCertificateImport(d *schema.ResourceData, met
 	return []*schema.ResourceData{d}, err
 }
 
-func resourceCloudflareDevicePolicyCertificateDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareDevicePolicyCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }

--- a/cloudflare/resource_cloudflare_device_policy.go
+++ b/cloudflare/resource_cloudflare_device_policy.go
@@ -6,18 +6,19 @@ import (
 	"log"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareDevicePolicyCertificates() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareDevicePolicyCertificatesSchema(),
+		Schema:        resourceCloudflareDevicePolicyCertificatesSchema(),
 		CreateContext: resourceCloudflareDevicePolicyCertificateUpdate,
-		ReadContext: resourceCloudflareDevicePolicyCertificateRead,
+		ReadContext:   resourceCloudflareDevicePolicyCertificateRead,
 		UpdateContext: resourceCloudflareDevicePolicyCertificateUpdate,
 		DeleteContext: resourceCloudflareDevicePolicyCertificateDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareDevicePolicyCertificateImport,
+			StateContext: resourceCloudflareDevicePolicyCertificateImport,
 		},
 	}
 }
@@ -52,15 +53,17 @@ func resourceCloudflareDevicePolicyCertificateRead(ctx context.Context, d *schem
 	return nil
 }
 
-func resourceCloudflareDevicePolicyCertificateImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareDevicePolicyCertificateImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	zoneID := d.Id()
 
 	log.Printf("[DEBUG] Importing Cloudflare device policy certificate setting: zoneID=%s", zoneID)
 
 	d.SetId(zoneID)
 	d.Set("zone_id", zoneID)
-	err := resourceCloudflareDevicePolicyCertificateRead(d, meta)
-	return []*schema.ResourceData{d}, err
+
+	resourceCloudflareDevicePolicyCertificateRead(ctx, d, meta)
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceCloudflareDevicePolicyCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/cloudflare/resource_cloudflare_device_posture_integration.go
+++ b/cloudflare/resource_cloudflare_device_posture_integration.go
@@ -25,7 +25,7 @@ func resourceCloudflareDevicePostureIntegration() *schema.Resource {
 	}
 }
 
-func resourceCloudflareDevicePostureIntegrationCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareDevicePostureIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -54,7 +54,7 @@ func resourceCloudflareDevicePostureIntegrationCreate(d *schema.ResourceData, me
 	return devicePostureIntegrationReadHelper(d, meta, savedSecret)
 }
 
-func resourceCloudflareDevicePostureIntegrationRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareDevicePostureIntegrationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Client secret is always read from the local state.
 	secret, _ := d.Get("config.0.client_secret").(string)
 	return devicePostureIntegrationReadHelper(d, meta, secret)
@@ -83,7 +83,7 @@ func devicePostureIntegrationReadHelper(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceCloudflareDevicePostureIntegrationUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareDevicePostureIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -113,7 +113,7 @@ func resourceCloudflareDevicePostureIntegrationUpdate(d *schema.ResourceData, me
 	return resourceCloudflareDevicePostureIntegrationRead(d, meta)
 }
 
-func resourceCloudflareDevicePostureIntegrationDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareDevicePostureIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	appID := d.Id()
 	accountID := d.Get("account_id").(string)

--- a/cloudflare/resource_cloudflare_device_posture_integration.go
+++ b/cloudflare/resource_cloudflare_device_posture_integration.go
@@ -38,7 +38,7 @@ func resourceCloudflareDevicePostureIntegrationCreate(ctx context.Context, d *sc
 
 	err := setDevicePostureIntegrationConfig(&newDevicePostureIntegration, d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Device Posture integration with provided config: %s", err))
+		return diag.FromErr(fmt.Errorf("error creating Device Posture integration with provided config: %w", err))
 	}
 	log.Printf("[DEBUG] Creating Cloudflare Device Posture Integration from struct: %+v\n", newDevicePostureIntegration)
 
@@ -47,7 +47,7 @@ func resourceCloudflareDevicePostureIntegrationCreate(ctx context.Context, d *sc
 
 	newDevicePostureIntegration, err = client.CreateDevicePostureIntegration(ctx, accountID, newDevicePostureIntegration)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule for account %q: %s %+v", accountID, err, newDevicePostureIntegration))
+		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule for account %q: %w %+v", accountID, err, newDevicePostureIntegration))
 	}
 
 	d.SetId(newDevicePostureIntegration.IntegrationID)
@@ -72,7 +72,7 @@ func devicePostureIntegrationReadHelper(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding device posture integration %q: %s", d.Id(), err)
+		return fmt.Errorf("error finding device posture integration %q: %w", d.Id(), err)
 	}
 
 	devicePostureIntegration.Config.ClientSecret = secret
@@ -97,14 +97,14 @@ func resourceCloudflareDevicePostureIntegrationUpdate(ctx context.Context, d *sc
 
 	err := setDevicePostureIntegrationConfig(&updatedDevicePostureIntegration, d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule with provided match input: %s", err))
+		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule with provided match input: %w", err))
 	}
 
 	log.Printf("[DEBUG] Updating Cloudflare device posture integration from struct: %+v", updatedDevicePostureIntegration)
 
 	devicePostureIntegration, err := client.UpdateDevicePostureIntegration(ctx, accountID, updatedDevicePostureIntegration)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating device posture integration for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error updating device posture integration for account %q: %w", accountID, err))
 	}
 
 	if devicePostureIntegration.IntegrationID == "" {
@@ -123,7 +123,7 @@ func resourceCloudflareDevicePostureIntegrationDelete(ctx context.Context, d *sc
 
 	err := client.DeleteDevicePostureIntegration(ctx, accountID, appID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Device Posture Rule for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error deleting Device Posture Rule for account %q: %w", accountID, err))
 	}
 
 	resourceCloudflareDevicePostureIntegrationRead(ctx, d, meta)

--- a/cloudflare/resource_cloudflare_device_posture_integration.go
+++ b/cloudflare/resource_cloudflare_device_posture_integration.go
@@ -15,10 +15,10 @@ const ws1 = "workspace_one"
 func resourceCloudflareDevicePostureIntegration() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareDevicePostureIntegrationSchema(),
-		Create: resourceCloudflareDevicePostureIntegrationCreate,
-		Read:   resourceCloudflareDevicePostureIntegrationRead,
-		Update: resourceCloudflareDevicePostureIntegrationUpdate,
-		Delete: resourceCloudflareDevicePostureIntegrationDelete,
+		CreateContext: resourceCloudflareDevicePostureIntegrationCreate,
+		ReadContext: resourceCloudflareDevicePostureIntegrationRead,
+		UpdateContext: resourceCloudflareDevicePostureIntegrationUpdate,
+		DeleteContext: resourceCloudflareDevicePostureIntegrationDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareDevicePostureIntegrationImport,
 		},

--- a/cloudflare/resource_cloudflare_device_posture_integration.go
+++ b/cloudflare/resource_cloudflare_device_posture_integration.go
@@ -45,7 +45,7 @@ func resourceCloudflareDevicePostureIntegrationCreate(ctx context.Context, d *sc
 	// The API does not return the client_secret so it must be stored in the state func on resource create.
 	savedSecret := newDevicePostureIntegration.Config.ClientSecret
 
-	newDevicePostureIntegration, err = client.CreateDevicePostureIntegration(context.Background(), accountID, newDevicePostureIntegration)
+	newDevicePostureIntegration, err = client.CreateDevicePostureIntegration(ctx, accountID, newDevicePostureIntegration)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule for account %q: %s %+v", accountID, err, newDevicePostureIntegration))
 	}
@@ -65,7 +65,7 @@ func devicePostureIntegrationReadHelper(ctx context.Context, d *schema.ResourceD
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	devicePostureIntegration, err := client.DevicePostureIntegration(context.Background(), accountID, d.Id())
+	devicePostureIntegration, err := client.DevicePostureIntegration(ctx, accountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[INFO] Device posture integration %s no longer exists", d.Id())
@@ -102,7 +102,7 @@ func resourceCloudflareDevicePostureIntegrationUpdate(ctx context.Context, d *sc
 
 	log.Printf("[DEBUG] Updating Cloudflare device posture integration from struct: %+v", updatedDevicePostureIntegration)
 
-	devicePostureIntegration, err := client.UpdateDevicePostureIntegration(context.Background(), accountID, updatedDevicePostureIntegration)
+	devicePostureIntegration, err := client.UpdateDevicePostureIntegration(ctx, accountID, updatedDevicePostureIntegration)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating device posture integration for account %q: %s", accountID, err))
 	}
@@ -121,7 +121,7 @@ func resourceCloudflareDevicePostureIntegrationDelete(ctx context.Context, d *sc
 
 	log.Printf("[DEBUG] Deleting Cloudflare device posture integration using ID: %s", appID)
 
-	err := client.DeleteDevicePostureIntegration(context.Background(), accountID, appID)
+	err := client.DeleteDevicePostureIntegration(ctx, accountID, appID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Device Posture Rule for account %q: %s", accountID, err))
 	}

--- a/cloudflare/resource_cloudflare_device_posture_integration.go
+++ b/cloudflare/resource_cloudflare_device_posture_integration.go
@@ -37,7 +37,7 @@ func resourceCloudflareDevicePostureIntegrationCreate(ctx context.Context, d *sc
 
 	err := setDevicePostureIntegrationConfig(&newDevicePostureIntegration, d)
 	if err != nil {
-		return fmt.Errorf("error creating Device Posture integration with provided config: %s", err)
+		return diag.FromErr(fmt.Errorf("error creating Device Posture integration with provided config: %s", err))
 	}
 	log.Printf("[DEBUG] Creating Cloudflare Device Posture Integration from struct: %+v\n", newDevicePostureIntegration)
 
@@ -46,7 +46,7 @@ func resourceCloudflareDevicePostureIntegrationCreate(ctx context.Context, d *sc
 
 	newDevicePostureIntegration, err = client.CreateDevicePostureIntegration(context.Background(), accountID, newDevicePostureIntegration)
 	if err != nil {
-		return fmt.Errorf("error creating Device Posture Rule for account %q: %s %+v", accountID, err, newDevicePostureIntegration)
+		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule for account %q: %s %+v", accountID, err, newDevicePostureIntegration))
 	}
 
 	d.SetId(newDevicePostureIntegration.IntegrationID)
@@ -71,7 +71,7 @@ func devicePostureIntegrationReadHelper(d *schema.ResourceData, meta interface{}
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding device posture integration %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding device posture integration %q: %s", d.Id(), err))
 	}
 
 	devicePostureIntegration.Config.ClientSecret = secret
@@ -96,18 +96,18 @@ func resourceCloudflareDevicePostureIntegrationUpdate(ctx context.Context, d *sc
 
 	err := setDevicePostureIntegrationConfig(&updatedDevicePostureIntegration, d)
 	if err != nil {
-		return fmt.Errorf("error creating Device Posture Rule with provided match input: %s", err)
+		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule with provided match input: %s", err))
 	}
 
 	log.Printf("[DEBUG] Updating Cloudflare device posture integration from struct: %+v", updatedDevicePostureIntegration)
 
 	devicePostureIntegration, err := client.UpdateDevicePostureIntegration(context.Background(), accountID, updatedDevicePostureIntegration)
 	if err != nil {
-		return fmt.Errorf("error updating device posture integration for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error updating device posture integration for account %q: %s", accountID, err))
 	}
 
 	if devicePostureIntegration.IntegrationID == "" {
-		return fmt.Errorf("failed to find device posture integration_id in update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find device posture integration_id in update response; resource was empty"))
 	}
 
 	return resourceCloudflareDevicePostureIntegrationRead(d, meta)
@@ -122,7 +122,7 @@ func resourceCloudflareDevicePostureIntegrationDelete(ctx context.Context, d *sc
 
 	err := client.DeleteDevicePostureIntegration(context.Background(), accountID, appID)
 	if err != nil {
-		return fmt.Errorf("error deleting Device Posture Rule for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error deleting Device Posture Rule for account %q: %s", accountID, err))
 	}
 
 	resourceCloudflareDevicePostureIntegrationRead(d, meta)
@@ -155,20 +155,20 @@ func setDevicePostureIntegrationConfig(integration *cloudflare.DevicePostureInte
 		switch integration.Type {
 		case ws1:
 			if config.ClientID, ok = d.Get("config.0.client_id").(string); !ok {
-				return fmt.Errorf("client_id is a string")
+				return diag.FromErr(fmt.Errorf("client_id is a string"))
 			}
 			if config.ClientSecret, ok = d.Get("config.0.client_secret").(string); !ok {
-				return fmt.Errorf("client_secret is a string")
+				return diag.FromErr(fmt.Errorf("client_secret is a string"))
 			}
 			if config.AuthUrl, ok = d.Get("config.0.auth_url").(string); !ok {
-				return fmt.Errorf("auth_url is a string")
+				return diag.FromErr(fmt.Errorf("auth_url is a string"))
 			}
 			if config.ApiUrl, ok = d.Get("config.0.api_url").(string); !ok {
-				return fmt.Errorf("api_url is a string")
+				return diag.FromErr(fmt.Errorf("api_url is a string"))
 			}
 			integration.Config = config
 		default:
-			return fmt.Errorf("unsupported integration type:%s", integration.Type)
+			return diag.FromErr(fmt.Errorf("unsupported integration type:%s", integration.Type))
 		}
 	}
 	return nil

--- a/cloudflare/resource_cloudflare_device_posture_rule.go
+++ b/cloudflare/resource_cloudflare_device_posture_rule.go
@@ -44,7 +44,7 @@ func resourceCloudflareDevicePostureRuleCreate(ctx context.Context, d *schema.Re
 	setDevicePostureRuleInput(&newDevicePostureRule, d)
 	log.Printf("[DEBUG] Creating Cloudflare Device Posture Rule from struct: %+v", newDevicePostureRule)
 
-	rule, err := client.CreateDevicePostureRule(context.Background(), accountID, newDevicePostureRule)
+	rule, err := client.CreateDevicePostureRule(ctx, accountID, newDevicePostureRule)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule for account %q: %s", accountID, err))
 	}
@@ -58,7 +58,7 @@ func resourceCloudflareDevicePostureRuleRead(ctx context.Context, d *schema.Reso
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	devicePostureRule, err := client.DevicePostureRule(context.Background(), accountID, d.Id())
+	devicePostureRule, err := client.DevicePostureRule(ctx, accountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[INFO] Device Posture Rule %s no longer exists", d.Id())
@@ -98,7 +98,7 @@ func resourceCloudflareDevicePostureRuleUpdate(ctx context.Context, d *schema.Re
 	setDevicePostureRuleInput(&updatedDevicePostureRule, d)
 	log.Printf("[DEBUG] Updating Cloudflare Device Posture Rule from struct: %+v", updatedDevicePostureRule)
 
-	devicePostureRule, err := client.UpdateDevicePostureRule(context.Background(), accountID, updatedDevicePostureRule)
+	devicePostureRule, err := client.UpdateDevicePostureRule(ctx, accountID, updatedDevicePostureRule)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Device Posture Rule for account %q: %s", accountID, err))
 	}
@@ -117,7 +117,7 @@ func resourceCloudflareDevicePostureRuleDelete(ctx context.Context, d *schema.Re
 
 	log.Printf("[DEBUG] Deleting Cloudflare Device Posture Rule using ID: %s", appID)
 
-	err := client.DeleteDevicePostureRule(context.Background(), accountID, appID)
+	err := client.DeleteDevicePostureRule(ctx, accountID, appID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Device Posture Rule for account %q: %s", accountID, err))
 	}

--- a/cloudflare/resource_cloudflare_device_posture_rule.go
+++ b/cloudflare/resource_cloudflare_device_posture_rule.go
@@ -24,7 +24,7 @@ func resourceCloudflareDevicePostureRule() *schema.Resource {
 	}
 }
 
-func resourceCloudflareDevicePostureRuleCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareDevicePostureRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -53,7 +53,7 @@ func resourceCloudflareDevicePostureRuleCreate(d *schema.ResourceData, meta inte
 	return resourceCloudflareDevicePostureRuleRead(d, meta)
 }
 
-func resourceCloudflareDevicePostureRuleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareDevicePostureRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -77,7 +77,7 @@ func resourceCloudflareDevicePostureRuleRead(d *schema.ResourceData, meta interf
 	return nil
 }
 
-func resourceCloudflareDevicePostureRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareDevicePostureRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -109,7 +109,7 @@ func resourceCloudflareDevicePostureRuleUpdate(d *schema.ResourceData, meta inte
 	return resourceCloudflareDevicePostureRuleRead(d, meta)
 }
 
-func resourceCloudflareDevicePostureRuleDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareDevicePostureRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	appID := d.Id()
 	accountID := d.Get("account_id").(string)
@@ -197,13 +197,13 @@ func setDevicePostureRuleMatch(rule *cloudflare.DevicePostureRule, d *schema.Res
 		for _, v := range match {
 			jsonString, err := json.Marshal(v.(map[string]interface{}))
 			if err != nil {
-				return err
+				return diag.FromErr(err)
 			}
 
 			var dprMatch cloudflare.DevicePostureRuleMatch
 			err = json.Unmarshal(jsonString, &dprMatch)
 			if err != nil {
-				return err
+				return diag.FromErr(err)
 			}
 
 			rule.Match = append(rule.Match, dprMatch)

--- a/cloudflare/resource_cloudflare_device_posture_rule.go
+++ b/cloudflare/resource_cloudflare_device_posture_rule.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareDevicePostureRule() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareDevicePostureRuleSchema(),
-		Create: resourceCloudflareDevicePostureRuleCreate,
-		Read:   resourceCloudflareDevicePostureRuleRead,
-		Update: resourceCloudflareDevicePostureRuleUpdate,
-		Delete: resourceCloudflareDevicePostureRuleDelete,
+		CreateContext: resourceCloudflareDevicePostureRuleCreate,
+		ReadContext: resourceCloudflareDevicePostureRuleRead,
+		UpdateContext: resourceCloudflareDevicePostureRuleUpdate,
+		DeleteContext: resourceCloudflareDevicePostureRuleDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareDevicePostureRuleImport,
 		},

--- a/cloudflare/resource_cloudflare_device_posture_rule.go
+++ b/cloudflare/resource_cloudflare_device_posture_rule.go
@@ -38,7 +38,7 @@ func resourceCloudflareDevicePostureRuleCreate(ctx context.Context, d *schema.Re
 
 	err := setDevicePostureRuleMatch(&newDevicePostureRule, d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule with provided match input: %s", err))
+		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule with provided match input: %w", err))
 	}
 
 	setDevicePostureRuleInput(&newDevicePostureRule, d)
@@ -46,7 +46,7 @@ func resourceCloudflareDevicePostureRuleCreate(ctx context.Context, d *schema.Re
 
 	rule, err := client.CreateDevicePostureRule(ctx, accountID, newDevicePostureRule)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule for account %q: %w", accountID, err))
 	}
 
 	d.SetId(rule.ID)
@@ -65,7 +65,7 @@ func resourceCloudflareDevicePostureRuleRead(ctx context.Context, d *schema.Reso
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding Device Posture Rule %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding Device Posture Rule %q: %w", d.Id(), err))
 	}
 
 	d.Set("name", devicePostureRule.Name)
@@ -92,7 +92,7 @@ func resourceCloudflareDevicePostureRuleUpdate(ctx context.Context, d *schema.Re
 
 	err := setDevicePostureRuleMatch(&updatedDevicePostureRule, d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule with provided match input: %s", err))
+		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule with provided match input: %w", err))
 	}
 
 	setDevicePostureRuleInput(&updatedDevicePostureRule, d)
@@ -100,7 +100,7 @@ func resourceCloudflareDevicePostureRuleUpdate(ctx context.Context, d *schema.Re
 
 	devicePostureRule, err := client.UpdateDevicePostureRule(ctx, accountID, updatedDevicePostureRule)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Device Posture Rule for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error updating Device Posture Rule for account %q: %w", accountID, err))
 	}
 
 	if devicePostureRule.ID == "" {
@@ -119,7 +119,7 @@ func resourceCloudflareDevicePostureRuleDelete(ctx context.Context, d *schema.Re
 
 	err := client.DeleteDevicePostureRule(ctx, accountID, appID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Device Posture Rule for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error deleting Device Posture Rule for account %q: %w", accountID, err))
 	}
 
 	resourceCloudflareDevicePostureRuleRead(ctx, d, meta)

--- a/cloudflare/resource_cloudflare_device_posture_rule.go
+++ b/cloudflare/resource_cloudflare_device_posture_rule.go
@@ -37,7 +37,7 @@ func resourceCloudflareDevicePostureRuleCreate(ctx context.Context, d *schema.Re
 
 	err := setDevicePostureRuleMatch(&newDevicePostureRule, d)
 	if err != nil {
-		return fmt.Errorf("error creating Device Posture Rule with provided match input: %s", err)
+		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule with provided match input: %s", err))
 	}
 
 	setDevicePostureRuleInput(&newDevicePostureRule, d)
@@ -45,7 +45,7 @@ func resourceCloudflareDevicePostureRuleCreate(ctx context.Context, d *schema.Re
 
 	rule, err := client.CreateDevicePostureRule(context.Background(), accountID, newDevicePostureRule)
 	if err != nil {
-		return fmt.Errorf("error creating Device Posture Rule for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule for account %q: %s", accountID, err))
 	}
 
 	d.SetId(rule.ID)
@@ -64,7 +64,7 @@ func resourceCloudflareDevicePostureRuleRead(ctx context.Context, d *schema.Reso
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Device Posture Rule %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Device Posture Rule %q: %s", d.Id(), err))
 	}
 
 	d.Set("name", devicePostureRule.Name)
@@ -91,7 +91,7 @@ func resourceCloudflareDevicePostureRuleUpdate(ctx context.Context, d *schema.Re
 
 	err := setDevicePostureRuleMatch(&updatedDevicePostureRule, d)
 	if err != nil {
-		return fmt.Errorf("error creating Device Posture Rule with provided match input: %s", err)
+		return diag.FromErr(fmt.Errorf("error creating Device Posture Rule with provided match input: %s", err))
 	}
 
 	setDevicePostureRuleInput(&updatedDevicePostureRule, d)
@@ -99,11 +99,11 @@ func resourceCloudflareDevicePostureRuleUpdate(ctx context.Context, d *schema.Re
 
 	devicePostureRule, err := client.UpdateDevicePostureRule(context.Background(), accountID, updatedDevicePostureRule)
 	if err != nil {
-		return fmt.Errorf("error updating Device Posture Rule for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error updating Device Posture Rule for account %q: %s", accountID, err))
 	}
 
 	if devicePostureRule.ID == "" {
-		return fmt.Errorf("failed to find Device Posture Rule ID in update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find Device Posture Rule ID in update response; resource was empty"))
 	}
 
 	return resourceCloudflareDevicePostureRuleRead(d, meta)
@@ -118,7 +118,7 @@ func resourceCloudflareDevicePostureRuleDelete(ctx context.Context, d *schema.Re
 
 	err := client.DeleteDevicePostureRule(context.Background(), accountID, appID)
 	if err != nil {
-		return fmt.Errorf("error deleting Device Posture Rule for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error deleting Device Posture Rule for account %q: %s", accountID, err))
 	}
 
 	resourceCloudflareDevicePostureRuleRead(d, meta)

--- a/cloudflare/resource_cloudflare_fallback_domain.go
+++ b/cloudflare/resource_cloudflare_fallback_domain.go
@@ -27,11 +27,11 @@ func resourceCloudflareFallbackDomainRead(ctx context.Context, d *schema.Resourc
 
 	domain, err := client.ListFallbackDomains(context.Background(), accountID)
 	if err != nil {
-		return fmt.Errorf("error finding Fallback Domains: %w", err)
+		return diag.FromErr(fmt.Errorf("error finding Fallback Domains: %w", err))
 	}
 
 	if err := d.Set("domains", flattenFallbackDomains(domain)); err != nil {
-		return fmt.Errorf("error setting domains attribute: %w", err)
+		return diag.FromErr(fmt.Errorf("error setting domains attribute: %w", err))
 	}
 
 	return nil
@@ -45,11 +45,11 @@ func resourceCloudflareFallbackDomainUpdate(ctx context.Context, d *schema.Resou
 
 	newFallbackDomains, err := client.UpdateFallbackDomain(context.Background(), accountID, domainList)
 	if err != nil {
-		return fmt.Errorf("error updating Fallback Domains: %w", err)
+		return diag.FromErr(fmt.Errorf("error updating Fallback Domains: %w", err))
 	}
 
 	if err := d.Set("domains", flattenFallbackDomains(newFallbackDomains)); err != nil {
-		return fmt.Errorf("error setting domain attribute: %w", err)
+		return diag.FromErr(fmt.Errorf("error setting domain attribute: %w", err))
 	}
 
 	d.SetId(accountID)

--- a/cloudflare/resource_cloudflare_fallback_domain.go
+++ b/cloudflare/resource_cloudflare_fallback_domain.go
@@ -11,10 +11,10 @@ import (
 func resourceCloudflareFallbackDomain() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareFallbackDomainSchema(),
-		Read:   resourceCloudflareFallbackDomainRead,
-		Create: resourceCloudflareFallbackDomainUpdate, // Intentionally identical to Update as the resource is always present
-		Update: resourceCloudflareFallbackDomainUpdate,
-		Delete: resourceCloudflareFallbackDomainDelete,
+		ReadContext: resourceCloudflareFallbackDomainRead,
+		CreateContext: resourceCloudflareFallbackDomainUpdate, // Intentionally identical to Update as the resource is always present
+		UpdateContext: resourceCloudflareFallbackDomainUpdate,
+		DeleteContext: resourceCloudflareFallbackDomainDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareFallbackDomainImport,
 		},

--- a/cloudflare/resource_cloudflare_fallback_domain.go
+++ b/cloudflare/resource_cloudflare_fallback_domain.go
@@ -26,7 +26,7 @@ func resourceCloudflareFallbackDomainRead(ctx context.Context, d *schema.Resourc
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	domain, err := client.ListFallbackDomains(context.Background(), accountID)
+	domain, err := client.ListFallbackDomains(ctx, accountID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error finding Fallback Domains: %w", err))
 	}
@@ -44,7 +44,7 @@ func resourceCloudflareFallbackDomainUpdate(ctx context.Context, d *schema.Resou
 
 	domainList := expandFallbackDomains(d.Get("domains").([]interface{}))
 
-	newFallbackDomains, err := client.UpdateFallbackDomain(context.Background(), accountID, domainList)
+	newFallbackDomains, err := client.UpdateFallbackDomain(ctx, accountID, domainList)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Fallback Domains: %w", err))
 	}
@@ -62,7 +62,7 @@ func resourceCloudflareFallbackDomainDelete(ctx context.Context, d *schema.Resou
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	err := client.RestoreFallbackDomainDefaults(context.Background(), accountID)
+	err := client.RestoreFallbackDomainDefaults(ctx, accountID)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/cloudflare/resource_cloudflare_fallback_domain.go
+++ b/cloudflare/resource_cloudflare_fallback_domain.go
@@ -21,7 +21,7 @@ func resourceCloudflareFallbackDomain() *schema.Resource {
 	}
 }
 
-func resourceCloudflareFallbackDomainRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareFallbackDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -37,7 +37,7 @@ func resourceCloudflareFallbackDomainRead(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func resourceCloudflareFallbackDomainUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareFallbackDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -57,13 +57,13 @@ func resourceCloudflareFallbackDomainUpdate(d *schema.ResourceData, meta interfa
 	return resourceCloudflareFallbackDomainRead(d, meta)
 }
 
-func resourceCloudflareFallbackDomainDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareFallbackDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
 	err := client.RestoreFallbackDomainDefaults(context.Background(), accountID)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId("")

--- a/cloudflare/resource_cloudflare_fallback_domain.go
+++ b/cloudflare/resource_cloudflare_fallback_domain.go
@@ -5,18 +5,19 @@ import (
 	"fmt"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareFallbackDomain() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareFallbackDomainSchema(),
-		ReadContext: resourceCloudflareFallbackDomainRead,
+		Schema:        resourceCloudflareFallbackDomainSchema(),
+		ReadContext:   resourceCloudflareFallbackDomainRead,
 		CreateContext: resourceCloudflareFallbackDomainUpdate, // Intentionally identical to Update as the resource is always present
 		UpdateContext: resourceCloudflareFallbackDomainUpdate,
 		DeleteContext: resourceCloudflareFallbackDomainDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareFallbackDomainImport,
+			StateContext: resourceCloudflareFallbackDomainImport,
 		},
 	}
 }
@@ -54,7 +55,7 @@ func resourceCloudflareFallbackDomainUpdate(ctx context.Context, d *schema.Resou
 
 	d.SetId(accountID)
 
-	return resourceCloudflareFallbackDomainRead(d, meta)
+	return resourceCloudflareFallbackDomainRead(ctx, d, meta)
 }
 
 func resourceCloudflareFallbackDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -70,7 +71,7 @@ func resourceCloudflareFallbackDomainDelete(ctx context.Context, d *schema.Resou
 	return nil
 }
 
-func resourceCloudflareFallbackDomainImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareFallbackDomainImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	accountID := d.Id()
 
 	if accountID == "" {
@@ -80,9 +81,9 @@ func resourceCloudflareFallbackDomainImport(d *schema.ResourceData, meta interfa
 	d.Set("account_id", accountID)
 	d.SetId(accountID)
 
-	readErr := resourceCloudflareFallbackDomainRead(d, meta)
+	resourceCloudflareFallbackDomainRead(ctx, d, meta)
 
-	return []*schema.ResourceData{d}, readErr
+	return []*schema.ResourceData{d}, nil
 }
 
 // flattenFallbackDomains accepts the cloudflare.FallbackDomain struct and returns the

--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareFilter() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareFilterSchema(),
+		Schema:        resourceCloudflareFilterSchema(),
 		CreateContext: resourceCloudflareFilterCreate,
-		ReadContext: resourceCloudflareFilterRead,
+		ReadContext:   resourceCloudflareFilterRead,
 		UpdateContext: resourceCloudflareFilterUpdate,
 		DeleteContext: resourceCloudflareFilterDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareFilterImport,
+			StateContext: resourceCloudflareFilterImport,
 		},
 	}
 }
@@ -63,7 +64,7 @@ func resourceCloudflareFilterCreate(ctx context.Context, d *schema.ResourceData,
 
 	log.Printf("[INFO] Cloudflare Filter ID: %s", d.Id())
 
-	return resourceCloudflareFilterRead(d, meta)
+	return resourceCloudflareFilterRead(ctx, d, meta)
 }
 
 func resourceCloudflareFilterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -130,7 +131,7 @@ func resourceCloudflareFilterUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(fmt.Errorf("failed to find id in Update response; resource was empty"))
 	}
 
-	return resourceCloudflareFilterRead(d, meta)
+	return resourceCloudflareFilterRead(ctx, d, meta)
 }
 
 func resourceCloudflareFilterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -148,7 +149,7 @@ func resourceCloudflareFilterDelete(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func resourceCloudflareFilterImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareFilterImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	// split the id so we can lookup
 	idAttr := strings.SplitN(d.Id(), "/", 2)
 
@@ -163,7 +164,7 @@ func resourceCloudflareFilterImport(d *schema.ResourceData, meta interface{}) ([
 	d.Set("zone_id", zoneID)
 	d.SetId(filterID)
 
-	resourceCloudflareFilterRead(d, meta)
+	resourceCloudflareFilterRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -52,11 +52,11 @@ func resourceCloudflareFilterCreate(ctx context.Context, d *schema.ResourceData,
 	r, err := client.CreateFilters(context.Background(), zoneID, []cloudflare.Filter{newFilter})
 
 	if err != nil {
-		return fmt.Errorf("error creating Filter for zone %q: %s", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error creating Filter for zone %q: %s", zoneID, err))
 	}
 
 	if len(r) == 0 {
-		return fmt.Errorf("failed to find id in Create response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find id in Create response; resource was empty"))
 	}
 
 	d.SetId(r[0].ID)
@@ -82,7 +82,7 @@ func resourceCloudflareFilterRead(ctx context.Context, d *schema.ResourceData, m
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Filter %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Filter %q: %s", d.Id(), err))
 	}
 
 	log.Printf("[DEBUG] Cloudflare Filter read configuration: %#v", filter)
@@ -123,11 +123,11 @@ func resourceCloudflareFilterUpdate(ctx context.Context, d *schema.ResourceData,
 	r, err := client.UpdateFilter(context.Background(), zoneID, newFilter)
 
 	if err != nil {
-		return fmt.Errorf("error updating Filter for zone %q: %s", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error updating Filter for zone %q: %s", zoneID, err))
 	}
 
 	if r.ID == "" {
-		return fmt.Errorf("failed to find id in Update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find id in Update response; resource was empty"))
 	}
 
 	return resourceCloudflareFilterRead(d, meta)
@@ -142,7 +142,7 @@ func resourceCloudflareFilterDelete(ctx context.Context, d *schema.ResourceData,
 	err := client.DeleteFilter(context.Background(), zoneID, d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error deleting Cloudflare Filter: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Filter: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -50,7 +50,7 @@ func resourceCloudflareFilterCreate(ctx context.Context, d *schema.ResourceData,
 
 	log.Printf("[DEBUG] Creating Cloudflare Filter from struct: %+v", newFilter)
 
-	r, err := client.CreateFilters(context.Background(), zoneID, []cloudflare.Filter{newFilter})
+	r, err := client.CreateFilters(ctx, zoneID, []cloudflare.Filter{newFilter})
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Filter for zone %q: %s", zoneID, err))
@@ -72,7 +72,7 @@ func resourceCloudflareFilterRead(ctx context.Context, d *schema.ResourceData, m
 	zoneID := d.Get("zone_id").(string)
 
 	log.Printf("[DEBUG] Getting a Filter record for zone %q, id %s", zoneID, d.Id())
-	filter, err := client.Filter(context.Background(), zoneID, d.Id())
+	filter, err := client.Filter(ctx, zoneID, d.Id())
 
 	log.Printf("[DEBUG] filter: %#v", filter)
 	log.Printf("[DEBUG] filter error: %#v", err)
@@ -121,7 +121,7 @@ func resourceCloudflareFilterUpdate(ctx context.Context, d *schema.ResourceData,
 
 	log.Printf("[DEBUG] Updating Cloudflare Filter from struct: %+v", newFilter)
 
-	r, err := client.UpdateFilter(context.Background(), zoneID, newFilter)
+	r, err := client.UpdateFilter(ctx, zoneID, newFilter)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Filter for zone %q: %s", zoneID, err))
@@ -140,7 +140,7 @@ func resourceCloudflareFilterDelete(ctx context.Context, d *schema.ResourceData,
 
 	log.Printf("[INFO] Deleting Cloudflare Filter: id %s for zone %s", d.Id(), zoneID)
 
-	err := client.DeleteFilter(context.Background(), zoneID, d.Id())
+	err := client.DeleteFilter(ctx, zoneID, d.Id())
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Filter: %s", err))

--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -23,7 +23,7 @@ func resourceCloudflareFilter() *schema.Resource {
 	}
 }
 
-func resourceCloudflareFilterCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareFilterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -66,7 +66,7 @@ func resourceCloudflareFilterCreate(d *schema.ResourceData, meta interface{}) er
 	return resourceCloudflareFilterRead(d, meta)
 }
 
-func resourceCloudflareFilterRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareFilterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -95,7 +95,7 @@ func resourceCloudflareFilterRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceCloudflareFilterUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareFilterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -133,7 +133,7 @@ func resourceCloudflareFilterUpdate(d *schema.ResourceData, meta interface{}) er
 	return resourceCloudflareFilterRead(d, meta)
 }
 
-func resourceCloudflareFilterDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareFilterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 

--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareFilter() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareFilterSchema(),
-		Create: resourceCloudflareFilterCreate,
-		Read:   resourceCloudflareFilterRead,
-		Update: resourceCloudflareFilterUpdate,
-		Delete: resourceCloudflareFilterDelete,
+		CreateContext: resourceCloudflareFilterCreate,
+		ReadContext: resourceCloudflareFilterRead,
+		UpdateContext: resourceCloudflareFilterUpdate,
+		DeleteContext: resourceCloudflareFilterDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareFilterImport,
 		},

--- a/cloudflare/resource_cloudflare_filter.go
+++ b/cloudflare/resource_cloudflare_filter.go
@@ -53,7 +53,7 @@ func resourceCloudflareFilterCreate(ctx context.Context, d *schema.ResourceData,
 	r, err := client.CreateFilters(ctx, zoneID, []cloudflare.Filter{newFilter})
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Filter for zone %q: %s", zoneID, err))
+		return diag.FromErr(fmt.Errorf("error creating Filter for zone %q: %w", zoneID, err))
 	}
 
 	if len(r) == 0 {
@@ -83,7 +83,7 @@ func resourceCloudflareFilterRead(ctx context.Context, d *schema.ResourceData, m
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding Filter %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding Filter %q: %w", d.Id(), err))
 	}
 
 	log.Printf("[DEBUG] Cloudflare Filter read configuration: %#v", filter)
@@ -124,7 +124,7 @@ func resourceCloudflareFilterUpdate(ctx context.Context, d *schema.ResourceData,
 	r, err := client.UpdateFilter(ctx, zoneID, newFilter)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Filter for zone %q: %s", zoneID, err))
+		return diag.FromErr(fmt.Errorf("error updating Filter for zone %q: %w", zoneID, err))
 	}
 
 	if r.ID == "" {
@@ -143,7 +143,7 @@ func resourceCloudflareFilterDelete(ctx context.Context, d *schema.ResourceData,
 	err := client.DeleteFilter(ctx, zoneID, d.Id())
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Filter: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Filter: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_firewall_rule.go
+++ b/cloudflare/resource_cloudflare_firewall_rule.go
@@ -65,7 +65,7 @@ func resourceCloudflareFirewallRuleCreate(ctx context.Context, d *schema.Resourc
 	r, err = client.CreateFirewallRules(ctx, zoneID, []cloudflare.FirewallRule{newFirewallRule})
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Firewall Rule for zone %q: %s", zoneID, err))
+		return diag.FromErr(fmt.Errorf("error creating Firewall Rule for zone %q: %w", zoneID, err))
 	}
 
 	if len(r) == 0 {
@@ -94,7 +94,7 @@ func resourceCloudflareFirewallRuleRead(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding Firewall Rule %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding Firewall Rule %q: %w", d.Id(), err))
 	}
 
 	log.Printf("[DEBUG] Cloudflare Firewall Rule read configuration: %#v", firewallRule)
@@ -148,7 +148,7 @@ func resourceCloudflareFirewallRuleUpdate(ctx context.Context, d *schema.Resourc
 	r, err := client.UpdateFirewallRule(ctx, zoneID, newFirewallRule)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Firewall Rule for zone %q: %s", zoneID, err))
+		return diag.FromErr(fmt.Errorf("error updating Firewall Rule for zone %q: %w", zoneID, err))
 	}
 
 	if r.ID == "" {
@@ -167,7 +167,7 @@ func resourceCloudflareFirewallRuleDelete(ctx context.Context, d *schema.Resourc
 	err := client.DeleteFirewallRule(ctx, zoneID, d.Id())
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Firewall Rule: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Firewall Rule: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_firewall_rule.go
+++ b/cloudflare/resource_cloudflare_firewall_rule.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareFirewallRule() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareFirewallRuleSchema(),
+		Schema:        resourceCloudflareFirewallRuleSchema(),
 		CreateContext: resourceCloudflareFirewallRuleCreate,
-		ReadContext: resourceCloudflareFirewallRuleRead,
+		ReadContext:   resourceCloudflareFirewallRuleRead,
 		UpdateContext: resourceCloudflareFirewallRuleUpdate,
 		DeleteContext: resourceCloudflareFirewallRuleDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareFirewallRuleImport,
+			StateContext: resourceCloudflareFirewallRuleImport,
 		},
 	}
 }
@@ -75,7 +76,7 @@ func resourceCloudflareFirewallRuleCreate(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[INFO] Cloudflare Firewall Rule ID: %s", d.Id())
 
-	return resourceCloudflareFirewallRuleRead(d, meta)
+	return resourceCloudflareFirewallRuleRead(ctx, d, meta)
 }
 
 func resourceCloudflareFirewallRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -154,7 +155,7 @@ func resourceCloudflareFirewallRuleUpdate(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(fmt.Errorf("failed to find id in Update response; resource was empty"))
 	}
 
-	return resourceCloudflareFirewallRuleRead(d, meta)
+	return resourceCloudflareFirewallRuleRead(ctx, d, meta)
 }
 
 func resourceCloudflareFirewallRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -172,7 +173,7 @@ func resourceCloudflareFirewallRuleDelete(ctx context.Context, d *schema.Resourc
 	return nil
 }
 
-func resourceCloudflareFirewallRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareFirewallRuleImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	// split the id so we can lookup
 	idAttr := strings.SplitN(d.Id(), "/", 2)
 
@@ -187,7 +188,7 @@ func resourceCloudflareFirewallRuleImport(d *schema.ResourceData, meta interface
 	d.Set("zone_id", zoneID)
 	d.SetId(ruleID)
 
-	resourceCloudflareFirewallRuleRead(d, meta)
+	resourceCloudflareFirewallRuleRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_firewall_rule.go
+++ b/cloudflare/resource_cloudflare_firewall_rule.go
@@ -64,11 +64,11 @@ func resourceCloudflareFirewallRuleCreate(ctx context.Context, d *schema.Resourc
 	r, err = client.CreateFirewallRules(context.Background(), zoneID, []cloudflare.FirewallRule{newFirewallRule})
 
 	if err != nil {
-		return fmt.Errorf("error creating Firewall Rule for zone %q: %s", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error creating Firewall Rule for zone %q: %s", zoneID, err))
 	}
 
 	if len(r) == 0 {
-		return fmt.Errorf("failed to find id in Create response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find id in Create response; resource was empty"))
 	}
 
 	d.SetId(r[0].ID)
@@ -93,7 +93,7 @@ func resourceCloudflareFirewallRuleRead(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Firewall Rule %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Firewall Rule %q: %s", d.Id(), err))
 	}
 
 	log.Printf("[DEBUG] Cloudflare Firewall Rule read configuration: %#v", firewallRule)
@@ -147,11 +147,11 @@ func resourceCloudflareFirewallRuleUpdate(ctx context.Context, d *schema.Resourc
 	r, err := client.UpdateFirewallRule(context.Background(), zoneID, newFirewallRule)
 
 	if err != nil {
-		return fmt.Errorf("error updating Firewall Rule for zone %q: %s", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error updating Firewall Rule for zone %q: %s", zoneID, err))
 	}
 
 	if r.ID == "" {
-		return fmt.Errorf("failed to find id in Update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find id in Update response; resource was empty"))
 	}
 
 	return resourceCloudflareFirewallRuleRead(d, meta)
@@ -166,7 +166,7 @@ func resourceCloudflareFirewallRuleDelete(ctx context.Context, d *schema.Resourc
 	err := client.DeleteFirewallRule(context.Background(), zoneID, d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error deleting Cloudflare Firewall Rule: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Firewall Rule: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_firewall_rule.go
+++ b/cloudflare/resource_cloudflare_firewall_rule.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareFirewallRule() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareFirewallRuleSchema(),
-		Create: resourceCloudflareFirewallRuleCreate,
-		Read:   resourceCloudflareFirewallRuleRead,
-		Update: resourceCloudflareFirewallRuleUpdate,
-		Delete: resourceCloudflareFirewallRuleDelete,
+		CreateContext: resourceCloudflareFirewallRuleCreate,
+		ReadContext: resourceCloudflareFirewallRuleRead,
+		UpdateContext: resourceCloudflareFirewallRuleUpdate,
+		DeleteContext: resourceCloudflareFirewallRuleDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareFirewallRuleImport,
 		},

--- a/cloudflare/resource_cloudflare_firewall_rule.go
+++ b/cloudflare/resource_cloudflare_firewall_rule.go
@@ -62,7 +62,7 @@ func resourceCloudflareFirewallRuleCreate(ctx context.Context, d *schema.Resourc
 
 	var r []cloudflare.FirewallRule
 
-	r, err = client.CreateFirewallRules(context.Background(), zoneID, []cloudflare.FirewallRule{newFirewallRule})
+	r, err = client.CreateFirewallRules(ctx, zoneID, []cloudflare.FirewallRule{newFirewallRule})
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Firewall Rule for zone %q: %s", zoneID, err))
@@ -83,7 +83,7 @@ func resourceCloudflareFirewallRuleRead(ctx context.Context, d *schema.ResourceD
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	firewallRule, err := client.FirewallRule(context.Background(), zoneID, d.Id())
+	firewallRule, err := client.FirewallRule(ctx, zoneID, d.Id())
 
 	log.Printf("[DEBUG] firewallRule: %#v", firewallRule)
 	log.Printf("[DEBUG] firewallRule error: %#v", err)
@@ -145,7 +145,7 @@ func resourceCloudflareFirewallRuleUpdate(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[DEBUG] Updating Cloudflare Firewall Rule from struct: %+v", newFirewallRule)
 
-	r, err := client.UpdateFirewallRule(context.Background(), zoneID, newFirewallRule)
+	r, err := client.UpdateFirewallRule(ctx, zoneID, newFirewallRule)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Firewall Rule for zone %q: %s", zoneID, err))
@@ -164,7 +164,7 @@ func resourceCloudflareFirewallRuleDelete(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[INFO] Deleting Cloudflare Firewall Rule: id %s for zone %s", d.Id(), zoneID)
 
-	err := client.DeleteFirewallRule(context.Background(), zoneID, d.Id())
+	err := client.DeleteFirewallRule(ctx, zoneID, d.Id())
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Firewall Rule: %s", err))

--- a/cloudflare/resource_cloudflare_firewall_rule.go
+++ b/cloudflare/resource_cloudflare_firewall_rule.go
@@ -23,7 +23,7 @@ func resourceCloudflareFirewallRule() *schema.Resource {
 	}
 }
 
-func resourceCloudflareFirewallRuleCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareFirewallRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -78,7 +78,7 @@ func resourceCloudflareFirewallRuleCreate(d *schema.ResourceData, meta interface
 	return resourceCloudflareFirewallRuleRead(d, meta)
 }
 
-func resourceCloudflareFirewallRuleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareFirewallRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -109,7 +109,7 @@ func resourceCloudflareFirewallRuleRead(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceCloudflareFirewallRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareFirewallRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -157,7 +157,7 @@ func resourceCloudflareFirewallRuleUpdate(d *schema.ResourceData, meta interface
 	return resourceCloudflareFirewallRuleRead(d, meta)
 }
 
-func resourceCloudflareFirewallRuleDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareFirewallRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 

--- a/cloudflare/resource_cloudflare_gre_tunnel.go
+++ b/cloudflare/resource_cloudflare_gre_tunnel.go
@@ -24,7 +24,7 @@ func resourceCloudflareGRETunnel() *schema.Resource {
 	}
 }
 
-func resourceCloudflareGRETunnelCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareGRETunnelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
@@ -59,7 +59,7 @@ func resourceCloudflareGRETunnelImport(d *schema.ResourceData, meta interface{})
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceCloudflareGRETunnelRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareGRETunnelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
@@ -90,19 +90,19 @@ func resourceCloudflareGRETunnelRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceCloudflareGRETunnelUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareGRETunnelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
 	_, err := client.UpdateMagicTransitGRETunnel(context.Background(), accountID, d.Id(), GRETunnelFromResource(d))
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error updating GRE tunnel %q", d.Id()))
+		return err.Wrap(err, fmt.Sprintf("error updating GRE tunnel %q", d.Id()))
 	}
 
 	return resourceCloudflareGRETunnelRead(d, meta)
 }
 
-func resourceCloudflareGRETunnelDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareGRETunnelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 

--- a/cloudflare/resource_cloudflare_gre_tunnel.go
+++ b/cloudflare/resource_cloudflare_gre_tunnel.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareGRETunnel() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareGRETunnelSchema(),
-		Create: resourceCloudflareGRETunnelCreate,
-		Read:   resourceCloudflareGRETunnelRead,
-		Update: resourceCloudflareGRETunnelUpdate,
-		Delete: resourceCloudflareGRETunnelDelete,
+		CreateContext: resourceCloudflareGRETunnelCreate,
+		ReadContext: resourceCloudflareGRETunnelRead,
+		UpdateContext: resourceCloudflareGRETunnelUpdate,
+		DeleteContext: resourceCloudflareGRETunnelDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareGRETunnelImport,
 		},

--- a/cloudflare/resource_cloudflare_gre_tunnel.go
+++ b/cloudflare/resource_cloudflare_gre_tunnel.go
@@ -33,7 +33,7 @@ func resourceCloudflareGRETunnelCreate(ctx context.Context, d *schema.ResourceDa
 	})
 
 	if err != nil {
-		return fmt.Errorf("error creating GRE tunnel %s: %w", d.Get("name").(string), err)
+		return diag.FromErr(fmt.Errorf("error creating GRE tunnel %s: %w", d.Get("name").(string), err))
 	}
 
 	d.SetId(newTunnel[0].ID)
@@ -70,7 +70,7 @@ func resourceCloudflareGRETunnelRead(ctx context.Context, d *schema.ResourceData
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading GRE tunnel ID %q: %w", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error reading GRE tunnel ID %q: %w", d.Id(), err))
 	}
 
 	d.Set("name", tunnel.Name)
@@ -110,7 +110,7 @@ func resourceCloudflareGRETunnelDelete(ctx context.Context, d *schema.ResourceDa
 
 	_, err := client.DeleteMagicTransitGRETunnel(context.Background(), accountID, d.Id())
 	if err != nil {
-		return fmt.Errorf("error deleting GRE tunnel: %w", err)
+		return diag.FromErr(fmt.Errorf("error deleting GRE tunnel: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_gre_tunnel.go
+++ b/cloudflare/resource_cloudflare_gre_tunnel.go
@@ -29,7 +29,7 @@ func resourceCloudflareGRETunnelCreate(ctx context.Context, d *schema.ResourceDa
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
-	newTunnel, err := client.CreateMagicTransitGRETunnels(context.Background(), accountID, []cloudflare.MagicTransitGRETunnel{
+	newTunnel, err := client.CreateMagicTransitGRETunnels(ctx, accountID, []cloudflare.MagicTransitGRETunnel{
 		GRETunnelFromResource(d),
 	})
 
@@ -65,7 +65,7 @@ func resourceCloudflareGRETunnelRead(ctx context.Context, d *schema.ResourceData
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
-	tunnel, err := client.GetMagicTransitGRETunnel(context.Background(), accountID, d.Id())
+	tunnel, err := client.GetMagicTransitGRETunnel(ctx, accountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "GRE tunnel not found") {
 			log.Printf("[INFO] GRE tunnel %s not found", d.Id())
@@ -96,7 +96,7 @@ func resourceCloudflareGRETunnelUpdate(ctx context.Context, d *schema.ResourceDa
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
-	_, err := client.UpdateMagicTransitGRETunnel(context.Background(), accountID, d.Id(), GRETunnelFromResource(d))
+	_, err := client.UpdateMagicTransitGRETunnel(ctx, accountID, d.Id(), GRETunnelFromResource(d))
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error updating GRE tunnel %q", d.Id())))
 	}
@@ -110,7 +110,7 @@ func resourceCloudflareGRETunnelDelete(ctx context.Context, d *schema.ResourceDa
 
 	log.Printf("[INFO] Deleting GRE tunnel:  %s", d.Id())
 
-	_, err := client.DeleteMagicTransitGRETunnel(context.Background(), accountID, d.Id())
+	_, err := client.DeleteMagicTransitGRETunnel(ctx, accountID, d.Id())
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting GRE tunnel: %w", err))
 	}

--- a/cloudflare/resource_cloudflare_healthcheck.go
+++ b/cloudflare/resource_cloudflare_healthcheck.go
@@ -31,7 +31,7 @@ func resourceCloudflareHealthcheck() *schema.Resource {
 	}
 }
 
-func resourceCloudflareHealthcheckRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareHealthcheckRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -42,7 +42,7 @@ func resourceCloudflareHealthcheckRead(d *schema.ResourceData, meta interface{})
 			d.SetId("")
 			return nil
 		}
-		return errors.Wrap(err, fmt.Sprintf("error reading healthcheck information for %q", d.Id()))
+		return err.Wrap(err, fmt.Sprintf("error reading healthcheck information for %q", d.Id()))
 	}
 
 	switch healthcheck.Type {
@@ -82,13 +82,13 @@ func resourceCloudflareHealthcheckRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceCloudflareHealthcheckCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareHealthcheckCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
 	healthcheck, err := healthcheckSetStruct(d)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error creating healthcheck struct"))
+		return err.Wrap(err, fmt.Sprintf("error creating healthcheck struct"))
 	}
 
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
@@ -108,30 +108,30 @@ func resourceCloudflareHealthcheckCreate(d *schema.ResourceData, meta interface{
 	})
 }
 
-func resourceCloudflareHealthcheckUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareHealthcheckUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
 	healthcheck, err := healthcheckSetStruct(d)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error creating healthcheck struct"))
+		return err.Wrap(err, fmt.Sprintf("error creating healthcheck struct"))
 	}
 
 	_, err = client.UpdateHealthcheck(context.Background(), zoneID, d.Id(), healthcheck)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error creating healthcheck"))
+		return err.Wrap(err, fmt.Sprintf("error creating healthcheck"))
 	}
 
 	return resourceCloudflareHealthcheckRead(d, meta)
 }
 
-func resourceCloudflareHealthcheckDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareHealthcheckDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
 	err := client.DeleteHealthcheck(context.Background(), zoneID, d.Id())
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error deleting standalone healthcheck"))
+		return err.Wrap(err, fmt.Sprintf("error deleting standalone healthcheck"))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_healthcheck.go
+++ b/cloudflare/resource_cloudflare_healthcheck.go
@@ -16,10 +16,10 @@ import (
 
 func resourceCloudflareHealthcheck() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudflareHealthcheckCreate,
-		Read:   resourceCloudflareHealthcheckRead,
-		Update: resourceCloudflareHealthcheckUpdate,
-		Delete: resourceCloudflareHealthcheckDelete,
+		CreateContext: resourceCloudflareHealthcheckCreate,
+		ReadContext: resourceCloudflareHealthcheckRead,
+		UpdateContext: resourceCloudflareHealthcheckUpdate,
+		DeleteContext: resourceCloudflareHealthcheckDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareHealthcheckImport,
 		},

--- a/cloudflare/resource_cloudflare_healthcheck.go
+++ b/cloudflare/resource_cloudflare_healthcheck.go
@@ -36,7 +36,7 @@ func resourceCloudflareHealthcheckRead(ctx context.Context, d *schema.ResourceDa
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	healthcheck, err := client.Healthcheck(context.Background(), zoneID, d.Id())
+	healthcheck, err := client.Healthcheck(ctx, zoneID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "object does not exist") {
 			log.Printf("[INFO] Healthcheck %s no longer exists", d.Id())
@@ -93,7 +93,7 @@ func resourceCloudflareHealthcheckCreate(ctx context.Context, d *schema.Resource
 	}
 
 	retry := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		hc, err := client.CreateHealthcheck(context.Background(), zoneID, healthcheck)
+		hc, err := client.CreateHealthcheck(ctx, zoneID, healthcheck)
 		if err != nil {
 			if strings.Contains(err.Error(), "no such host") {
 				return resource.RetryableError(fmt.Errorf("hostname resolution failed"))
@@ -124,7 +124,7 @@ func resourceCloudflareHealthcheckUpdate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error creating healthcheck struct")))
 	}
 
-	_, err = client.UpdateHealthcheck(context.Background(), zoneID, d.Id(), healthcheck)
+	_, err = client.UpdateHealthcheck(ctx, zoneID, d.Id(), healthcheck)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error creating healthcheck")))
 	}
@@ -136,7 +136,7 @@ func resourceCloudflareHealthcheckDelete(ctx context.Context, d *schema.Resource
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	err := client.DeleteHealthcheck(context.Background(), zoneID, d.Id())
+	err := client.DeleteHealthcheck(ctx, zoneID, d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error deleting standalone healthcheck")))
 	}

--- a/cloudflare/resource_cloudflare_ip_list.go
+++ b/cloudflare/resource_cloudflare_ip_list.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareIPList() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareIPListSchema(),
-		Create: resourceCloudflareIPListCreate,
-		Read:   resourceCloudflareIPListRead,
-		Update: resourceCloudflareIPListUpdate,
-		Delete: resourceCloudflareIPListDelete,
+		CreateContext: resourceCloudflareIPListCreate,
+		ReadContext: resourceCloudflareIPListRead,
+		UpdateContext: resourceCloudflareIPListUpdate,
+		DeleteContext: resourceCloudflareIPListDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareIPListImport,
 		},

--- a/cloudflare/resource_cloudflare_ip_list.go
+++ b/cloudflare/resource_cloudflare_ip_list.go
@@ -24,13 +24,13 @@ func resourceCloudflareIPList() *schema.Resource {
 	}
 }
 
-func resourceCloudflareIPListCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareIPListCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
 	list, err := client.CreateIPList(context.Background(), accountID, d.Get("name").(string), d.Get("description").(string), d.Get("kind").(string))
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error creating IP List %s", d.Get("name").(string)))
+		return err.Wrap(err, fmt.Sprintf("error creating IP List %s", d.Get("name").(string)))
 	}
 
 	d.SetId(list.ID)
@@ -39,7 +39,7 @@ func resourceCloudflareIPListCreate(d *schema.ResourceData, meta interface{}) er
 		IPListItems := buildIPListItemsCreateRequest(items.(*schema.Set).List())
 		_, err = client.CreateIPListItems(context.Background(), accountID, d.Id(), IPListItems)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("error creating IP List Items"))
+			return err.Wrap(err, fmt.Sprintf("error creating IP List Items"))
 		}
 	}
 
@@ -62,7 +62,7 @@ func resourceCloudflareIPListImport(d *schema.ResourceData, meta interface{}) ([
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceCloudflareIPListRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareIPListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -73,7 +73,7 @@ func resourceCloudflareIPListRead(d *schema.ResourceData, meta interface{}) erro
 			d.SetId("")
 			return nil
 		}
-		return errors.Wrap(err, fmt.Sprintf("error reading IP List with ID %q", d.Id()))
+		return err.Wrap(err, fmt.Sprintf("error reading IP List with ID %q", d.Id()))
 	}
 
 	d.Set("name", list.Name)
@@ -82,7 +82,7 @@ func resourceCloudflareIPListRead(d *schema.ResourceData, meta interface{}) erro
 
 	items, err := client.ListIPListItems(context.Background(), accountID, d.Id())
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error reading IP List Items"))
+		return err.Wrap(err, fmt.Sprintf("error reading IP List Items"))
 	}
 
 	var itemData []map[string]interface{}
@@ -101,33 +101,33 @@ func resourceCloudflareIPListRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceCloudflareIPListUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareIPListUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
 	_, err := client.UpdateIPList(context.Background(), accountID, d.Id(), d.Get("description").(string))
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error updating IP List description"))
+		return err.Wrap(err, fmt.Sprintf("error updating IP List description"))
 	}
 
 	if items, ok := d.GetOk("item"); ok {
 		IPListItems := buildIPListItemsCreateRequest(items.(*schema.Set).List())
 		_, err = client.ReplaceIPListItems(context.Background(), accountID, d.Id(), IPListItems)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("error creating IP List Items"))
+			return err.Wrap(err, fmt.Sprintf("error creating IP List Items"))
 		}
 	}
 
 	return resourceCloudflareIPListRead(d, meta)
 }
 
-func resourceCloudflareIPListDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareIPListDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
 	_, err := client.DeleteIPList(context.Background(), accountID, d.Id())
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error deleting IP List with ID %q", d.Id()))
+		return err.Wrap(err, fmt.Sprintf("error deleting IP List with ID %q", d.Id()))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_ip_list.go
+++ b/cloudflare/resource_cloudflare_ip_list.go
@@ -29,7 +29,7 @@ func resourceCloudflareIPListCreate(ctx context.Context, d *schema.ResourceData,
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	list, err := client.CreateIPList(context.Background(), accountID, d.Get("name").(string), d.Get("description").(string), d.Get("kind").(string))
+	list, err := client.CreateIPList(ctx, accountID, d.Get("name").(string), d.Get("description").(string), d.Get("kind").(string))
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error creating IP List %s", d.Get("name").(string))))
 	}
@@ -38,7 +38,7 @@ func resourceCloudflareIPListCreate(ctx context.Context, d *schema.ResourceData,
 
 	if items, ok := d.GetOk("item"); ok {
 		IPListItems := buildIPListItemsCreateRequest(items.(*schema.Set).List())
-		_, err = client.CreateIPListItems(context.Background(), accountID, d.Id(), IPListItems)
+		_, err = client.CreateIPListItems(ctx, accountID, d.Id(), IPListItems)
 		if err != nil {
 			return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error creating IP List Items")))
 		}
@@ -67,7 +67,7 @@ func resourceCloudflareIPListRead(ctx context.Context, d *schema.ResourceData, m
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	list, err := client.GetIPList(context.Background(), accountID, d.Id())
+	list, err := client.GetIPList(ctx, accountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "could not find list") {
 			log.Printf("[INFO] IP List %s no longer exists", d.Id())
@@ -81,7 +81,7 @@ func resourceCloudflareIPListRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("description", list.Description)
 	d.Set("kind", list.Kind)
 
-	items, err := client.ListIPListItems(context.Background(), accountID, d.Id())
+	items, err := client.ListIPListItems(ctx, accountID, d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error reading IP List Items")))
 	}
@@ -106,14 +106,14 @@ func resourceCloudflareIPListUpdate(ctx context.Context, d *schema.ResourceData,
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	_, err := client.UpdateIPList(context.Background(), accountID, d.Id(), d.Get("description").(string))
+	_, err := client.UpdateIPList(ctx, accountID, d.Id(), d.Get("description").(string))
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error updating IP List description")))
 	}
 
 	if items, ok := d.GetOk("item"); ok {
 		IPListItems := buildIPListItemsCreateRequest(items.(*schema.Set).List())
-		_, err = client.ReplaceIPListItems(context.Background(), accountID, d.Id(), IPListItems)
+		_, err = client.ReplaceIPListItems(ctx, accountID, d.Id(), IPListItems)
 		if err != nil {
 			return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error creating IP List Items")))
 		}
@@ -126,7 +126,7 @@ func resourceCloudflareIPListDelete(ctx context.Context, d *schema.ResourceData,
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	_, err := client.DeleteIPList(context.Background(), accountID, d.Id())
+	_, err := client.DeleteIPList(ctx, accountID, d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error deleting IP List with ID %q", d.Id())))
 	}

--- a/cloudflare/resource_cloudflare_ipsec_tunnel.go
+++ b/cloudflare/resource_cloudflare_ipsec_tunnel.go
@@ -33,7 +33,7 @@ func resourceCloudflareIPsecTunnelCreate(ctx context.Context, d *schema.Resource
 	})
 
 	if err != nil {
-		return fmt.Errorf("error creating IPSec tunnel %s: %w", d.Get("name").(string), err)
+		return diag.FromErr(fmt.Errorf("error creating IPSec tunnel %s: %w", d.Get("name").(string), err))
 	}
 
 	d.SetId(newTunnel[0].ID)
@@ -70,7 +70,7 @@ func resourceCloudflareIPsecTunnelRead(ctx context.Context, d *schema.ResourceDa
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading IPsec tunnel ID %q: %w", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error reading IPsec tunnel ID %q: %w", d.Id(), err))
 	}
 
 	d.Set("name", tunnel.Name)
@@ -105,7 +105,7 @@ func resourceCloudflareIPsecTunnelDelete(ctx context.Context, d *schema.Resource
 
 	_, err := client.DeleteMagicTransitIPsecTunnel(context.Background(), accountID, d.Id())
 	if err != nil {
-		return fmt.Errorf("error deleting IPsec tunnel: %w", err)
+		return diag.FromErr(fmt.Errorf("error deleting IPsec tunnel: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_ipsec_tunnel.go
+++ b/cloudflare/resource_cloudflare_ipsec_tunnel.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareIPsecTunnel() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareIPsecTunnelSchema(),
-		Create: resourceCloudflareIPsecTunnelCreate,
-		Read:   resourceCloudflareIPsecTunnelRead,
-		Update: resourceCloudflareIPsecTunnelUpdate,
-		Delete: resourceCloudflareIPsecTunnelDelete,
+		CreateContext: resourceCloudflareIPsecTunnelCreate,
+		ReadContext: resourceCloudflareIPsecTunnelRead,
+		UpdateContext: resourceCloudflareIPsecTunnelUpdate,
+		DeleteContext: resourceCloudflareIPsecTunnelDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareIPsecTunnelImport,
 		},

--- a/cloudflare/resource_cloudflare_ipsec_tunnel.go
+++ b/cloudflare/resource_cloudflare_ipsec_tunnel.go
@@ -24,7 +24,7 @@ func resourceCloudflareIPsecTunnel() *schema.Resource {
 	}
 }
 
-func resourceCloudflareIPsecTunnelCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareIPsecTunnelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
@@ -59,7 +59,7 @@ func resourceCloudflareIPsecTunnelImport(d *schema.ResourceData, meta interface{
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceCloudflareIPsecTunnelRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareIPsecTunnelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
@@ -85,19 +85,19 @@ func resourceCloudflareIPsecTunnelRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceCloudflareIPsecTunnelUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareIPsecTunnelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
 	_, err := client.UpdateMagicTransitIPsecTunnel(context.Background(), accountID, d.Id(), IPsecTunnelFromResource(d))
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error updating IPsec tunnel %q", d.Id()))
+		return err.Wrap(err, fmt.Sprintf("error updating IPsec tunnel %q", d.Id()))
 	}
 
 	return resourceCloudflareIPsecTunnelRead(d, meta)
 }
 
-func resourceCloudflareIPsecTunnelDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareIPsecTunnelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 

--- a/cloudflare/resource_cloudflare_ipsec_tunnel.go
+++ b/cloudflare/resource_cloudflare_ipsec_tunnel.go
@@ -29,7 +29,7 @@ func resourceCloudflareIPsecTunnelCreate(ctx context.Context, d *schema.Resource
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
-	newTunnel, err := client.CreateMagicTransitIPsecTunnels(context.Background(), accountID, []cloudflare.MagicTransitIPsecTunnel{
+	newTunnel, err := client.CreateMagicTransitIPsecTunnels(ctx, accountID, []cloudflare.MagicTransitIPsecTunnel{
 		IPsecTunnelFromResource(d),
 	})
 
@@ -65,7 +65,7 @@ func resourceCloudflareIPsecTunnelRead(ctx context.Context, d *schema.ResourceDa
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
-	tunnel, err := client.GetMagicTransitIPsecTunnel(context.Background(), accountID, d.Id())
+	tunnel, err := client.GetMagicTransitIPsecTunnel(ctx, accountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "IPsec tunnel not found") {
 			log.Printf("[INFO] IPsec tunnel %s not found", d.Id())
@@ -91,7 +91,7 @@ func resourceCloudflareIPsecTunnelUpdate(ctx context.Context, d *schema.Resource
 	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
-	_, err := client.UpdateMagicTransitIPsecTunnel(context.Background(), accountID, d.Id(), IPsecTunnelFromResource(d))
+	_, err := client.UpdateMagicTransitIPsecTunnel(ctx, accountID, d.Id(), IPsecTunnelFromResource(d))
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error updating IPsec tunnel %q", d.Id())))
 	}
@@ -105,7 +105,7 @@ func resourceCloudflareIPsecTunnelDelete(ctx context.Context, d *schema.Resource
 
 	log.Printf("[INFO] Deleting IPsec tunnel:  %s", d.Id())
 
-	_, err := client.DeleteMagicTransitIPsecTunnel(context.Background(), accountID, d.Id())
+	_, err := client.DeleteMagicTransitIPsecTunnel(ctx, accountID, d.Id())
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting IPsec tunnel: %w", err))
 	}

--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -405,17 +405,17 @@ func resourceCloudflareLoadBalancerRead(ctx context.Context, d *schema.ResourceD
 
 	if _, sessionAffinityAttrsOk := d.GetOk("session_affinity_attributes"); sessionAffinityAttrsOk {
 		if err := d.Set("session_affinity_attributes", flattenSessionAffinityAttrs(loadBalancer.SessionAffinityAttributes)); err != nil {
-			return diag.FromErr(fmt.Errorf("failed to set session_affinity_attributes: %s", err))
+			return diag.FromErr(fmt.Errorf("failed to set session_affinity_attributes: %w", err))
 		}
 	}
 
 	if len(loadBalancer.Rules) > 0 {
 		fr, err := flattenRules(d, loadBalancer.Rules)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("failed to flatten rules: %s", err))
+			return diag.FromErr(fmt.Errorf("failed to flatten rules: %w", err))
 		}
 		if err := d.Set("rules", fr); err != nil {
-			return diag.FromErr(fmt.Errorf("failed to set rules: %s\n %v", err, fr))
+			return diag.FromErr(fmt.Errorf("failed to set rules: %w\n %v", err, fr))
 		}
 	}
 
@@ -467,7 +467,7 @@ func resourceCloudflareLoadBalancerDelete(ctx context.Context, d *schema.Resourc
 
 	err := client.DeleteLoadBalancer(ctx, zoneID, loadBalancerID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Load Balancer: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Load Balancer: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -280,7 +280,7 @@ func resourceCloudflareLoadBalancerCreate(ctx context.Context, d *schema.Resourc
 	}
 
 	if r.ID == "" {
-		return fmt.Errorf("failed to find id in Create response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find id in Create response; resource was empty"))
 	}
 
 	d.SetId(r.ID)
@@ -404,17 +404,17 @@ func resourceCloudflareLoadBalancerRead(ctx context.Context, d *schema.ResourceD
 
 	if _, sessionAffinityAttrsOk := d.GetOk("session_affinity_attributes"); sessionAffinityAttrsOk {
 		if err := d.Set("session_affinity_attributes", flattenSessionAffinityAttrs(loadBalancer.SessionAffinityAttributes)); err != nil {
-			return fmt.Errorf("failed to set session_affinity_attributes: %s", err)
+			return diag.FromErr(fmt.Errorf("failed to set session_affinity_attributes: %s", err))
 		}
 	}
 
 	if len(loadBalancer.Rules) > 0 {
 		fr, err := flattenRules(d, loadBalancer.Rules)
 		if err != nil {
-			return fmt.Errorf("failed to flatten rules: %s", err)
+			return diag.FromErr(fmt.Errorf("failed to flatten rules: %s", err))
 		}
 		if err := d.Set("rules", fr); err != nil {
-			return fmt.Errorf("failed to set rules: %s\n %v", err, fr)
+			return diag.FromErr(fmt.Errorf("failed to set rules: %s\n %v", err, fr))
 		}
 	}
 
@@ -466,7 +466,7 @@ func resourceCloudflareLoadBalancerDelete(ctx context.Context, d *schema.Resourc
 
 	err := client.DeleteLoadBalancer(context.Background(), zoneID, loadBalancerID)
 	if err != nil {
-		return fmt.Errorf("error deleting Cloudflare Load Balancer: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Load Balancer: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -275,7 +275,7 @@ func resourceCloudflareLoadBalancerCreate(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[INFO] Creating Cloudflare Load Balancer from struct: %+v", newLoadBalancer)
 
-	r, err := client.CreateLoadBalancer(context.Background(), zoneID, newLoadBalancer)
+	r, err := client.CreateLoadBalancer(ctx, zoneID, newLoadBalancer)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating load balancer for zone"))
 	}
@@ -351,7 +351,7 @@ func resourceCloudflareLoadBalancerUpdate(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[INFO] Updating Cloudflare Load Balancer from struct: %+v", loadBalancer)
 
-	_, err := client.ModifyLoadBalancer(context.Background(), zoneID, loadBalancer)
+	_, err := client.ModifyLoadBalancer(ctx, zoneID, loadBalancer)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating load balancer for zone"))
 	}
@@ -380,7 +380,7 @@ func resourceCloudflareLoadBalancerRead(ctx context.Context, d *schema.ResourceD
 	zoneID := d.Get("zone_id").(string)
 	loadBalancerID := d.Id()
 
-	loadBalancer, err := client.LoadBalancerDetails(context.Background(), zoneID, loadBalancerID)
+	loadBalancer, err := client.LoadBalancerDetails(ctx, zoneID, loadBalancerID)
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[INFO] Load balancer %s in zone %s not found", loadBalancerID, zoneID)
@@ -465,7 +465,7 @@ func resourceCloudflareLoadBalancerDelete(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[INFO] Deleting Cloudflare Load Balancer: %s in zone: %s", loadBalancerID, zoneID)
 
-	err := client.DeleteLoadBalancer(context.Background(), zoneID, loadBalancerID)
+	err := client.DeleteLoadBalancer(ctx, zoneID, loadBalancerID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Load Balancer: %s", err))
 	}

--- a/cloudflare/resource_cloudflare_load_balancer.go
+++ b/cloudflare/resource_cloudflare_load_balancer.go
@@ -17,10 +17,10 @@ import (
 
 func resourceCloudflareLoadBalancer() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudflareLoadBalancerCreate,
-		Read:   resourceCloudflareLoadBalancerRead,
-		Update: resourceCloudflareLoadBalancerUpdate,
-		Delete: resourceCloudflareLoadBalancerDelete,
+		CreateContext: resourceCloudflareLoadBalancerCreate,
+		ReadContext: resourceCloudflareLoadBalancerRead,
+		UpdateContext: resourceCloudflareLoadBalancerUpdate,
+		DeleteContext: resourceCloudflareLoadBalancerDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareLoadBalancerImport,
 		},

--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -62,7 +62,7 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(ctx context.Context, d *sch
 		if expectedCodes, ok := d.GetOk("expected_codes"); ok {
 			loadBalancerMonitor.ExpectedCodes = expectedCodes.(string)
 		} else {
-			return fmt.Errorf("expected_codes must be set")
+			return diag.FromErr(fmt.Errorf("expected_codes must be set"))
 		}
 
 		if followRedirects, ok := d.GetOk("follow_redirects"); ok {
@@ -100,7 +100,7 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(ctx context.Context, d *sch
 	}
 
 	if r.ID == "" {
-		return fmt.Errorf("failed to find id in create response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find id in create response; resource was empty"))
 	}
 
 	d.SetId(r.ID)
@@ -150,7 +150,7 @@ func resourceCloudflareLoadBalancerPoolMonitorUpdate(ctx context.Context, d *sch
 		if expectedCodes, ok := d.GetOk("expected_codes"); ok {
 			loadBalancerMonitor.ExpectedCodes = expectedCodes.(string)
 		} else {
-			return fmt.Errorf("expected_codes must be set")
+			return diag.FromErr(fmt.Errorf("expected_codes must be set"))
 		}
 
 		if header, ok := d.GetOk("header"); ok {

--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -9,19 +9,20 @@ import (
 	"time"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 )
 
 func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareLoadBalancerMonitorSchema(),
+		Schema:        resourceCloudflareLoadBalancerMonitorSchema(),
 		CreateContext: resourceCloudflareLoadBalancerPoolMonitorCreate,
-		ReadContext: resourceCloudflareLoadBalancerPoolMonitorRead,
+		ReadContext:   resourceCloudflareLoadBalancerPoolMonitorRead,
 		UpdateContext: resourceCloudflareLoadBalancerPoolMonitorUpdate,
 		DeleteContext: resourceCloudflareLoadBalancerPoolMonitorDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }
@@ -96,7 +97,7 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(ctx context.Context, d *sch
 
 	r, err := client.CreateLoadBalancerMonitor(context.Background(), loadBalancerMonitor)
 	if err != nil {
-		return err.Wrap(err, "error creating load balancer monitor")
+		return diag.FromErr(errors.Wrap(err, "error creating load balancer monitor"))
 	}
 
 	if r.ID == "" {
@@ -107,7 +108,7 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(ctx context.Context, d *sch
 
 	log.Printf("[INFO] New Cloudflare Load Balancer Monitor created with  ID: %s", d.Id())
 
-	return resourceCloudflareLoadBalancerPoolMonitorRead(d, meta)
+	return resourceCloudflareLoadBalancerPoolMonitorRead(ctx, d, meta)
 }
 
 func resourceCloudflareLoadBalancerPoolMonitorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -184,12 +185,12 @@ func resourceCloudflareLoadBalancerPoolMonitorUpdate(ctx context.Context, d *sch
 
 	_, err := client.ModifyLoadBalancerMonitor(context.Background(), loadBalancerMonitor)
 	if err != nil {
-		return err.Wrap(err, "error modifying load balancer monitor")
+		return diag.FromErr(errors.Wrap(err, "error modifying load balancer monitor"))
 	}
 
 	log.Printf("[INFO] Cloudflare Load Balancer Monitor %q was modified", d.Id())
 
-	return resourceCloudflareLoadBalancerPoolMonitorRead(d, meta)
+	return resourceCloudflareLoadBalancerPoolMonitorRead(ctx, d, meta)
 }
 
 func expandLoadBalancerMonitorHeader(cfgSet interface{}) map[string][]string {
@@ -212,8 +213,8 @@ func resourceCloudflareLoadBalancerPoolMonitorRead(ctx context.Context, d *schem
 			d.SetId("")
 			return nil
 		} else {
-			return err.Wrap(err,
-				fmt.Sprintf("Error reading load balancer monitor from API for resource %s ", d.Id()))
+			return diag.FromErr(errors.Wrap(err,
+				fmt.Sprintf("Error reading load balancer monitor from API for resource %s ", d.Id())))
 		}
 	}
 	log.Printf("[DEBUG] Read Cloudflare Load Balancer Monitor from API as struct: %+v", loadBalancerMonitor)
@@ -267,7 +268,7 @@ func resourceCloudflareLoadBalancerPoolMonitorDelete(ctx context.Context, d *sch
 			log.Printf("[INFO] Load balancer monitor %s no longer exists", d.Id())
 			return nil
 		} else {
-			return err.Wrap(err, "error deleting cloudflare load balancer monitor")
+			return diag.FromErr(errors.Wrap(err, "error deleting cloudflare load balancer monitor"))
 		}
 	}
 

--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -16,10 +16,10 @@ import (
 func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareLoadBalancerMonitorSchema(),
-		Create: resourceCloudflareLoadBalancerPoolMonitorCreate,
-		Read:   resourceCloudflareLoadBalancerPoolMonitorRead,
-		Update: resourceCloudflareLoadBalancerPoolMonitorUpdate,
-		Delete: resourceCloudflareLoadBalancerPoolMonitorDelete,
+		CreateContext: resourceCloudflareLoadBalancerPoolMonitorCreate,
+		ReadContext: resourceCloudflareLoadBalancerPoolMonitorRead,
+		UpdateContext: resourceCloudflareLoadBalancerPoolMonitorUpdate,
+		DeleteContext: resourceCloudflareLoadBalancerPoolMonitorDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -95,7 +95,7 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(ctx context.Context, d *sch
 
 	log.Printf("[DEBUG] Creating Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
 
-	r, err := client.CreateLoadBalancerMonitor(context.Background(), loadBalancerMonitor)
+	r, err := client.CreateLoadBalancerMonitor(ctx, loadBalancerMonitor)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating load balancer monitor"))
 	}
@@ -183,7 +183,7 @@ func resourceCloudflareLoadBalancerPoolMonitorUpdate(ctx context.Context, d *sch
 
 	log.Printf("[DEBUG] Update Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor)
 
-	_, err := client.ModifyLoadBalancerMonitor(context.Background(), loadBalancerMonitor)
+	_, err := client.ModifyLoadBalancerMonitor(ctx, loadBalancerMonitor)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error modifying load balancer monitor"))
 	}
@@ -206,7 +206,7 @@ func expandLoadBalancerMonitorHeader(cfgSet interface{}) map[string][]string {
 func resourceCloudflareLoadBalancerPoolMonitorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
-	loadBalancerMonitor, err := client.LoadBalancerMonitorDetails(context.Background(), d.Id())
+	loadBalancerMonitor, err := client.LoadBalancerMonitorDetails(ctx, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[INFO] Load balancer monitor %s no longer exists", d.Id())
@@ -262,7 +262,7 @@ func resourceCloudflareLoadBalancerPoolMonitorDelete(ctx context.Context, d *sch
 
 	log.Printf("[INFO] Deleting Cloudflare Load Balancer Monitor: %s ", d.Id())
 
-	err := client.DeleteLoadBalancerMonitor(context.Background(), d.Id())
+	err := client.DeleteLoadBalancerMonitor(ctx, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[INFO] Load balancer monitor %s no longer exists", d.Id())

--- a/cloudflare/resource_cloudflare_load_balancer_monitor.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor.go
@@ -26,7 +26,7 @@ func resourceCloudflareLoadBalancerMonitor() *schema.Resource {
 	}
 }
 
-func resourceCloudflareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolMonitorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	loadBalancerMonitor := cloudflare.LoadBalancerMonitor{
@@ -96,7 +96,7 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, met
 
 	r, err := client.CreateLoadBalancerMonitor(context.Background(), loadBalancerMonitor)
 	if err != nil {
-		return errors.Wrap(err, "error creating load balancer monitor")
+		return err.Wrap(err, "error creating load balancer monitor")
 	}
 
 	if r.ID == "" {
@@ -110,7 +110,7 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(d *schema.ResourceData, met
 	return resourceCloudflareLoadBalancerPoolMonitorRead(d, meta)
 }
 
-func resourceCloudflareLoadBalancerPoolMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolMonitorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	loadBalancerMonitor := cloudflare.LoadBalancerMonitor{
@@ -184,7 +184,7 @@ func resourceCloudflareLoadBalancerPoolMonitorUpdate(d *schema.ResourceData, met
 
 	_, err := client.ModifyLoadBalancerMonitor(context.Background(), loadBalancerMonitor)
 	if err != nil {
-		return errors.Wrap(err, "error modifying load balancer monitor")
+		return err.Wrap(err, "error modifying load balancer monitor")
 	}
 
 	log.Printf("[INFO] Cloudflare Load Balancer Monitor %q was modified", d.Id())
@@ -202,7 +202,7 @@ func expandLoadBalancerMonitorHeader(cfgSet interface{}) map[string][]string {
 	return header
 }
 
-func resourceCloudflareLoadBalancerPoolMonitorRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolMonitorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	loadBalancerMonitor, err := client.LoadBalancerMonitorDetails(context.Background(), d.Id())
@@ -212,7 +212,7 @@ func resourceCloudflareLoadBalancerPoolMonitorRead(d *schema.ResourceData, meta 
 			d.SetId("")
 			return nil
 		} else {
-			return errors.Wrap(err,
+			return err.Wrap(err,
 				fmt.Sprintf("Error reading load balancer monitor from API for resource %s ", d.Id()))
 		}
 	}
@@ -256,7 +256,7 @@ func flattenLoadBalancerMonitorHeader(header map[string][]string) *schema.Set {
 	return schema.NewSet(HashByMapKey("header"), flattened)
 }
 
-func resourceCloudflareLoadBalancerPoolMonitorDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolMonitorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	log.Printf("[INFO] Deleting Cloudflare Load Balancer Monitor: %s ", d.Id())
@@ -267,7 +267,7 @@ func resourceCloudflareLoadBalancerPoolMonitorDelete(d *schema.ResourceData, met
 			log.Printf("[INFO] Load balancer monitor %s no longer exists", d.Id())
 			return nil
 		} else {
-			return errors.Wrap(err, "error deleting cloudflare load balancer monitor")
+			return err.Wrap(err, "error deleting cloudflare load balancer monitor")
 		}
 	}
 

--- a/cloudflare/resource_cloudflare_load_balancer_monitor_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_monitor_test.go
@@ -149,7 +149,6 @@ func TestAccCloudflareLoadBalancerMonitor_PremiumTypes(t *testing.T) {
 }
 
 func TestAccCloudflareLoadBalancerMonitor_NoRequired(t *testing.T) {
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -274,7 +273,6 @@ func testAccCheckCloudflareLoadBalancerMonitorExists(n string, load *cloudflare.
 
 func testAccCheckCloudflareLoadBalancerMonitorDates(n string, loadBalancerMonitor *cloudflare.LoadBalancerMonitor, testStartTime time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		rs, _ := s.RootModule().Resources[n]
 
 		for timeStampAttr, serverVal := range map[string]time.Time{"created_on": *loadBalancerMonitor.CreatedOn, "modified_on": *loadBalancerMonitor.ModifiedOn} {

--- a/cloudflare/resource_cloudflare_load_balancer_pool.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool.go
@@ -78,7 +78,7 @@ func resourceCloudflareLoadBalancerPoolCreate(ctx context.Context, d *schema.Res
 	}
 
 	if r.ID == "" {
-		return fmt.Errorf("cailed to find id in create response; resource was empty")
+		return diag.FromErr(fmt.Errorf("cailed to find id in create response; resource was empty"))
 	}
 
 	d.SetId(r.ID)

--- a/cloudflare/resource_cloudflare_load_balancer_pool.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool.go
@@ -27,7 +27,7 @@ func resourceCloudflareLoadBalancerPool() *schema.Resource {
 	}
 }
 
-func resourceCloudflareLoadBalancerPoolCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	loadBalancerPool := cloudflare.LoadBalancerPool{
@@ -74,7 +74,7 @@ func resourceCloudflareLoadBalancerPoolCreate(d *schema.ResourceData, meta inter
 
 	r, err := client.CreateLoadBalancerPool(context.Background(), loadBalancerPool)
 	if err != nil {
-		return errors.Wrap(err, "error creating load balancer pool")
+		return err.Wrap(err, "error creating load balancer pool")
 	}
 
 	if r.ID == "" {
@@ -88,7 +88,7 @@ func resourceCloudflareLoadBalancerPoolCreate(d *schema.ResourceData, meta inter
 	return resourceCloudflareLoadBalancerPoolRead(d, meta)
 }
 
-func resourceCloudflareLoadBalancerPoolUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	loadBalancerPool := cloudflare.LoadBalancerPool{
@@ -136,7 +136,7 @@ func resourceCloudflareLoadBalancerPoolUpdate(d *schema.ResourceData, meta inter
 
 	_, err := client.ModifyLoadBalancerPool(context.Background(), loadBalancerPool)
 	if err != nil {
-		return errors.Wrap(err, "error updating load balancer pool")
+		return err.Wrap(err, "error updating load balancer pool")
 	}
 
 	return resourceCloudflareLoadBalancerPoolRead(d, meta)
@@ -212,7 +212,7 @@ func expandLoadBalancerOrigins(originSet *schema.Set) (origins []cloudflare.Load
 	return
 }
 
-func resourceCloudflareLoadBalancerPoolRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	loadBalancerPool, err := client.LoadBalancerPoolDetails(context.Background(), d.Id())
@@ -222,7 +222,7 @@ func resourceCloudflareLoadBalancerPoolRead(d *schema.ResourceData, meta interfa
 			d.SetId("")
 			return nil
 		} else {
-			return errors.Wrap(err,
+			return err.Wrap(err,
 				fmt.Sprintf("Error reading load balancer pool from API for resource %s ", d.Id()))
 		}
 	}
@@ -302,14 +302,14 @@ func flattenLoadBalancerOrigins(d *schema.ResourceData, origins []cloudflare.Loa
 	return schema.NewSet(schema.HashResource(originsElem), flattened)
 }
 
-func resourceCloudflareLoadBalancerPoolDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLoadBalancerPoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	log.Printf("[INFO] Deleting Cloudflare Load Balancer Pool: %s ", d.Id())
 
 	err := client.DeleteLoadBalancerPool(context.Background(), d.Id())
 	if err != nil {
-		return errors.Wrap(err, "error deleting Cloudflare Load Balancer Pool")
+		return err.Wrap(err, "error deleting Cloudflare Load Balancer Pool")
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_load_balancer_pool.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool.go
@@ -17,10 +17,10 @@ import (
 func resourceCloudflareLoadBalancerPool() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareLoadBalancerPoolSchema(),
-		Create: resourceCloudflareLoadBalancerPoolCreate,
-		Update: resourceCloudflareLoadBalancerPoolUpdate,
-		Read:   resourceCloudflareLoadBalancerPoolRead,
-		Delete: resourceCloudflareLoadBalancerPoolDelete,
+		CreateContext: resourceCloudflareLoadBalancerPoolCreate,
+		UpdateContext: resourceCloudflareLoadBalancerPoolUpdate,
+		ReadContext: resourceCloudflareLoadBalancerPoolRead,
+		DeleteContext: resourceCloudflareLoadBalancerPoolDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/cloudflare/resource_cloudflare_load_balancer_pool.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool.go
@@ -73,7 +73,7 @@ func resourceCloudflareLoadBalancerPoolCreate(ctx context.Context, d *schema.Res
 
 	log.Printf("[DEBUG] Creating Cloudflare Load Balancer Pool from struct: %+v", loadBalancerPool)
 
-	r, err := client.CreateLoadBalancerPool(context.Background(), loadBalancerPool)
+	r, err := client.CreateLoadBalancerPool(ctx, loadBalancerPool)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating load balancer pool"))
 	}
@@ -135,7 +135,7 @@ func resourceCloudflareLoadBalancerPoolUpdate(ctx context.Context, d *schema.Res
 
 	log.Printf("[DEBUG] Updating Cloudflare Load Balancer Pool from struct: %+v", loadBalancerPool)
 
-	_, err := client.ModifyLoadBalancerPool(context.Background(), loadBalancerPool)
+	_, err := client.ModifyLoadBalancerPool(ctx, loadBalancerPool)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error updating load balancer pool"))
 	}
@@ -216,7 +216,7 @@ func expandLoadBalancerOrigins(originSet *schema.Set) (origins []cloudflare.Load
 func resourceCloudflareLoadBalancerPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
-	loadBalancerPool, err := client.LoadBalancerPoolDetails(context.Background(), d.Id())
+	loadBalancerPool, err := client.LoadBalancerPoolDetails(ctx, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[INFO] Load balancer pool %s no longer exists", d.Id())
@@ -308,7 +308,7 @@ func resourceCloudflareLoadBalancerPoolDelete(ctx context.Context, d *schema.Res
 
 	log.Printf("[INFO] Deleting Cloudflare Load Balancer Pool: %s ", d.Id())
 
-	err := client.DeleteLoadBalancerPool(context.Background(), d.Id())
+	err := client.DeleteLoadBalancerPool(ctx, d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error deleting Cloudflare Load Balancer Pool"))
 	}

--- a/cloudflare/resource_cloudflare_load_balancer_pool_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_pool_test.go
@@ -175,7 +175,6 @@ func testAccCheckCloudflareLoadBalancerPoolExists(n string, loadBalancerPool *cl
 
 func testAccCheckCloudflareLoadBalancerPoolDates(n string, loadBalancerPool *cloudflare.LoadBalancerPool, testStartTime time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		rs, _ := s.RootModule().Resources[n]
 
 		for timeStampAttr, serverVal := range map[string]time.Time{"created_on": *loadBalancerPool.CreatedOn, "modified_on": *loadBalancerPool.ModifiedOn} {

--- a/cloudflare/resource_cloudflare_load_balancer_test.go
+++ b/cloudflare/resource_cloudflare_load_balancer_test.go
@@ -374,7 +374,6 @@ func testAccCheckCloudflareLoadBalancerIDIsValid(n, expectedZoneID string) resou
 
 func testAccCheckCloudflareLoadBalancerDates(n string, loadBalancer *cloudflare.LoadBalancer, testStartTime time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		rs, _ := s.RootModule().Resources[n]
 
 		for timeStampAttr, serverVal := range map[string]time.Time{"created_on": *loadBalancer.CreatedOn, "modified_on": *loadBalancer.ModifiedOn} {

--- a/cloudflare/resource_cloudflare_logpull_retention.go
+++ b/cloudflare/resource_cloudflare_logpull_retention.go
@@ -28,7 +28,7 @@ func resourceCloudflareLogpullRetentionSet(ctx context.Context, d *schema.Resour
 	zoneID := d.Get("zone_id").(string)
 	status := d.Get("enabled").(bool)
 
-	_, err := client.SetLogpullRetentionFlag(context.Background(), zoneID, status)
+	_, err := client.SetLogpullRetentionFlag(ctx, zoneID, status)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error setting Logpull Retention for zone ID %q: %s", zoneID, err))
 	}
@@ -42,7 +42,7 @@ func resourceCloudflareLogpullRetentionRead(ctx context.Context, d *schema.Resou
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	logpullConf, err := client.GetLogpullRetentionFlag(context.Background(), zoneID)
+	logpullConf, err := client.GetLogpullRetentionFlag(ctx, zoneID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting Logpull Retention for zone ID %q: %s", zoneID, err))
 	}
@@ -56,7 +56,7 @@ func resourceCloudflareLogpullRetentionDelete(ctx context.Context, d *schema.Res
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	_, err := client.SetLogpullRetentionFlag(context.Background(), zoneID, false)
+	_, err := client.SetLogpullRetentionFlag(ctx, zoneID, false)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error setting Logpull Retention for zone ID %q: %s", zoneID, err))
 	}

--- a/cloudflare/resource_cloudflare_logpull_retention.go
+++ b/cloudflare/resource_cloudflare_logpull_retention.go
@@ -22,7 +22,7 @@ func resourceCloudflareLogpullRetention() *schema.Resource {
 	}
 }
 
-func resourceCloudflareLogpullRetentionSet(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLogpullRetentionSet(d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	status := d.Get("enabled").(bool)
@@ -37,7 +37,7 @@ func resourceCloudflareLogpullRetentionSet(d *schema.ResourceData, meta interfac
 	return resourceCloudflareLogpullRetentionRead(d, meta)
 }
 
-func resourceCloudflareLogpullRetentionRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLogpullRetentionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -51,7 +51,7 @@ func resourceCloudflareLogpullRetentionRead(d *schema.ResourceData, meta interfa
 	return nil
 }
 
-func resourceCloudflareLogpullRetentionDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLogpullRetentionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 

--- a/cloudflare/resource_cloudflare_logpull_retention.go
+++ b/cloudflare/resource_cloudflare_logpull_retention.go
@@ -6,23 +6,24 @@ import (
 	"log"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareLogpullRetention() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareLogpullRetentionSchema(),
+		Schema:        resourceCloudflareLogpullRetentionSchema(),
 		CreateContext: resourceCloudflareLogpullRetentionSet,
-		ReadContext: resourceCloudflareLogpullRetentionRead,
+		ReadContext:   resourceCloudflareLogpullRetentionRead,
 		UpdateContext: resourceCloudflareLogpullRetentionSet,
 		DeleteContext: resourceCloudflareLogpullRetentionDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareLogpullRetentionImport,
+			StateContext: resourceCloudflareLogpullRetentionImport,
 		},
 	}
 }
 
-func resourceCloudflareLogpullRetentionSet(d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCloudflareLogpullRetentionSet(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	status := d.Get("enabled").(bool)
@@ -34,7 +35,7 @@ func resourceCloudflareLogpullRetentionSet(d *schema.ResourceData, meta interfac
 
 	d.SetId(stringChecksum("logpull-retention/" + zoneID))
 
-	return resourceCloudflareLogpullRetentionRead(d, meta)
+	return resourceCloudflareLogpullRetentionRead(context.TODO(), d, meta)
 }
 
 func resourceCloudflareLogpullRetentionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -65,7 +66,7 @@ func resourceCloudflareLogpullRetentionDelete(ctx context.Context, d *schema.Res
 	return nil
 }
 
-func resourceCloudflareLogpullRetentionImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareLogpullRetentionImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	zoneID := d.Id()
 
 	log.Printf("[DEBUG] Importing Cloudflare Logpull Retention option for zone ID: %s", zoneID)
@@ -73,7 +74,7 @@ func resourceCloudflareLogpullRetentionImport(d *schema.ResourceData, meta inter
 	d.Set("zone_id", zoneID)
 	d.SetId(stringChecksum("logpull-retention/" + zoneID))
 
-	resourceCloudflareLogpullRetentionRead(d, meta)
+	resourceCloudflareLogpullRetentionRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_logpull_retention.go
+++ b/cloudflare/resource_cloudflare_logpull_retention.go
@@ -29,7 +29,7 @@ func resourceCloudflareLogpullRetentionSet(d *schema.ResourceData, meta interfac
 
 	_, err := client.SetLogpullRetentionFlag(context.Background(), zoneID, status)
 	if err != nil {
-		return fmt.Errorf("error setting Logpull Retention for zone ID %q: %s", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error setting Logpull Retention for zone ID %q: %s", zoneID, err))
 	}
 
 	d.SetId(stringChecksum("logpull-retention/" + zoneID))
@@ -43,7 +43,7 @@ func resourceCloudflareLogpullRetentionRead(ctx context.Context, d *schema.Resou
 
 	logpullConf, err := client.GetLogpullRetentionFlag(context.Background(), zoneID)
 	if err != nil {
-		return fmt.Errorf("error getting Logpull Retention for zone ID %q: %s", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error getting Logpull Retention for zone ID %q: %s", zoneID, err))
 	}
 
 	d.Set("enabled", logpullConf.Flag)
@@ -57,7 +57,7 @@ func resourceCloudflareLogpullRetentionDelete(ctx context.Context, d *schema.Res
 
 	_, err := client.SetLogpullRetentionFlag(context.Background(), zoneID, false)
 	if err != nil {
-		return fmt.Errorf("error setting Logpull Retention for zone ID %q: %s", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error setting Logpull Retention for zone ID %q: %s", zoneID, err))
 	}
 
 	d.SetId("")

--- a/cloudflare/resource_cloudflare_logpull_retention.go
+++ b/cloudflare/resource_cloudflare_logpull_retention.go
@@ -30,12 +30,12 @@ func resourceCloudflareLogpullRetentionSet(ctx context.Context, d *schema.Resour
 
 	_, err := client.SetLogpullRetentionFlag(ctx, zoneID, status)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error setting Logpull Retention for zone ID %q: %s", zoneID, err))
+		return diag.FromErr(fmt.Errorf("error setting Logpull Retention for zone ID %q: %w", zoneID, err))
 	}
 
 	d.SetId(stringChecksum("logpull-retention/" + zoneID))
 
-	return resourceCloudflareLogpullRetentionRead(context.TODO(), d, meta)
+	return resourceCloudflareLogpullRetentionRead(ctx, d, meta)
 }
 
 func resourceCloudflareLogpullRetentionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -44,7 +44,7 @@ func resourceCloudflareLogpullRetentionRead(ctx context.Context, d *schema.Resou
 
 	logpullConf, err := client.GetLogpullRetentionFlag(ctx, zoneID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error getting Logpull Retention for zone ID %q: %s", zoneID, err))
+		return diag.FromErr(fmt.Errorf("error getting Logpull Retention for zone ID %q: %w", zoneID, err))
 	}
 
 	d.Set("enabled", logpullConf.Flag)
@@ -58,7 +58,7 @@ func resourceCloudflareLogpullRetentionDelete(ctx context.Context, d *schema.Res
 
 	_, err := client.SetLogpullRetentionFlag(ctx, zoneID, false)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error setting Logpull Retention for zone ID %q: %s", zoneID, err))
+		return diag.FromErr(fmt.Errorf("error setting Logpull Retention for zone ID %q: %w", zoneID, err))
 	}
 
 	d.SetId("")

--- a/cloudflare/resource_cloudflare_logpull_retention.go
+++ b/cloudflare/resource_cloudflare_logpull_retention.go
@@ -12,10 +12,10 @@ import (
 func resourceCloudflareLogpullRetention() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareLogpullRetentionSchema(),
-		Create: resourceCloudflareLogpullRetentionSet,
-		Read:   resourceCloudflareLogpullRetentionRead,
-		Update: resourceCloudflareLogpullRetentionSet,
-		Delete: resourceCloudflareLogpullRetentionDelete,
+		CreateContext: resourceCloudflareLogpullRetentionSet,
+		ReadContext: resourceCloudflareLogpullRetentionRead,
+		UpdateContext: resourceCloudflareLogpullRetentionSet,
+		DeleteContext: resourceCloudflareLogpullRetentionDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareLogpullRetentionImport,
 		},

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -75,9 +75,9 @@ func resourceCloudflareLogpushJobRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 	if identifier.Type == AccountType {
-		job, err = client.GetAccountLogpushJob(context.Background(), identifier.Value, jobID)
+		job, err = client.GetAccountLogpushJob(ctx, identifier.Value, jobID)
 	} else {
-		job, err = client.GetZoneLogpushJob(context.Background(), identifier.Value, jobID)
+		job, err = client.GetZoneLogpushJob(ctx, identifier.Value, jobID)
 	}
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
@@ -114,9 +114,9 @@ func resourceCloudflareLogpushJobCreate(ctx context.Context, d *schema.ResourceD
 
 	var j *cloudflare.LogpushJob
 	if identifier.Type == AccountType {
-		j, err = client.CreateAccountLogpushJob(context.Background(), identifier.Value, job)
+		j, err = client.CreateAccountLogpushJob(ctx, identifier.Value, job)
 	} else {
-		j, err = client.CreateZoneLogpushJob(context.Background(), identifier.Value, job)
+		j, err = client.CreateZoneLogpushJob(ctx, identifier.Value, job)
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating logpush job for %s: %w", identifier, err))
@@ -143,9 +143,9 @@ func resourceCloudflareLogpushJobUpdate(ctx context.Context, d *schema.ResourceD
 	log.Printf("[INFO] Updating Cloudflare Logpush job for %s from struct: %+v", identifier, job)
 
 	if identifier.Type == AccountType {
-		err = client.UpdateAccountLogpushJob(context.Background(), identifier.Value, job.ID, job)
+		err = client.UpdateAccountLogpushJob(ctx, identifier.Value, job.ID, job)
 	} else {
-		err = client.UpdateZoneLogpushJob(context.Background(), identifier.Value, job.ID, job)
+		err = client.UpdateZoneLogpushJob(ctx, identifier.Value, job.ID, job)
 	}
 
 	if err != nil {
@@ -166,9 +166,9 @@ func resourceCloudflareLogpushJobDelete(ctx context.Context, d *schema.ResourceD
 	log.Printf("[DEBUG] Deleting Cloudflare Logpush job for %s with id: %+v", identifier, job.ID)
 
 	if identifier.Type == AccountType {
-		err = client.DeleteAccountLogpushJob(context.Background(), identifier.Value, job.ID)
+		err = client.DeleteAccountLogpushJob(ctx, identifier.Value, job.ID)
 	} else {
-		err = client.DeleteZoneLogpushJob(context.Background(), identifier.Value, job.ID)
+		err = client.DeleteZoneLogpushJob(ctx, identifier.Value, job.ID)
 	}
 	if err != nil {
 		if strings.Contains(err.Error(), "job not found") {

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -61,7 +61,7 @@ func getJobFromResource(d *schema.ResourceData) (cloudflare.LogpushJob, *AccessI
 	return job, identifier, nil
 }
 
-func resourceCloudflareLogpushJobRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLogpushJobRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	jobID, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -71,7 +71,7 @@ func resourceCloudflareLogpushJobRead(d *schema.ResourceData, meta interface{}) 
 	var job cloudflare.LogpushJob
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if identifier.Type == AccountType {
 		job, err = client.GetAccountLogpushJob(context.Background(), identifier.Value, jobID)
@@ -101,7 +101,7 @@ func resourceCloudflareLogpushJobRead(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceCloudflareLogpushJobCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLogpushJobCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	job, identifier, err := getJobFromResource(d)
@@ -131,7 +131,7 @@ func resourceCloudflareLogpushJobCreate(d *schema.ResourceData, meta interface{}
 	return resourceCloudflareLogpushJobRead(d, meta)
 }
 
-func resourceCloudflareLogpushJobUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLogpushJobUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	job, identifier, err := getJobFromResource(d)
@@ -154,7 +154,7 @@ func resourceCloudflareLogpushJobUpdate(d *schema.ResourceData, meta interface{}
 	return resourceCloudflareLogpushJobRead(d, meta)
 }
 
-func resourceCloudflareLogpushJobDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLogpushJobDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	job, identifier, err := getJobFromResource(d)

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -9,18 +9,19 @@ import (
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareLogpushJob() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareLogpushJobSchema(),
+		Schema:        resourceCloudflareLogpushJobSchema(),
 		CreateContext: resourceCloudflareLogpushJobCreate,
-		ReadContext: resourceCloudflareLogpushJobRead,
+		ReadContext:   resourceCloudflareLogpushJobRead,
 		UpdateContext: resourceCloudflareLogpushJobUpdate,
 		DeleteContext: resourceCloudflareLogpushJobDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareLogpushJobImport,
+			StateContext: resourceCloudflareLogpushJobImport,
 		},
 	}
 }
@@ -128,7 +129,7 @@ func resourceCloudflareLogpushJobCreate(ctx context.Context, d *schema.ResourceD
 
 	log.Printf("[INFO] Created Cloudflare Logpush Job for %s: %s", identifier, d.Id())
 
-	return resourceCloudflareLogpushJobRead(d, meta)
+	return resourceCloudflareLogpushJobRead(ctx, d, meta)
 }
 
 func resourceCloudflareLogpushJobUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -151,7 +152,7 @@ func resourceCloudflareLogpushJobUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(fmt.Errorf("error updating logpush job id %q for %s: %w", job.ID, identifier, err))
 	}
 
-	return resourceCloudflareLogpushJobRead(d, meta)
+	return resourceCloudflareLogpushJobRead(ctx, d, meta)
 }
 
 func resourceCloudflareLogpushJobDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -183,7 +184,7 @@ func resourceCloudflareLogpushJobDelete(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func resourceCloudflareLogpushJobImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareLogpushJobImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	// split the id so we can lookup
 	idAttr := strings.Split(d.Id(), "/")
 
@@ -210,7 +211,7 @@ func resourceCloudflareLogpushJobImport(d *schema.ResourceData, meta interface{}
 	}
 	d.SetId(logpushJobID)
 
-	err := resourceCloudflareLogpushJobRead(d, meta)
+	resourceCloudflareLogpushJobRead(ctx, d, meta)
 
-	return []*schema.ResourceData{d}, err
+	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -15,10 +15,10 @@ import (
 func resourceCloudflareLogpushJob() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareLogpushJobSchema(),
-		Create: resourceCloudflareLogpushJobCreate,
-		Read:   resourceCloudflareLogpushJobRead,
-		Update: resourceCloudflareLogpushJobUpdate,
-		Delete: resourceCloudflareLogpushJobDelete,
+		CreateContext: resourceCloudflareLogpushJobCreate,
+		ReadContext: resourceCloudflareLogpushJobRead,
+		UpdateContext: resourceCloudflareLogpushJobUpdate,
+		DeleteContext: resourceCloudflareLogpushJobDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareLogpushJobImport,
 		},

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -65,7 +65,7 @@ func resourceCloudflareLogpushJobRead(ctx context.Context, d *schema.ResourceDat
 	client := meta.(*cloudflare.API)
 	jobID, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf("could not extract Logpush job from resource - invalid identifier (%s): %w", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("could not extract Logpush job from resource - invalid identifier (%s): %w", d.Id(), err))
 	}
 
 	var job cloudflare.LogpushJob
@@ -84,7 +84,7 @@ func resourceCloudflareLogpushJobRead(ctx context.Context, d *schema.ResourceDat
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading logpush job %q for %s: %w", jobID, identifier, err)
+		return diag.FromErr(fmt.Errorf("error reading logpush job %q for %s: %w", jobID, identifier, err))
 	}
 
 	if job.ID == 0 {
@@ -106,7 +106,7 @@ func resourceCloudflareLogpushJobCreate(ctx context.Context, d *schema.ResourceD
 
 	job, identifier, err := getJobFromResource(d)
 	if err != nil {
-		return fmt.Errorf("error parsing logpush job from resource: %w", err)
+		return diag.FromErr(fmt.Errorf("error parsing logpush job from resource: %w", err))
 	}
 
 	log.Printf("[DEBUG] Creating Cloudflare Logpush job for %s from struct: %+v", identifier, job)
@@ -118,10 +118,10 @@ func resourceCloudflareLogpushJobCreate(ctx context.Context, d *schema.ResourceD
 		j, err = client.CreateZoneLogpushJob(context.Background(), identifier.Value, job)
 	}
 	if err != nil {
-		return fmt.Errorf("error creating logpush job for %s: %w", identifier, err)
+		return diag.FromErr(fmt.Errorf("error creating logpush job for %s: %w", identifier, err))
 	}
 	if j.ID == 0 {
-		return fmt.Errorf("failed to find ID in Create response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find ID in Create response; resource was empty"))
 	}
 
 	d.SetId(strconv.Itoa(j.ID))
@@ -136,7 +136,7 @@ func resourceCloudflareLogpushJobUpdate(ctx context.Context, d *schema.ResourceD
 
 	job, identifier, err := getJobFromResource(d)
 	if err != nil {
-		return fmt.Errorf("error parsing logpush job from resource: %w", err)
+		return diag.FromErr(fmt.Errorf("error parsing logpush job from resource: %w", err))
 	}
 
 	log.Printf("[INFO] Updating Cloudflare Logpush job for %s from struct: %+v", identifier, job)
@@ -148,7 +148,7 @@ func resourceCloudflareLogpushJobUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return fmt.Errorf("error updating logpush job id %q for %s: %w", job.ID, identifier, err)
+		return diag.FromErr(fmt.Errorf("error updating logpush job id %q for %s: %w", job.ID, identifier, err))
 	}
 
 	return resourceCloudflareLogpushJobRead(d, meta)
@@ -159,7 +159,7 @@ func resourceCloudflareLogpushJobDelete(ctx context.Context, d *schema.ResourceD
 
 	job, identifier, err := getJobFromResource(d)
 	if err != nil {
-		return fmt.Errorf("error parsing logpush job from resource: %w", err)
+		return diag.FromErr(fmt.Errorf("error parsing logpush job from resource: %w", err))
 	}
 
 	log.Printf("[DEBUG] Deleting Cloudflare Logpush job for %s with id: %+v", identifier, job.ID)
@@ -175,7 +175,7 @@ func resourceCloudflareLogpushJobDelete(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error deleting logpush job id %v for %s: %w", job.ID, identifier, err)
+		return diag.FromErr(fmt.Errorf("error deleting logpush job id %v for %s: %w", job.ID, identifier, err))
 	}
 
 	d.SetId("")

--- a/cloudflare/resource_cloudflare_logpush_ownership_challenge.go
+++ b/cloudflare/resource_cloudflare_logpush_ownership_challenge.go
@@ -12,10 +12,10 @@ import (
 func resourceCloudflareLogpushOwnershipChallenge() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareLogpushOwnershipChallengeSchema(),
-		Create: resourceCloudflareLogpushOwnershipChallengeCreate,
-		Update: resourceCloudflareLogpushOwnershipChallengeCreate,
-		Read:   resourceCloudflareLogpushOwnershipChallengeNoop,
-		Delete: resourceCloudflareLogpushOwnershipChallengeNoop,
+		CreateContext: resourceCloudflareLogpushOwnershipChallengeCreate,
+		UpdateContext: resourceCloudflareLogpushOwnershipChallengeCreate,
+		ReadContext: resourceCloudflareLogpushOwnershipChallengeNoop,
+		DeleteContext: resourceCloudflareLogpushOwnershipChallengeNoop,
 	}
 }
 

--- a/cloudflare/resource_cloudflare_logpush_ownership_challenge.go
+++ b/cloudflare/resource_cloudflare_logpush_ownership_challenge.go
@@ -19,17 +19,17 @@ func resourceCloudflareLogpushOwnershipChallenge() *schema.Resource {
 	}
 }
 
-func resourceCloudflareLogpushOwnershipChallengeNoop(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLogpushOwnershipChallengeNoop(d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceCloudflareLogpushOwnershipChallengeCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareLogpushOwnershipChallengeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	destinationConf := d.Get("destination_conf").(string)
 	identifier, err := initIdentifier(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var challenge *cloudflare.LogpushGetOwnershipChallenge

--- a/cloudflare/resource_cloudflare_logpush_ownership_challenge.go
+++ b/cloudflare/resource_cloudflare_logpush_ownership_challenge.go
@@ -35,9 +35,9 @@ func resourceCloudflareLogpushOwnershipChallengeCreate(ctx context.Context, d *s
 
 	var challenge *cloudflare.LogpushGetOwnershipChallenge
 	if identifier.Type == AccountType {
-		challenge, err = client.GetAccountLogpushOwnershipChallenge(context.Background(), identifier.Value, destinationConf)
+		challenge, err = client.GetAccountLogpushOwnershipChallenge(ctx, identifier.Value, destinationConf)
 	} else {
-		challenge, err = client.GetZoneLogpushOwnershipChallenge(context.Background(), identifier.Value, destinationConf)
+		challenge, err = client.GetZoneLogpushOwnershipChallenge(ctx, identifier.Value, destinationConf)
 	}
 
 	if err != nil {

--- a/cloudflare/resource_cloudflare_logpush_ownership_challenge.go
+++ b/cloudflare/resource_cloudflare_logpush_ownership_challenge.go
@@ -40,7 +40,7 @@ func resourceCloudflareLogpushOwnershipChallengeCreate(ctx context.Context, d *s
 	}
 
 	if err != nil {
-		return fmt.Errorf("error requesting ownership challenge for %s: %w", identifier, err)
+		return diag.FromErr(fmt.Errorf("error requesting ownership challenge for %s: %w", identifier, err))
 	}
 
 	// The ownership challenge doesn't have a unique identifier so we generate it

--- a/cloudflare/resource_cloudflare_logpush_ownership_challenge.go
+++ b/cloudflare/resource_cloudflare_logpush_ownership_challenge.go
@@ -6,20 +6,21 @@ import (
 	"log"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareLogpushOwnershipChallenge() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareLogpushOwnershipChallengeSchema(),
+		Schema:        resourceCloudflareLogpushOwnershipChallengeSchema(),
 		CreateContext: resourceCloudflareLogpushOwnershipChallengeCreate,
 		UpdateContext: resourceCloudflareLogpushOwnershipChallengeCreate,
-		ReadContext: resourceCloudflareLogpushOwnershipChallengeNoop,
+		ReadContext:   resourceCloudflareLogpushOwnershipChallengeNoop,
 		DeleteContext: resourceCloudflareLogpushOwnershipChallengeNoop,
 	}
 }
 
-func resourceCloudflareLogpushOwnershipChallengeNoop(d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCloudflareLogpushOwnershipChallengeNoop(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }
 

--- a/cloudflare/resource_cloudflare_magic_firewall_ruleset.go
+++ b/cloudflare/resource_cloudflare_magic_firewall_ruleset.go
@@ -25,13 +25,13 @@ func resourceCloudflareMagicFirewallRuleset() *schema.Resource {
 	}
 }
 
-func resourceCloudflareMagicFirewallRulesetCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareMagicFirewallRulesetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
 	rules, err := buildMagicFirewallRulesetRulesFromResource(d.Get("rules"))
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error building ruleset from resource"))
+		return err.Wrap(err, fmt.Sprintf("error building ruleset from resource"))
 	}
 
 	ruleset, err := client.CreateMagicFirewallRuleset(context.Background(),
@@ -41,7 +41,7 @@ func resourceCloudflareMagicFirewallRulesetCreate(d *schema.ResourceData, meta i
 		rules)
 
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error creating firewall ruleset %s", d.Get("name").(string)))
+		return err.Wrap(err, fmt.Sprintf("error creating firewall ruleset %s", d.Get("name").(string)))
 	}
 
 	d.SetId(ruleset.ID)
@@ -65,7 +65,7 @@ func resourceCloudflareMagicFirewallRulesetImport(d *schema.ResourceData, meta i
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceCloudflareMagicFirewallRulesetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareMagicFirewallRulesetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -76,7 +76,7 @@ func resourceCloudflareMagicFirewallRulesetRead(d *schema.ResourceData, meta int
 			d.SetId("")
 			return nil
 		}
-		return errors.Wrap(err, fmt.Sprintf("error reading Magic Firewall Ruleset ID %q", d.Id()))
+		return err.Wrap(err, fmt.Sprintf("error reading Magic Firewall Ruleset ID %q", d.Id()))
 	}
 
 	d.Set("name", ruleset.Name)
@@ -86,30 +86,30 @@ func resourceCloudflareMagicFirewallRulesetRead(d *schema.ResourceData, meta int
 	return nil
 }
 
-func resourceCloudflareMagicFirewallRulesetUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareMagicFirewallRulesetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
 	rules, err := buildMagicFirewallRulesetRulesFromResource(d.Get("rules"))
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error building ruleset from resource"))
+		return err.Wrap(err, fmt.Sprintf("error building ruleset from resource"))
 	}
 
 	_, err = client.UpdateMagicFirewallRuleset(context.Background(), accountID, d.Id(), d.Get("description").(string), rules)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error updating Magic Firewall ruleset with ID %q", d.Id()))
+		return err.Wrap(err, fmt.Sprintf("error updating Magic Firewall ruleset with ID %q", d.Id()))
 	}
 
 	return resourceCloudflareMagicFirewallRulesetRead(d, meta)
 }
 
-func resourceCloudflareMagicFirewallRulesetDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareMagicFirewallRulesetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
 	err := client.DeleteMagicFirewallRuleset(context.Background(), accountID, d.Id())
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error deleting Magic Firewall ruleset with ID %q", d.Id()))
+		return err.Wrap(err, fmt.Sprintf("error deleting Magic Firewall ruleset with ID %q", d.Id()))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_magic_firewall_ruleset.go
+++ b/cloudflare/resource_cloudflare_magic_firewall_ruleset.go
@@ -15,10 +15,10 @@ import (
 func resourceCloudflareMagicFirewallRuleset() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareMagicFirewallRulesetSchema(),
-		Create: resourceCloudflareMagicFirewallRulesetCreate,
-		Read:   resourceCloudflareMagicFirewallRulesetRead,
-		Update: resourceCloudflareMagicFirewallRulesetUpdate,
-		Delete: resourceCloudflareMagicFirewallRulesetDelete,
+		CreateContext: resourceCloudflareMagicFirewallRulesetCreate,
+		ReadContext: resourceCloudflareMagicFirewallRulesetRead,
+		UpdateContext: resourceCloudflareMagicFirewallRulesetUpdate,
+		DeleteContext: resourceCloudflareMagicFirewallRulesetDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareMagicFirewallRulesetImport,
 		},

--- a/cloudflare/resource_cloudflare_magic_firewall_ruleset.go
+++ b/cloudflare/resource_cloudflare_magic_firewall_ruleset.go
@@ -35,7 +35,7 @@ func resourceCloudflareMagicFirewallRulesetCreate(ctx context.Context, d *schema
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error building ruleset from resource")))
 	}
 
-	ruleset, err := client.CreateMagicFirewallRuleset(context.Background(),
+	ruleset, err := client.CreateMagicFirewallRuleset(ctx,
 		accountID,
 		d.Get("name").(string),
 		d.Get("description").(string),
@@ -70,7 +70,7 @@ func resourceCloudflareMagicFirewallRulesetRead(ctx context.Context, d *schema.R
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	ruleset, err := client.GetMagicFirewallRuleset(context.Background(), accountID, d.Id())
+	ruleset, err := client.GetMagicFirewallRuleset(ctx, accountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "could not find ruleset") {
 			log.Printf("[INFO] Magic Firewall Ruleset %s no longer exists", d.Id())
@@ -96,7 +96,7 @@ func resourceCloudflareMagicFirewallRulesetUpdate(ctx context.Context, d *schema
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error building ruleset from resource")))
 	}
 
-	_, err = client.UpdateMagicFirewallRuleset(context.Background(), accountID, d.Id(), d.Get("description").(string), rules)
+	_, err = client.UpdateMagicFirewallRuleset(ctx, accountID, d.Id(), d.Get("description").(string), rules)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error updating Magic Firewall ruleset with ID %q", d.Id())))
 	}
@@ -108,7 +108,7 @@ func resourceCloudflareMagicFirewallRulesetDelete(ctx context.Context, d *schema
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	err := client.DeleteMagicFirewallRuleset(context.Background(), accountID, d.Id())
+	err := client.DeleteMagicFirewallRuleset(ctx, accountID, d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error deleting Magic Firewall ruleset with ID %q", d.Id())))
 	}

--- a/cloudflare/resource_cloudflare_notification_policy.go
+++ b/cloudflare/resource_cloudflare_notification_policy.go
@@ -23,7 +23,7 @@ func resourceCloudflareNotificationPolicy() *schema.Resource {
 	}
 }
 
-func resourceCloudflareNotificationPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareNotificationPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -39,7 +39,7 @@ func resourceCloudflareNotificationPolicyCreate(d *schema.ResourceData, meta int
 	return resourceCloudflareNotificationPolicyRead(d, meta)
 }
 
-func resourceCloudflareNotificationPolicyRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareNotificationPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	policyID := d.Id()
 	accountID := d.Get("account_id").(string)
@@ -79,7 +79,7 @@ func resourceCloudflareNotificationPolicyRead(d *schema.ResourceData, meta inter
 	return nil
 }
 
-func resourceCloudflareNotificationPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareNotificationPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	policyID := d.Id()
 	accountID := d.Get("account_id").(string)
@@ -96,7 +96,7 @@ func resourceCloudflareNotificationPolicyUpdate(d *schema.ResourceData, meta int
 	return resourceCloudflareNotificationPolicyRead(d, meta)
 }
 
-func resourceCloudflareNotificationPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareNotificationPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	policyID := d.Id()
 	accountID := d.Get("account_id").(string)

--- a/cloudflare/resource_cloudflare_notification_policy.go
+++ b/cloudflare/resource_cloudflare_notification_policy.go
@@ -32,7 +32,7 @@ func resourceCloudflareNotificationPolicyCreate(ctx context.Context, d *schema.R
 	policy, err := client.CreateNotificationPolicy(context.Background(), accountID, notificationPolicy)
 
 	if err != nil {
-		return fmt.Errorf("error creating policy %s: %s", notificationPolicy.Name, err)
+		return diag.FromErr(fmt.Errorf("error creating policy %s: %s", notificationPolicy.Name, err))
 	}
 	d.SetId(policy.Result.ID)
 
@@ -48,7 +48,7 @@ func resourceCloudflareNotificationPolicyRead(ctx context.Context, d *schema.Res
 
 	name := d.Get("name").(string)
 	if err != nil {
-		return fmt.Errorf("error retrieving notification policy %s: %s", name, err)
+		return diag.FromErr(fmt.Errorf("error retrieving notification policy %s: %s", name, err))
 	}
 
 	d.Set("name", policy.Result.Name)
@@ -60,20 +60,20 @@ func resourceCloudflareNotificationPolicyRead(ctx context.Context, d *schema.Res
 
 	if policy.Result.Filters != nil && len(policy.Result.Filters) > 0 {
 		if err := d.Set("filters", flattenNotificationPolicyFilter(policy.Result.Filters)); err != nil {
-			return fmt.Errorf("failed to set filters: %s", err)
+			return diag.FromErr(fmt.Errorf("failed to set filters: %s", err))
 		}
 	}
 
 	if err := d.Set("email_integration", setNotificationMechanisms(policy.Result.Mechanisms["email"])); err != nil {
-		return fmt.Errorf("failed to set email integration: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to set email integration: %s", err))
 	}
 
 	if err := d.Set("pagerduty_integration", setNotificationMechanisms(policy.Result.Mechanisms["pagerduty"])); err != nil {
-		return fmt.Errorf("failed to set pagerduty integration: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to set pagerduty integration: %s", err))
 	}
 
 	if err := d.Set("webhooks_integration", setNotificationMechanisms(policy.Result.Mechanisms["webhooks"])); err != nil {
-		return fmt.Errorf("failed to set webhooks integration: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to set webhooks integration: %s", err))
 	}
 
 	return nil
@@ -90,7 +90,7 @@ func resourceCloudflareNotificationPolicyUpdate(ctx context.Context, d *schema.R
 	_, err := client.UpdateNotificationPolicy(context.Background(), accountID, &notificationPolicy)
 
 	if err != nil {
-		return fmt.Errorf("error updating notification policy %s: %s", policyID, err)
+		return diag.FromErr(fmt.Errorf("error updating notification policy %s: %s", policyID, err))
 	}
 
 	return resourceCloudflareNotificationPolicyRead(d, meta)
@@ -104,7 +104,7 @@ func resourceCloudflareNotificationPolicyDelete(ctx context.Context, d *schema.R
 	_, err := client.DeleteNotificationPolicy(context.Background(), accountID, policyID)
 
 	if err != nil {
-		return fmt.Errorf("error deleting notification policy %s: %s", policyID, err)
+		return diag.FromErr(fmt.Errorf("error deleting notification policy %s: %s", policyID, err))
 	}
 	return nil
 }

--- a/cloudflare/resource_cloudflare_notification_policy.go
+++ b/cloudflare/resource_cloudflare_notification_policy.go
@@ -30,7 +30,7 @@ func resourceCloudflareNotificationPolicyCreate(ctx context.Context, d *schema.R
 
 	notificationPolicy := buildNotificationPolicy(d)
 
-	policy, err := client.CreateNotificationPolicy(context.Background(), accountID, notificationPolicy)
+	policy, err := client.CreateNotificationPolicy(ctx, accountID, notificationPolicy)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating policy %s: %s", notificationPolicy.Name, err))
@@ -45,7 +45,7 @@ func resourceCloudflareNotificationPolicyRead(ctx context.Context, d *schema.Res
 	policyID := d.Id()
 	accountID := d.Get("account_id").(string)
 
-	policy, err := client.GetNotificationPolicy(context.Background(), accountID, policyID)
+	policy, err := client.GetNotificationPolicy(ctx, accountID, policyID)
 
 	name := d.Get("name").(string)
 	if err != nil {
@@ -88,7 +88,7 @@ func resourceCloudflareNotificationPolicyUpdate(ctx context.Context, d *schema.R
 	notificationPolicy := buildNotificationPolicy(d)
 	notificationPolicy.ID = policyID
 
-	_, err := client.UpdateNotificationPolicy(context.Background(), accountID, &notificationPolicy)
+	_, err := client.UpdateNotificationPolicy(ctx, accountID, &notificationPolicy)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating notification policy %s: %s", policyID, err))
@@ -102,7 +102,7 @@ func resourceCloudflareNotificationPolicyDelete(ctx context.Context, d *schema.R
 	policyID := d.Id()
 	accountID := d.Get("account_id").(string)
 
-	_, err := client.DeleteNotificationPolicy(context.Background(), accountID, policyID)
+	_, err := client.DeleteNotificationPolicy(ctx, accountID, policyID)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting notification policy %s: %s", policyID, err))

--- a/cloudflare/resource_cloudflare_notification_policy.go
+++ b/cloudflare/resource_cloudflare_notification_policy.go
@@ -7,18 +7,19 @@ import (
 	"time"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareNotificationPolicy() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareNotificationPolicySchema(),
+		Schema:        resourceCloudflareNotificationPolicySchema(),
 		CreateContext: resourceCloudflareNotificationPolicyCreate,
-		ReadContext: resourceCloudflareNotificationPolicyRead,
+		ReadContext:   resourceCloudflareNotificationPolicyRead,
 		UpdateContext: resourceCloudflareNotificationPolicyUpdate,
 		DeleteContext: resourceCloudflareNotificationPolicyDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceNotificationPolicyImport,
+			StateContext: resourceNotificationPolicyImport,
 		},
 	}
 }
@@ -36,7 +37,7 @@ func resourceCloudflareNotificationPolicyCreate(ctx context.Context, d *schema.R
 	}
 	d.SetId(policy.Result.ID)
 
-	return resourceCloudflareNotificationPolicyRead(d, meta)
+	return resourceCloudflareNotificationPolicyRead(ctx, d, meta)
 }
 
 func resourceCloudflareNotificationPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -93,7 +94,7 @@ func resourceCloudflareNotificationPolicyUpdate(ctx context.Context, d *schema.R
 		return diag.FromErr(fmt.Errorf("error updating notification policy %s: %s", policyID, err))
 	}
 
-	return resourceCloudflareNotificationPolicyRead(d, meta)
+	return resourceCloudflareNotificationPolicyRead(ctx, d, meta)
 }
 
 func resourceCloudflareNotificationPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -109,7 +110,7 @@ func resourceCloudflareNotificationPolicyDelete(ctx context.Context, d *schema.R
 	return nil
 }
 
-func resourceNotificationPolicyImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceNotificationPolicyImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -120,7 +121,7 @@ func resourceNotificationPolicyImport(d *schema.ResourceData, meta interface{}) 
 	d.SetId(policyID)
 	d.Set("account_id", accountID)
 
-	resourceCloudflareNotificationPolicyRead(d, meta)
+	resourceCloudflareNotificationPolicyRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 

--- a/cloudflare/resource_cloudflare_notification_policy.go
+++ b/cloudflare/resource_cloudflare_notification_policy.go
@@ -33,7 +33,7 @@ func resourceCloudflareNotificationPolicyCreate(ctx context.Context, d *schema.R
 	policy, err := client.CreateNotificationPolicy(ctx, accountID, notificationPolicy)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating policy %s: %s", notificationPolicy.Name, err))
+		return diag.FromErr(fmt.Errorf("error creating policy %s: %w", notificationPolicy.Name, err))
 	}
 	d.SetId(policy.Result.ID)
 
@@ -49,7 +49,7 @@ func resourceCloudflareNotificationPolicyRead(ctx context.Context, d *schema.Res
 
 	name := d.Get("name").(string)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error retrieving notification policy %s: %s", name, err))
+		return diag.FromErr(fmt.Errorf("error retrieving notification policy %s: %w", name, err))
 	}
 
 	d.Set("name", policy.Result.Name)
@@ -61,20 +61,20 @@ func resourceCloudflareNotificationPolicyRead(ctx context.Context, d *schema.Res
 
 	if policy.Result.Filters != nil && len(policy.Result.Filters) > 0 {
 		if err := d.Set("filters", flattenNotificationPolicyFilter(policy.Result.Filters)); err != nil {
-			return diag.FromErr(fmt.Errorf("failed to set filters: %s", err))
+			return diag.FromErr(fmt.Errorf("failed to set filters: %w", err))
 		}
 	}
 
 	if err := d.Set("email_integration", setNotificationMechanisms(policy.Result.Mechanisms["email"])); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set email integration: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to set email integration: %w", err))
 	}
 
 	if err := d.Set("pagerduty_integration", setNotificationMechanisms(policy.Result.Mechanisms["pagerduty"])); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set pagerduty integration: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to set pagerduty integration: %w", err))
 	}
 
 	if err := d.Set("webhooks_integration", setNotificationMechanisms(policy.Result.Mechanisms["webhooks"])); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set webhooks integration: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to set webhooks integration: %w", err))
 	}
 
 	return nil
@@ -91,7 +91,7 @@ func resourceCloudflareNotificationPolicyUpdate(ctx context.Context, d *schema.R
 	_, err := client.UpdateNotificationPolicy(ctx, accountID, &notificationPolicy)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating notification policy %s: %s", policyID, err))
+		return diag.FromErr(fmt.Errorf("error updating notification policy %s: %w", policyID, err))
 	}
 
 	return resourceCloudflareNotificationPolicyRead(ctx, d, meta)
@@ -105,7 +105,7 @@ func resourceCloudflareNotificationPolicyDelete(ctx context.Context, d *schema.R
 	_, err := client.DeleteNotificationPolicy(ctx, accountID, policyID)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting notification policy %s: %s", policyID, err))
+		return diag.FromErr(fmt.Errorf("error deleting notification policy %s: %w", policyID, err))
 	}
 	return nil
 }
@@ -124,7 +124,6 @@ func resourceNotificationPolicyImport(ctx context.Context, d *schema.ResourceDat
 	resourceCloudflareNotificationPolicyRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
-
 }
 
 func buildNotificationPolicy(d *schema.ResourceData) cloudflare.NotificationPolicy {

--- a/cloudflare/resource_cloudflare_notification_policy.go
+++ b/cloudflare/resource_cloudflare_notification_policy.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareNotificationPolicy() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareNotificationPolicySchema(),
-		Create: resourceCloudflareNotificationPolicyCreate,
-		Read:   resourceCloudflareNotificationPolicyRead,
-		Update: resourceCloudflareNotificationPolicyUpdate,
-		Delete: resourceCloudflareNotificationPolicyDelete,
+		CreateContext: resourceCloudflareNotificationPolicyCreate,
+		ReadContext: resourceCloudflareNotificationPolicyRead,
+		UpdateContext: resourceCloudflareNotificationPolicyUpdate,
+		DeleteContext: resourceCloudflareNotificationPolicyDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceNotificationPolicyImport,
 		},

--- a/cloudflare/resource_cloudflare_notification_policy_test.go
+++ b/cloudflare/resource_cloudflare_notification_policy_test.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -162,12 +163,12 @@ func testCheckCloudflareNotificationPolicyWithFiltersAttributeUpdated(name, poli
 
 func TestFlattenExpandFilters(t *testing.T) {
 	filters := map[string][]string{
-		"services": []string{"waf", "firewallrules"},
-		"zones":    []string{"abc123"},
+		"services": {"waf", "firewallrules"},
+		"zones":    {"abc123"},
 	}
 	flattenedFilters := flattenNotificationPolicyFilter(filters)
 	expandedFilters := expandNotificationPolicyFilter(flattenedFilters)
-	for k, _ := range filters {
+	for k := range filters {
 		sort.Strings(filters[k])
 		sort.Strings(expandedFilters[k])
 		assert.EqualValuesf(t, filters[k], expandedFilters[k], "values should equal without order")

--- a/cloudflare/resource_cloudflare_notification_policy_webhooks.go
+++ b/cloudflare/resource_cloudflare_notification_policy_webhooks.go
@@ -33,11 +33,11 @@ func resourceCloudflareNotificationPolicyWebhooksCreate(ctx context.Context, d *
 	webhooksDestination, err := client.CreateNotificationWebhooks(context.Background(), accountID, &notificationWebhooks)
 
 	if err != nil {
-		return fmt.Errorf("error connecting webhooks destination %s: %s", notificationWebhooks.Name, err)
+		return diag.FromErr(fmt.Errorf("error connecting webhooks destination %s: %s", notificationWebhooks.Name, err))
 	}
 	formattedWebhookID, err := uuid.Parse(webhooksDestination.Result.ID)
 	if err != nil {
-		return fmt.Errorf("error setting notification webhooks: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting notification webhooks: %s", err))
 	}
 
 	d.SetId(formattedWebhookID.String())
@@ -54,7 +54,7 @@ func resourceCloudflareNotificationPolicyWebhooksRead(ctx context.Context, d *sc
 
 	name := d.Get("name").(string)
 	if err != nil {
-		return fmt.Errorf("error retrieving notification webhooks %s: %s", name, err)
+		return diag.FromErr(fmt.Errorf("error retrieving notification webhooks %s: %s", name, err))
 	}
 
 	d.Set("name", notificationWebhooks.Result.Name)
@@ -82,7 +82,7 @@ func resourceCloudflareNotificationPolicyWebhooksUpdate(ctx context.Context, d *
 	_, err := client.UpdateNotificationWebhooks(context.Background(), accountID, webhooksID, &notificationWebhooks)
 
 	if err != nil {
-		return fmt.Errorf("error updating notification webhooks destination %s: %s", webhooksID, err)
+		return diag.FromErr(fmt.Errorf("error updating notification webhooks destination %s: %s", webhooksID, err))
 	}
 
 	return resourceCloudflareNotificationPolicyWebhooksRead(d, meta)
@@ -96,7 +96,7 @@ func resourceCloudflareNotificationPolicyWebhooksDelete(ctx context.Context, d *
 	_, err := client.DeleteNotificationWebhooks(context.Background(), accountID, webhooksID)
 
 	if err != nil {
-		return fmt.Errorf("error deleting notification webhooks destination %s: %s", webhooksID, err)
+		return diag.FromErr(fmt.Errorf("error deleting notification webhooks destination %s: %s", webhooksID, err))
 	}
 	return nil
 }

--- a/cloudflare/resource_cloudflare_notification_policy_webhooks.go
+++ b/cloudflare/resource_cloudflare_notification_policy_webhooks.go
@@ -31,7 +31,7 @@ func resourceCloudflareNotificationPolicyWebhooksCreate(ctx context.Context, d *
 
 	notificationWebhooks := buildNotificationPolicyWebhooks(d)
 
-	webhooksDestination, err := client.CreateNotificationWebhooks(context.Background(), accountID, &notificationWebhooks)
+	webhooksDestination, err := client.CreateNotificationWebhooks(ctx, accountID, &notificationWebhooks)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error connecting webhooks destination %s: %s", notificationWebhooks.Name, err))
@@ -51,7 +51,7 @@ func resourceCloudflareNotificationPolicyWebhooksRead(ctx context.Context, d *sc
 	webhooksDestinationID := d.Id()
 	accountID := d.Get("account_id").(string)
 
-	notificationWebhooks, err := client.GetNotificationWebhooks(context.Background(), accountID, webhooksDestinationID)
+	notificationWebhooks, err := client.GetNotificationWebhooks(ctx, accountID, webhooksDestinationID)
 
 	name := d.Get("name").(string)
 	if err != nil {
@@ -80,7 +80,7 @@ func resourceCloudflareNotificationPolicyWebhooksUpdate(ctx context.Context, d *
 
 	notificationWebhooks := buildNotificationPolicyWebhooks(d)
 
-	_, err := client.UpdateNotificationWebhooks(context.Background(), accountID, webhooksID, &notificationWebhooks)
+	_, err := client.UpdateNotificationWebhooks(ctx, accountID, webhooksID, &notificationWebhooks)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating notification webhooks destination %s: %s", webhooksID, err))
@@ -94,7 +94,7 @@ func resourceCloudflareNotificationPolicyWebhooksDelete(ctx context.Context, d *
 	webhooksID := d.Id()
 	accountID := d.Get("account_id").(string)
 
-	_, err := client.DeleteNotificationWebhooks(context.Background(), accountID, webhooksID)
+	_, err := client.DeleteNotificationWebhooks(ctx, accountID, webhooksID)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting notification webhooks destination %s: %s", webhooksID, err))

--- a/cloudflare/resource_cloudflare_notification_policy_webhooks.go
+++ b/cloudflare/resource_cloudflare_notification_policy_webhooks.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareNotificationPolicyWebhooks() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareNotificationPolicyWebhooksSchema(),
-		Create: resourceCloudflareNotificationPolicyWebhooksCreate,
-		Read:   resourceCloudflareNotificationPolicyWebhooksRead,
-		Update: resourceCloudflareNotificationPolicyWebhooksUpdate,
-		Delete: resourceCloudflareNotificationPolicyWebhooksDelete,
+		CreateContext: resourceCloudflareNotificationPolicyWebhooksCreate,
+		ReadContext: resourceCloudflareNotificationPolicyWebhooksRead,
+		UpdateContext: resourceCloudflareNotificationPolicyWebhooksUpdate,
+		DeleteContext: resourceCloudflareNotificationPolicyWebhooksDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareNotificationPolicyWebhooksImport,
 		},

--- a/cloudflare/resource_cloudflare_notification_policy_webhooks.go
+++ b/cloudflare/resource_cloudflare_notification_policy_webhooks.go
@@ -24,7 +24,7 @@ func resourceCloudflareNotificationPolicyWebhooks() *schema.Resource {
 	}
 }
 
-func resourceCloudflareNotificationPolicyWebhooksCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareNotificationPolicyWebhooksCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -45,7 +45,7 @@ func resourceCloudflareNotificationPolicyWebhooksCreate(d *schema.ResourceData, 
 	return resourceCloudflareNotificationPolicyWebhooksRead(d, meta)
 }
 
-func resourceCloudflareNotificationPolicyWebhooksRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareNotificationPolicyWebhooksRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	webhooksDestinationID := d.Id()
 	accountID := d.Get("account_id").(string)
@@ -72,7 +72,7 @@ func resourceCloudflareNotificationPolicyWebhooksRead(d *schema.ResourceData, me
 	return nil
 }
 
-func resourceCloudflareNotificationPolicyWebhooksUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareNotificationPolicyWebhooksUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	webhooksID := d.Id()
 	accountID := d.Get("account_id").(string)
@@ -88,7 +88,7 @@ func resourceCloudflareNotificationPolicyWebhooksUpdate(d *schema.ResourceData, 
 	return resourceCloudflareNotificationPolicyWebhooksRead(d, meta)
 }
 
-func resourceCloudflareNotificationPolicyWebhooksDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareNotificationPolicyWebhooksDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	webhooksID := d.Id()
 	accountID := d.Get("account_id").(string)

--- a/cloudflare/resource_cloudflare_notification_policy_webhooks.go
+++ b/cloudflare/resource_cloudflare_notification_policy_webhooks.go
@@ -34,11 +34,11 @@ func resourceCloudflareNotificationPolicyWebhooksCreate(ctx context.Context, d *
 	webhooksDestination, err := client.CreateNotificationWebhooks(ctx, accountID, &notificationWebhooks)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error connecting webhooks destination %s: %s", notificationWebhooks.Name, err))
+		return diag.FromErr(fmt.Errorf("error connecting webhooks destination %s: %w", notificationWebhooks.Name, err))
 	}
 	formattedWebhookID, err := uuid.Parse(webhooksDestination.Result.ID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error setting notification webhooks: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting notification webhooks: %w", err))
 	}
 
 	d.SetId(formattedWebhookID.String())
@@ -55,7 +55,7 @@ func resourceCloudflareNotificationPolicyWebhooksRead(ctx context.Context, d *sc
 
 	name := d.Get("name").(string)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error retrieving notification webhooks %s: %s", name, err))
+		return diag.FromErr(fmt.Errorf("error retrieving notification webhooks %s: %w", name, err))
 	}
 
 	d.Set("name", notificationWebhooks.Result.Name)
@@ -83,7 +83,7 @@ func resourceCloudflareNotificationPolicyWebhooksUpdate(ctx context.Context, d *
 	_, err := client.UpdateNotificationWebhooks(ctx, accountID, webhooksID, &notificationWebhooks)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating notification webhooks destination %s: %s", webhooksID, err))
+		return diag.FromErr(fmt.Errorf("error updating notification webhooks destination %s: %w", webhooksID, err))
 	}
 
 	return resourceCloudflareNotificationPolicyWebhooksRead(ctx, d, meta)
@@ -97,7 +97,7 @@ func resourceCloudflareNotificationPolicyWebhooksDelete(ctx context.Context, d *
 	_, err := client.DeleteNotificationWebhooks(ctx, accountID, webhooksID)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting notification webhooks destination %s: %s", webhooksID, err))
+		return diag.FromErr(fmt.Errorf("error deleting notification webhooks destination %s: %w", webhooksID, err))
 	}
 	return nil
 }
@@ -116,7 +116,6 @@ func resourceCloudflareNotificationPolicyWebhooksImport(ctx context.Context, d *
 	resourceCloudflareNotificationPolicyWebhooksRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
-
 }
 
 func buildNotificationPolicyWebhooks(d *schema.ResourceData) cloudflare.NotificationUpsertWebhooks {

--- a/cloudflare/resource_cloudflare_notification_policy_webhooks.go
+++ b/cloudflare/resource_cloudflare_notification_policy_webhooks.go
@@ -8,18 +8,19 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareNotificationPolicyWebhooks() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareNotificationPolicyWebhooksSchema(),
+		Schema:        resourceCloudflareNotificationPolicyWebhooksSchema(),
 		CreateContext: resourceCloudflareNotificationPolicyWebhooksCreate,
-		ReadContext: resourceCloudflareNotificationPolicyWebhooksRead,
+		ReadContext:   resourceCloudflareNotificationPolicyWebhooksRead,
 		UpdateContext: resourceCloudflareNotificationPolicyWebhooksUpdate,
 		DeleteContext: resourceCloudflareNotificationPolicyWebhooksDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareNotificationPolicyWebhooksImport,
+			StateContext: resourceCloudflareNotificationPolicyWebhooksImport,
 		},
 	}
 }
@@ -42,7 +43,7 @@ func resourceCloudflareNotificationPolicyWebhooksCreate(ctx context.Context, d *
 
 	d.SetId(formattedWebhookID.String())
 
-	return resourceCloudflareNotificationPolicyWebhooksRead(d, meta)
+	return resourceCloudflareNotificationPolicyWebhooksRead(ctx, d, meta)
 }
 
 func resourceCloudflareNotificationPolicyWebhooksRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -85,7 +86,7 @@ func resourceCloudflareNotificationPolicyWebhooksUpdate(ctx context.Context, d *
 		return diag.FromErr(fmt.Errorf("error updating notification webhooks destination %s: %s", webhooksID, err))
 	}
 
-	return resourceCloudflareNotificationPolicyWebhooksRead(d, meta)
+	return resourceCloudflareNotificationPolicyWebhooksRead(ctx, d, meta)
 }
 
 func resourceCloudflareNotificationPolicyWebhooksDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -101,7 +102,7 @@ func resourceCloudflareNotificationPolicyWebhooksDelete(ctx context.Context, d *
 	return nil
 }
 
-func resourceCloudflareNotificationPolicyWebhooksImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareNotificationPolicyWebhooksImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -112,7 +113,7 @@ func resourceCloudflareNotificationPolicyWebhooksImport(d *schema.ResourceData, 
 	d.SetId(webhooksID)
 	d.Set("account_id", accountID)
 
-	resourceCloudflareNotificationPolicyWebhooksRead(d, meta)
+	resourceCloudflareNotificationPolicyWebhooksRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -53,7 +53,7 @@ func resourceCloudflareOriginCACertificateCreate(ctx context.Context, d *schema.
 	cert, err := client.CreateOriginCertificate(context.Background(), certInput)
 
 	if err != nil {
-		return fmt.Errorf("error creating origin certificate: %s", err)
+		return diag.FromErr(fmt.Errorf("error creating origin certificate: %s", err))
 	}
 
 	d.SetId(cert.ID)
@@ -74,7 +74,7 @@ func resourceCloudflareOriginCACertificateRead(ctx context.Context, d *schema.Re
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding OriginCACertificate %q: %s", certID, err)
+		return diag.FromErr(fmt.Errorf("error finding OriginCACertificate %q: %s", certID, err))
 	}
 
 	if cert.RevokedAt != (time.Time{}) {
@@ -95,12 +95,12 @@ func resourceCloudflareOriginCACertificateRead(ctx context.Context, d *schema.Re
 
 	certBlock, _ := pem.Decode([]byte(cert.Certificate))
 	if certBlock == nil {
-		return fmt.Errorf("error decoding OriginCACertificate %q: %s", certID, err)
+		return diag.FromErr(fmt.Errorf("error decoding OriginCACertificate %q: %s", certID, err))
 	}
 
 	x509Cert, err := x509.ParseCertificate(certBlock.Bytes)
 	if err != nil {
-		return fmt.Errorf("error parsing OriginCACertificate %q: %s", certID, err)
+		return diag.FromErr(fmt.Errorf("error parsing OriginCACertificate %q: %s", certID, err))
 	}
 	d.Set("requested_validity", calculateRequestedValidityFromCertificate(x509Cert))
 
@@ -116,7 +116,7 @@ func resourceCloudflareOriginCACertificateDelete(ctx context.Context, d *schema.
 	_, err := client.RevokeOriginCertificate(context.Background(), certID)
 
 	if err != nil {
-		return fmt.Errorf("error revoking Cloudflare OriginCACertificate: %s", err)
+		return diag.FromErr(fmt.Errorf("error revoking Cloudflare OriginCACertificate: %s", err))
 	}
 
 	d.SetId("")

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -11,18 +11,19 @@ import (
 	"time"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareOriginCACertificate() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareOriginCACertificateSchema(),
+		Schema:        resourceCloudflareOriginCACertificateSchema(),
 		CreateContext: resourceCloudflareOriginCACertificateCreate,
 		UpdateContext: resourceCloudflareOriginCACertificateCreate,
-		ReadContext: resourceCloudflareOriginCACertificateRead,
+		ReadContext:   resourceCloudflareOriginCACertificateRead,
 		DeleteContext: resourceCloudflareOriginCACertificateDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }
@@ -58,7 +59,7 @@ func resourceCloudflareOriginCACertificateCreate(ctx context.Context, d *schema.
 
 	d.SetId(cert.ID)
 
-	return resourceCloudflareOriginCACertificateRead(d, meta)
+	return resourceCloudflareOriginCACertificateRead(ctx, d, meta)
 }
 
 func resourceCloudflareOriginCACertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -51,7 +51,7 @@ func resourceCloudflareOriginCACertificateCreate(ctx context.Context, d *schema.
 	}
 
 	log.Printf("[INFO] Creating Cloudflare OriginCACertificate: %#v", certInput)
-	cert, err := client.CreateOriginCertificate(context.Background(), certInput)
+	cert, err := client.CreateOriginCertificate(ctx, certInput)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating origin certificate: %s", err))
@@ -65,7 +65,7 @@ func resourceCloudflareOriginCACertificateCreate(ctx context.Context, d *schema.
 func resourceCloudflareOriginCACertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	certID := d.Id()
-	cert, err := client.OriginCertificate(context.Background(), certID)
+	cert, err := client.OriginCertificate(ctx, certID)
 
 	log.Printf("[DEBUG] OriginCACertificate: %#v", cert)
 
@@ -114,7 +114,7 @@ func resourceCloudflareOriginCACertificateDelete(ctx context.Context, d *schema.
 
 	log.Printf("[INFO] Revoking Cloudflare OriginCACertificate: id %s", certID)
 
-	_, err := client.RevokeOriginCertificate(context.Background(), certID)
+	_, err := client.RevokeOriginCertificate(ctx, certID)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error revoking Cloudflare OriginCACertificate: %s", err))

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -54,7 +54,7 @@ func resourceCloudflareOriginCACertificateCreate(ctx context.Context, d *schema.
 	cert, err := client.CreateOriginCertificate(ctx, certInput)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating origin certificate: %s", err))
+		return diag.FromErr(fmt.Errorf("error creating origin certificate: %w", err))
 	}
 
 	d.SetId(cert.ID)
@@ -75,7 +75,7 @@ func resourceCloudflareOriginCACertificateRead(ctx context.Context, d *schema.Re
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding OriginCACertificate %q: %s", certID, err))
+		return diag.FromErr(fmt.Errorf("error finding OriginCACertificate %q: %w", certID, err))
 	}
 
 	if cert.RevokedAt != (time.Time{}) {
@@ -96,12 +96,12 @@ func resourceCloudflareOriginCACertificateRead(ctx context.Context, d *schema.Re
 
 	certBlock, _ := pem.Decode([]byte(cert.Certificate))
 	if certBlock == nil {
-		return diag.FromErr(fmt.Errorf("error decoding OriginCACertificate %q: %s", certID, err))
+		return diag.FromErr(fmt.Errorf("error decoding OriginCACertificate %q: %w", certID, err))
 	}
 
 	x509Cert, err := x509.ParseCertificate(certBlock.Bytes)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error parsing OriginCACertificate %q: %s", certID, err))
+		return diag.FromErr(fmt.Errorf("error parsing OriginCACertificate %q: %w", certID, err))
 	}
 	d.Set("requested_validity", calculateRequestedValidityFromCertificate(x509Cert))
 
@@ -117,7 +117,7 @@ func resourceCloudflareOriginCACertificateDelete(ctx context.Context, d *schema.
 	_, err := client.RevokeOriginCertificate(ctx, certID)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error revoking Cloudflare OriginCACertificate: %s", err))
+		return diag.FromErr(fmt.Errorf("error revoking Cloudflare OriginCACertificate: %w", err))
 	}
 
 	d.SetId("")
@@ -133,7 +133,7 @@ func validateCSR(v interface{}, k string) (ws []string, errors []error) {
 
 	_, err := x509.ParseCertificateRequest(block.Bytes)
 	if err != nil {
-		errors = append(errors, fmt.Errorf("%q: %s", k, err.Error()))
+		errors = append(errors, fmt.Errorf("%q: %w", k, err))
 	}
 	return
 }

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -17,10 +17,10 @@ import (
 func resourceCloudflareOriginCACertificate() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareOriginCACertificateSchema(),
-		Create: resourceCloudflareOriginCACertificateCreate,
-		Update: resourceCloudflareOriginCACertificateCreate,
-		Read:   resourceCloudflareOriginCACertificateRead,
-		Delete: resourceCloudflareOriginCACertificateDelete,
+		CreateContext: resourceCloudflareOriginCACertificateCreate,
+		UpdateContext: resourceCloudflareOriginCACertificateCreate,
+		ReadContext: resourceCloudflareOriginCACertificateRead,
+		DeleteContext: resourceCloudflareOriginCACertificateDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/cloudflare/resource_cloudflare_origin_ca_certificate.go
+++ b/cloudflare/resource_cloudflare_origin_ca_certificate.go
@@ -27,7 +27,7 @@ func resourceCloudflareOriginCACertificate() *schema.Resource {
 	}
 }
 
-func resourceCloudflareOriginCACertificateCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareOriginCACertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	hostnames := []string{}
@@ -61,7 +61,7 @@ func resourceCloudflareOriginCACertificateCreate(d *schema.ResourceData, meta in
 	return resourceCloudflareOriginCACertificateRead(d, meta)
 }
 
-func resourceCloudflareOriginCACertificateRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareOriginCACertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	certID := d.Id()
 	cert, err := client.OriginCertificate(context.Background(), certID)
@@ -107,7 +107,7 @@ func resourceCloudflareOriginCACertificateRead(d *schema.ResourceData, meta inte
 	return nil
 }
 
-func resourceCloudflareOriginCACertificateDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareOriginCACertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	certID := d.Id()
 

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -9,18 +9,19 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflarePageRule() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflarePageRuleSchema(),
+		Schema:        resourceCloudflarePageRuleSchema(),
 		CreateContext: resourceCloudflarePageRuleCreate,
-		ReadContext: resourceCloudflarePageRuleRead,
+		ReadContext:   resourceCloudflarePageRuleRead,
 		UpdateContext: resourceCloudflarePageRuleUpdate,
 		DeleteContext: resourceCloudflarePageRuleDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflarePageRuleImport,
+			StateContext: resourceCloudflarePageRuleImport,
 		},
 	}
 }
@@ -91,7 +92,7 @@ func resourceCloudflarePageRuleCreate(ctx context.Context, d *schema.ResourceDat
 
 	d.SetId(r.ID)
 
-	return resourceCloudflarePageRuleRead(d, meta)
+	return resourceCloudflarePageRuleRead(ctx, d, meta)
 }
 
 func pageRuleActionsToMap(vs []cloudflare.PageRuleAction) map[string]interface{} {
@@ -151,7 +152,7 @@ func resourceCloudflarePageRuleUpdate(ctx context.Context, d *schema.ResourceDat
 
 	if target, ok := d.GetOk("target"); ok {
 		updatePageRule.Targets = []cloudflare.PageRuleTarget{
-			cloudflare.PageRuleTarget{
+			{
 				Target: "url",
 				Constraint: struct {
 					Operator string `json:"operator"`
@@ -197,7 +198,7 @@ func resourceCloudflarePageRuleUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(fmt.Errorf("failed to update Cloudflare Page Rule: %s", err))
 	}
 
-	return resourceCloudflarePageRuleRead(d, meta)
+	return resourceCloudflarePageRuleRead(ctx, d, meta)
 }
 
 func resourceCloudflarePageRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -496,7 +497,7 @@ func transformToCloudflarePageRuleAction(id string, value interface{}, d *schema
 	return
 }
 
-func resourceCloudflarePageRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflarePageRuleImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	// split the id so we can lookup
 	idAttr := strings.SplitN(d.Id(), "/", 2)
 	var zoneID string
@@ -510,7 +511,7 @@ func resourceCloudflarePageRuleImport(d *schema.ResourceData, meta interface{}) 
 		return nil, fmt.Errorf("invalid id (%q) specified, should be in format \"zoneID/pageRuleID\"", d.Id())
 	}
 
-	resourceCloudflarePageRuleRead(d, meta)
+	resourceCloudflarePageRuleRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -81,7 +81,7 @@ func resourceCloudflarePageRuleCreate(ctx context.Context, d *schema.ResourceDat
 
 	log.Printf("[DEBUG] Cloudflare Page Rule create configuration: %#v", newPageRule)
 
-	r, err := client.CreatePageRule(context.Background(), zoneID, newPageRule)
+	r, err := client.CreatePageRule(ctx, zoneID, newPageRule)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to create page rule: %s", err))
 	}
@@ -107,7 +107,7 @@ func resourceCloudflarePageRuleRead(ctx context.Context, d *schema.ResourceData,
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	pageRule, err := client.PageRule(context.Background(), zoneID, d.Id())
+	pageRule, err := client.PageRule(ctx, zoneID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "Invalid Page Rule identifier") || // api bug - this indicates non-existing resource
 			strings.Contains(err.Error(), "HTTP status 404") {
@@ -194,7 +194,7 @@ func resourceCloudflarePageRuleUpdate(ctx context.Context, d *schema.ResourceDat
 
 	log.Printf("[DEBUG] Cloudflare Page Rule update configuration: %#v", updatePageRule)
 
-	if err := client.UpdatePageRule(context.Background(), zoneID, d.Id(), updatePageRule); err != nil {
+	if err := client.UpdatePageRule(ctx, zoneID, d.Id(), updatePageRule); err != nil {
 		return diag.FromErr(fmt.Errorf("failed to update Cloudflare Page Rule: %s", err))
 	}
 
@@ -207,7 +207,7 @@ func resourceCloudflarePageRuleDelete(ctx context.Context, d *schema.ResourceDat
 
 	log.Printf("[INFO] Deleting Cloudflare Page Rule: %s, %s", zoneID, d.Id())
 
-	if err := client.DeletePageRule(context.Background(), zoneID, d.Id()); err != nil {
+	if err := client.DeletePageRule(ctx, zoneID, d.Id()); err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Page Rule: %s", err))
 	}
 

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -33,7 +33,7 @@ func suppressEquivalentURLs(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
-func resourceCloudflarePageRuleCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflarePageRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -59,7 +59,7 @@ func resourceCloudflarePageRuleCreate(d *schema.ResourceData, meta interface{}) 
 
 			newPageRuleAction, err := transformToCloudflarePageRuleAction(id, value, d)
 			if err != nil {
-				return err
+				return diag.FromErr(err)
 			} else if newPageRuleAction.Value == nil || newPageRuleAction.Value == "" {
 				continue
 			}
@@ -102,7 +102,7 @@ func pageRuleActionsToMap(vs []cloudflare.PageRuleAction) map[string]interface{}
 	return vsm
 }
 
-func resourceCloudflarePageRuleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflarePageRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -143,7 +143,7 @@ func resourceCloudflarePageRuleRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceCloudflarePageRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflarePageRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -172,7 +172,7 @@ func resourceCloudflarePageRuleUpdate(d *schema.ResourceData, meta interface{}) 
 			for id, value := range action.(map[string]interface{}) {
 				newPageRuleAction, err := transformToCloudflarePageRuleAction(id, value, d)
 				if err != nil {
-					return err
+					return diag.FromErr(err)
 				} else if newPageRuleAction.Value == nil {
 					continue
 				}
@@ -200,7 +200,7 @@ func resourceCloudflarePageRuleUpdate(d *schema.ResourceData, meta interface{}) 
 	return resourceCloudflarePageRuleRead(d, meta)
 }
 
-func resourceCloudflarePageRuleDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflarePageRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -68,7 +68,7 @@ func resourceCloudflarePageRuleCreate(ctx context.Context, d *schema.ResourceDat
 	}
 	pageRulesActionMap := pageRuleActionsToMap(newPageRuleActions)
 	if _, ok := pageRulesActionMap["forwarding_url"]; ok && len(pageRulesActionMap) > 1 {
-		return fmt.Errorf("\"forwarding_url\" cannot be set with any other actions")
+		return diag.FromErr(fmt.Errorf("\"forwarding_url\" cannot be set with any other actions"))
 	}
 
 	newPageRule := cloudflare.PageRule{
@@ -82,11 +82,11 @@ func resourceCloudflarePageRuleCreate(ctx context.Context, d *schema.ResourceDat
 
 	r, err := client.CreatePageRule(context.Background(), zoneID, newPageRule)
 	if err != nil {
-		return fmt.Errorf("failed to create page rule: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to create page rule: %s", err))
 	}
 
 	if r.ID == "" {
-		return fmt.Errorf("Failed to find page rule in Create response; ID was empty")
+		return diag.FromErr(fmt.Errorf("Failed to find page rule in Create response; ID was empty"))
 	}
 
 	d.SetId(r.ID)
@@ -114,7 +114,7 @@ func resourceCloudflarePageRuleRead(ctx context.Context, d *schema.ResourceData,
 			d.SetId("")
 			return nil
 		} else {
-			return fmt.Errorf("error finding page rule %q: %s", d.Id(), err)
+			return diag.FromErr(fmt.Errorf("error finding page rule %q: %s", d.Id(), err))
 		}
 	}
 	log.Printf("[DEBUG] Cloudflare Page Rule read configuration: %#v", pageRule)
@@ -130,7 +130,7 @@ func resourceCloudflarePageRuleRead(ctx context.Context, d *schema.ResourceData,
 	for _, pageRuleAction := range pageRule.Actions {
 		key, value, err := transformFromCloudflarePageRuleAction(&pageRuleAction)
 		if err != nil {
-			return fmt.Errorf("failed to parse page rule action: %s", err)
+			return diag.FromErr(fmt.Errorf("failed to parse page rule action: %s", err))
 		}
 		actions[key] = value
 	}
@@ -194,7 +194,7 @@ func resourceCloudflarePageRuleUpdate(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[DEBUG] Cloudflare Page Rule update configuration: %#v", updatePageRule)
 
 	if err := client.UpdatePageRule(context.Background(), zoneID, d.Id(), updatePageRule); err != nil {
-		return fmt.Errorf("failed to update Cloudflare Page Rule: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to update Cloudflare Page Rule: %s", err))
 	}
 
 	return resourceCloudflarePageRuleRead(d, meta)
@@ -207,7 +207,7 @@ func resourceCloudflarePageRuleDelete(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[INFO] Deleting Cloudflare Page Rule: %s, %s", zoneID, d.Id())
 
 	if err := client.DeletePageRule(context.Background(), zoneID, d.Id()); err != nil {
-		return fmt.Errorf("error deleting Cloudflare Page Rule: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Page Rule: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -57,7 +57,6 @@ func resourceCloudflarePageRuleCreate(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[DEBUG] Actions found in config: %#v", actions)
 	for _, action := range actions {
 		for id, value := range action.(map[string]interface{}) {
-
 			newPageRuleAction, err := transformToCloudflarePageRuleAction(id, value, d)
 			if err != nil {
 				return diag.FromErr(err)
@@ -83,7 +82,7 @@ func resourceCloudflarePageRuleCreate(ctx context.Context, d *schema.ResourceDat
 
 	r, err := client.CreatePageRule(ctx, zoneID, newPageRule)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to create page rule: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to create page rule: %w", err))
 	}
 
 	if r.ID == "" {
@@ -115,7 +114,7 @@ func resourceCloudflarePageRuleRead(ctx context.Context, d *schema.ResourceData,
 			d.SetId("")
 			return nil
 		} else {
-			return diag.FromErr(fmt.Errorf("error finding page rule %q: %s", d.Id(), err))
+			return diag.FromErr(fmt.Errorf("error finding page rule %q: %w", d.Id(), err))
 		}
 	}
 	log.Printf("[DEBUG] Cloudflare Page Rule read configuration: %#v", pageRule)
@@ -131,7 +130,7 @@ func resourceCloudflarePageRuleRead(ctx context.Context, d *schema.ResourceData,
 	for _, pageRuleAction := range pageRule.Actions {
 		key, value, err := transformFromCloudflarePageRuleAction(&pageRuleAction)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("failed to parse page rule action: %s", err))
+			return diag.FromErr(fmt.Errorf("failed to parse page rule action: %w", err))
 		}
 		actions[key] = value
 	}
@@ -195,7 +194,7 @@ func resourceCloudflarePageRuleUpdate(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[DEBUG] Cloudflare Page Rule update configuration: %#v", updatePageRule)
 
 	if err := client.UpdatePageRule(ctx, zoneID, d.Id(), updatePageRule); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update Cloudflare Page Rule: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to update Cloudflare Page Rule: %w", err))
 	}
 
 	return resourceCloudflarePageRuleRead(ctx, d, meta)
@@ -208,7 +207,7 @@ func resourceCloudflarePageRuleDelete(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[INFO] Deleting Cloudflare Page Rule: %s, %s", zoneID, d.Id())
 
 	if err := client.DeletePageRule(ctx, zoneID, d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Page Rule: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Page Rule: %w", err))
 	}
 
 	return nil
@@ -347,7 +346,6 @@ func transformFromCloudflarePageRuleAction(pageRuleAction *cloudflare.PageRuleAc
 }
 
 func transformToCloudflarePageRuleAction(id string, value interface{}, d *schema.ResourceData) (pageRuleAction cloudflare.PageRuleAction, err error) {
-
 	pageRuleAction.ID = id
 
 	if strValue, ok := value.(string); ok {

--- a/cloudflare/resource_cloudflare_page_rule.go
+++ b/cloudflare/resource_cloudflare_page_rule.go
@@ -15,10 +15,10 @@ import (
 func resourceCloudflarePageRule() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflarePageRuleSchema(),
-		Create: resourceCloudflarePageRuleCreate,
-		Read:   resourceCloudflarePageRuleRead,
-		Update: resourceCloudflarePageRuleUpdate,
-		Delete: resourceCloudflarePageRuleDelete,
+		CreateContext: resourceCloudflarePageRuleCreate,
+		ReadContext: resourceCloudflarePageRuleRead,
+		UpdateContext: resourceCloudflarePageRuleUpdate,
+		DeleteContext: resourceCloudflarePageRuleDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflarePageRuleImport,
 		},

--- a/cloudflare/resource_cloudflare_page_rule_test.go
+++ b/cloudflare/resource_cloudflare_page_rule_test.go
@@ -798,7 +798,6 @@ func testAccCheckCloudflarePageRuleDestroy(s *terraform.State) error {
 
 func testAccCheckCloudflarePageRuleAttributesBasic(pageRule *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		// check the api only has attributes we set non-empty values for
 		// this covers on/off attribute types and setting enum-type strings
 
@@ -830,7 +829,6 @@ func testAccCheckCloudflarePageRuleAttributesBasic(pageRule *cloudflare.PageRule
 
 func testAccCheckCloudflarePageRuleAttributesUpdated(pageRule *cloudflare.PageRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		actionMap := pageRuleActionsToMap(pageRule.Actions)
 
 		if _, ok := actionMap["disable_apps"]; ok {

--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareRateLimit() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareRateLimitSchema(),
-		Create: resourceCloudflareRateLimitCreate,
-		Read:   resourceCloudflareRateLimitRead,
-		Update: resourceCloudflareRateLimitUpdate,
-		Delete: resourceCloudflareRateLimitDelete,
+		CreateContext: resourceCloudflareRateLimitCreate,
+		ReadContext: resourceCloudflareRateLimitRead,
+		UpdateContext: resourceCloudflareRateLimitUpdate,
+		DeleteContext: resourceCloudflareRateLimitDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareRateLimitImport,
 		},

--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -75,7 +75,7 @@ func resourceCloudflareRateLimitCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if r.ID == "" {
-		return fmt.Errorf("cailed to find id in Create response; resource was empty")
+		return diag.FromErr(fmt.Errorf("cailed to find id in Create response; resource was empty"))
 	}
 
 	d.SetId(r.ID)
@@ -390,7 +390,7 @@ func resourceCloudflareRateLimitDelete(ctx context.Context, d *schema.ResourceDa
 
 	err := client.DeleteRateLimit(context.Background(), zoneID, rateLimitId)
 	if err != nil {
-		return fmt.Errorf("error deleting Cloudflare Rate Limit for zone: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Rate Limit for zone: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -390,7 +390,7 @@ func resourceCloudflareRateLimitDelete(ctx context.Context, d *schema.ResourceDa
 
 	err := client.DeleteRateLimit(ctx, zoneID, rateLimitId)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Rate Limit for zone: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Rate Limit for zone: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_rate_limit.go
+++ b/cloudflare/resource_cloudflare_rate_limit.go
@@ -69,7 +69,7 @@ func resourceCloudflareRateLimitCreate(ctx context.Context, d *schema.ResourceDa
 
 	log.Printf("[DEBUG] Creating Cloudflare Rate Limit from struct: %+v", newRateLimit)
 
-	r, err := client.CreateRateLimit(context.Background(), zoneID, newRateLimit)
+	r, err := client.CreateRateLimit(ctx, zoneID, newRateLimit)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating rate limit for zone"))
 	}
@@ -128,7 +128,7 @@ func resourceCloudflareRateLimitUpdate(ctx context.Context, d *schema.ResourceDa
 
 	updatedRateLimit.Correlate, _ = expandRateLimitCorrelate(d)
 
-	_, err = client.UpdateRateLimit(context.Background(), zoneID, rateLimitId, updatedRateLimit)
+	_, err = client.UpdateRateLimit(ctx, zoneID, rateLimitId, updatedRateLimit)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating rate limit for zone"))
 	}
@@ -262,7 +262,7 @@ func resourceCloudflareRateLimitRead(ctx context.Context, d *schema.ResourceData
 	zoneID := d.Get("zone_id").(string)
 	rateLimitId := d.Id()
 
-	rateLimit, err := client.RateLimit(context.Background(), zoneID, rateLimitId)
+	rateLimit, err := client.RateLimit(ctx, zoneID, rateLimitId)
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[INFO] Resource %s in zone %s no longer exists", rateLimitId, zoneID)
@@ -388,7 +388,7 @@ func resourceCloudflareRateLimitDelete(ctx context.Context, d *schema.ResourceDa
 
 	log.Printf("[INFO] Deleting Cloudflare Rate Limit: %s for zone: %s", rateLimitId, zoneID)
 
-	err := client.DeleteRateLimit(context.Background(), zoneID, rateLimitId)
+	err := client.DeleteRateLimit(ctx, zoneID, rateLimitId)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Rate Limit for zone: %s", err))
 	}

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -78,9 +78,9 @@ func resourceCloudflareRecordCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if valueOk == dataOk {
-		return fmt.Errorf(
+		return diag.FromErr(fmt.Errorf(
 			"either 'value' (present: %t) or 'data' (present: %t) must be provided",
-			valueOk, dataOk)
+			valueOk, dataOk))
 	}
 
 	if priority, ok := d.GetOkExists("priority"); ok {
@@ -90,7 +90,7 @@ func resourceCloudflareRecordCreate(ctx context.Context, d *schema.ResourceData,
 
 	if ttl, ok := d.GetOk("ttl"); ok {
 		if ttl.(int) != 1 && proxiedOk && *newRecord.Proxied {
-			return fmt.Errorf("error validating record %s: ttl must be set to 1 when `proxied` is true", newRecord.Name)
+			return diag.FromErr(fmt.Errorf("error validating record %s: ttl must be set to 1 when `proxied` is true", newRecord.Name))
 		}
 
 		newRecord.TTL = ttl.(int)
@@ -98,7 +98,7 @@ func resourceCloudflareRecordCreate(ctx context.Context, d *schema.ResourceData,
 
 	// Validate value based on type
 	if err := validateRecordName(newRecord.Type, newRecord.Content); err != nil {
-		return fmt.Errorf("error validating record name %q: %s", newRecord.Name, err)
+		return diag.FromErr(fmt.Errorf("error validating record name %q: %s", newRecord.Name, err))
 	}
 
 	var proxiedVal *bool
@@ -110,7 +110,7 @@ func resourceCloudflareRecordCreate(ctx context.Context, d *schema.ResourceData,
 
 	// Validate type
 	if err := validateRecordType(newRecord.Type, *proxiedVal); err != nil {
-		return fmt.Errorf("error validating record type %q: %s", newRecord.Type, err)
+		return diag.FromErr(fmt.Errorf("error validating record type %q: %s", newRecord.Type, err))
 	}
 
 	log.Printf("[DEBUG] Cloudflare Record create configuration: %#v", newRecord)
@@ -275,7 +275,7 @@ func resourceCloudflareRecordUpdate(ctx context.Context, d *schema.ResourceData,
 
 	if ttl, ok := d.GetOk("ttl"); ok {
 		if ttl.(int) != 1 && proxiedOk && *updateRecord.Proxied {
-			return fmt.Errorf("error validating record %s: ttl must be set to 1 when `proxied` is true", updateRecord.Name)
+			return diag.FromErr(fmt.Errorf("error validating record %s: ttl must be set to 1 when `proxied` is true", updateRecord.Name))
 		}
 
 		updateRecord.TTL = ttl.(int)
@@ -306,7 +306,7 @@ func resourceCloudflareRecordDelete(ctx context.Context, d *schema.ResourceData,
 
 	err := client.DeleteDNSRecord(context.Background(), zoneID, d.Id())
 	if err != nil {
-		return fmt.Errorf("error deleting Cloudflare Record: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Record: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -14,10 +14,10 @@ import (
 
 func resourceCloudflareRecord() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudflareRecordCreate,
-		Read:   resourceCloudflareRecordRead,
-		Update: resourceCloudflareRecordUpdate,
-		Delete: resourceCloudflareRecordDelete,
+		CreateContext: resourceCloudflareRecordCreate,
+		ReadContext: resourceCloudflareRecordRead,
+		UpdateContext: resourceCloudflareRecordUpdate,
+		DeleteContext: resourceCloudflareRecordDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareRecordImport,
 		},

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -100,7 +100,7 @@ func resourceCloudflareRecordCreate(ctx context.Context, d *schema.ResourceData,
 
 	// Validate value based on type
 	if err := validateRecordName(newRecord.Type, newRecord.Content); err != nil {
-		return diag.FromErr(fmt.Errorf("error validating record name %q: %s", newRecord.Name, err))
+		return diag.FromErr(fmt.Errorf("error validating record name %q: %w", newRecord.Name, err))
 	}
 
 	var proxiedVal *bool
@@ -112,7 +112,7 @@ func resourceCloudflareRecordCreate(ctx context.Context, d *schema.ResourceData,
 
 	// Validate type
 	if err := validateRecordType(newRecord.Type, *proxiedVal); err != nil {
-		return diag.FromErr(fmt.Errorf("error validating record type %q: %s", newRecord.Type, err))
+		return diag.FromErr(fmt.Errorf("error validating record type %q: %w", newRecord.Type, err))
 	}
 
 	log.Printf("[DEBUG] Cloudflare Record create configuration: %#v", newRecord)
@@ -156,7 +156,7 @@ func resourceCloudflareRecordCreate(ctx context.Context, d *schema.ResourceData,
 				return resource.RetryableError(fmt.Errorf("expected DNS record to not already be present but already exists"))
 			}
 
-			return resource.NonRetryableError(fmt.Errorf("failed to create DNS record: %s", err))
+			return resource.NonRetryableError(fmt.Errorf("failed to create DNS record: %w", err))
 		}
 
 		// In the event that the API returns an empty DNS Record, we verify that the
@@ -298,7 +298,7 @@ func resourceCloudflareRecordUpdate(ctx context.Context, d *schema.ResourceData,
 				return resource.RetryableError(fmt.Errorf("expected DNS record to not already be present but already exists"))
 			}
 
-			return resource.NonRetryableError(fmt.Errorf("failed to create DNS record: %s", err))
+			return resource.NonRetryableError(fmt.Errorf("failed to create DNS record: %w", err))
 		}
 
 		resourceCloudflareRecordRead(ctx, d, meta)
@@ -320,7 +320,7 @@ func resourceCloudflareRecordDelete(ctx context.Context, d *schema.ResourceData,
 
 	err := client.DeleteDNSRecord(ctx, zoneID, d.Id())
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Record: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Record: %w", err))
 	}
 
 	return nil
@@ -356,7 +356,7 @@ func resourceCloudflareRecordImport(ctx context.Context, d *schema.ResourceData,
 
 	record, err := client.DNSRecord(ctx, zoneID, recordID)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to find record with ID %q: %q", d.Id(), err)
+		return nil, fmt.Errorf("Unable to find record with ID %q: %w", d.Id(), err)
 	}
 
 	log.Printf("[INFO] Found record: %s", record.Name)

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -38,7 +38,7 @@ func resourceCloudflareRecord() *schema.Resource {
 	}
 }
 
-func resourceCloudflareRecordCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	newRecord := cloudflare.DNSRecord{
@@ -67,7 +67,7 @@ func resourceCloudflareRecordCreate(d *schema.ResourceData, meta interface{}) er
 		for id, value := range dataMap.(map[string]interface{}) {
 			newData, err := transformToCloudflareDNSData(newRecord.Type, id, value)
 			if err != nil {
-				return err
+				return diag.FromErr(err)
 			} else if newData == nil {
 				continue
 			}
@@ -171,7 +171,7 @@ func resourceCloudflareRecordCreate(d *schema.ResourceData, meta interface{}) er
 	})
 }
 
-func resourceCloudflareRecordRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -183,7 +183,7 @@ func resourceCloudflareRecordRead(d *schema.ResourceData, meta interface{}) erro
 			d.SetId("")
 			return nil
 		}
-		return err
+		return diag.FromErr(err)
 	}
 
 	data, dataOk := d.GetOk("data")
@@ -197,7 +197,7 @@ func resourceCloudflareRecordRead(d *schema.ResourceData, meta interface{}) erro
 			for id, value := range dataMap.(map[string]interface{}) {
 				newData, err := transformToCloudflareDNSData(record.Type, id, value)
 				if err != nil {
-					return err
+					return diag.FromErr(err)
 				} else if newData == nil {
 					continue
 				}
@@ -231,7 +231,7 @@ func resourceCloudflareRecordRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceCloudflareRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -253,7 +253,7 @@ func resourceCloudflareRecordUpdate(d *schema.ResourceData, meta interface{}) er
 		for id, value := range dataMap.(map[string]interface{}) {
 			newData, err := transformToCloudflareDNSData(updateRecord.Type, id, value)
 			if err != nil {
-				return err
+				return diag.FromErr(err)
 			} else if newData == nil {
 				continue
 			}
@@ -298,7 +298,7 @@ func resourceCloudflareRecordUpdate(d *schema.ResourceData, meta interface{}) er
 	})
 }
 
-func resourceCloudflareRecordDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRecordDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 

--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -507,7 +507,6 @@ func testAccManuallyDeleteRecord(record *cloudflare.DNSRecord) resource.TestChec
 
 func testAccCheckCloudflareRecordAttributes(record *cloudflare.DNSRecord) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		if record.Content != "192.168.0.10" {
 			return fmt.Errorf("bad content: %s", record.Content)
 		}
@@ -518,7 +517,6 @@ func testAccCheckCloudflareRecordAttributes(record *cloudflare.DNSRecord) resour
 
 func testAccCheckCloudflareRecordAttributesUpdated(record *cloudflare.DNSRecord) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		if record.Content != "192.168.0.11" {
 			return fmt.Errorf("bad content: %s", record.Content)
 		}
@@ -529,7 +527,6 @@ func testAccCheckCloudflareRecordAttributesUpdated(record *cloudflare.DNSRecord)
 
 func testAccCheckCloudflareRecordDates(n string, record *cloudflare.DNSRecord, testStartTime time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		rs, _ := s.RootModule().Resources[n]
 
 		for timeStampAttr, serverVal := range map[string]time.Time{"created_on": record.CreatedOn, "modified_on": record.ModifiedOn} {

--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -46,6 +46,7 @@ func testSweepCloudflareRecord(r string) error {
 
 	for _, record := range records {
 		log.Printf("[INFO] Deleting Cloudflare DNS record ID: %s", record.ID)
+		//nolint:errcheck
 		client.DeleteDNSRecord(context.Background(), zoneID, record.ID)
 	}
 

--- a/cloudflare/resource_cloudflare_record_test.go
+++ b/cloudflare/resource_cloudflare_record_test.go
@@ -3,6 +3,7 @@ package cloudflare
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"regexp"
 	"testing"
@@ -11,7 +12,45 @@ import (
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/pkg/errors"
 )
+
+func init() {
+	resource.AddTestSweepers("cloudflare_record", &resource.Sweeper{
+		Name: "cloudflare_record",
+		F:    testSweepCloudflareRecord,
+	})
+}
+
+func testSweepCloudflareRecord(r string) error {
+	client, clientErr := sharedClient()
+	if clientErr != nil {
+		log.Printf("[ERROR] Failed to create Cloudflare client: %s", clientErr)
+	}
+
+	// Clean up the account level rulesets
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	if zoneID == "" {
+		return errors.New("CLOUDFLARE_ZONE_ID must be set")
+	}
+
+	records, err := client.DNSRecords(context.Background(), zoneID, cloudflare.DNSRecord{})
+	if err != nil {
+		log.Printf("[ERROR] Failed to fetch Cloudflare DNS records: %s", err)
+	}
+
+	if len(records) == 0 {
+		log.Print("[DEBUG] No Cloudflare DNS records to sweep")
+		return nil
+	}
+
+	for _, record := range records {
+		log.Printf("[INFO] Deleting Cloudflare DNS record ID: %s", record.ID)
+		client.DeleteDNSRecord(context.Background(), zoneID, record.ID)
+	}
+
+	return nil
+}
 
 func TestAccCloudflareRecord_Basic(t *testing.T) {
 	t.Parallel()

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -41,7 +41,7 @@ func resourceCloudflareRuleset() *schema.Resource {
 	}
 }
 
-func resourceCloudflareRulesetCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRulesetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	zoneID := d.Get("zone_id").(string)
@@ -135,7 +135,7 @@ func resourceCloudflareRulesetImport(d *schema.ResourceData, meta interface{}) (
 	return nil, errors.New("Import is not yet supported for Rulesets")
 }
 
-func resourceCloudflareRulesetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRulesetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	zoneID := d.Get("zone_id").(string)
@@ -168,7 +168,7 @@ func resourceCloudflareRulesetRead(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceCloudflareRulesetUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRulesetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	zoneID := d.Get("zone_id").(string)
@@ -192,7 +192,7 @@ func resourceCloudflareRulesetUpdate(d *schema.ResourceData, meta interface{}) e
 	return resourceCloudflareRulesetRead(d, meta)
 }
 
-func resourceCloudflareRulesetDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareRulesetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	zoneID := d.Get("zone_id").(string)

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -163,7 +163,7 @@ func resourceCloudflareRulesetRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("description", ruleset.Description)
 
 	if err := d.Set("rules", buildStateFromRulesetRules(ruleset.Rules)); err != nil {
-		log.Fatalf("failed to set rules: %s", err)
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -23,10 +23,10 @@ const (
 func resourceCloudflareRuleset() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareRulesetSchema(),
-		Create: resourceCloudflareRulesetCreate,
-		Read:   resourceCloudflareRulesetRead,
-		Update: resourceCloudflareRulesetUpdate,
-		Delete: resourceCloudflareRulesetDelete,
+		CreateContext: resourceCloudflareRulesetCreate,
+		ReadContext: resourceCloudflareRulesetRead,
+		UpdateContext: resourceCloudflareRulesetUpdate,
+		DeleteContext: resourceCloudflareRulesetDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareRulesetImport,
 		},

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -60,7 +60,7 @@ func resourceCloudflareRulesetCreate(ctx context.Context, d *schema.ResourceData
 		if accountID == "" {
 			deleteRulesetURL = zoneLevelRulesetDeleteURL
 		}
-		return fmt.Errorf(duplicateRulesetError, rulesetPhase, deleteRulesetURL)
+		return diag.FromErr(fmt.Errorf(duplicateRulesetError, rulesetPhase, deleteRulesetURL))
 	}
 
 	rulesetName := d.Get("name").(string)
@@ -75,7 +75,7 @@ func resourceCloudflareRulesetCreate(ctx context.Context, d *schema.ResourceData
 
 	rules, err := buildRulesetRulesFromResource(d)
 	if err != nil {
-		return fmt.Errorf("error building ruleset rules from resource: %w", err)
+		return diag.FromErr(fmt.Errorf("error building ruleset rules from resource: %w", err))
 	}
 
 	if len(rules) > 0 {
@@ -92,7 +92,7 @@ func resourceCloudflareRulesetCreate(ctx context.Context, d *schema.ResourceData
 		}
 
 		if deleteRulesetErr != nil {
-			return fmt.Errorf("failed to delete ruleset: %w", deleteRulesetErr)
+			return diag.FromErr(fmt.Errorf("failed to delete ruleset: %w", deleteRulesetErr))
 		}
 	}
 
@@ -104,7 +104,7 @@ func resourceCloudflareRulesetCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if rulesetCreateErr != nil {
-		return fmt.Errorf("error creating ruleset %s: %w", rulesetName, rulesetCreateErr)
+		return diag.FromErr(fmt.Errorf("error creating ruleset %s: %w", rulesetName, rulesetCreateErr))
 	}
 
 	rulesetEntryPoint := cloudflare.Ruleset{
@@ -122,7 +122,7 @@ func resourceCloudflareRulesetCreate(ctx context.Context, d *schema.ResourceData
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating ruleset phase entrypoint %s: %w", rulesetName, err)
+			return diag.FromErr(fmt.Errorf("error updating ruleset phase entrypoint %s: %w", rulesetName, err))
 		}
 	}
 
@@ -155,7 +155,7 @@ func resourceCloudflareRulesetRead(ctx context.Context, d *schema.ResourceData, 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading ruleset ID %q: %w", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error reading ruleset ID %q: %w", d.Id(), err))
 	}
 
 	d.Set("name", ruleset.Name)
@@ -175,7 +175,7 @@ func resourceCloudflareRulesetUpdate(ctx context.Context, d *schema.ResourceData
 
 	rules, err := buildRulesetRulesFromResource(d)
 	if err != nil {
-		return fmt.Errorf("error building ruleset from resource: %w", err)
+		return diag.FromErr(fmt.Errorf("error building ruleset from resource: %w", err))
 	}
 
 	description := d.Get("description").(string)
@@ -186,7 +186,7 @@ func resourceCloudflareRulesetUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if err != nil {
-		return fmt.Errorf("error updating ruleset with ID %q: %w", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error updating ruleset with ID %q: %w", d.Id(), err))
 	}
 
 	return resourceCloudflareRulesetRead(d, meta)
@@ -205,7 +205,7 @@ func resourceCloudflareRulesetDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting ruleset with ID %q: %w", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error deleting ruleset with ID %q: %w", d.Id(), err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -51,9 +51,9 @@ func resourceCloudflareRulesetCreate(ctx context.Context, d *schema.ResourceData
 	var ruleset cloudflare.Ruleset
 	var sempahoreErr error
 	if accountID != "" {
-		ruleset, sempahoreErr = client.GetAccountRulesetPhase(context.Background(), accountID, rulesetPhase)
+		ruleset, sempahoreErr = client.GetAccountRulesetPhase(ctx, accountID, rulesetPhase)
 	} else {
-		ruleset, sempahoreErr = client.GetZoneRulesetPhase(context.Background(), zoneID, rulesetPhase)
+		ruleset, sempahoreErr = client.GetZoneRulesetPhase(ctx, zoneID, rulesetPhase)
 	}
 
 	if len(ruleset.Rules) > 0 {
@@ -87,9 +87,9 @@ func resourceCloudflareRulesetCreate(ctx context.Context, d *schema.ResourceData
 		log.Print("[DEBUG] default ruleset created by the UI with empty rules found, recreating from scratch")
 		var deleteRulesetErr error
 		if accountID != "" {
-			deleteRulesetErr = client.DeleteAccountRuleset(context.Background(), accountID, ruleset.ID)
+			deleteRulesetErr = client.DeleteAccountRuleset(ctx, accountID, ruleset.ID)
 		} else {
-			deleteRulesetErr = client.DeleteZoneRuleset(context.Background(), zoneID, ruleset.ID)
+			deleteRulesetErr = client.DeleteZoneRuleset(ctx, zoneID, ruleset.ID)
 		}
 
 		if deleteRulesetErr != nil {
@@ -99,9 +99,9 @@ func resourceCloudflareRulesetCreate(ctx context.Context, d *schema.ResourceData
 
 	var rulesetCreateErr error
 	if accountID != "" {
-		ruleset, rulesetCreateErr = client.CreateAccountRuleset(context.Background(), accountID, rs)
+		ruleset, rulesetCreateErr = client.CreateAccountRuleset(ctx, accountID, rs)
 	} else {
-		ruleset, rulesetCreateErr = client.CreateZoneRuleset(context.Background(), zoneID, rs)
+		ruleset, rulesetCreateErr = client.CreateZoneRuleset(ctx, zoneID, rs)
 	}
 
 	if rulesetCreateErr != nil {
@@ -117,9 +117,9 @@ func resourceCloudflareRulesetCreate(ctx context.Context, d *schema.ResourceData
 	// endpoint.
 	if rulesetKind != string(cloudflare.RulesetKindCustom) {
 		if accountID != "" {
-			_, err = client.UpdateAccountRulesetPhase(context.Background(), accountID, rulesetPhase, rulesetEntryPoint)
+			_, err = client.UpdateAccountRulesetPhase(ctx, accountID, rulesetPhase, rulesetEntryPoint)
 		} else {
-			_, err = client.UpdateZoneRulesetPhase(context.Background(), zoneID, rulesetPhase, rulesetEntryPoint)
+			_, err = client.UpdateZoneRulesetPhase(ctx, zoneID, rulesetPhase, rulesetEntryPoint)
 		}
 
 		if err != nil {
@@ -145,9 +145,9 @@ func resourceCloudflareRulesetRead(ctx context.Context, d *schema.ResourceData, 
 	var err error
 
 	if accountID != "" {
-		ruleset, err = client.GetAccountRuleset(context.Background(), accountID, d.Id())
+		ruleset, err = client.GetAccountRuleset(ctx, accountID, d.Id())
 	} else {
-		ruleset, err = client.GetZoneRuleset(context.Background(), zoneID, d.Id())
+		ruleset, err = client.GetZoneRuleset(ctx, zoneID, d.Id())
 	}
 
 	if err != nil {
@@ -181,9 +181,9 @@ func resourceCloudflareRulesetUpdate(ctx context.Context, d *schema.ResourceData
 
 	description := d.Get("description").(string)
 	if accountID != "" {
-		_, err = client.UpdateAccountRuleset(context.Background(), accountID, d.Id(), description, rules)
+		_, err = client.UpdateAccountRuleset(ctx, accountID, d.Id(), description, rules)
 	} else {
-		_, err = client.UpdateZoneRuleset(context.Background(), zoneID, d.Id(), description, rules)
+		_, err = client.UpdateZoneRuleset(ctx, zoneID, d.Id(), description, rules)
 	}
 
 	if err != nil {
@@ -200,9 +200,9 @@ func resourceCloudflareRulesetDelete(ctx context.Context, d *schema.ResourceData
 	var err error
 
 	if accountID != "" {
-		err = client.DeleteAccountRuleset(context.Background(), accountID, d.Id())
+		err = client.DeleteAccountRuleset(ctx, accountID, d.Id())
 	} else {
-		err = client.DeleteZoneRuleset(context.Background(), zoneID, d.Id())
+		err = client.DeleteZoneRuleset(ctx, zoneID, d.Id())
 	}
 
 	if err != nil {

--- a/cloudflare/resource_cloudflare_ruleset.go
+++ b/cloudflare/resource_cloudflare_ruleset.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 )
@@ -22,13 +23,13 @@ const (
 
 func resourceCloudflareRuleset() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareRulesetSchema(),
+		Schema:        resourceCloudflareRulesetSchema(),
 		CreateContext: resourceCloudflareRulesetCreate,
-		ReadContext: resourceCloudflareRulesetRead,
+		ReadContext:   resourceCloudflareRulesetRead,
 		UpdateContext: resourceCloudflareRulesetUpdate,
 		DeleteContext: resourceCloudflareRulesetDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareRulesetImport,
+			StateContext: resourceCloudflareRulesetImport,
 		},
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
@@ -128,10 +129,10 @@ func resourceCloudflareRulesetCreate(ctx context.Context, d *schema.ResourceData
 
 	d.SetId(ruleset.ID)
 
-	return resourceCloudflareRulesetRead(d, meta)
+	return resourceCloudflareRulesetRead(ctx, d, meta)
 }
 
-func resourceCloudflareRulesetImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareRulesetImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	return nil, errors.New("Import is not yet supported for Rulesets")
 }
 
@@ -189,7 +190,7 @@ func resourceCloudflareRulesetUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(fmt.Errorf("error updating ruleset with ID %q: %w", d.Id(), err))
 	}
 
-	return resourceCloudflareRulesetRead(d, meta)
+	return resourceCloudflareRulesetRead(ctx, d, meta)
 }
 
 func resourceCloudflareRulesetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/cloudflare/resource_cloudflare_spectrum_application.go
+++ b/cloudflare/resource_cloudflare_spectrum_application.go
@@ -15,10 +15,10 @@ import (
 func resourceCloudflareSpectrumApplication() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareSpectrumApplicationSchema(),
-		Create: resourceCloudflareSpectrumApplicationCreate,
-		Read:   resourceCloudflareSpectrumApplicationRead,
-		Update: resourceCloudflareSpectrumApplicationUpdate,
-		Delete: resourceCloudflareSpectrumApplicationDelete,
+		CreateContext: resourceCloudflareSpectrumApplicationCreate,
+		ReadContext: resourceCloudflareSpectrumApplicationRead,
+		UpdateContext: resourceCloudflareSpectrumApplicationUpdate,
+		DeleteContext: resourceCloudflareSpectrumApplicationDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareSpectrumApplicationImport,
 		},

--- a/cloudflare/resource_cloudflare_spectrum_application.go
+++ b/cloudflare/resource_cloudflare_spectrum_application.go
@@ -25,7 +25,7 @@ func resourceCloudflareSpectrumApplication() *schema.Resource {
 	}
 }
 
-func resourceCloudflareSpectrumApplicationCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareSpectrumApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	newSpectrumApp := applicationFromResource(d)
@@ -35,7 +35,7 @@ func resourceCloudflareSpectrumApplicationCreate(d *schema.ResourceData, meta in
 
 	r, err := client.CreateSpectrumApplication(context.Background(), zoneID, newSpectrumApp)
 	if err != nil {
-		return errors.Wrap(err, "error creating spectrum application for zone")
+		return err.Wrap(err, "error creating spectrum application for zone")
 	}
 
 	if r.ID == "" {
@@ -49,7 +49,7 @@ func resourceCloudflareSpectrumApplicationCreate(d *schema.ResourceData, meta in
 	return resourceCloudflareSpectrumApplicationRead(d, meta)
 }
 
-func resourceCloudflareSpectrumApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareSpectrumApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -59,13 +59,13 @@ func resourceCloudflareSpectrumApplicationUpdate(d *schema.ResourceData, meta in
 
 	_, err := client.UpdateSpectrumApplication(context.Background(), zoneID, application.ID, application)
 	if err != nil {
-		return errors.Wrap(err, "error creating spectrum application for zone")
+		return err.Wrap(err, "error creating spectrum application for zone")
 	}
 
 	return resourceCloudflareSpectrumApplicationRead(d, meta)
 }
 
-func resourceCloudflareSpectrumApplicationRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareSpectrumApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	applicationID := d.Id()
@@ -77,7 +77,7 @@ func resourceCloudflareSpectrumApplicationRead(d *schema.ResourceData, meta inte
 			d.SetId("")
 			return nil
 		}
-		return errors.Wrap(err,
+		return err.Wrap(err,
 			fmt.Sprintf("Error reading spectrum application resource from API for resource %s in zone %s", applicationID, zoneID))
 	}
 
@@ -127,7 +127,7 @@ func resourceCloudflareSpectrumApplicationRead(d *schema.ResourceData, meta inte
 	return nil
 }
 
-func resourceCloudflareSpectrumApplicationDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareSpectrumApplicationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	applicationID := d.Id()

--- a/cloudflare/resource_cloudflare_spectrum_application.go
+++ b/cloudflare/resource_cloudflare_spectrum_application.go
@@ -34,7 +34,7 @@ func resourceCloudflareSpectrumApplicationCreate(ctx context.Context, d *schema.
 
 	log.Printf("[INFO] Creating Cloudflare Spectrum Application from struct: %+v", newSpectrumApp)
 
-	r, err := client.CreateSpectrumApplication(context.Background(), zoneID, newSpectrumApp)
+	r, err := client.CreateSpectrumApplication(ctx, zoneID, newSpectrumApp)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating spectrum application for zone"))
 	}
@@ -58,7 +58,7 @@ func resourceCloudflareSpectrumApplicationUpdate(ctx context.Context, d *schema.
 
 	log.Printf("[INFO] Updating Cloudflare Spectrum Application from struct: %+v", application)
 
-	_, err := client.UpdateSpectrumApplication(context.Background(), zoneID, application.ID, application)
+	_, err := client.UpdateSpectrumApplication(ctx, zoneID, application.ID, application)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating spectrum application for zone"))
 	}
@@ -71,7 +71,7 @@ func resourceCloudflareSpectrumApplicationRead(ctx context.Context, d *schema.Re
 	zoneID := d.Get("zone_id").(string)
 	applicationID := d.Id()
 
-	application, err := client.SpectrumApplication(context.Background(), zoneID, applicationID)
+	application, err := client.SpectrumApplication(ctx, zoneID, applicationID)
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[INFO] Spectrum application %s in zone %s not found", applicationID, zoneID)
@@ -135,7 +135,7 @@ func resourceCloudflareSpectrumApplicationDelete(ctx context.Context, d *schema.
 
 	log.Printf("[INFO] Deleting Cloudflare Spectrum Application: %s in zone: %s", applicationID, zoneID)
 
-	err := client.DeleteSpectrumApplication(context.Background(), zoneID, applicationID)
+	err := client.DeleteSpectrumApplication(ctx, zoneID, applicationID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Spectrum Application: %s", err))
 	}

--- a/cloudflare/resource_cloudflare_spectrum_application.go
+++ b/cloudflare/resource_cloudflare_spectrum_application.go
@@ -39,7 +39,7 @@ func resourceCloudflareSpectrumApplicationCreate(ctx context.Context, d *schema.
 	}
 
 	if r.ID == "" {
-		return fmt.Errorf("failed to find id in Create response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find id in Create response; resource was empty"))
 	}
 
 	d.SetId(r.ID)
@@ -136,7 +136,7 @@ func resourceCloudflareSpectrumApplicationDelete(ctx context.Context, d *schema.
 
 	err := client.DeleteSpectrumApplication(context.Background(), zoneID, applicationID)
 	if err != nil {
-		return fmt.Errorf("error deleting Cloudflare Spectrum Application: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Spectrum Application: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_spectrum_application.go
+++ b/cloudflare/resource_cloudflare_spectrum_application.go
@@ -137,7 +137,7 @@ func resourceCloudflareSpectrumApplicationDelete(ctx context.Context, d *schema.
 
 	err := client.DeleteSpectrumApplication(ctx, zoneID, applicationID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Spectrum Application: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Spectrum Application: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_split_tunnel.go
+++ b/cloudflare/resource_cloudflare_split_tunnel.go
@@ -30,11 +30,11 @@ func resourceCloudflareSplitTunnelRead(ctx context.Context, d *schema.ResourceDa
 
 	splitTunnel, err := client.ListSplitTunnels(context.Background(), accountID, mode)
 	if err != nil {
-		return fmt.Errorf("error finding %q Split Tunnels: %s", mode, err)
+		return diag.FromErr(fmt.Errorf("error finding %q Split Tunnels: %s", mode, err))
 	}
 
 	if err := d.Set("tunnels", flattenSplitTunnels(splitTunnel)); err != nil {
-		return fmt.Errorf("error setting %q tunnels attribute: %s", mode, err)
+		return diag.FromErr(fmt.Errorf("error setting %q tunnels attribute: %s", mode, err))
 	}
 
 	return nil
@@ -47,16 +47,16 @@ func resourceCloudflareSplitTunnelUpdate(ctx context.Context, d *schema.Resource
 
 	tunnelList, err := expandSplitTunnels(d.Get("tunnels").([]interface{}))
 	if err != nil {
-		return fmt.Errorf("error updating %q Split Tunnels: %s", mode, err)
+		return diag.FromErr(fmt.Errorf("error updating %q Split Tunnels: %s", mode, err))
 	}
 
 	newSplitTunnels, err := client.UpdateSplitTunnel(context.Background(), accountID, mode, tunnelList)
 	if err != nil {
-		return fmt.Errorf("error updating %q Split Tunnels: %s", mode, err)
+		return diag.FromErr(fmt.Errorf("error updating %q Split Tunnels: %s", mode, err))
 	}
 
 	if err := d.Set("tunnels", flattenSplitTunnels(newSplitTunnels)); err != nil {
-		return fmt.Errorf("error setting %q tunnels attribute: %s", mode, err)
+		return diag.FromErr(fmt.Errorf("error setting %q tunnels attribute: %s", mode, err))
 	}
 
 	d.SetId(accountID)

--- a/cloudflare/resource_cloudflare_split_tunnel.go
+++ b/cloudflare/resource_cloudflare_split_tunnel.go
@@ -31,11 +31,11 @@ func resourceCloudflareSplitTunnelRead(ctx context.Context, d *schema.ResourceDa
 
 	splitTunnel, err := client.ListSplitTunnels(ctx, accountID, mode)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error finding %q Split Tunnels: %s", mode, err))
+		return diag.FromErr(fmt.Errorf("error finding %q Split Tunnels: %w", mode, err))
 	}
 
 	if err := d.Set("tunnels", flattenSplitTunnels(splitTunnel)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting %q tunnels attribute: %s", mode, err))
+		return diag.FromErr(fmt.Errorf("error setting %q tunnels attribute: %w", mode, err))
 	}
 
 	return nil
@@ -48,16 +48,16 @@ func resourceCloudflareSplitTunnelUpdate(ctx context.Context, d *schema.Resource
 
 	tunnelList, err := expandSplitTunnels(d.Get("tunnels").([]interface{}))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating %q Split Tunnels: %s", mode, err))
+		return diag.FromErr(fmt.Errorf("error updating %q Split Tunnels: %w", mode, err))
 	}
 
 	newSplitTunnels, err := client.UpdateSplitTunnel(ctx, accountID, mode, tunnelList)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating %q Split Tunnels: %s", mode, err))
+		return diag.FromErr(fmt.Errorf("error updating %q Split Tunnels: %w", mode, err))
 	}
 
 	if err := d.Set("tunnels", flattenSplitTunnels(newSplitTunnels)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting %q tunnels attribute: %s", mode, err))
+		return diag.FromErr(fmt.Errorf("error setting %q tunnels attribute: %w", mode, err))
 	}
 
 	d.SetId(accountID)
@@ -70,7 +70,10 @@ func resourceCloudflareSplitTunnelDelete(ctx context.Context, d *schema.Resource
 	accountID := d.Get("account_id").(string)
 	mode := d.Get("mode").(string)
 
-	client.UpdateSplitTunnel(ctx, accountID, mode, nil)
+	_, err := client.UpdateSplitTunnel(ctx, accountID, mode, nil)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	d.SetId("")
 	return nil

--- a/cloudflare/resource_cloudflare_split_tunnel.go
+++ b/cloudflare/resource_cloudflare_split_tunnel.go
@@ -6,19 +6,20 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 )
 
 func resourceCloudflareSplitTunnel() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareSplitTunnelSchema(),
-		ReadContext: resourceCloudflareSplitTunnelRead,
+		Schema:        resourceCloudflareSplitTunnelSchema(),
+		ReadContext:   resourceCloudflareSplitTunnelRead,
 		CreateContext: resourceCloudflareSplitTunnelUpdate, // Intentionally identical to Update as the resource is always present
 		UpdateContext: resourceCloudflareSplitTunnelUpdate,
 		DeleteContext: resourceCloudflareSplitTunnelDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareSplitTunnelImport,
+			StateContext: resourceCloudflareSplitTunnelImport,
 		},
 	}
 }
@@ -61,7 +62,7 @@ func resourceCloudflareSplitTunnelUpdate(ctx context.Context, d *schema.Resource
 
 	d.SetId(accountID)
 
-	return resourceCloudflareSplitTunnelRead(d, meta)
+	return resourceCloudflareSplitTunnelRead(ctx, d, meta)
 }
 
 func resourceCloudflareSplitTunnelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -75,7 +76,7 @@ func resourceCloudflareSplitTunnelDelete(ctx context.Context, d *schema.Resource
 	return nil
 }
 
-func resourceCloudflareSplitTunnelImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareSplitTunnelImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -88,7 +89,7 @@ func resourceCloudflareSplitTunnelImport(d *schema.ResourceData, meta interface{
 	d.Set("account_id", accountID)
 	d.SetId(accountID)
 
-	resourceCloudflareSplitTunnelRead(d, meta)
+	resourceCloudflareSplitTunnelRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_split_tunnel.go
+++ b/cloudflare/resource_cloudflare_split_tunnel.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareSplitTunnel() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareSplitTunnelSchema(),
-		Read:   resourceCloudflareSplitTunnelRead,
-		Create: resourceCloudflareSplitTunnelUpdate, // Intentionally identical to Update as the resource is always present
-		Update: resourceCloudflareSplitTunnelUpdate,
-		Delete: resourceCloudflareSplitTunnelDelete,
+		ReadContext: resourceCloudflareSplitTunnelRead,
+		CreateContext: resourceCloudflareSplitTunnelUpdate, // Intentionally identical to Update as the resource is always present
+		UpdateContext: resourceCloudflareSplitTunnelUpdate,
+		DeleteContext: resourceCloudflareSplitTunnelDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareSplitTunnelImport,
 		},

--- a/cloudflare/resource_cloudflare_split_tunnel.go
+++ b/cloudflare/resource_cloudflare_split_tunnel.go
@@ -29,7 +29,7 @@ func resourceCloudflareSplitTunnelRead(ctx context.Context, d *schema.ResourceDa
 	accountID := d.Get("account_id").(string)
 	mode := d.Get("mode").(string)
 
-	splitTunnel, err := client.ListSplitTunnels(context.Background(), accountID, mode)
+	splitTunnel, err := client.ListSplitTunnels(ctx, accountID, mode)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error finding %q Split Tunnels: %s", mode, err))
 	}
@@ -51,7 +51,7 @@ func resourceCloudflareSplitTunnelUpdate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(fmt.Errorf("error updating %q Split Tunnels: %s", mode, err))
 	}
 
-	newSplitTunnels, err := client.UpdateSplitTunnel(context.Background(), accountID, mode, tunnelList)
+	newSplitTunnels, err := client.UpdateSplitTunnel(ctx, accountID, mode, tunnelList)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating %q Split Tunnels: %s", mode, err))
 	}
@@ -70,7 +70,7 @@ func resourceCloudflareSplitTunnelDelete(ctx context.Context, d *schema.Resource
 	accountID := d.Get("account_id").(string)
 	mode := d.Get("mode").(string)
 
-	client.UpdateSplitTunnel(context.Background(), accountID, mode, nil)
+	client.UpdateSplitTunnel(ctx, accountID, mode, nil)
 
 	d.SetId("")
 	return nil

--- a/cloudflare/resource_cloudflare_split_tunnel.go
+++ b/cloudflare/resource_cloudflare_split_tunnel.go
@@ -23,7 +23,7 @@ func resourceCloudflareSplitTunnel() *schema.Resource {
 	}
 }
 
-func resourceCloudflareSplitTunnelRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareSplitTunnelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	mode := d.Get("mode").(string)
@@ -40,7 +40,7 @@ func resourceCloudflareSplitTunnelRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceCloudflareSplitTunnelUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareSplitTunnelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	mode := d.Get("mode").(string)
@@ -64,7 +64,7 @@ func resourceCloudflareSplitTunnelUpdate(d *schema.ResourceData, meta interface{
 	return resourceCloudflareSplitTunnelRead(d, meta)
 }
 
-func resourceCloudflareSplitTunnelDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareSplitTunnelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	mode := d.Get("mode").(string)

--- a/cloudflare/resource_cloudflare_static_route.go
+++ b/cloudflare/resource_cloudflare_static_route.go
@@ -110,7 +110,7 @@ func resourceCloudflareStaticRouteDelete(ctx context.Context, d *schema.Resource
 
 	_, err := client.DeleteMagicTransitStaticRoute(ctx, accountID, d.Id())
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Static Route: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Static Route: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_static_route.go
+++ b/cloudflare/resource_cloudflare_static_route.go
@@ -109,7 +109,7 @@ func resourceCloudflareStaticRouteDelete(ctx context.Context, d *schema.Resource
 
 	_, err := client.DeleteMagicTransitStaticRoute(context.Background(), accountID, d.Id())
 	if err != nil {
-		return fmt.Errorf("error deleting Static Route: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Static Route: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_static_route.go
+++ b/cloudflare/resource_cloudflare_static_route.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareStaticRoute() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareStaticRouteSchema(),
-		Create: resourceCloudflareStaticRouteCreate,
-		Read:   resourceCloudflareStaticRouteRead,
-		Update: resourceCloudflareStaticRouteUpdate,
-		Delete: resourceCloudflareStaticRouteDelete,
+		CreateContext: resourceCloudflareStaticRouteCreate,
+		ReadContext: resourceCloudflareStaticRouteRead,
+		UpdateContext: resourceCloudflareStaticRouteUpdate,
+		DeleteContext: resourceCloudflareStaticRouteDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareStaticRouteImport,
 		},

--- a/cloudflare/resource_cloudflare_static_route.go
+++ b/cloudflare/resource_cloudflare_static_route.go
@@ -24,14 +24,14 @@ func resourceCloudflareStaticRoute() *schema.Resource {
 	}
 }
 
-func resourceCloudflareStaticRouteCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareStaticRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
 	newStaticRoute, err := client.CreateMagicTransitStaticRoute(context.Background(), accountID, staticRouteFromResource(d))
 
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error creating static route for prefix %s", d.Get("prefix").(string)))
+		return err.Wrap(err, fmt.Sprintf("error creating static route for prefix %s", d.Get("prefix").(string)))
 	}
 
 	d.SetId(newStaticRoute[0].ID)
@@ -55,7 +55,7 @@ func resourceCloudflareStaticRouteImport(d *schema.ResourceData, meta interface{
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceCloudflareStaticRouteRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareStaticRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -66,7 +66,7 @@ func resourceCloudflareStaticRouteRead(d *schema.ResourceData, meta interface{})
 			d.SetId("")
 			return nil
 		}
-		return errors.Wrap(err, fmt.Sprintf("error reading Static Route ID %q", d.Id()))
+		return err.Wrap(err, fmt.Sprintf("error reading Static Route ID %q", d.Id()))
 	}
 
 	d.Set("prefix", staticRoute.Prefix)
@@ -89,19 +89,19 @@ func resourceCloudflareStaticRouteRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceCloudflareStaticRouteUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareStaticRouteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
 	_, err := client.UpdateMagicTransitStaticRoute(context.Background(), accountID, d.Id(), staticRouteFromResource(d))
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error updating static route with ID %q", d.Id()))
+		return err.Wrap(err, fmt.Sprintf("error updating static route with ID %q", d.Id()))
 	}
 
 	return resourceCloudflareStaticRouteRead(d, meta)
 }
 
-func resourceCloudflareStaticRouteDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareStaticRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 

--- a/cloudflare/resource_cloudflare_static_route.go
+++ b/cloudflare/resource_cloudflare_static_route.go
@@ -29,7 +29,7 @@ func resourceCloudflareStaticRouteCreate(ctx context.Context, d *schema.Resource
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	newStaticRoute, err := client.CreateMagicTransitStaticRoute(context.Background(), accountID, staticRouteFromResource(d))
+	newStaticRoute, err := client.CreateMagicTransitStaticRoute(ctx, accountID, staticRouteFromResource(d))
 
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error creating static route for prefix %s", d.Get("prefix").(string))))
@@ -60,7 +60,7 @@ func resourceCloudflareStaticRouteRead(ctx context.Context, d *schema.ResourceDa
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	staticRoute, err := client.GetMagicTransitStaticRoute(context.Background(), accountID, d.Id())
+	staticRoute, err := client.GetMagicTransitStaticRoute(ctx, accountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "Route not found") {
 			log.Printf("[INFO] Static Route %s not found", d.Id())
@@ -94,7 +94,7 @@ func resourceCloudflareStaticRouteUpdate(ctx context.Context, d *schema.Resource
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	_, err := client.UpdateMagicTransitStaticRoute(context.Background(), accountID, d.Id(), staticRouteFromResource(d))
+	_, err := client.UpdateMagicTransitStaticRoute(ctx, accountID, d.Id(), staticRouteFromResource(d))
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error updating static route with ID %q", d.Id())))
 	}
@@ -108,7 +108,7 @@ func resourceCloudflareStaticRouteDelete(ctx context.Context, d *schema.Resource
 
 	log.Printf("[INFO] Deleting Static Route:  %s", d.Id())
 
-	_, err := client.DeleteMagicTransitStaticRoute(context.Background(), accountID, d.Id())
+	_, err := client.DeleteMagicTransitStaticRoute(ctx, accountID, d.Id())
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Static Route: %s", err))
 	}

--- a/cloudflare/resource_cloudflare_teams_accounts.go
+++ b/cloudflare/resource_cloudflare_teams_accounts.go
@@ -24,7 +24,7 @@ func resourceCloudflareTeamsAccount() *schema.Resource {
 	}
 }
 
-func resourceCloudflareTeamsAccountRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -95,7 +95,7 @@ func resourceCloudflareTeamsAccountRead(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceCloudflareTeamsAccountUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsAccountUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	blockPageConfig := inflateBlockPageConfig(d.Get("block_page"))

--- a/cloudflare/resource_cloudflare_teams_accounts.go
+++ b/cloudflare/resource_cloudflare_teams_accounts.go
@@ -13,9 +13,9 @@ import (
 func resourceCloudflareTeamsAccount() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareTeamsAccountSchema(),
-		Read:   resourceCloudflareTeamsAccountRead,
-		Update: resourceCloudflareTeamsAccountUpdate,
-		Create: resourceCloudflareTeamsAccountUpdate,
+		ReadContext: resourceCloudflareTeamsAccountRead,
+		UpdateContext: resourceCloudflareTeamsAccountUpdate,
+		CreateContext: resourceCloudflareTeamsAccountUpdate,
 		// This resource is a top-level account configuration and cant be "deleted"
 		Delete: func(_ *schema.ResourceData, _ interface{}) error { return nil },
 		Importer: &schema.ResourceImporter{

--- a/cloudflare/resource_cloudflare_teams_accounts.go
+++ b/cloudflare/resource_cloudflare_teams_accounts.go
@@ -29,7 +29,7 @@ func resourceCloudflareTeamsAccountRead(ctx context.Context, d *schema.ResourceD
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	configuration, err := client.TeamsAccountConfiguration(context.Background(), accountID)
+	configuration, err := client.TeamsAccountConfiguration(ctx, accountID)
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 400") {
 			log.Printf("[INFO] Teams Account config %s does not exists", d.Id())
@@ -73,7 +73,7 @@ func resourceCloudflareTeamsAccountRead(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	logSettings, err := client.TeamsAccountLoggingConfiguration(context.Background(), accountID)
+	logSettings, err := client.TeamsAccountLoggingConfiguration(ctx, accountID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error finding Teams Account log settings %q: %w", d.Id(), err))
 	}
@@ -84,7 +84,7 @@ func resourceCloudflareTeamsAccountRead(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	deviceSettings, err := client.TeamsAccountDeviceConfiguration(context.Background(), accountID)
+	deviceSettings, err := client.TeamsAccountDeviceConfiguration(ctx, accountID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error finding Teams Account device settings %q: %w", d.Id(), err))
 	}
@@ -132,18 +132,18 @@ func resourceCloudflareTeamsAccountUpdate(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[DEBUG] Updating Cloudflare Teams Account configuration from struct: %+v", updatedTeamsAccount)
 
-	if _, err := client.TeamsAccountUpdateConfiguration(context.Background(), accountID, updatedTeamsAccount); err != nil {
+	if _, err := client.TeamsAccountUpdateConfiguration(ctx, accountID, updatedTeamsAccount); err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Teams Account configuration for account %q: %w", accountID, err))
 	}
 
 	if loggingConfig != nil {
-		if _, err := client.TeamsAccountUpdateLoggingConfiguration(context.Background(), accountID, *loggingConfig); err != nil {
+		if _, err := client.TeamsAccountUpdateLoggingConfiguration(ctx, accountID, *loggingConfig); err != nil {
 			return diag.FromErr(fmt.Errorf("error updating Teams Account logging settings for account %q: %w", accountID, err))
 		}
 	}
 
 	if deviceConfig != nil {
-		if _, err := client.TeamsAccountDeviceUpdateConfiguration(context.Background(), accountID, *deviceConfig); err != nil {
+		if _, err := client.TeamsAccountDeviceUpdateConfiguration(ctx, accountID, *deviceConfig); err != nil {
 			return diag.FromErr(fmt.Errorf("error updating Teams Account proxy settings for account %q: %w", accountID, err))
 		}
 	}

--- a/cloudflare/resource_cloudflare_teams_accounts.go
+++ b/cloudflare/resource_cloudflare_teams_accounts.go
@@ -35,61 +35,61 @@ func resourceCloudflareTeamsAccountRead(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Teams Account config %q: %w", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Teams Account config %q: %w", d.Id(), err))
 	}
 
 	if configuration.Settings.BlockPage != nil {
 		if err := d.Set("block_page", flattenBlockPageConfig(configuration.Settings.BlockPage)); err != nil {
-			return fmt.Errorf("error parsing account block page config: %w", err)
+			return diag.FromErr(fmt.Errorf("error parsing account block page config: %w", err))
 		}
 	}
 
 	if configuration.Settings.Antivirus != nil {
 		if err := d.Set("antivirus", flattenAntivirusConfig(configuration.Settings.Antivirus)); err != nil {
-			return fmt.Errorf("error parsing account antivirus config: %w", err)
+			return diag.FromErr(fmt.Errorf("error parsing account antivirus config: %w", err))
 		}
 	}
 
 	if configuration.Settings.TLSDecrypt != nil {
 		if err := d.Set("tls_decrypt_enabled", configuration.Settings.TLSDecrypt.Enabled); err != nil {
-			return fmt.Errorf("error parsing account tls decrypt enablement: %w", err)
+			return diag.FromErr(fmt.Errorf("error parsing account tls decrypt enablement: %w", err))
 		}
 	}
 
 	if err := d.Set("activity_log_enabled", configuration.Settings.ActivityLog.Enabled); err != nil {
-		return fmt.Errorf("error parsing account activity log enablement: %w", err)
+		return diag.FromErr(fmt.Errorf("error parsing account activity log enablement: %w", err))
 	}
 
 	if configuration.Settings.FIPS != nil {
 		if err := d.Set("fips", flattenFIPSConfig(configuration.Settings.FIPS)); err != nil {
-			return fmt.Errorf("error parsing account FIPS config: %w", err)
+			return diag.FromErr(fmt.Errorf("error parsing account FIPS config: %w", err))
 		}
 	}
 
 	if configuration.Settings.BrowserIsolation != nil {
 		if err := d.Set("url_browser_isolation_enabled", configuration.Settings.BrowserIsolation.UrlBrowserIsolationEnabled); err != nil {
-			return fmt.Errorf("error parsing account url browser isolation enablement: %w", err)
+			return diag.FromErr(fmt.Errorf("error parsing account url browser isolation enablement: %w", err))
 		}
 	}
 
 	logSettings, err := client.TeamsAccountLoggingConfiguration(context.Background(), accountID)
 	if err != nil {
-		return fmt.Errorf("error finding Teams Account log settings %q: %w", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Teams Account log settings %q: %w", d.Id(), err))
 	}
 
 	if logSettings.LoggingSettingsByRuleType != nil {
 		if err := d.Set("logging", flattenTeamsLoggingSettings(&logSettings)); err != nil {
-			return fmt.Errorf("error parsing teams account log settings: %w", err)
+			return diag.FromErr(fmt.Errorf("error parsing teams account log settings: %w", err))
 		}
 	}
 
 	deviceSettings, err := client.TeamsAccountDeviceConfiguration(context.Background(), accountID)
 	if err != nil {
-		return fmt.Errorf("error finding Teams Account device settings %q: %w", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Teams Account device settings %q: %w", d.Id(), err))
 	}
 
 	if err := d.Set("proxy", flattenTeamsDeviceSettings(&deviceSettings)); err != nil {
-		return fmt.Errorf("error parsing teams account device settings: %w", err)
+		return diag.FromErr(fmt.Errorf("error parsing teams account device settings: %w", err))
 	}
 
 	return nil
@@ -132,18 +132,18 @@ func resourceCloudflareTeamsAccountUpdate(ctx context.Context, d *schema.Resourc
 	log.Printf("[DEBUG] Updating Cloudflare Teams Account configuration from struct: %+v", updatedTeamsAccount)
 
 	if _, err := client.TeamsAccountUpdateConfiguration(context.Background(), accountID, updatedTeamsAccount); err != nil {
-		return fmt.Errorf("error updating Teams Account configuration for account %q: %w", accountID, err)
+		return diag.FromErr(fmt.Errorf("error updating Teams Account configuration for account %q: %w", accountID, err))
 	}
 
 	if loggingConfig != nil {
 		if _, err := client.TeamsAccountUpdateLoggingConfiguration(context.Background(), accountID, *loggingConfig); err != nil {
-			return fmt.Errorf("error updating Teams Account logging settings for account %q: %w", accountID, err)
+			return diag.FromErr(fmt.Errorf("error updating Teams Account logging settings for account %q: %w", accountID, err))
 		}
 	}
 
 	if deviceConfig != nil {
 		if _, err := client.TeamsAccountDeviceUpdateConfiguration(context.Background(), accountID, *deviceConfig); err != nil {
-			return fmt.Errorf("error updating Teams Account proxy settings for account %q: %w", accountID, err)
+			return diag.FromErr(fmt.Errorf("error updating Teams Account proxy settings for account %q: %w", accountID, err))
 		}
 	}
 

--- a/cloudflare/resource_cloudflare_teams_accounts.go
+++ b/cloudflare/resource_cloudflare_teams_accounts.go
@@ -7,19 +7,20 @@ import (
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareTeamsAccount() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareTeamsAccountSchema(),
-		ReadContext: resourceCloudflareTeamsAccountRead,
+		Schema:        resourceCloudflareTeamsAccountSchema(),
+		ReadContext:   resourceCloudflareTeamsAccountRead,
 		UpdateContext: resourceCloudflareTeamsAccountUpdate,
 		CreateContext: resourceCloudflareTeamsAccountUpdate,
 		// This resource is a top-level account configuration and cant be "deleted"
 		Delete: func(_ *schema.ResourceData, _ interface{}) error { return nil },
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareTeamsAccountImport,
+			StateContext: resourceCloudflareTeamsAccountImport,
 		},
 	}
 }
@@ -148,15 +149,16 @@ func resourceCloudflareTeamsAccountUpdate(ctx context.Context, d *schema.Resourc
 	}
 
 	d.SetId(accountID)
-	return resourceCloudflareTeamsAccountRead(d, meta)
+	return resourceCloudflareTeamsAccountRead(ctx, d, meta)
 }
 
-func resourceCloudflareTeamsAccountImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareTeamsAccountImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	d.SetId(d.Id())
 	d.Set("account_id", d.Id())
 
-	err := resourceCloudflareTeamsAccountRead(d, meta)
-	return []*schema.ResourceData{d}, err
+	resourceCloudflareTeamsAccountRead(ctx, d, meta)
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func flattenBlockPageConfig(blockPage *cloudflare.TeamsBlockPage) []interface{} {

--- a/cloudflare/resource_cloudflare_teams_list.go
+++ b/cloudflare/resource_cloudflare_teams_list.go
@@ -43,7 +43,7 @@ func resourceCloudflareTeamsListCreate(ctx context.Context, d *schema.ResourceDa
 
 	list, err := client.CreateTeamsList(context.Background(), accountID, newTeamsList)
 	if err != nil {
-		return fmt.Errorf("error creating Teams List for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error creating Teams List for account %q: %s", accountID, err))
 	}
 
 	d.SetId(list.ID)
@@ -62,7 +62,7 @@ func resourceCloudflareTeamsListRead(ctx context.Context, d *schema.ResourceData
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Teams List %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Teams List %q: %s", d.Id(), err))
 	}
 
 	d.Set("name", list.Name)
@@ -71,7 +71,7 @@ func resourceCloudflareTeamsListRead(ctx context.Context, d *schema.ResourceData
 
 	listItems, _, err := client.TeamsListItems(context.Background(), accountID, d.Id())
 	if err != nil {
-		return fmt.Errorf("error finding Teams List %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Teams List %q: %s", d.Id(), err))
 	}
 	d.Set("items", convertListItemsToSchema(listItems))
 
@@ -94,10 +94,10 @@ func resourceCloudflareTeamsListUpdate(ctx context.Context, d *schema.ResourceDa
 
 	teamsList, err := client.UpdateTeamsList(context.Background(), accountID, updatedTeamsList)
 	if err != nil {
-		return fmt.Errorf("error updating Teams List for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error updating Teams List for account %q: %s", accountID, err))
 	}
 	if teamsList.ID == "" {
-		return fmt.Errorf("failed to find Teams List ID in update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find Teams List ID in update response; resource was empty"))
 	}
 
 	if d.HasChange("items") {
@@ -108,7 +108,7 @@ func resourceCloudflareTeamsListUpdate(ctx context.Context, d *schema.ResourceDa
 		setListItemDiff(&patchTeamsList, oldItems, newItems)
 		l, err := client.PatchTeamsList(context.Background(), accountID, patchTeamsList)
 		if err != nil {
-			return fmt.Errorf("error updating Teams List for account %q: %s", accountID, err)
+			return diag.FromErr(fmt.Errorf("error updating Teams List for account %q: %s", accountID, err))
 		}
 
 		teamsList.Items = l.Items
@@ -126,7 +126,7 @@ func resourceCloudflareTeamsListDelete(ctx context.Context, d *schema.ResourceDa
 
 	err := client.DeleteTeamsList(context.Background(), accountID, appID)
 	if err != nil {
-		return fmt.Errorf("error deleting Teams List for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error deleting Teams List for account %q: %s", accountID, err))
 	}
 
 	resourceCloudflareTeamsListRead(d, meta)

--- a/cloudflare/resource_cloudflare_teams_list.go
+++ b/cloudflare/resource_cloudflare_teams_list.go
@@ -23,7 +23,7 @@ func resourceCloudflareTeamsList() *schema.Resource {
 	}
 }
 
-func resourceCloudflareTeamsListCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsListCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	newTeamsList := cloudflare.TeamsList{
@@ -51,7 +51,7 @@ func resourceCloudflareTeamsListCreate(d *schema.ResourceData, meta interface{})
 	return resourceCloudflareTeamsListRead(d, meta)
 }
 
-func resourceCloudflareTeamsListRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -78,7 +78,7 @@ func resourceCloudflareTeamsListRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceCloudflareTeamsListUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsListUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	updatedTeamsList := cloudflare.TeamsList{
@@ -117,7 +117,7 @@ func resourceCloudflareTeamsListUpdate(d *schema.ResourceData, meta interface{})
 	return resourceCloudflareTeamsListRead(d, meta)
 }
 
-func resourceCloudflareTeamsListDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsListDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	appID := d.Id()
 	accountID := d.Get("account_id").(string)

--- a/cloudflare/resource_cloudflare_teams_list.go
+++ b/cloudflare/resource_cloudflare_teams_list.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareTeamsList() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareTeamsListSchema(),
+		Schema:        resourceCloudflareTeamsListSchema(),
 		CreateContext: resourceCloudflareTeamsListCreate,
-		ReadContext: resourceCloudflareTeamsListRead,
+		ReadContext:   resourceCloudflareTeamsListRead,
 		UpdateContext: resourceCloudflareTeamsListUpdate,
 		DeleteContext: resourceCloudflareTeamsListDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareTeamsListImport,
+			StateContext: resourceCloudflareTeamsListImport,
 		},
 	}
 }
@@ -48,7 +49,7 @@ func resourceCloudflareTeamsListCreate(ctx context.Context, d *schema.ResourceDa
 
 	d.SetId(list.ID)
 
-	return resourceCloudflareTeamsListRead(d, meta)
+	return resourceCloudflareTeamsListRead(ctx, d, meta)
 }
 
 func resourceCloudflareTeamsListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -114,7 +115,7 @@ func resourceCloudflareTeamsListUpdate(ctx context.Context, d *schema.ResourceDa
 		teamsList.Items = l.Items
 	}
 
-	return resourceCloudflareTeamsListRead(d, meta)
+	return resourceCloudflareTeamsListRead(ctx, d, meta)
 }
 
 func resourceCloudflareTeamsListDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -129,12 +130,12 @@ func resourceCloudflareTeamsListDelete(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(fmt.Errorf("error deleting Teams List for account %q: %s", accountID, err))
 	}
 
-	resourceCloudflareTeamsListRead(d, meta)
+	resourceCloudflareTeamsListRead(ctx, d, meta)
 
 	return nil
 }
 
-func resourceCloudflareTeamsListImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareTeamsListImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -148,7 +149,7 @@ func resourceCloudflareTeamsListImport(d *schema.ResourceData, meta interface{})
 	d.Set("account_id", accountID)
 	d.SetId(teamsListID)
 
-	resourceCloudflareTeamsListRead(d, meta)
+	resourceCloudflareTeamsListRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_teams_list.go
+++ b/cloudflare/resource_cloudflare_teams_list.go
@@ -44,7 +44,7 @@ func resourceCloudflareTeamsListCreate(ctx context.Context, d *schema.ResourceDa
 
 	list, err := client.CreateTeamsList(ctx, accountID, newTeamsList)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Teams List for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error creating Teams List for account %q: %w", accountID, err))
 	}
 
 	d.SetId(list.ID)
@@ -63,7 +63,7 @@ func resourceCloudflareTeamsListRead(ctx context.Context, d *schema.ResourceData
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding Teams List %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding Teams List %q: %w", d.Id(), err))
 	}
 
 	d.Set("name", list.Name)
@@ -72,7 +72,7 @@ func resourceCloudflareTeamsListRead(ctx context.Context, d *schema.ResourceData
 
 	listItems, _, err := client.TeamsListItems(ctx, accountID, d.Id())
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error finding Teams List %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding Teams List %q: %w", d.Id(), err))
 	}
 	d.Set("items", convertListItemsToSchema(listItems))
 
@@ -95,7 +95,7 @@ func resourceCloudflareTeamsListUpdate(ctx context.Context, d *schema.ResourceDa
 
 	teamsList, err := client.UpdateTeamsList(ctx, accountID, updatedTeamsList)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Teams List for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error updating Teams List for account %q: %w", accountID, err))
 	}
 	if teamsList.ID == "" {
 		return diag.FromErr(fmt.Errorf("failed to find Teams List ID in update response; resource was empty"))
@@ -109,7 +109,7 @@ func resourceCloudflareTeamsListUpdate(ctx context.Context, d *schema.ResourceDa
 		setListItemDiff(&patchTeamsList, oldItems, newItems)
 		l, err := client.PatchTeamsList(ctx, accountID, patchTeamsList)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error updating Teams List for account %q: %s", accountID, err))
+			return diag.FromErr(fmt.Errorf("error updating Teams List for account %q: %w", accountID, err))
 		}
 
 		teamsList.Items = l.Items
@@ -127,7 +127,7 @@ func resourceCloudflareTeamsListDelete(ctx context.Context, d *schema.ResourceDa
 
 	err := client.DeleteTeamsList(ctx, accountID, appID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Teams List for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error deleting Teams List for account %q: %w", accountID, err))
 	}
 
 	resourceCloudflareTeamsListRead(ctx, d, meta)

--- a/cloudflare/resource_cloudflare_teams_list.go
+++ b/cloudflare/resource_cloudflare_teams_list.go
@@ -42,7 +42,7 @@ func resourceCloudflareTeamsListCreate(ctx context.Context, d *schema.ResourceDa
 
 	accountID := d.Get("account_id").(string)
 
-	list, err := client.CreateTeamsList(context.Background(), accountID, newTeamsList)
+	list, err := client.CreateTeamsList(ctx, accountID, newTeamsList)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Teams List for account %q: %s", accountID, err))
 	}
@@ -56,7 +56,7 @@ func resourceCloudflareTeamsListRead(ctx context.Context, d *schema.ResourceData
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	list, err := client.TeamsList(context.Background(), accountID, d.Id())
+	list, err := client.TeamsList(ctx, accountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[INFO] Teams List %s no longer exists", d.Id())
@@ -70,7 +70,7 @@ func resourceCloudflareTeamsListRead(ctx context.Context, d *schema.ResourceData
 	d.Set("type", list.Type)
 	d.Set("description", list.Description)
 
-	listItems, _, err := client.TeamsListItems(context.Background(), accountID, d.Id())
+	listItems, _, err := client.TeamsListItems(ctx, accountID, d.Id())
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error finding Teams List %q: %s", d.Id(), err))
 	}
@@ -93,7 +93,7 @@ func resourceCloudflareTeamsListUpdate(ctx context.Context, d *schema.ResourceDa
 
 	accountID := d.Get("account_id").(string)
 
-	teamsList, err := client.UpdateTeamsList(context.Background(), accountID, updatedTeamsList)
+	teamsList, err := client.UpdateTeamsList(ctx, accountID, updatedTeamsList)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Teams List for account %q: %s", accountID, err))
 	}
@@ -107,7 +107,7 @@ func resourceCloudflareTeamsListUpdate(ctx context.Context, d *schema.ResourceDa
 		newItems := newItemsIface.(*schema.Set).List()
 		patchTeamsList := cloudflare.PatchTeamsList{ID: d.Id()}
 		setListItemDiff(&patchTeamsList, oldItems, newItems)
-		l, err := client.PatchTeamsList(context.Background(), accountID, patchTeamsList)
+		l, err := client.PatchTeamsList(ctx, accountID, patchTeamsList)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error updating Teams List for account %q: %s", accountID, err))
 		}
@@ -125,7 +125,7 @@ func resourceCloudflareTeamsListDelete(ctx context.Context, d *schema.ResourceDa
 
 	log.Printf("[DEBUG] Deleting Cloudflare Teams List using ID: %s", appID)
 
-	err := client.DeleteTeamsList(context.Background(), accountID, appID)
+	err := client.DeleteTeamsList(ctx, accountID, appID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Teams List for account %q: %s", accountID, err))
 	}

--- a/cloudflare/resource_cloudflare_teams_list.go
+++ b/cloudflare/resource_cloudflare_teams_list.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareTeamsList() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareTeamsListSchema(),
-		Create: resourceCloudflareTeamsListCreate,
-		Read:   resourceCloudflareTeamsListRead,
-		Update: resourceCloudflareTeamsListUpdate,
-		Delete: resourceCloudflareTeamsListDelete,
+		CreateContext: resourceCloudflareTeamsListCreate,
+		ReadContext: resourceCloudflareTeamsListRead,
+		UpdateContext: resourceCloudflareTeamsListUpdate,
+		DeleteContext: resourceCloudflareTeamsListDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareTeamsListImport,
 		},

--- a/cloudflare/resource_cloudflare_teams_location.go
+++ b/cloudflare/resource_cloudflare_teams_location.go
@@ -35,32 +35,32 @@ func resourceCloudflareTeamsLocationRead(ctx context.Context, d *schema.Resource
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Teams Location %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Teams Location %q: %s", d.Id(), err))
 	}
 
 	if err := d.Set("name", location.Name); err != nil {
-		return fmt.Errorf("error parsing Location name")
+		return diag.FromErr(fmt.Errorf("error parsing Location name"))
 	}
 	if err := d.Set("networks", flattenTeamsLocationNetworks(location.Networks)); err != nil {
-		return fmt.Errorf("error parsing Location networks")
+		return diag.FromErr(fmt.Errorf("error parsing Location networks"))
 	}
 	if err := d.Set("policy_ids", location.PolicyIDs); err != nil {
-		return fmt.Errorf("error parsing Location policy IDs")
+		return diag.FromErr(fmt.Errorf("error parsing Location policy IDs"))
 	}
 	if err := d.Set("ip", location.Ip); err != nil {
-		return fmt.Errorf("error parsing Location IP")
+		return diag.FromErr(fmt.Errorf("error parsing Location IP"))
 	}
 	if err := d.Set("doh_subdomain", location.Subdomain); err != nil {
-		return fmt.Errorf("error parsing Location DOH subdomain")
+		return diag.FromErr(fmt.Errorf("error parsing Location DOH subdomain"))
 	}
 	if err := d.Set("anonymized_logs_enabled", location.AnonymizedLogsEnabled); err != nil {
-		return fmt.Errorf("error parsing Location anonimized log enablement")
+		return diag.FromErr(fmt.Errorf("error parsing Location anonimized log enablement"))
 	}
 	if err := d.Set("ipv4_destination", location.IPv4Destination); err != nil {
-		return fmt.Errorf("error parsing Location IPv4 destination")
+		return diag.FromErr(fmt.Errorf("error parsing Location IPv4 destination"))
 	}
 	if err := d.Set("client_default", location.ClientDefault); err != nil {
-		return fmt.Errorf("error parsing Location client default")
+		return diag.FromErr(fmt.Errorf("error parsing Location client default"))
 	}
 
 	return nil
@@ -84,7 +84,7 @@ func resourceCloudflareTeamsLocationCreate(ctx context.Context, d *schema.Resour
 
 	location, err := client.CreateTeamsLocation(context.Background(), accountID, newTeamLocation)
 	if err != nil {
-		return fmt.Errorf("error creating Teams Location for account %q: %s, %v", accountID, err, networks)
+		return diag.FromErr(fmt.Errorf("error creating Teams Location for account %q: %s, %v", accountID, err, networks))
 	}
 
 	d.SetId(location.ID)
@@ -108,10 +108,10 @@ func resourceCloudflareTeamsLocationUpdate(ctx context.Context, d *schema.Resour
 
 	teamsLocation, err := client.UpdateTeamsLocation(context.Background(), accountID, updatedTeamsLocation)
 	if err != nil {
-		return fmt.Errorf("error updating Teams Location for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error updating Teams Location for account %q: %s", accountID, err))
 	}
 	if teamsLocation.ID == "" {
-		return fmt.Errorf("failed to find Teams Location ID in update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find Teams Location ID in update response; resource was empty"))
 	}
 	return resourceCloudflareTeamsLocationRead(d, meta)
 }
@@ -125,7 +125,7 @@ func resourceCloudflareTeamsLocationDelete(ctx context.Context, d *schema.Resour
 
 	err := client.DeleteTeamsLocation(context.Background(), accountID, id)
 	if err != nil {
-		return fmt.Errorf("error deleting Teams Location for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error deleting Teams Location for account %q: %s", accountID, err))
 	}
 
 	return resourceCloudflareTeamsLocationRead(d, meta)

--- a/cloudflare/resource_cloudflare_teams_location.go
+++ b/cloudflare/resource_cloudflare_teams_location.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareTeamsLocation() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareTeamsLocationSchema(),
-		Create: resourceCloudflareTeamsLocationCreate,
-		Read:   resourceCloudflareTeamsLocationRead,
-		Update: resourceCloudflareTeamsLocationUpdate,
-		Delete: resourceCloudflareTeamsLocationDelete,
+		CreateContext: resourceCloudflareTeamsLocationCreate,
+		ReadContext: resourceCloudflareTeamsLocationRead,
+		UpdateContext: resourceCloudflareTeamsLocationUpdate,
+		DeleteContext: resourceCloudflareTeamsLocationDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareTeamsLocationImport,
 		},

--- a/cloudflare/resource_cloudflare_teams_location.go
+++ b/cloudflare/resource_cloudflare_teams_location.go
@@ -29,7 +29,7 @@ func resourceCloudflareTeamsLocationRead(ctx context.Context, d *schema.Resource
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	location, err := client.TeamsLocation(context.Background(), accountID, d.Id())
+	location, err := client.TeamsLocation(ctx, accountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 400") {
 			log.Printf("[INFO] Teams Location %s no longer exists", d.Id())
@@ -83,7 +83,7 @@ func resourceCloudflareTeamsLocationCreate(ctx context.Context, d *schema.Resour
 
 	log.Printf("[DEBUG] Creating Cloudflare Teams Location from struct: %+v", newTeamLocation)
 
-	location, err := client.CreateTeamsLocation(context.Background(), accountID, newTeamLocation)
+	location, err := client.CreateTeamsLocation(ctx, accountID, newTeamLocation)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Teams Location for account %q: %s, %v", accountID, err, networks))
 	}
@@ -107,7 +107,7 @@ func resourceCloudflareTeamsLocationUpdate(ctx context.Context, d *schema.Resour
 	}
 	log.Printf("[DEBUG] Updating Cloudflare Teams Location from struct: %+v", updatedTeamsLocation)
 
-	teamsLocation, err := client.UpdateTeamsLocation(context.Background(), accountID, updatedTeamsLocation)
+	teamsLocation, err := client.UpdateTeamsLocation(ctx, accountID, updatedTeamsLocation)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Teams Location for account %q: %s", accountID, err))
 	}
@@ -124,7 +124,7 @@ func resourceCloudflareTeamsLocationDelete(ctx context.Context, d *schema.Resour
 
 	log.Printf("[DEBUG] Deleting Cloudflare Teams Location using ID: %s", id)
 
-	err := client.DeleteTeamsLocation(context.Background(), accountID, id)
+	err := client.DeleteTeamsLocation(ctx, accountID, id)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Teams Location for account %q: %s", accountID, err))
 	}

--- a/cloudflare/resource_cloudflare_teams_location.go
+++ b/cloudflare/resource_cloudflare_teams_location.go
@@ -24,7 +24,7 @@ func resourceCloudflareTeamsLocation() *schema.Resource {
 	}
 }
 
-func resourceCloudflareTeamsLocationRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsLocationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -65,13 +65,13 @@ func resourceCloudflareTeamsLocationRead(d *schema.ResourceData, meta interface{
 
 	return nil
 }
-func resourceCloudflareTeamsLocationCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsLocationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	accountID := d.Get("account_id").(string)
 	networks, err := inflateTeamsLocationNetworks(d.Get("networks"))
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error creating Teams Location for account %q: %s, %v", accountID, err, networks))
+		return err.Wrap(err, fmt.Sprintf("error creating Teams Location for account %q: %s, %v", accountID, err, networks))
 	}
 
 	newTeamLocation := cloudflare.TeamsLocation{
@@ -91,12 +91,12 @@ func resourceCloudflareTeamsLocationCreate(d *schema.ResourceData, meta interfac
 	return resourceCloudflareTeamsLocationRead(d, meta)
 
 }
-func resourceCloudflareTeamsLocationUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsLocationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	networks, err := inflateTeamsLocationNetworks(d.Get("networks"))
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error updating Teams Location for account %q: %s, %v", accountID, err, networks))
+		return err.Wrap(err, fmt.Sprintf("error updating Teams Location for account %q: %s, %v", accountID, err, networks))
 	}
 	updatedTeamsLocation := cloudflare.TeamsLocation{
 		ID:            d.Id(),
@@ -116,7 +116,7 @@ func resourceCloudflareTeamsLocationUpdate(d *schema.ResourceData, meta interfac
 	return resourceCloudflareTeamsLocationRead(d, meta)
 }
 
-func resourceCloudflareTeamsLocationDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsLocationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	id := d.Id()
 	accountID := d.Get("account_id").(string)

--- a/cloudflare/resource_cloudflare_teams_proxy_endpoints.go
+++ b/cloudflare/resource_cloudflare_teams_proxy_endpoints.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareTeamsProxyEndpoint() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareTeamsProxyEndpointSchema(),
+		Schema:        resourceCloudflareTeamsProxyEndpointSchema(),
 		CreateContext: resourceCloudflareTeamsProxyEndpointCreate,
-		ReadContext: resourceCloudflareTeamsProxyEndpointRead,
+		ReadContext:   resourceCloudflareTeamsProxyEndpointRead,
 		UpdateContext: resourceCloudflareTeamsProxyEndpointUpdate,
 		DeleteContext: resourceCloudflareTeamsProxyEndpointDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareTeamsProxyEndpointImport,
+			StateContext: resourceCloudflareTeamsProxyEndpointImport,
 		},
 	}
 }
@@ -69,7 +70,7 @@ func resourceCloudflareTeamsProxyEndpointCreate(ctx context.Context, d *schema.R
 	}
 
 	d.SetId(proxyEndpoint.ID)
-	return resourceCloudflareTeamsProxyEndpointRead(d, meta)
+	return resourceCloudflareTeamsProxyEndpointRead(ctx, d, meta)
 
 }
 
@@ -93,7 +94,7 @@ func resourceCloudflareTeamsProxyEndpointUpdate(ctx context.Context, d *schema.R
 	if teamsProxyEndpoint.ID == "" {
 		return diag.FromErr(fmt.Errorf("failed to find Teams Proxy Endpoint ID in update response; resource was empty"))
 	}
-	return resourceCloudflareTeamsProxyEndpointRead(d, meta)
+	return resourceCloudflareTeamsProxyEndpointRead(ctx, d, meta)
 }
 
 func resourceCloudflareTeamsProxyEndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -108,10 +109,10 @@ func resourceCloudflareTeamsProxyEndpointDelete(ctx context.Context, d *schema.R
 		return diag.FromErr(fmt.Errorf("error deleting Teams Proxy Endpoint for account %q: %s", accountID, err))
 	}
 
-	return resourceCloudflareTeamsProxyEndpointRead(d, meta)
+	return resourceCloudflareTeamsProxyEndpointRead(ctx, d, meta)
 }
 
-func resourceCloudflareTeamsProxyEndpointImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareTeamsProxyEndpointImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -125,8 +126,8 @@ func resourceCloudflareTeamsProxyEndpointImport(d *schema.ResourceData, meta int
 	d.Set("account_id", accountID)
 	d.SetId(teamsProxyEndpointID)
 
-	err := resourceCloudflareTeamsProxyEndpointRead(d, meta)
+	resourceCloudflareTeamsProxyEndpointRead(ctx, d, meta)
 
-	return []*schema.ResourceData{d}, err
+	return []*schema.ResourceData{d}, nil
 
 }

--- a/cloudflare/resource_cloudflare_teams_proxy_endpoints.go
+++ b/cloudflare/resource_cloudflare_teams_proxy_endpoints.go
@@ -34,19 +34,19 @@ func resourceCloudflareTeamsProxyEndpointRead(ctx context.Context, d *schema.Res
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Teams Proxy Endpoint %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Teams Proxy Endpoint %q: %s", d.Id(), err))
 	}
 
 	if err := d.Set("name", endpoint.Name); err != nil {
-		return fmt.Errorf("error parsing Proxy Endpoint name")
+		return diag.FromErr(fmt.Errorf("error parsing Proxy Endpoint name"))
 	}
 
 	if err := d.Set("ips", endpoint.IPs); err != nil {
-		return fmt.Errorf("error parsing Proxy Endpoint IPs")
+		return diag.FromErr(fmt.Errorf("error parsing Proxy Endpoint IPs"))
 	}
 
 	if err := d.Set("subdomain", endpoint.Subdomain); err != nil {
-		return fmt.Errorf("error parsing Proxy Endpoint subdomain")
+		return diag.FromErr(fmt.Errorf("error parsing Proxy Endpoint subdomain"))
 	}
 
 	return nil
@@ -65,7 +65,7 @@ func resourceCloudflareTeamsProxyEndpointCreate(ctx context.Context, d *schema.R
 
 	proxyEndpoint, err := client.CreateTeamsProxyEndpoint(context.Background(), accountID, newProxyEndpoint)
 	if err != nil {
-		return fmt.Errorf("error creating Teams Proxy Endpoint for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error creating Teams Proxy Endpoint for account %q: %s", accountID, err))
 	}
 
 	d.SetId(proxyEndpoint.ID)
@@ -87,11 +87,11 @@ func resourceCloudflareTeamsProxyEndpointUpdate(ctx context.Context, d *schema.R
 	teamsProxyEndpoint, err := client.UpdateTeamsProxyEndpoint(context.Background(), accountID, updatedProxyEndpoint)
 
 	if err != nil {
-		return fmt.Errorf("error updating Teams Proxy Endpoint for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error updating Teams Proxy Endpoint for account %q: %s", accountID, err))
 	}
 
 	if teamsProxyEndpoint.ID == "" {
-		return fmt.Errorf("failed to find Teams Proxy Endpoint ID in update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find Teams Proxy Endpoint ID in update response; resource was empty"))
 	}
 	return resourceCloudflareTeamsProxyEndpointRead(d, meta)
 }
@@ -105,7 +105,7 @@ func resourceCloudflareTeamsProxyEndpointDelete(ctx context.Context, d *schema.R
 
 	err := client.DeleteTeamsProxyEndpoint(context.Background(), accountID, id)
 	if err != nil {
-		return fmt.Errorf("error deleting Teams Proxy Endpoint for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error deleting Teams Proxy Endpoint for account %q: %s", accountID, err))
 	}
 
 	return resourceCloudflareTeamsProxyEndpointRead(d, meta)

--- a/cloudflare/resource_cloudflare_teams_proxy_endpoints.go
+++ b/cloudflare/resource_cloudflare_teams_proxy_endpoints.go
@@ -23,7 +23,7 @@ func resourceCloudflareTeamsProxyEndpoint() *schema.Resource {
 	}
 }
 
-func resourceCloudflareTeamsProxyEndpointRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsProxyEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -52,7 +52,7 @@ func resourceCloudflareTeamsProxyEndpointRead(d *schema.ResourceData, meta inter
 	return nil
 }
 
-func resourceCloudflareTeamsProxyEndpointCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsProxyEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	accountID := d.Get("account_id").(string)
@@ -73,7 +73,7 @@ func resourceCloudflareTeamsProxyEndpointCreate(d *schema.ResourceData, meta int
 
 }
 
-func resourceCloudflareTeamsProxyEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsProxyEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	updatedProxyEndpoint := cloudflare.TeamsProxyEndpoint{
@@ -96,7 +96,7 @@ func resourceCloudflareTeamsProxyEndpointUpdate(d *schema.ResourceData, meta int
 	return resourceCloudflareTeamsProxyEndpointRead(d, meta)
 }
 
-func resourceCloudflareTeamsProxyEndpointDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsProxyEndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	id := d.Id()
 	accountID := d.Get("account_id").(string)

--- a/cloudflare/resource_cloudflare_teams_proxy_endpoints.go
+++ b/cloudflare/resource_cloudflare_teams_proxy_endpoints.go
@@ -35,7 +35,7 @@ func resourceCloudflareTeamsProxyEndpointRead(ctx context.Context, d *schema.Res
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding Teams Proxy Endpoint %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding Teams Proxy Endpoint %q: %w", d.Id(), err))
 	}
 
 	if err := d.Set("name", endpoint.Name); err != nil {
@@ -66,12 +66,11 @@ func resourceCloudflareTeamsProxyEndpointCreate(ctx context.Context, d *schema.R
 
 	proxyEndpoint, err := client.CreateTeamsProxyEndpoint(ctx, accountID, newProxyEndpoint)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Teams Proxy Endpoint for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error creating Teams Proxy Endpoint for account %q: %w", accountID, err))
 	}
 
 	d.SetId(proxyEndpoint.ID)
 	return resourceCloudflareTeamsProxyEndpointRead(ctx, d, meta)
-
 }
 
 func resourceCloudflareTeamsProxyEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -88,7 +87,7 @@ func resourceCloudflareTeamsProxyEndpointUpdate(ctx context.Context, d *schema.R
 	teamsProxyEndpoint, err := client.UpdateTeamsProxyEndpoint(ctx, accountID, updatedProxyEndpoint)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Teams Proxy Endpoint for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error updating Teams Proxy Endpoint for account %q: %w", accountID, err))
 	}
 
 	if teamsProxyEndpoint.ID == "" {
@@ -106,7 +105,7 @@ func resourceCloudflareTeamsProxyEndpointDelete(ctx context.Context, d *schema.R
 
 	err := client.DeleteTeamsProxyEndpoint(ctx, accountID, id)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Teams Proxy Endpoint for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error deleting Teams Proxy Endpoint for account %q: %w", accountID, err))
 	}
 
 	return resourceCloudflareTeamsProxyEndpointRead(ctx, d, meta)
@@ -129,5 +128,4 @@ func resourceCloudflareTeamsProxyEndpointImport(ctx context.Context, d *schema.R
 	resourceCloudflareTeamsProxyEndpointRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
-
 }

--- a/cloudflare/resource_cloudflare_teams_proxy_endpoints.go
+++ b/cloudflare/resource_cloudflare_teams_proxy_endpoints.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareTeamsProxyEndpoint() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareTeamsProxyEndpointSchema(),
-		Create: resourceCloudflareTeamsProxyEndpointCreate,
-		Read:   resourceCloudflareTeamsProxyEndpointRead,
-		Update: resourceCloudflareTeamsProxyEndpointUpdate,
-		Delete: resourceCloudflareTeamsProxyEndpointDelete,
+		CreateContext: resourceCloudflareTeamsProxyEndpointCreate,
+		ReadContext: resourceCloudflareTeamsProxyEndpointRead,
+		UpdateContext: resourceCloudflareTeamsProxyEndpointUpdate,
+		DeleteContext: resourceCloudflareTeamsProxyEndpointDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareTeamsProxyEndpointImport,
 		},

--- a/cloudflare/resource_cloudflare_teams_proxy_endpoints.go
+++ b/cloudflare/resource_cloudflare_teams_proxy_endpoints.go
@@ -28,7 +28,7 @@ func resourceCloudflareTeamsProxyEndpointRead(ctx context.Context, d *schema.Res
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	endpoint, err := client.TeamsProxyEndpoint(context.Background(), accountID, d.Id())
+	endpoint, err := client.TeamsProxyEndpoint(ctx, accountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 400") {
 			log.Printf("[INFO] Teams Proxy Endpoint %s no longer exists", d.Id())
@@ -64,7 +64,7 @@ func resourceCloudflareTeamsProxyEndpointCreate(ctx context.Context, d *schema.R
 
 	log.Printf("[DEBUG] Creating Cloudflare Teams Proxy Endpoint from struct: %+v", newProxyEndpoint)
 
-	proxyEndpoint, err := client.CreateTeamsProxyEndpoint(context.Background(), accountID, newProxyEndpoint)
+	proxyEndpoint, err := client.CreateTeamsProxyEndpoint(ctx, accountID, newProxyEndpoint)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Teams Proxy Endpoint for account %q: %s", accountID, err))
 	}
@@ -85,7 +85,7 @@ func resourceCloudflareTeamsProxyEndpointUpdate(ctx context.Context, d *schema.R
 
 	log.Printf("[DEBUG] Updating Cloudflare Teams Proxy Endpoint from struct: %+v", updatedProxyEndpoint)
 
-	teamsProxyEndpoint, err := client.UpdateTeamsProxyEndpoint(context.Background(), accountID, updatedProxyEndpoint)
+	teamsProxyEndpoint, err := client.UpdateTeamsProxyEndpoint(ctx, accountID, updatedProxyEndpoint)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Teams Proxy Endpoint for account %q: %s", accountID, err))
@@ -104,7 +104,7 @@ func resourceCloudflareTeamsProxyEndpointDelete(ctx context.Context, d *schema.R
 
 	log.Printf("[DEBUG] Deleting Cloudflare Teams Proxy Endpoint using ID: %s", id)
 
-	err := client.DeleteTeamsProxyEndpoint(context.Background(), accountID, id)
+	err := client.DeleteTeamsProxyEndpoint(ctx, accountID, id)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Teams Proxy Endpoint for account %q: %s", accountID, err))
 	}

--- a/cloudflare/resource_cloudflare_teams_rules.go
+++ b/cloudflare/resource_cloudflare_teams_rules.go
@@ -30,7 +30,7 @@ func resourceCloudflareTeamsRuleRead(ctx context.Context, d *schema.ResourceData
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	rule, err := client.TeamsRule(context.Background(), accountID, d.Id())
+	rule, err := client.TeamsRule(ctx, accountID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 400") {
 			log.Printf("[INFO] Teams Rule config %s doesnt exists", d.Id())
@@ -105,7 +105,7 @@ func resourceCloudflareTeamsRuleCreate(ctx context.Context, d *schema.ResourceDa
 
 	log.Printf("[DEBUG] Creating Cloudflare Teams Rule from struct: %+v", newTeamsRule)
 
-	rule, err := client.TeamsCreateRule(context.Background(), accountID, newTeamsRule)
+	rule, err := client.TeamsCreateRule(ctx, accountID, newTeamsRule)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Teams rule for account %q: %s", accountID, err))
 	}
@@ -143,7 +143,7 @@ func resourceCloudflareTeamsRuleUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 	log.Printf("[DEBUG] Updating Cloudflare Teams rule from struct: %+v", teamsRule)
 
-	updatedTeamsRule, err := client.TeamsUpdateRule(context.Background(), accountID, teamsRule.ID, teamsRule)
+	updatedTeamsRule, err := client.TeamsUpdateRule(ctx, accountID, teamsRule.ID, teamsRule)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Teams rule for account %q: %s", accountID, err))
 	}
@@ -160,7 +160,7 @@ func resourceCloudflareTeamsRuleDelete(ctx context.Context, d *schema.ResourceDa
 
 	log.Printf("[DEBUG] Deleting Cloudflare Teams Rule using ID: %s", id)
 
-	err := client.TeamsDeleteRule(context.Background(), accountID, id)
+	err := client.TeamsDeleteRule(ctx, accountID, id)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Teams Rule for account %q: %s", accountID, err))
 	}

--- a/cloudflare/resource_cloudflare_teams_rules.go
+++ b/cloudflare/resource_cloudflare_teams_rules.go
@@ -36,40 +36,40 @@ func resourceCloudflareTeamsRuleRead(ctx context.Context, d *schema.ResourceData
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Teams Rule %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Teams Rule %q: %s", d.Id(), err))
 	}
 	if err := d.Set("name", rule.Name); err != nil {
-		return fmt.Errorf("error parsing rule name")
+		return diag.FromErr(fmt.Errorf("error parsing rule name"))
 	}
 	if err := d.Set("description", rule.Description); err != nil {
-		return fmt.Errorf("error parsing rule description")
+		return diag.FromErr(fmt.Errorf("error parsing rule description"))
 	}
 	if err := d.Set("precedence", int64(rule.Precedence)); err != nil {
-		return fmt.Errorf("error parsing rule precedence")
+		return diag.FromErr(fmt.Errorf("error parsing rule precedence"))
 	}
 	if err := d.Set("enabled", rule.Enabled); err != nil {
-		return fmt.Errorf("error parsing rule enablement")
+		return diag.FromErr(fmt.Errorf("error parsing rule enablement"))
 	}
 	if err := d.Set("action", rule.Action); err != nil {
-		return fmt.Errorf("error parsing rule action")
+		return diag.FromErr(fmt.Errorf("error parsing rule action"))
 	}
 	if err := d.Set("filters", rule.Filters); err != nil {
-		return fmt.Errorf("error parsing rule filters")
+		return diag.FromErr(fmt.Errorf("error parsing rule filters"))
 	}
 	if err := d.Set("traffic", rule.Traffic); err != nil {
-		return fmt.Errorf("error parsing rule traffic")
+		return diag.FromErr(fmt.Errorf("error parsing rule traffic"))
 	}
 	if err := d.Set("identity", rule.Identity); err != nil {
-		return fmt.Errorf("error parsing rule identity")
+		return diag.FromErr(fmt.Errorf("error parsing rule identity"))
 	}
 	if err := d.Set("device_posture", rule.DevicePosture); err != nil {
-		return fmt.Errorf("error parsing rule device_posture")
+		return diag.FromErr(fmt.Errorf("error parsing rule device_posture"))
 	}
 	if err := d.Set("version", int64(rule.Version)); err != nil {
-		return fmt.Errorf("error parsing rule version")
+		return diag.FromErr(fmt.Errorf("error parsing rule version"))
 	}
 	if err := d.Set("rule_settings", flattenTeamsRuleSettings(&rule.RuleSettings)); err != nil {
-		return fmt.Errorf("error parsing rule settings")
+		return diag.FromErr(fmt.Errorf("error parsing rule settings"))
 	}
 	return nil
 }
@@ -106,7 +106,7 @@ func resourceCloudflareTeamsRuleCreate(ctx context.Context, d *schema.ResourceDa
 
 	rule, err := client.TeamsCreateRule(context.Background(), accountID, newTeamsRule)
 	if err != nil {
-		return fmt.Errorf("error creating Teams rule for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error creating Teams rule for account %q: %s", accountID, err))
 	}
 
 	d.SetId(rule.ID)
@@ -144,10 +144,10 @@ func resourceCloudflareTeamsRuleUpdate(ctx context.Context, d *schema.ResourceDa
 
 	updatedTeamsRule, err := client.TeamsUpdateRule(context.Background(), accountID, teamsRule.ID, teamsRule)
 	if err != nil {
-		return fmt.Errorf("error updating Teams rule for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error updating Teams rule for account %q: %s", accountID, err))
 	}
 	if updatedTeamsRule.ID == "" {
-		return fmt.Errorf("failed to find Teams Rule ID in update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find Teams Rule ID in update response; resource was empty"))
 	}
 	return resourceCloudflareTeamsRuleRead(d, meta)
 }
@@ -161,7 +161,7 @@ func resourceCloudflareTeamsRuleDelete(ctx context.Context, d *schema.ResourceDa
 
 	err := client.TeamsDeleteRule(context.Background(), accountID, id)
 	if err != nil {
-		return fmt.Errorf("error deleting Teams Rule for account %q: %s", accountID, err)
+		return diag.FromErr(fmt.Errorf("error deleting Teams Rule for account %q: %s", accountID, err))
 	}
 
 	return resourceCloudflareTeamsRuleRead(d, meta)

--- a/cloudflare/resource_cloudflare_teams_rules.go
+++ b/cloudflare/resource_cloudflare_teams_rules.go
@@ -15,10 +15,10 @@ import (
 func resourceCloudflareTeamsRule() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareTeamsRuleSchema(),
-		Read:   resourceCloudflareTeamsRuleRead,
-		Update: resourceCloudflareTeamsRuleUpdate,
-		Create: resourceCloudflareTeamsRuleCreate,
-		Delete: resourceCloudflareTeamsRuleDelete,
+		ReadContext: resourceCloudflareTeamsRuleRead,
+		UpdateContext: resourceCloudflareTeamsRuleUpdate,
+		CreateContext: resourceCloudflareTeamsRuleCreate,
+		DeleteContext: resourceCloudflareTeamsRuleDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareTeamsRuleImport,
 		},

--- a/cloudflare/resource_cloudflare_teams_rules.go
+++ b/cloudflare/resource_cloudflare_teams_rules.go
@@ -37,7 +37,7 @@ func resourceCloudflareTeamsRuleRead(ctx context.Context, d *schema.ResourceData
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding Teams Rule %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding Teams Rule %q: %w", d.Id(), err))
 	}
 	if err := d.Set("name", rule.Name); err != nil {
 		return diag.FromErr(fmt.Errorf("error parsing rule name"))
@@ -107,7 +107,7 @@ func resourceCloudflareTeamsRuleCreate(ctx context.Context, d *schema.ResourceDa
 
 	rule, err := client.TeamsCreateRule(ctx, accountID, newTeamsRule)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Teams rule for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error creating Teams rule for account %q: %w", accountID, err))
 	}
 
 	d.SetId(rule.ID)
@@ -145,7 +145,7 @@ func resourceCloudflareTeamsRuleUpdate(ctx context.Context, d *schema.ResourceDa
 
 	updatedTeamsRule, err := client.TeamsUpdateRule(ctx, accountID, teamsRule.ID, teamsRule)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Teams rule for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error updating Teams rule for account %q: %w", accountID, err))
 	}
 	if updatedTeamsRule.ID == "" {
 		return diag.FromErr(fmt.Errorf("failed to find Teams Rule ID in update response; resource was empty"))
@@ -162,7 +162,7 @@ func resourceCloudflareTeamsRuleDelete(ctx context.Context, d *schema.ResourceDa
 
 	err := client.TeamsDeleteRule(ctx, accountID, id)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Teams Rule for account %q: %s", accountID, err))
+		return diag.FromErr(fmt.Errorf("error deleting Teams Rule for account %q: %w", accountID, err))
 	}
 
 	return resourceCloudflareTeamsRuleRead(ctx, d, meta)

--- a/cloudflare/resource_cloudflare_teams_rules.go
+++ b/cloudflare/resource_cloudflare_teams_rules.go
@@ -25,7 +25,7 @@ func resourceCloudflareTeamsRule() *schema.Resource {
 	}
 }
 
-func resourceCloudflareTeamsRuleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -74,7 +74,7 @@ func resourceCloudflareTeamsRuleRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceCloudflareTeamsRuleCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	accountID := d.Get("account_id").(string)
@@ -113,7 +113,7 @@ func resourceCloudflareTeamsRuleCreate(d *schema.ResourceData, meta interface{})
 	return resourceCloudflareTeamsRuleRead(d, meta)
 }
 
-func resourceCloudflareTeamsRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	settings := inflateTeamsRuleSettings(d.Get("rule_settings"))
@@ -152,7 +152,7 @@ func resourceCloudflareTeamsRuleUpdate(d *schema.ResourceData, meta interface{})
 	return resourceCloudflareTeamsRuleRead(d, meta)
 }
 
-func resourceCloudflareTeamsRuleDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTeamsRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	id := d.Id()
 	accountID := d.Get("account_id").(string)

--- a/cloudflare/resource_cloudflare_teams_rules.go
+++ b/cloudflare/resource_cloudflare_teams_rules.go
@@ -9,18 +9,19 @@ import (
 	"time"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareTeamsRule() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareTeamsRuleSchema(),
-		ReadContext: resourceCloudflareTeamsRuleRead,
+		Schema:        resourceCloudflareTeamsRuleSchema(),
+		ReadContext:   resourceCloudflareTeamsRuleRead,
 		UpdateContext: resourceCloudflareTeamsRuleUpdate,
 		CreateContext: resourceCloudflareTeamsRuleCreate,
 		DeleteContext: resourceCloudflareTeamsRuleDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareTeamsRuleImport,
+			StateContext: resourceCloudflareTeamsRuleImport,
 		},
 	}
 }
@@ -110,7 +111,7 @@ func resourceCloudflareTeamsRuleCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	d.SetId(rule.ID)
-	return resourceCloudflareTeamsRuleRead(d, meta)
+	return resourceCloudflareTeamsRuleRead(ctx, d, meta)
 }
 
 func resourceCloudflareTeamsRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -149,7 +150,7 @@ func resourceCloudflareTeamsRuleUpdate(ctx context.Context, d *schema.ResourceDa
 	if updatedTeamsRule.ID == "" {
 		return diag.FromErr(fmt.Errorf("failed to find Teams Rule ID in update response; resource was empty"))
 	}
-	return resourceCloudflareTeamsRuleRead(d, meta)
+	return resourceCloudflareTeamsRuleRead(ctx, d, meta)
 }
 
 func resourceCloudflareTeamsRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -164,10 +165,10 @@ func resourceCloudflareTeamsRuleDelete(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(fmt.Errorf("error deleting Teams Rule for account %q: %s", accountID, err))
 	}
 
-	return resourceCloudflareTeamsRuleRead(d, meta)
+	return resourceCloudflareTeamsRuleRead(ctx, d, meta)
 }
 
-func resourceCloudflareTeamsRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareTeamsRuleImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -181,9 +182,9 @@ func resourceCloudflareTeamsRuleImport(d *schema.ResourceData, meta interface{})
 	d.Set("account_id", accountID)
 	d.SetId(teamsRuleID)
 
-	err := resourceCloudflareTeamsRuleRead(d, meta)
+	resourceCloudflareTeamsRuleRead(ctx, d, meta)
 
-	return []*schema.ResourceData{d}, err
+	return []*schema.ResourceData{d}, nil
 }
 
 func flattenTeamsRuleSettings(settings *cloudflare.TeamsRuleSettings) []interface{} {

--- a/cloudflare/resource_cloudflare_tunnel_route.go
+++ b/cloudflare/resource_cloudflare_tunnel_route.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareTunnelRoute() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareTunnelRouteSchema(),
-		Create: resourceCloudflareTunnelRouteCreate,
-		Read:   resourceCloudflareTunnelRouteRead,
-		Update: resourceCloudflareTunnelRouteUpdate,
-		Delete: resourceCloudflareTunnelRouteDelete,
+		CreateContext: resourceCloudflareTunnelRouteCreate,
+		ReadContext: resourceCloudflareTunnelRouteRead,
+		UpdateContext: resourceCloudflareTunnelRouteUpdate,
+		DeleteContext: resourceCloudflareTunnelRouteDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareTunnelRouteImport,
 		},

--- a/cloudflare/resource_cloudflare_tunnel_route.go
+++ b/cloudflare/resource_cloudflare_tunnel_route.go
@@ -36,7 +36,7 @@ func resourceCloudflareTunnelRouteRead(ctx context.Context, d *schema.ResourceDa
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to fetch Tunnel Route: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to fetch Tunnel Route: %w", err))
 	}
 
 	if len(tunnelRoutes) < 1 {
@@ -71,7 +71,7 @@ func resourceCloudflareTunnelRouteCreate(ctx context.Context, d *schema.Resource
 
 	newTunnelRoute, err := client.CreateTunnelRoute(context.Background(), resource)
 	if err != nil {
-		return fmt.Errorf("error creating Tunnel Route for Network %q: %w", d.Get("network").(string), err)
+		return diag.FromErr(fmt.Errorf("error creating Tunnel Route for Network %q: %w", d.Get("network").(string), err))
 	}
 
 	d.SetId(newTunnelRoute.Network)
@@ -95,7 +95,7 @@ func resourceCloudflareTunnelRouteUpdate(ctx context.Context, d *schema.Resource
 
 	_, err := client.UpdateTunnelRoute(context.Background(), resource)
 	if err != nil {
-		return fmt.Errorf("error updating Tunnel Route for Network %q: %w", d.Get("network").(string), err)
+		return diag.FromErr(fmt.Errorf("error updating Tunnel Route for Network %q: %w", d.Get("network").(string), err))
 	}
 
 	return resourceCloudflareTunnelRouteRead(d, meta)
@@ -109,7 +109,7 @@ func resourceCloudflareTunnelRouteDelete(ctx context.Context, d *schema.Resource
 		Network:   d.Get("network").(string),
 	})
 	if err != nil {
-		return fmt.Errorf("error deleting Tunnel Route for Network %q: %w", d.Get("network").(string), err)
+		return diag.FromErr(fmt.Errorf("error deleting Tunnel Route for Network %q: %w", d.Get("network").(string), err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_tunnel_route.go
+++ b/cloudflare/resource_cloudflare_tunnel_route.go
@@ -30,7 +30,7 @@ func resourceCloudflareTunnelRouteRead(ctx context.Context, d *schema.ResourceDa
 	accountID := d.Get("account_id").(string)
 	network := d.Get("network").(string)
 
-	tunnelRoutes, err := client.ListTunnelRoutes(context.Background(), cloudflare.TunnelRoutesListParams{
+	tunnelRoutes, err := client.ListTunnelRoutes(ctx, cloudflare.TunnelRoutesListParams{
 		AccountID:       accountID,
 		IsDeleted:       cloudflare.BoolPtr(false),
 		NetworkSubset:   network,
@@ -71,7 +71,7 @@ func resourceCloudflareTunnelRouteCreate(ctx context.Context, d *schema.Resource
 		resource.Comment = comment
 	}
 
-	newTunnelRoute, err := client.CreateTunnelRoute(context.Background(), resource)
+	newTunnelRoute, err := client.CreateTunnelRoute(ctx, resource)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating Tunnel Route for Network %q: %w", d.Get("network").(string), err))
 	}
@@ -95,7 +95,7 @@ func resourceCloudflareTunnelRouteUpdate(ctx context.Context, d *schema.Resource
 		resource.Comment = comment
 	}
 
-	_, err := client.UpdateTunnelRoute(context.Background(), resource)
+	_, err := client.UpdateTunnelRoute(ctx, resource)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Tunnel Route for Network %q: %w", d.Get("network").(string), err))
 	}
@@ -106,7 +106,7 @@ func resourceCloudflareTunnelRouteUpdate(ctx context.Context, d *schema.Resource
 func resourceCloudflareTunnelRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
-	err := client.DeleteTunnelRoute(context.Background(), cloudflare.TunnelRoutesDeleteParams{
+	err := client.DeleteTunnelRoute(ctx, cloudflare.TunnelRoutesDeleteParams{
 		AccountID: d.Get("account_id").(string),
 		Network:   d.Get("network").(string),
 	})

--- a/cloudflare/resource_cloudflare_tunnel_route.go
+++ b/cloudflare/resource_cloudflare_tunnel_route.go
@@ -23,7 +23,7 @@ func resourceCloudflareTunnelRoute() *schema.Resource {
 	}
 }
 
-func resourceCloudflareTunnelRouteRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTunnelRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 	network := d.Get("network").(string)
@@ -56,7 +56,7 @@ func resourceCloudflareTunnelRouteRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceCloudflareTunnelRouteCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTunnelRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	resource := cloudflare.TunnelRoutesCreateParams{
@@ -79,7 +79,7 @@ func resourceCloudflareTunnelRouteCreate(d *schema.ResourceData, meta interface{
 	return resourceCloudflareTunnelRouteRead(d, meta)
 }
 
-func resourceCloudflareTunnelRouteUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTunnelRouteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	resource := cloudflare.TunnelRoutesUpdateParams{
@@ -101,7 +101,7 @@ func resourceCloudflareTunnelRouteUpdate(d *schema.ResourceData, meta interface{
 	return resourceCloudflareTunnelRouteRead(d, meta)
 }
 
-func resourceCloudflareTunnelRouteDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareTunnelRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	err := client.DeleteTunnelRoute(context.Background(), cloudflare.TunnelRoutesDeleteParams{

--- a/cloudflare/resource_cloudflare_tunnel_route.go
+++ b/cloudflare/resource_cloudflare_tunnel_route.go
@@ -2,23 +2,25 @@ package cloudflare
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareTunnelRoute() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareTunnelRouteSchema(),
+		Schema:        resourceCloudflareTunnelRouteSchema(),
 		CreateContext: resourceCloudflareTunnelRouteCreate,
-		ReadContext: resourceCloudflareTunnelRouteRead,
+		ReadContext:   resourceCloudflareTunnelRouteRead,
 		UpdateContext: resourceCloudflareTunnelRouteUpdate,
 		DeleteContext: resourceCloudflareTunnelRouteDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareTunnelRouteImport,
+			StateContext: resourceCloudflareTunnelRouteImport,
 		},
 	}
 }
@@ -76,7 +78,7 @@ func resourceCloudflareTunnelRouteCreate(ctx context.Context, d *schema.Resource
 
 	d.SetId(newTunnelRoute.Network)
 
-	return resourceCloudflareTunnelRouteRead(d, meta)
+	return resourceCloudflareTunnelRouteRead(ctx, d, meta)
 }
 
 func resourceCloudflareTunnelRouteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -98,7 +100,7 @@ func resourceCloudflareTunnelRouteUpdate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(fmt.Errorf("error updating Tunnel Route for Network %q: %w", d.Get("network").(string), err))
 	}
 
-	return resourceCloudflareTunnelRouteRead(d, meta)
+	return resourceCloudflareTunnelRouteRead(ctx, d, meta)
 }
 
 func resourceCloudflareTunnelRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -115,7 +117,7 @@ func resourceCloudflareTunnelRouteDelete(ctx context.Context, d *schema.Resource
 	return nil
 }
 
-func resourceCloudflareTunnelRouteImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareTunnelRouteImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	attributes := strings.SplitN(d.Id(), "/", 2)
 
 	if len(attributes) != 2 {
@@ -128,9 +130,9 @@ func resourceCloudflareTunnelRouteImport(d *schema.ResourceData, meta interface{
 	d.Set("account_id", accountID)
 	d.Set("network", network)
 
-	err := resourceCloudflareTunnelRouteRead(d, meta)
+	err := resourceCloudflareTunnelRouteRead(ctx, d, meta)
 	if err != nil {
-		return nil, err
+		return nil, errors.New("failed to read Tunnel Route state")
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/cloudflare/resource_cloudflare_tunnel_route_test.go
+++ b/cloudflare/resource_cloudflare_tunnel_route_test.go
@@ -43,6 +43,7 @@ func testSweepCloudflareTunnelRoute(r string) error {
 
 	for _, tunnel := range tunnelRoutes {
 		log.Printf("[INFO] Deleting Cloudflare Tunnel Route network: %s", tunnel.Network)
+		//nolint:errcheck
 		client.DeleteTunnelRoute(context.Background(), cloudflare.TunnelRoutesDeleteParams{AccountID: accountID, Network: tunnel.Network})
 	}
 

--- a/cloudflare/resource_cloudflare_waf_group.go
+++ b/cloudflare/resource_cloudflare_waf_group.go
@@ -92,7 +92,7 @@ func resourceCloudflareWAFGroupCreate(ctx context.Context, d *schema.ResourceDat
 		return resourceCloudflareWAFGroupRead(d, meta)
 	}
 
-	return fmt.Errorf("unable to find WAF Group %s", groupID)
+	return diag.FromErr(fmt.Errorf("unable to find WAF Group %s", groupID))
 }
 
 func resourceCloudflareWAFGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/cloudflare/resource_cloudflare_waf_group.go
+++ b/cloudflare/resource_cloudflare_waf_group.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareWAFGroup() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareWAFGroupSchema(),
-		Create: resourceCloudflareWAFGroupCreate,
-		Read:   resourceCloudflareWAFGroupRead,
-		Update: resourceCloudflareWAFGroupUpdate,
-		Delete: resourceCloudflareWAFGroupDelete,
+		CreateContext: resourceCloudflareWAFGroupCreate,
+		ReadContext: resourceCloudflareWAFGroupRead,
+		UpdateContext: resourceCloudflareWAFGroupUpdate,
+		DeleteContext: resourceCloudflareWAFGroupDelete,
 
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareWAFGroupImport,

--- a/cloudflare/resource_cloudflare_waf_group.go
+++ b/cloudflare/resource_cloudflare_waf_group.go
@@ -155,7 +155,7 @@ func resourceCloudflareWAFGroupImport(ctx context.Context, d *schema.ResourceDat
 
 	pkgList, err := client.ListWAFPackages(ctx, zoneID)
 	if err != nil {
-		return nil, fmt.Errorf("error listing WAF packages: %s", err)
+		return nil, fmt.Errorf("error listing WAF packages: %w", err)
 	}
 
 	for _, pkg := range pkgList {

--- a/cloudflare/resource_cloudflare_waf_group.go
+++ b/cloudflare/resource_cloudflare_waf_group.go
@@ -32,7 +32,7 @@ func resourceCloudflareWAFGroupRead(ctx context.Context, d *schema.ResourceData,
 	zoneID := d.Get("zone_id").(string)
 	packageID := d.Get("package_id").(string)
 
-	group, err := client.WAFGroup(context.Background(), zoneID, packageID, groupID)
+	group, err := client.WAFGroup(ctx, zoneID, packageID, groupID)
 	if err != nil {
 		var requestError *cloudflare.RequestError
 		if errors.As(err, &requestError) && (sliceContainsInt(requestError.ErrorCodes(), 1002) || sliceContainsInt(requestError.ErrorCodes(), 1003)) {
@@ -61,7 +61,7 @@ func resourceCloudflareWAFGroupCreate(ctx context.Context, d *schema.ResourceDat
 	var pkgList []cloudflare.WAFPackage
 	if packageID == "" {
 		var err error
-		pkgList, err = client.ListWAFPackages(context.Background(), zoneID)
+		pkgList, err = client.ListWAFPackages(ctx, zoneID)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -73,7 +73,7 @@ func resourceCloudflareWAFGroupCreate(ctx context.Context, d *schema.ResourceDat
 		var err error
 		var group cloudflare.WAFGroup
 
-		group, err = client.WAFGroup(context.Background(), zoneID, pkg.ID, groupID)
+		group, err = client.WAFGroup(ctx, zoneID, pkg.ID, groupID)
 		if err != nil {
 			continue
 		}
@@ -103,7 +103,7 @@ func resourceCloudflareWAFGroupDelete(ctx context.Context, d *schema.ResourceDat
 	zoneID := d.Get("zone_id").(string)
 	packageID := d.Get("package_id").(string)
 
-	group, err := client.WAFGroup(context.Background(), zoneID, packageID, groupID)
+	group, err := client.WAFGroup(ctx, zoneID, packageID, groupID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -113,7 +113,7 @@ func resourceCloudflareWAFGroupDelete(ctx context.Context, d *schema.ResourceDat
 	defaultMode := schema["mode"].Default.(string)
 
 	if group.Mode != defaultMode {
-		_, err = client.UpdateWAFGroup(context.Background(), zoneID, packageID, groupID, defaultMode)
+		_, err = client.UpdateWAFGroup(ctx, zoneID, packageID, groupID, defaultMode)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -131,7 +131,7 @@ func resourceCloudflareWAFGroupUpdate(ctx context.Context, d *schema.ResourceDat
 	packageID := d.Get("package_id").(string)
 
 	// We can only update the mode of a WAF Group
-	_, err := client.UpdateWAFGroup(context.Background(), zoneID, packageID, groupID, mode)
+	_, err := client.UpdateWAFGroup(ctx, zoneID, packageID, groupID, mode)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -153,13 +153,13 @@ func resourceCloudflareWAFGroupImport(ctx context.Context, d *schema.ResourceDat
 		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneID/GroupID\" for import", d.Id())
 	}
 
-	pkgList, err := client.ListWAFPackages(context.Background(), zoneID)
+	pkgList, err := client.ListWAFPackages(ctx, zoneID)
 	if err != nil {
 		return nil, fmt.Errorf("error listing WAF packages: %s", err)
 	}
 
 	for _, pkg := range pkgList {
-		group, err := client.WAFGroup(context.Background(), zoneID, pkg.ID, groupID)
+		group, err := client.WAFGroup(ctx, zoneID, pkg.ID, groupID)
 		if err != nil {
 			continue
 		}

--- a/cloudflare/resource_cloudflare_waf_group.go
+++ b/cloudflare/resource_cloudflare_waf_group.go
@@ -24,7 +24,7 @@ func resourceCloudflareWAFGroup() *schema.Resource {
 	}
 }
 
-func resourceCloudflareWAFGroupRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	groupID := d.Get("group_id").(string)
@@ -39,7 +39,7 @@ func resourceCloudflareWAFGroupRead(d *schema.ResourceData, meta interface{}) er
 			return nil
 		}
 
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Only need to set mode as that is the only attribute that could have changed
@@ -49,7 +49,7 @@ func resourceCloudflareWAFGroupRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceCloudflareWAFGroupCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	groupID := d.Get("group_id").(string)
 	zoneID := d.Get("zone_id").(string)
@@ -62,7 +62,7 @@ func resourceCloudflareWAFGroupCreate(d *schema.ResourceData, meta interface{}) 
 		var err error
 		pkgList, err = client.ListWAFPackages(context.Background(), zoneID)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	} else {
 		pkgList = append(pkgList, cloudflare.WAFPackage{ID: packageID})
@@ -85,7 +85,7 @@ func resourceCloudflareWAFGroupCreate(d *schema.ResourceData, meta interface{}) 
 			err = resourceCloudflareWAFGroupUpdate(d, meta)
 			if err != nil {
 				d.SetId("")
-				return err
+				return diag.FromErr(err)
 			}
 		}
 
@@ -95,7 +95,7 @@ func resourceCloudflareWAFGroupCreate(d *schema.ResourceData, meta interface{}) 
 	return fmt.Errorf("unable to find WAF Group %s", groupID)
 }
 
-func resourceCloudflareWAFGroupDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	groupID := d.Get("group_id").(string)
@@ -104,7 +104,7 @@ func resourceCloudflareWAFGroupDelete(d *schema.ResourceData, meta interface{}) 
 
 	group, err := client.WAFGroup(context.Background(), zoneID, packageID, groupID)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Can't delete WAF Group so instead reset it to default
@@ -114,14 +114,14 @@ func resourceCloudflareWAFGroupDelete(d *schema.ResourceData, meta interface{}) 
 	if group.Mode != defaultMode {
 		_, err = client.UpdateWAFGroup(context.Background(), zoneID, packageID, groupID, defaultMode)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
 	return nil
 }
 
-func resourceCloudflareWAFGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	groupID := d.Get("group_id").(string)
@@ -132,7 +132,7 @@ func resourceCloudflareWAFGroupUpdate(d *schema.ResourceData, meta interface{}) 
 	// We can only update the mode of a WAF Group
 	_, err := client.UpdateWAFGroup(context.Background(), zoneID, packageID, groupID, mode)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	return resourceCloudflareWAFGroupRead(d, meta)

--- a/cloudflare/resource_cloudflare_waf_group.go
+++ b/cloudflare/resource_cloudflare_waf_group.go
@@ -7,19 +7,20 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareWAFGroup() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareWAFGroupSchema(),
+		Schema:        resourceCloudflareWAFGroupSchema(),
 		CreateContext: resourceCloudflareWAFGroupCreate,
-		ReadContext: resourceCloudflareWAFGroupRead,
+		ReadContext:   resourceCloudflareWAFGroupRead,
 		UpdateContext: resourceCloudflareWAFGroupUpdate,
 		DeleteContext: resourceCloudflareWAFGroupDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareWAFGroupImport,
+			StateContext: resourceCloudflareWAFGroupImport,
 		},
 	}
 }
@@ -82,14 +83,14 @@ func resourceCloudflareWAFGroupCreate(ctx context.Context, d *schema.ResourceDat
 		d.Set("package_id", pkg.ID)
 
 		if group.Mode != mode {
-			err = resourceCloudflareWAFGroupUpdate(d, meta)
+			err := resourceCloudflareWAFGroupUpdate(ctx, d, meta)
 			if err != nil {
 				d.SetId("")
-				return diag.FromErr(err)
+				return err
 			}
 		}
 
-		return resourceCloudflareWAFGroupRead(d, meta)
+		return resourceCloudflareWAFGroupRead(ctx, d, meta)
 	}
 
 	return diag.FromErr(fmt.Errorf("unable to find WAF Group %s", groupID))
@@ -135,10 +136,10 @@ func resourceCloudflareWAFGroupUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	return resourceCloudflareWAFGroupRead(d, meta)
+	return resourceCloudflareWAFGroupRead(ctx, d, meta)
 }
 
-func resourceCloudflareWAFGroupImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareWAFGroupImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*cloudflare.API)
 
 	// split the id so we can lookup

--- a/cloudflare/resource_cloudflare_waf_group_test.go
+++ b/cloudflare/resource_cloudflare_waf_group_test.go
@@ -65,13 +65,13 @@ func testAccGetWAFGroup(zoneID string) (string, error) {
 
 	pkgList, err := client.ListWAFPackages(context.Background(), zoneID)
 	if err != nil {
-		return "", fmt.Errorf("Error while listing WAF packages: %s", err)
+		return "", fmt.Errorf("Error while listing WAF packages: %w", err)
 	}
 
 	for _, pkg := range pkgList {
 		groupList, err := client.ListWAFGroups(context.Background(), zoneID, pkg.ID)
 		if err != nil {
-			return "", fmt.Errorf("Error while listing WAF groups for WAF package %s: %s", pkg.ID, err)
+			return "", fmt.Errorf("Error while listing WAF groups for WAF package %s: %w", pkg.ID, err)
 		}
 
 		for _, group := range groupList {

--- a/cloudflare/resource_cloudflare_waf_override.go
+++ b/cloudflare/resource_cloudflare_waf_override.go
@@ -35,7 +35,7 @@ func resourceCloudflareWAFOverrideRead(ctx context.Context, d *schema.ResourceDa
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("failed to find WAF override %s: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("failed to find WAF override %s: %w", d.Id(), err))
 	}
 
 	d.Set("zone_id", zoneID)
@@ -68,7 +68,7 @@ func resourceCloudflareWAFOverrideCreate(ctx context.Context, d *schema.Resource
 
 	override, err := client.CreateWAFOverride(ctx, zoneID, newOverride)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to create WAF override: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to create WAF override: %w", err))
 	}
 
 	d.SetId(override.ID)
@@ -84,7 +84,7 @@ func resourceCloudflareWAFOverrideUpdate(ctx context.Context, d *schema.Resource
 
 	_, err := client.UpdateWAFOverride(ctx, zoneID, overrideID, updatedOverride)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update WAF override: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to update WAF override: %w", err))
 	}
 
 	return resourceCloudflareWAFOverrideRead(ctx, d, meta)
@@ -97,7 +97,7 @@ func resourceCloudflareWAFOverrideDelete(ctx context.Context, d *schema.Resource
 
 	err := client.DeleteWAFOverride(ctx, zoneID, overrideID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to delete WAF override ID %s: %s", overrideID, err))
+		return diag.FromErr(fmt.Errorf("failed to delete WAF override ID %s: %w", overrideID, err))
 	}
 
 	return resourceCloudflareWAFOverrideRead(ctx, d, meta)

--- a/cloudflare/resource_cloudflare_waf_override.go
+++ b/cloudflare/resource_cloudflare_waf_override.go
@@ -28,7 +28,7 @@ func resourceCloudflareWAFOverrideRead(ctx context.Context, d *schema.ResourceDa
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	override, err := client.WAFOverride(context.Background(), zoneID, d.Id())
+	override, err := client.WAFOverride(ctx, zoneID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "wafuriconfig.api.not_found") {
 			log.Printf("[INFO] WAF override %s no longer exists", d.Id())
@@ -66,7 +66,7 @@ func resourceCloudflareWAFOverrideCreate(ctx context.Context, d *schema.Resource
 	zoneID := d.Get("zone_id").(string)
 	newOverride, _ := buildWAFOverride(d)
 
-	override, err := client.CreateWAFOverride(context.Background(), zoneID, newOverride)
+	override, err := client.CreateWAFOverride(ctx, zoneID, newOverride)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to create WAF override: %s", err))
 	}
@@ -82,7 +82,7 @@ func resourceCloudflareWAFOverrideUpdate(ctx context.Context, d *schema.Resource
 	overrideID := d.Get("override_id").(string)
 	updatedOverride, _ := buildWAFOverride(d)
 
-	_, err := client.UpdateWAFOverride(context.Background(), zoneID, overrideID, updatedOverride)
+	_, err := client.UpdateWAFOverride(ctx, zoneID, overrideID, updatedOverride)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to update WAF override: %s", err))
 	}
@@ -95,7 +95,7 @@ func resourceCloudflareWAFOverrideDelete(ctx context.Context, d *schema.Resource
 	overrideID := d.Get("override_id").(string)
 	zoneID := d.Get("zone_id").(string)
 
-	err := client.DeleteWAFOverride(context.Background(), zoneID, overrideID)
+	err := client.DeleteWAFOverride(ctx, zoneID, overrideID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to delete WAF override ID %s: %s", overrideID, err))
 	}

--- a/cloudflare/resource_cloudflare_waf_override.go
+++ b/cloudflare/resource_cloudflare_waf_override.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareWAFOverride() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareWAFOverrideSchema(),
+		Schema:        resourceCloudflareWAFOverrideSchema(),
 		CreateContext: resourceCloudflareWAFOverrideCreate,
-		ReadContext: resourceCloudflareWAFOverrideRead,
+		ReadContext:   resourceCloudflareWAFOverrideRead,
 		UpdateContext: resourceCloudflareWAFOverrideUpdate,
 		DeleteContext: resourceCloudflareWAFOverrideDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareWAFOverrideImport,
+			StateContext: resourceCloudflareWAFOverrideImport,
 		},
 	}
 }
@@ -72,7 +73,7 @@ func resourceCloudflareWAFOverrideCreate(ctx context.Context, d *schema.Resource
 
 	d.SetId(override.ID)
 
-	return resourceCloudflareWAFOverrideRead(d, meta)
+	return resourceCloudflareWAFOverrideRead(ctx, d, meta)
 }
 
 func resourceCloudflareWAFOverrideUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -86,7 +87,7 @@ func resourceCloudflareWAFOverrideUpdate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(fmt.Errorf("failed to update WAF override: %s", err))
 	}
 
-	return resourceCloudflareWAFOverrideRead(d, meta)
+	return resourceCloudflareWAFOverrideRead(ctx, d, meta)
 }
 
 func resourceCloudflareWAFOverrideDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -99,10 +100,10 @@ func resourceCloudflareWAFOverrideDelete(ctx context.Context, d *schema.Resource
 		return diag.FromErr(fmt.Errorf("failed to delete WAF override ID %s: %s", overrideID, err))
 	}
 
-	return resourceCloudflareWAFOverrideRead(d, meta)
+	return resourceCloudflareWAFOverrideRead(ctx, d, meta)
 }
 
-func resourceCloudflareWAFOverrideImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareWAFOverrideImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	idAttr := strings.SplitN(d.Id(), "/", 2)
 
 	if len(idAttr) != 2 {
@@ -117,7 +118,7 @@ func resourceCloudflareWAFOverrideImport(d *schema.ResourceData, meta interface{
 	d.Set("override_id", WAFOverrideID)
 	d.SetId(WAFOverrideID)
 
-	resourceCloudflareWAFOverrideRead(d, meta)
+	resourceCloudflareWAFOverrideRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_waf_override.go
+++ b/cloudflare/resource_cloudflare_waf_override.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareWAFOverride() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareWAFOverrideSchema(),
-		Create: resourceCloudflareWAFOverrideCreate,
-		Read:   resourceCloudflareWAFOverrideRead,
-		Update: resourceCloudflareWAFOverrideUpdate,
-		Delete: resourceCloudflareWAFOverrideDelete,
+		CreateContext: resourceCloudflareWAFOverrideCreate,
+		ReadContext: resourceCloudflareWAFOverrideRead,
+		UpdateContext: resourceCloudflareWAFOverrideUpdate,
+		DeleteContext: resourceCloudflareWAFOverrideDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareWAFOverrideImport,
 		},

--- a/cloudflare/resource_cloudflare_waf_override.go
+++ b/cloudflare/resource_cloudflare_waf_override.go
@@ -34,7 +34,7 @@ func resourceCloudflareWAFOverrideRead(ctx context.Context, d *schema.ResourceDa
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("failed to find WAF override %s: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("failed to find WAF override %s: %s", d.Id(), err))
 	}
 
 	d.Set("zone_id", zoneID)
@@ -67,7 +67,7 @@ func resourceCloudflareWAFOverrideCreate(ctx context.Context, d *schema.Resource
 
 	override, err := client.CreateWAFOverride(context.Background(), zoneID, newOverride)
 	if err != nil {
-		return fmt.Errorf("failed to create WAF override: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to create WAF override: %s", err))
 	}
 
 	d.SetId(override.ID)
@@ -83,7 +83,7 @@ func resourceCloudflareWAFOverrideUpdate(ctx context.Context, d *schema.Resource
 
 	_, err := client.UpdateWAFOverride(context.Background(), zoneID, overrideID, updatedOverride)
 	if err != nil {
-		return fmt.Errorf("failed to update WAF override: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to update WAF override: %s", err))
 	}
 
 	return resourceCloudflareWAFOverrideRead(d, meta)
@@ -96,7 +96,7 @@ func resourceCloudflareWAFOverrideDelete(ctx context.Context, d *schema.Resource
 
 	err := client.DeleteWAFOverride(context.Background(), zoneID, overrideID)
 	if err != nil {
-		return fmt.Errorf("failed to delete WAF override ID %s: %s", overrideID, err)
+		return diag.FromErr(fmt.Errorf("failed to delete WAF override ID %s: %s", overrideID, err))
 	}
 
 	return resourceCloudflareWAFOverrideRead(d, meta)

--- a/cloudflare/resource_cloudflare_waf_override.go
+++ b/cloudflare/resource_cloudflare_waf_override.go
@@ -23,7 +23,7 @@ func resourceCloudflareWAFOverride() *schema.Resource {
 	}
 }
 
-func resourceCloudflareWAFOverrideRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFOverrideRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -60,7 +60,7 @@ func resourceCloudflareWAFOverrideRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceCloudflareWAFOverrideCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFOverrideCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	newOverride, _ := buildWAFOverride(d)
@@ -75,7 +75,7 @@ func resourceCloudflareWAFOverrideCreate(d *schema.ResourceData, meta interface{
 	return resourceCloudflareWAFOverrideRead(d, meta)
 }
 
-func resourceCloudflareWAFOverrideUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFOverrideUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	overrideID := d.Get("override_id").(string)
@@ -89,7 +89,7 @@ func resourceCloudflareWAFOverrideUpdate(d *schema.ResourceData, meta interface{
 	return resourceCloudflareWAFOverrideRead(d, meta)
 }
 
-func resourceCloudflareWAFOverrideDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFOverrideDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	overrideID := d.Get("override_id").(string)
 	zoneID := d.Get("zone_id").(string)

--- a/cloudflare/resource_cloudflare_waf_package.go
+++ b/cloudflare/resource_cloudflare_waf_package.go
@@ -24,7 +24,7 @@ func resourceCloudflareWAFPackage() *schema.Resource {
 	}
 }
 
-func resourceCloudflareWAFPackageRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFPackageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	packageID := d.Get("package_id").(string)
@@ -38,7 +38,7 @@ func resourceCloudflareWAFPackageRead(d *schema.ResourceData, meta interface{}) 
 			return nil
 		}
 
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("sensitivity", pkg.Sensitivity)
@@ -48,7 +48,7 @@ func resourceCloudflareWAFPackageRead(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceCloudflareWAFPackageCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFPackageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	packageID := d.Get("package_id").(string)
@@ -77,14 +77,14 @@ func resourceCloudflareWAFPackageCreate(d *schema.ResourceData, meta interface{}
 		err = resourceCloudflareWAFPackageUpdate(d, meta)
 		if err != nil {
 			d.SetId("")
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
 	return nil
 }
 
-func resourceCloudflareWAFPackageDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFPackageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	packageID := d.Get("package_id").(string)
@@ -92,7 +92,7 @@ func resourceCloudflareWAFPackageDelete(d *schema.ResourceData, meta interface{}
 
 	pkg, err := client.WAFPackage(context.Background(), zoneID, packageID)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Can't delete WAF Package so instead reset it to default
@@ -108,14 +108,14 @@ func resourceCloudflareWAFPackageDelete(d *schema.ResourceData, meta interface{}
 
 		_, err = client.UpdateWAFPackage(context.Background(), zoneID, packageID, options)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
 	return nil
 }
 
-func resourceCloudflareWAFPackageUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFPackageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	packageID := d.Get("package_id").(string)
@@ -130,7 +130,7 @@ func resourceCloudflareWAFPackageUpdate(d *schema.ResourceData, meta interface{}
 
 	_, err := client.UpdateWAFPackage(context.Background(), zoneID, packageID, options)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_waf_package.go
+++ b/cloudflare/resource_cloudflare_waf_package.go
@@ -7,19 +7,20 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareWAFPackage() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareWAFPackageSchema(),
+		Schema:        resourceCloudflareWAFPackageSchema(),
 		CreateContext: resourceCloudflareWAFPackageCreate,
-		ReadContext: resourceCloudflareWAFPackageRead,
+		ReadContext:   resourceCloudflareWAFPackageRead,
 		UpdateContext: resourceCloudflareWAFPackageUpdate,
 		DeleteContext: resourceCloudflareWAFPackageDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareWAFPackageImport,
+			StateContext: resourceCloudflareWAFPackageImport,
 		},
 	}
 }
@@ -74,10 +75,10 @@ func resourceCloudflareWAFPackageCreate(ctx context.Context, d *schema.ResourceD
 	d.SetId(packageID)
 
 	if pkg.Sensitivity != sensitivity || pkg.ActionMode != actionMode {
-		err = resourceCloudflareWAFPackageUpdate(d, meta)
+		err := resourceCloudflareWAFPackageUpdate(ctx, d, meta)
 		if err != nil {
 			d.SetId("")
-			return diag.FromErr(err)
+			return err
 		}
 	}
 
@@ -136,7 +137,7 @@ func resourceCloudflareWAFPackageUpdate(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func resourceCloudflareWAFPackageImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareWAFPackageImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*cloudflare.API)
 
 	// split the id so we can lookup

--- a/cloudflare/resource_cloudflare_waf_package.go
+++ b/cloudflare/resource_cloudflare_waf_package.go
@@ -31,7 +31,7 @@ func resourceCloudflareWAFPackageRead(ctx context.Context, d *schema.ResourceDat
 	packageID := d.Get("package_id").(string)
 	zoneID := d.Get("zone_id").(string)
 
-	pkg, err := client.WAFPackage(context.Background(), zoneID, packageID)
+	pkg, err := client.WAFPackage(ctx, zoneID, packageID)
 	if err != nil {
 		var requestError *cloudflare.RequestError
 		if errors.As(err, &requestError) && sliceContainsInt(requestError.ErrorCodes(), 1002) {
@@ -57,7 +57,7 @@ func resourceCloudflareWAFPackageCreate(ctx context.Context, d *schema.ResourceD
 	sensitivity := d.Get("sensitivity").(string)
 	actionMode := d.Get("action_mode").(string)
 
-	pkg, err := client.WAFPackage(context.Background(), zoneID, packageID)
+	pkg, err := client.WAFPackage(ctx, zoneID, packageID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("unable to find WAF Package %s", packageID))
 	}
@@ -91,7 +91,7 @@ func resourceCloudflareWAFPackageDelete(ctx context.Context, d *schema.ResourceD
 	packageID := d.Get("package_id").(string)
 	zoneID := d.Get("zone_id").(string)
 
-	pkg, err := client.WAFPackage(context.Background(), zoneID, packageID)
+	pkg, err := client.WAFPackage(ctx, zoneID, packageID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -107,7 +107,7 @@ func resourceCloudflareWAFPackageDelete(ctx context.Context, d *schema.ResourceD
 			ActionMode:  defaultActionMode,
 		}
 
-		_, err = client.UpdateWAFPackage(context.Background(), zoneID, packageID, options)
+		_, err = client.UpdateWAFPackage(ctx, zoneID, packageID, options)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -129,7 +129,7 @@ func resourceCloudflareWAFPackageUpdate(ctx context.Context, d *schema.ResourceD
 		ActionMode:  actionMode,
 	}
 
-	_, err := client.UpdateWAFPackage(context.Background(), zoneID, packageID, options)
+	_, err := client.UpdateWAFPackage(ctx, zoneID, packageID, options)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -151,7 +151,7 @@ func resourceCloudflareWAFPackageImport(ctx context.Context, d *schema.ResourceD
 		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneID/PackageID\" for import", d.Id())
 	}
 
-	pkg, err := client.WAFPackage(context.Background(), zoneID, packageID)
+	pkg, err := client.WAFPackage(ctx, zoneID, packageID)
 	if err != nil {
 		return nil, err
 	}

--- a/cloudflare/resource_cloudflare_waf_package.go
+++ b/cloudflare/resource_cloudflare_waf_package.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareWAFPackage() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareWAFPackageSchema(),
-		Create: resourceCloudflareWAFPackageCreate,
-		Read:   resourceCloudflareWAFPackageRead,
-		Update: resourceCloudflareWAFPackageUpdate,
-		Delete: resourceCloudflareWAFPackageDelete,
+		CreateContext: resourceCloudflareWAFPackageCreate,
+		ReadContext: resourceCloudflareWAFPackageRead,
+		UpdateContext: resourceCloudflareWAFPackageUpdate,
+		DeleteContext: resourceCloudflareWAFPackageDelete,
 
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareWAFPackageImport,

--- a/cloudflare/resource_cloudflare_waf_package.go
+++ b/cloudflare/resource_cloudflare_waf_package.go
@@ -58,7 +58,7 @@ func resourceCloudflareWAFPackageCreate(ctx context.Context, d *schema.ResourceD
 
 	pkg, err := client.WAFPackage(context.Background(), zoneID, packageID)
 	if err != nil {
-		return fmt.Errorf("unable to find WAF Package %s", packageID)
+		return diag.FromErr(fmt.Errorf("unable to find WAF Package %s", packageID))
 	}
 
 	d.Set("zone_id", zoneID)

--- a/cloudflare/resource_cloudflare_waf_package_test.go
+++ b/cloudflare/resource_cloudflare_waf_package_test.go
@@ -65,7 +65,7 @@ func testAccGetWAFPackage(zoneID string) (string, error) {
 
 	pkgList, err := client.ListWAFPackages(context.Background(), zoneID)
 	if err != nil {
-		return "", fmt.Errorf("Error while listing WAF packages: %s", err)
+		return "", fmt.Errorf("Error while listing WAF packages: %w", err)
 	}
 
 	for _, pkg := range pkgList {

--- a/cloudflare/resource_cloudflare_waf_rule.go
+++ b/cloudflare/resource_cloudflare_waf_rule.go
@@ -94,7 +94,7 @@ func resourceCloudflareWAFRuleCreate(ctx context.Context, d *schema.ResourceData
 		return resourceCloudflareWAFRuleRead(d, meta)
 	}
 
-	return fmt.Errorf("unable to find WAF Rule %s", ruleID)
+	return diag.FromErr(fmt.Errorf("unable to find WAF Rule %s", ruleID))
 }
 
 func resourceCloudflareWAFRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/cloudflare/resource_cloudflare_waf_rule.go
+++ b/cloudflare/resource_cloudflare_waf_rule.go
@@ -160,7 +160,7 @@ func resourceCloudflareWAFRuleImport(ctx context.Context, d *schema.ResourceData
 
 	packs, err := client.ListWAFPackages(ctx, zoneID)
 	if err != nil {
-		return nil, fmt.Errorf("error listing WAF packages: %s", err)
+		return nil, fmt.Errorf("error listing WAF packages: %w", err)
 	}
 
 	for _, p := range packs {

--- a/cloudflare/resource_cloudflare_waf_rule.go
+++ b/cloudflare/resource_cloudflare_waf_rule.go
@@ -24,7 +24,7 @@ func resourceCloudflareWAFRule() *schema.Resource {
 	}
 }
 
-func resourceCloudflareWAFRuleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	ruleID := d.Get("rule_id").(string)
@@ -39,7 +39,7 @@ func resourceCloudflareWAFRuleRead(d *schema.ResourceData, meta interface{}) err
 			return nil
 		}
 
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Only need to set mode as that is the only attribute that could have changed
@@ -50,7 +50,7 @@ func resourceCloudflareWAFRuleRead(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceCloudflareWAFRuleCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	ruleID := d.Get("rule_id").(string)
 	zoneID := d.Get("zone_id").(string)
@@ -63,7 +63,7 @@ func resourceCloudflareWAFRuleCreate(d *schema.ResourceData, meta interface{}) e
 		var err error
 		pkgList, err = client.ListWAFPackages(context.Background(), zoneID)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	} else {
 		pkgList = append(pkgList, cloudflare.WAFPackage{ID: packageID})
@@ -87,7 +87,7 @@ func resourceCloudflareWAFRuleCreate(d *schema.ResourceData, meta interface{}) e
 			err = resourceCloudflareWAFRuleUpdate(d, meta)
 			if err != nil {
 				d.SetId("")
-				return err
+				return diag.FromErr(err)
 			}
 		}
 
@@ -97,7 +97,7 @@ func resourceCloudflareWAFRuleCreate(d *schema.ResourceData, meta interface{}) e
 	return fmt.Errorf("unable to find WAF Rule %s", ruleID)
 }
 
-func resourceCloudflareWAFRuleDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	ruleID := d.Get("rule_id").(string)
@@ -106,7 +106,7 @@ func resourceCloudflareWAFRuleDelete(d *schema.ResourceData, meta interface{}) e
 
 	rule, err := client.WAFRule(context.Background(), zoneID, packageID, ruleID)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Find the default mode to be used
@@ -119,14 +119,14 @@ func resourceCloudflareWAFRuleDelete(d *schema.ResourceData, meta interface{}) e
 	if rule.Mode != defaultMode {
 		_, err = client.UpdateWAFRule(context.Background(), zoneID, packageID, ruleID, defaultMode)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
 	return nil
 }
 
-func resourceCloudflareWAFRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWAFRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	ruleID := d.Get("rule_id").(string)
@@ -137,7 +137,7 @@ func resourceCloudflareWAFRuleUpdate(d *schema.ResourceData, meta interface{}) e
 	// We can only update the mode of a WAF Rule
 	_, err := client.UpdateWAFRule(context.Background(), zoneID, packageID, ruleID, mode)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	return resourceCloudflareWAFRuleRead(d, meta)

--- a/cloudflare/resource_cloudflare_waf_rule.go
+++ b/cloudflare/resource_cloudflare_waf_rule.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareWAFRule() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareWAFRuleSchema(),
-		Create: resourceCloudflareWAFRuleCreate,
-		Read:   resourceCloudflareWAFRuleRead,
-		Update: resourceCloudflareWAFRuleUpdate,
-		Delete: resourceCloudflareWAFRuleDelete,
+		CreateContext: resourceCloudflareWAFRuleCreate,
+		ReadContext: resourceCloudflareWAFRuleRead,
+		UpdateContext: resourceCloudflareWAFRuleUpdate,
+		DeleteContext: resourceCloudflareWAFRuleDelete,
 
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareWAFRuleImport,

--- a/cloudflare/resource_cloudflare_waiting_room.go
+++ b/cloudflare/resource_cloudflare_waiting_room.go
@@ -53,7 +53,7 @@ func resourceCloudflareWaitingRoomCreate(ctx context.Context, d *schema.Resource
 
 	newWaitingRoom := buildWaitingRoom(d)
 
-	waitingRoom, err := client.CreateWaitingRoom(context.Background(), zoneID, newWaitingRoom)
+	waitingRoom, err := client.CreateWaitingRoom(ctx, zoneID, newWaitingRoom)
 
 	if err != nil {
 		name := d.Get("name").(string)
@@ -70,7 +70,7 @@ func resourceCloudflareWaitingRoomRead(ctx context.Context, d *schema.ResourceDa
 	waitingRoomID := d.Id()
 	zoneID := d.Get("zone_id").(string)
 
-	waitingRoom, err := client.WaitingRoom(context.Background(), zoneID, waitingRoomID)
+	waitingRoom, err := client.WaitingRoom(ctx, zoneID, waitingRoomID)
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[WARN] Removing waiting room from state because it's not found in API")
@@ -103,7 +103,7 @@ func resourceCloudflareWaitingRoomUpdate(ctx context.Context, d *schema.Resource
 
 	waitingRoom := buildWaitingRoom(d)
 
-	_, err := client.ChangeWaitingRoom(context.Background(), zoneID, waitingRoomID, waitingRoom)
+	_, err := client.ChangeWaitingRoom(ctx, zoneID, waitingRoomID, waitingRoom)
 
 	if err != nil {
 		name := d.Get("name").(string)
@@ -118,7 +118,7 @@ func resourceCloudflareWaitingRoomDelete(ctx context.Context, d *schema.Resource
 	waitingRoomID := d.Id()
 	zoneID := d.Get("zone_id").(string)
 
-	err := client.DeleteWaitingRoom(context.Background(), zoneID, waitingRoomID)
+	err := client.DeleteWaitingRoom(ctx, zoneID, waitingRoomID)
 
 	if err != nil {
 		name := d.Get("name").(string)
@@ -140,7 +140,7 @@ func resourceCloudflareWaitingRoomImport(ctx context.Context, d *schema.Resource
 		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneID/waitingRoomID\" for import", d.Id())
 	}
 
-	waitingRoom, err := client.WaitingRoom(context.Background(), zoneID, waitingRoomID)
+	waitingRoom, err := client.WaitingRoom(ctx, zoneID, waitingRoomID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch Waiting room %s", waitingRoomID)
 	}

--- a/cloudflare/resource_cloudflare_waiting_room.go
+++ b/cloudflare/resource_cloudflare_waiting_room.go
@@ -46,7 +46,7 @@ func buildWaitingRoom(d *schema.ResourceData) cloudflare.WaitingRoom {
 	}
 }
 
-func resourceCloudflareWaitingRoomCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWaitingRoomCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -64,7 +64,7 @@ func resourceCloudflareWaitingRoomCreate(d *schema.ResourceData, meta interface{
 	return resourceCloudflareWaitingRoomRead(d, meta)
 }
 
-func resourceCloudflareWaitingRoomRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWaitingRoomRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	waitingRoomID := d.Id()
 	zoneID := d.Get("zone_id").(string)
@@ -95,7 +95,7 @@ func resourceCloudflareWaitingRoomRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceCloudflareWaitingRoomUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWaitingRoomUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	waitingRoomID := d.Id()
 	zoneID := d.Get("zone_id").(string)
@@ -112,7 +112,7 @@ func resourceCloudflareWaitingRoomUpdate(d *schema.ResourceData, meta interface{
 	return resourceCloudflareWaitingRoomRead(d, meta)
 }
 
-func resourceCloudflareWaitingRoomDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWaitingRoomDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	waitingRoomID := d.Id()
 	zoneID := d.Get("zone_id").(string)

--- a/cloudflare/resource_cloudflare_waiting_room.go
+++ b/cloudflare/resource_cloudflare_waiting_room.go
@@ -13,10 +13,10 @@ import (
 
 func resourceCloudflareWaitingRoom() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudflareWaitingRoomCreate,
-		Read:   resourceCloudflareWaitingRoomRead,
-		Update: resourceCloudflareWaitingRoomUpdate,
-		Delete: resourceCloudflareWaitingRoomDelete,
+		CreateContext: resourceCloudflareWaitingRoomCreate,
+		ReadContext: resourceCloudflareWaitingRoomRead,
+		UpdateContext: resourceCloudflareWaitingRoomUpdate,
+		DeleteContext: resourceCloudflareWaitingRoomDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareWaitingRoomImport,
 		},

--- a/cloudflare/resource_cloudflare_waiting_room.go
+++ b/cloudflare/resource_cloudflare_waiting_room.go
@@ -56,7 +56,7 @@ func resourceCloudflareWaitingRoomCreate(ctx context.Context, d *schema.Resource
 
 	if err != nil {
 		name := d.Get("name").(string)
-		return fmt.Errorf("error creating waiting room %q: %s", name, err)
+		return diag.FromErr(fmt.Errorf("error creating waiting room %q: %s", name, err))
 	}
 
 	d.SetId(waitingRoom.ID)
@@ -77,7 +77,7 @@ func resourceCloudflareWaitingRoomRead(ctx context.Context, d *schema.ResourceDa
 			return nil
 		}
 		name := d.Get("name").(string)
-		return fmt.Errorf("error getting waiting room %q: %s", name, err)
+		return diag.FromErr(fmt.Errorf("error getting waiting room %q: %s", name, err))
 	}
 	d.SetId(waitingRoom.ID)
 	d.Set("name", waitingRoom.Name)
@@ -106,7 +106,7 @@ func resourceCloudflareWaitingRoomUpdate(ctx context.Context, d *schema.Resource
 
 	if err != nil {
 		name := d.Get("name").(string)
-		return fmt.Errorf("error updating waiting room %q: %s", name, err)
+		return diag.FromErr(fmt.Errorf("error updating waiting room %q: %s", name, err))
 	}
 
 	return resourceCloudflareWaitingRoomRead(d, meta)
@@ -121,7 +121,7 @@ func resourceCloudflareWaitingRoomDelete(ctx context.Context, d *schema.Resource
 
 	if err != nil {
 		name := d.Get("name").(string)
-		return fmt.Errorf("error deleting waiting room %q: %s", name, err)
+		return diag.FromErr(fmt.Errorf("error deleting waiting room %q: %s", name, err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_waiting_room.go
+++ b/cloudflare/resource_cloudflare_waiting_room.go
@@ -8,17 +8,18 @@ import (
 	"time"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareWaitingRoom() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceCloudflareWaitingRoomCreate,
-		ReadContext: resourceCloudflareWaitingRoomRead,
+		ReadContext:   resourceCloudflareWaitingRoomRead,
 		UpdateContext: resourceCloudflareWaitingRoomUpdate,
 		DeleteContext: resourceCloudflareWaitingRoomDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareWaitingRoomImport,
+			StateContext: resourceCloudflareWaitingRoomImport,
 		},
 
 		Schema: resourceCloudflareWaitingRoomSchema(),
@@ -61,7 +62,7 @@ func resourceCloudflareWaitingRoomCreate(ctx context.Context, d *schema.Resource
 
 	d.SetId(waitingRoom.ID)
 
-	return resourceCloudflareWaitingRoomRead(d, meta)
+	return resourceCloudflareWaitingRoomRead(ctx, d, meta)
 }
 
 func resourceCloudflareWaitingRoomRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -109,7 +110,7 @@ func resourceCloudflareWaitingRoomUpdate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(fmt.Errorf("error updating waiting room %q: %s", name, err))
 	}
 
-	return resourceCloudflareWaitingRoomRead(d, meta)
+	return resourceCloudflareWaitingRoomRead(ctx, d, meta)
 }
 
 func resourceCloudflareWaitingRoomDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -127,7 +128,7 @@ func resourceCloudflareWaitingRoomDelete(ctx context.Context, d *schema.Resource
 	return nil
 }
 
-func resourceCloudflareWaitingRoomImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareWaitingRoomImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*cloudflare.API)
 	idAttr := strings.SplitN(d.Id(), "/", 2)
 	var zoneID string
@@ -147,6 +148,6 @@ func resourceCloudflareWaitingRoomImport(d *schema.ResourceData, meta interface{
 	d.SetId(waitingRoom.ID)
 	d.Set("zone_id", zoneID)
 
-	resourceCloudflareWaitingRoomRead(d, meta)
+	resourceCloudflareWaitingRoomRead(ctx, d, meta)
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_waiting_room.go
+++ b/cloudflare/resource_cloudflare_waiting_room.go
@@ -57,7 +57,7 @@ func resourceCloudflareWaitingRoomCreate(ctx context.Context, d *schema.Resource
 
 	if err != nil {
 		name := d.Get("name").(string)
-		return diag.FromErr(fmt.Errorf("error creating waiting room %q: %s", name, err))
+		return diag.FromErr(fmt.Errorf("error creating waiting room %q: %w", name, err))
 	}
 
 	d.SetId(waitingRoom.ID)
@@ -78,7 +78,7 @@ func resourceCloudflareWaitingRoomRead(ctx context.Context, d *schema.ResourceDa
 			return nil
 		}
 		name := d.Get("name").(string)
-		return diag.FromErr(fmt.Errorf("error getting waiting room %q: %s", name, err))
+		return diag.FromErr(fmt.Errorf("error getting waiting room %q: %w", name, err))
 	}
 	d.SetId(waitingRoom.ID)
 	d.Set("name", waitingRoom.Name)
@@ -107,7 +107,7 @@ func resourceCloudflareWaitingRoomUpdate(ctx context.Context, d *schema.Resource
 
 	if err != nil {
 		name := d.Get("name").(string)
-		return diag.FromErr(fmt.Errorf("error updating waiting room %q: %s", name, err))
+		return diag.FromErr(fmt.Errorf("error updating waiting room %q: %w", name, err))
 	}
 
 	return resourceCloudflareWaitingRoomRead(ctx, d, meta)
@@ -122,7 +122,7 @@ func resourceCloudflareWaitingRoomDelete(ctx context.Context, d *schema.Resource
 
 	if err != nil {
 		name := d.Get("name").(string)
-		return diag.FromErr(fmt.Errorf("error deleting waiting room %q: %s", name, err))
+		return diag.FromErr(fmt.Errorf("error deleting waiting room %q: %w", name, err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_waiting_room_event.go
+++ b/cloudflare/resource_cloudflare_waiting_room_event.go
@@ -13,10 +13,10 @@ import (
 
 func resourceCloudflareWaitingRoomEvent() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudflareWaitingRoomEventCreate,
-		Read:   resourceCloudflareWaitingRoomEventRead,
-		Update: resourceCloudflareWaitingRoomEventUpdate,
-		Delete: resourceCloudflareWaitingRoomEventDelete,
+		CreateContext: resourceCloudflareWaitingRoomEventCreate,
+		ReadContext: resourceCloudflareWaitingRoomEventRead,
+		UpdateContext: resourceCloudflareWaitingRoomEventUpdate,
+		DeleteContext: resourceCloudflareWaitingRoomEventDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareWaitingRoomEventImport,
 		},

--- a/cloudflare/resource_cloudflare_waiting_room_event.go
+++ b/cloudflare/resource_cloudflare_waiting_room_event.go
@@ -78,7 +78,7 @@ func resourceCloudflareWaitingRoomEventCreate(ctx context.Context, d *schema.Res
 		return diag.FromErr(fmt.Errorf("error building waiting room event %q: %w", waitingRoomEventName, err))
 	}
 
-	waitingRoomEvent, err := client.CreateWaitingRoomEvent(context.Background(), zoneID, waitingRoomID, newWaitingRoomEvent)
+	waitingRoomEvent, err := client.CreateWaitingRoomEvent(ctx, zoneID, waitingRoomID, newWaitingRoomEvent)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating waiting room event %q: %w", waitingRoomEventName, err))
@@ -94,7 +94,7 @@ func resourceCloudflareWaitingRoomEventRead(ctx context.Context, d *schema.Resou
 	waitingRoomID := d.Get("waiting_room_id").(string)
 	zoneID := d.Get("zone_id").(string)
 
-	waitingRoomEvent, err := client.WaitingRoomEvent(context.Background(), zoneID, waitingRoomID, d.Id())
+	waitingRoomEvent, err := client.WaitingRoomEvent(ctx, zoneID, waitingRoomID, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
 			log.Printf("[WARN] Removing waiting room event from state because it's not found in API")
@@ -153,7 +153,7 @@ func resourceCloudflareWaitingRoomEventUpdate(ctx context.Context, d *schema.Res
 		return diag.FromErr(fmt.Errorf("error building waiting room event %q: %w", waitingRoomEventName, err))
 	}
 
-	_, err = client.ChangeWaitingRoomEvent(context.Background(), zoneID, waitingRoomID, waitingRoomEvent)
+	_, err = client.ChangeWaitingRoomEvent(ctx, zoneID, waitingRoomID, waitingRoomEvent)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating waiting room event %q: %w", waitingRoomEventName, err))
@@ -168,7 +168,7 @@ func resourceCloudflareWaitingRoomEventDelete(ctx context.Context, d *schema.Res
 	waitingRoomID := d.Get("waiting_room_id").(string)
 	zoneID := d.Get("zone_id").(string)
 
-	err := client.DeleteWaitingRoomEvent(context.Background(), zoneID, waitingRoomID, waitingRoomEventID)
+	err := client.DeleteWaitingRoomEvent(ctx, zoneID, waitingRoomID, waitingRoomEventID)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting waiting room event %q: %w", d.Get("name").(string), err))
@@ -191,7 +191,7 @@ func resourceCloudflareWaitingRoomEventImport(ctx context.Context, d *schema.Res
 		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneID/waitingRoomID/eventID\" for import", d.Id())
 	}
 
-	waitingRoomEvent, err := client.WaitingRoomEvent(context.Background(), zoneID, waitingRoomID, waitingRoomEventID)
+	waitingRoomEvent, err := client.WaitingRoomEvent(ctx, zoneID, waitingRoomID, waitingRoomEventID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch Waiting room event %s", waitingRoomID)
 	}

--- a/cloudflare/resource_cloudflare_waiting_room_event.go
+++ b/cloudflare/resource_cloudflare_waiting_room_event.go
@@ -66,7 +66,7 @@ func expandWaitingRoomEvent(d *schema.ResourceData) (cloudflare.WaitingRoomEvent
 	}, nil
 }
 
-func resourceCloudflareWaitingRoomEventCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWaitingRoomEventCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	waitingRoomID := d.Get("waiting_room_id").(string)
 	zoneID := d.Get("zone_id").(string)
@@ -88,7 +88,7 @@ func resourceCloudflareWaitingRoomEventCreate(d *schema.ResourceData, meta inter
 	return resourceCloudflareWaitingRoomEventRead(d, meta)
 }
 
-func resourceCloudflareWaitingRoomEventRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWaitingRoomEventRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	waitingRoomID := d.Get("waiting_room_id").(string)
 	zoneID := d.Get("zone_id").(string)
@@ -142,7 +142,7 @@ func resourceCloudflareWaitingRoomEventRead(d *schema.ResourceData, meta interfa
 	return nil
 }
 
-func resourceCloudflareWaitingRoomEventUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWaitingRoomEventUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	waitingRoomID := d.Get("waiting_room_id").(string)
 	zoneID := d.Get("zone_id").(string)
@@ -161,7 +161,7 @@ func resourceCloudflareWaitingRoomEventUpdate(d *schema.ResourceData, meta inter
 	return resourceCloudflareWaitingRoomEventRead(d, meta)
 }
 
-func resourceCloudflareWaitingRoomEventDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWaitingRoomEventDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	waitingRoomEventID := d.Id()
 	waitingRoomID := d.Get("waiting_room_id").(string)

--- a/cloudflare/resource_cloudflare_waiting_room_event.go
+++ b/cloudflare/resource_cloudflare_waiting_room_event.go
@@ -8,17 +8,18 @@ import (
 	"time"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareWaitingRoomEvent() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceCloudflareWaitingRoomEventCreate,
-		ReadContext: resourceCloudflareWaitingRoomEventRead,
+		ReadContext:   resourceCloudflareWaitingRoomEventRead,
 		UpdateContext: resourceCloudflareWaitingRoomEventUpdate,
 		DeleteContext: resourceCloudflareWaitingRoomEventDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareWaitingRoomEventImport,
+			StateContext: resourceCloudflareWaitingRoomEventImport,
 		},
 
 		Schema: resourceCloudflareWaitingRoomEventSchema(),
@@ -85,7 +86,7 @@ func resourceCloudflareWaitingRoomEventCreate(ctx context.Context, d *schema.Res
 
 	d.SetId(waitingRoomEvent.ID)
 
-	return resourceCloudflareWaitingRoomEventRead(d, meta)
+	return resourceCloudflareWaitingRoomEventRead(ctx, d, meta)
 }
 
 func resourceCloudflareWaitingRoomEventRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -158,7 +159,7 @@ func resourceCloudflareWaitingRoomEventUpdate(ctx context.Context, d *schema.Res
 		return diag.FromErr(fmt.Errorf("error updating waiting room event %q: %w", waitingRoomEventName, err))
 	}
 
-	return resourceCloudflareWaitingRoomEventRead(d, meta)
+	return resourceCloudflareWaitingRoomEventRead(ctx, d, meta)
 }
 
 func resourceCloudflareWaitingRoomEventDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -176,7 +177,7 @@ func resourceCloudflareWaitingRoomEventDelete(ctx context.Context, d *schema.Res
 	return nil
 }
 
-func resourceCloudflareWaitingRoomEventImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareWaitingRoomEventImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*cloudflare.API)
 	idAttr := strings.SplitN(d.Id(), "/", 3)
 	var zoneID string
@@ -199,6 +200,7 @@ func resourceCloudflareWaitingRoomEventImport(d *schema.ResourceData, meta inter
 	d.Set("waiting_room_id", waitingRoomID)
 	d.Set("zone_id", zoneID)
 
-	err = resourceCloudflareWaitingRoomEventRead(d, meta)
-	return []*schema.ResourceData{d}, err
+	resourceCloudflareWaitingRoomEventRead(ctx, d, meta)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_waiting_room_event.go
+++ b/cloudflare/resource_cloudflare_waiting_room_event.go
@@ -74,13 +74,13 @@ func resourceCloudflareWaitingRoomEventCreate(ctx context.Context, d *schema.Res
 	newWaitingRoomEvent, err := expandWaitingRoomEvent(d)
 
 	if err != nil {
-		return fmt.Errorf("error building waiting room event %q: %w", waitingRoomEventName, err)
+		return diag.FromErr(fmt.Errorf("error building waiting room event %q: %w", waitingRoomEventName, err))
 	}
 
 	waitingRoomEvent, err := client.CreateWaitingRoomEvent(context.Background(), zoneID, waitingRoomID, newWaitingRoomEvent)
 
 	if err != nil {
-		return fmt.Errorf("error creating waiting room event %q: %w", waitingRoomEventName, err)
+		return diag.FromErr(fmt.Errorf("error creating waiting room event %q: %w", waitingRoomEventName, err))
 	}
 
 	d.SetId(waitingRoomEvent.ID)
@@ -100,7 +100,7 @@ func resourceCloudflareWaitingRoomEventRead(ctx context.Context, d *schema.Resou
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error getting waiting room event %q: %w", d.Get("name").(string), err)
+		return diag.FromErr(fmt.Errorf("error getting waiting room event %q: %w", d.Get("name").(string), err))
 	}
 
 	d.Set("name", waitingRoomEvent.Name)
@@ -149,13 +149,13 @@ func resourceCloudflareWaitingRoomEventUpdate(ctx context.Context, d *schema.Res
 	waitingRoomEventName := d.Get("name").(string)
 	waitingRoomEvent, err := expandWaitingRoomEvent(d)
 	if err != nil {
-		return fmt.Errorf("error building waiting room event %q: %w", waitingRoomEventName, err)
+		return diag.FromErr(fmt.Errorf("error building waiting room event %q: %w", waitingRoomEventName, err))
 	}
 
 	_, err = client.ChangeWaitingRoomEvent(context.Background(), zoneID, waitingRoomID, waitingRoomEvent)
 
 	if err != nil {
-		return fmt.Errorf("error updating waiting room event %q: %w", waitingRoomEventName, err)
+		return diag.FromErr(fmt.Errorf("error updating waiting room event %q: %w", waitingRoomEventName, err))
 	}
 
 	return resourceCloudflareWaitingRoomEventRead(d, meta)
@@ -170,7 +170,7 @@ func resourceCloudflareWaitingRoomEventDelete(ctx context.Context, d *schema.Res
 	err := client.DeleteWaitingRoomEvent(context.Background(), zoneID, waitingRoomID, waitingRoomEventID)
 
 	if err != nil {
-		return fmt.Errorf("error deleting waiting room event %q: %w", d.Get("name").(string), err)
+		return diag.FromErr(fmt.Errorf("error deleting waiting room event %q: %w", d.Get("name").(string), err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_worker_cron_trigger.go
+++ b/cloudflare/resource_cloudflare_worker_cron_trigger.go
@@ -33,7 +33,7 @@ func resourceCloudflareWorkerCronTriggerUpdate(ctx context.Context, d *schema.Re
 
 	_, err := client.UpdateWorkerCronTriggers(ctx, accountID, scriptName, transformSchemaToWorkerCronTriggerStruct(d))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update Worker Cron Trigger: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to update Worker Cron Trigger: %w", err))
 	}
 
 	d.SetId(stringChecksum(scriptName))
@@ -54,11 +54,11 @@ func resourceCloudflareWorkerCronTriggerRead(ctx context.Context, d *schema.Reso
 			return nil
 		}
 
-		return diag.FromErr(fmt.Errorf("failed to read Worker Cron Trigger: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to read Worker Cron Trigger: %w", err))
 	}
 
 	if err := d.Set("schedules", transformWorkerCronTriggerStructToSet(s)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set schedules attribute: %s", err))
+		return diag.FromErr(fmt.Errorf("failed to set schedules attribute: %w", err))
 	}
 
 	return nil
@@ -69,7 +69,10 @@ func resourceCloudflareWorkerCronTriggerDelete(ctx context.Context, d *schema.Re
 	scriptName := d.Get("script_name").(string)
 	accountID := d.Get("account_id").(string)
 
-	client.UpdateWorkerCronTriggers(ctx, accountID, scriptName, []cloudflare.WorkerCronTrigger{})
+	_, err := client.UpdateWorkerCronTriggers(ctx, accountID, scriptName, []cloudflare.WorkerCronTrigger{})
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	d.SetId("")
 

--- a/cloudflare/resource_cloudflare_worker_cron_trigger.go
+++ b/cloudflare/resource_cloudflare_worker_cron_trigger.go
@@ -24,7 +24,7 @@ func resourceCloudflareWorkerCronTrigger() *schema.Resource {
 
 // resourceCloudflareWorkerCronTriggerUpdate is used for creation and updates of
 // Worker Cron Triggers as the remote API endpoint is shared uses HTTP PUT.
-func resourceCloudflareWorkerCronTriggerUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkerCronTriggerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
@@ -40,7 +40,7 @@ func resourceCloudflareWorkerCronTriggerUpdate(d *schema.ResourceData, meta inte
 	return nil
 }
 
-func resourceCloudflareWorkerCronTriggerRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkerCronTriggerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	scriptName := d.Get("script_name").(string)
 	accountID := d.Get("account_id").(string)
@@ -63,7 +63,7 @@ func resourceCloudflareWorkerCronTriggerRead(d *schema.ResourceData, meta interf
 	return nil
 }
 
-func resourceCloudflareWorkerCronTriggerDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkerCronTriggerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	scriptName := d.Get("script_name").(string)
 	accountID := d.Get("account_id").(string)

--- a/cloudflare/resource_cloudflare_worker_cron_trigger.go
+++ b/cloudflare/resource_cloudflare_worker_cron_trigger.go
@@ -12,10 +12,10 @@ import (
 func resourceCloudflareWorkerCronTrigger() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareWorkerCronTriggerSchema(),
-		Create: resourceCloudflareWorkerCronTriggerUpdate,
-		Read:   resourceCloudflareWorkerCronTriggerRead,
-		Update: resourceCloudflareWorkerCronTriggerUpdate,
-		Delete: resourceCloudflareWorkerCronTriggerDelete,
+		CreateContext: resourceCloudflareWorkerCronTriggerUpdate,
+		ReadContext: resourceCloudflareWorkerCronTriggerRead,
+		UpdateContext: resourceCloudflareWorkerCronTriggerUpdate,
+		DeleteContext: resourceCloudflareWorkerCronTriggerDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareWorkerCronTriggerImport,
 		},

--- a/cloudflare/resource_cloudflare_worker_cron_trigger.go
+++ b/cloudflare/resource_cloudflare_worker_cron_trigger.go
@@ -31,7 +31,7 @@ func resourceCloudflareWorkerCronTriggerUpdate(ctx context.Context, d *schema.Re
 
 	scriptName := d.Get("script_name").(string)
 
-	_, err := client.UpdateWorkerCronTriggers(context.Background(), accountID, scriptName, transformSchemaToWorkerCronTriggerStruct(d))
+	_, err := client.UpdateWorkerCronTriggers(ctx, accountID, scriptName, transformSchemaToWorkerCronTriggerStruct(d))
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to update Worker Cron Trigger: %s", err))
 	}
@@ -46,7 +46,7 @@ func resourceCloudflareWorkerCronTriggerRead(ctx context.Context, d *schema.Reso
 	scriptName := d.Get("script_name").(string)
 	accountID := d.Get("account_id").(string)
 
-	s, err := client.ListWorkerCronTriggers(context.Background(), accountID, scriptName)
+	s, err := client.ListWorkerCronTriggers(ctx, accountID, scriptName)
 	if err != nil {
 		// If the script is removed, we also need to remove the triggers.
 		if strings.Contains(err.Error(), "workers.api.error.script_not_found") {
@@ -69,7 +69,7 @@ func resourceCloudflareWorkerCronTriggerDelete(ctx context.Context, d *schema.Re
 	scriptName := d.Get("script_name").(string)
 	accountID := d.Get("account_id").(string)
 
-	client.UpdateWorkerCronTriggers(context.Background(), accountID, scriptName, []cloudflare.WorkerCronTrigger{})
+	client.UpdateWorkerCronTriggers(ctx, accountID, scriptName, []cloudflare.WorkerCronTrigger{})
 
 	d.SetId("")
 

--- a/cloudflare/resource_cloudflare_worker_cron_trigger.go
+++ b/cloudflare/resource_cloudflare_worker_cron_trigger.go
@@ -32,7 +32,7 @@ func resourceCloudflareWorkerCronTriggerUpdate(ctx context.Context, d *schema.Re
 
 	_, err := client.UpdateWorkerCronTriggers(context.Background(), accountID, scriptName, transformSchemaToWorkerCronTriggerStruct(d))
 	if err != nil {
-		return fmt.Errorf("failed to update Worker Cron Trigger: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to update Worker Cron Trigger: %s", err))
 	}
 
 	d.SetId(stringChecksum(scriptName))
@@ -53,11 +53,11 @@ func resourceCloudflareWorkerCronTriggerRead(ctx context.Context, d *schema.Reso
 			return nil
 		}
 
-		return fmt.Errorf("failed to read Worker Cron Trigger: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to read Worker Cron Trigger: %s", err))
 	}
 
 	if err := d.Set("schedules", transformWorkerCronTriggerStructToSet(s)); err != nil {
-		return fmt.Errorf("failed to set schedules attribute: %s", err)
+		return diag.FromErr(fmt.Errorf("failed to set schedules attribute: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_worker_cron_trigger.go
+++ b/cloudflare/resource_cloudflare_worker_cron_trigger.go
@@ -6,18 +6,19 @@ import (
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareWorkerCronTrigger() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareWorkerCronTriggerSchema(),
+		Schema:        resourceCloudflareWorkerCronTriggerSchema(),
 		CreateContext: resourceCloudflareWorkerCronTriggerUpdate,
-		ReadContext: resourceCloudflareWorkerCronTriggerRead,
+		ReadContext:   resourceCloudflareWorkerCronTriggerRead,
 		UpdateContext: resourceCloudflareWorkerCronTriggerUpdate,
 		DeleteContext: resourceCloudflareWorkerCronTriggerDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareWorkerCronTriggerImport,
+			StateContext: resourceCloudflareWorkerCronTriggerImport,
 		},
 	}
 }
@@ -75,10 +76,10 @@ func resourceCloudflareWorkerCronTriggerDelete(ctx context.Context, d *schema.Re
 	return nil
 }
 
-func resourceCloudflareWorkerCronTriggerImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareWorkerCronTriggerImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	d.SetId(stringChecksum(d.Id()))
 
-	resourceCloudflareWorkerCronTriggerRead(d, meta)
+	resourceCloudflareWorkerCronTriggerRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_worker_kv.go
+++ b/cloudflare/resource_cloudflare_worker_kv.go
@@ -29,7 +29,7 @@ func resourceCloudflareWorkersKVRead(ctx context.Context, d *schema.ResourceData
 	client := meta.(*cloudflare.API)
 	namespaceID, key := parseId(d.Id())
 
-	value, err := client.ReadWorkersKV(context.Background(), namespaceID, key)
+	value, err := client.ReadWorkersKV(ctx, namespaceID, key)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error reading workers kv"))
 	}
@@ -49,7 +49,7 @@ func resourceCloudflareWorkersKVUpdate(ctx context.Context, d *schema.ResourceDa
 	key := d.Get("key").(string)
 	value := d.Get("value").(string)
 
-	_, err := client.WriteWorkersKV(context.Background(), namespaceID, key, []byte(value))
+	_, err := client.WriteWorkersKV(ctx, namespaceID, key, []byte(value))
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating workers kv"))
 	}
@@ -67,7 +67,7 @@ func resourceCloudflareWorkersKVDelete(ctx context.Context, d *schema.ResourceDa
 
 	log.Printf("[INFO] Deleting Cloudflare Workers KV with id: %+v", d.Id())
 
-	_, err := client.DeleteWorkersKV(context.Background(), namespaceID, key)
+	_, err := client.DeleteWorkersKV(ctx, namespaceID, key)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error deleting workers kv"))
 	}

--- a/cloudflare/resource_cloudflare_worker_kv.go
+++ b/cloudflare/resource_cloudflare_worker_kv.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareWorkerKV() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareWorkerKVSchema(),
-		Create: resourceCloudflareWorkersKVUpdate,
-		Read:   resourceCloudflareWorkersKVRead,
-		Update: resourceCloudflareWorkersKVUpdate,
-		Delete: resourceCloudflareWorkersKVDelete,
+		CreateContext: resourceCloudflareWorkersKVUpdate,
+		ReadContext: resourceCloudflareWorkersKVRead,
+		UpdateContext: resourceCloudflareWorkersKVUpdate,
+		DeleteContext: resourceCloudflareWorkersKVDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareWorkersKVImport,
 		},

--- a/cloudflare/resource_cloudflare_worker_kv.go
+++ b/cloudflare/resource_cloudflare_worker_kv.go
@@ -24,13 +24,13 @@ func resourceCloudflareWorkerKV() *schema.Resource {
 	}
 }
 
-func resourceCloudflareWorkersKVRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkersKVRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	namespaceID, key := parseId(d.Id())
 
 	value, err := client.ReadWorkersKV(context.Background(), namespaceID, key)
 	if err != nil {
-		return errors.Wrap(err, "error reading workers kv")
+		return err.Wrap(err, "error reading workers kv")
 	}
 
 	if value == nil {
@@ -42,7 +42,7 @@ func resourceCloudflareWorkersKVRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceCloudflareWorkersKVUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkersKVUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	namespaceID := d.Get("namespace_id").(string)
 	key := d.Get("key").(string)
@@ -50,7 +50,7 @@ func resourceCloudflareWorkersKVUpdate(d *schema.ResourceData, meta interface{})
 
 	_, err := client.WriteWorkersKV(context.Background(), namespaceID, key, []byte(value))
 	if err != nil {
-		return errors.Wrap(err, "error creating workers kv")
+		return err.Wrap(err, "error creating workers kv")
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", namespaceID, key))
@@ -60,7 +60,7 @@ func resourceCloudflareWorkersKVUpdate(d *schema.ResourceData, meta interface{})
 	return resourceCloudflareWorkersKVRead(d, meta)
 }
 
-func resourceCloudflareWorkersKVDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkersKVDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	namespaceID, key := parseId(d.Id())
 
@@ -68,7 +68,7 @@ func resourceCloudflareWorkersKVDelete(d *schema.ResourceData, meta interface{})
 
 	_, err := client.DeleteWorkersKV(context.Background(), namespaceID, key)
 	if err != nil {
-		return errors.Wrap(err, "error deleting workers kv")
+		return err.Wrap(err, "error deleting workers kv")
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_worker_route.go
+++ b/cloudflare/resource_cloudflare_worker_route.go
@@ -33,7 +33,7 @@ func getRouteFromResource(d *schema.ResourceData) cloudflare.WorkerRoute {
 	return route
 }
 
-func resourceCloudflareWorkerRouteCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkerRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	route := getRouteFromResource(d)
 	zoneID := d.Get("zone_id").(string)
@@ -42,7 +42,7 @@ func resourceCloudflareWorkerRouteCreate(d *schema.ResourceData, meta interface{
 
 	r, err := client.CreateWorkerRoute(context.Background(), zoneID, route)
 	if err != nil {
-		return errors.Wrap(err, "error creating worker route")
+		return err.Wrap(err, "error creating worker route")
 	}
 
 	if r.ID == "" {
@@ -56,7 +56,7 @@ func resourceCloudflareWorkerRouteCreate(d *schema.ResourceData, meta interface{
 	return nil
 }
 
-func resourceCloudflareWorkerRouteRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkerRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	routeID := d.Id()
@@ -66,7 +66,7 @@ func resourceCloudflareWorkerRouteRead(d *schema.ResourceData, meta interface{})
 	resp, err := client.ListWorkerRoutes(context.Background(), zoneID)
 
 	if err != nil {
-		return errors.Wrap(err, "error reading worker routes")
+		return err.Wrap(err, "error reading worker routes")
 	}
 
 	var route cloudflare.WorkerRoute
@@ -90,7 +90,7 @@ func resourceCloudflareWorkerRouteRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceCloudflareWorkerRouteUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkerRouteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	route := getRouteFromResource(d)
@@ -99,13 +99,13 @@ func resourceCloudflareWorkerRouteUpdate(d *schema.ResourceData, meta interface{
 
 	_, err := client.UpdateWorkerRoute(context.Background(), zoneID, route.ID, route)
 	if err != nil {
-		return errors.Wrap(err, "error updating worker route")
+		return err.Wrap(err, "error updating worker route")
 	}
 
 	return nil
 }
 
-func resourceCloudflareWorkerRouteDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkerRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 	route := getRouteFromResource(d)
@@ -114,7 +114,7 @@ func resourceCloudflareWorkerRouteDelete(d *schema.ResourceData, meta interface{
 
 	_, err := client.DeleteWorkerRoute(context.Background(), zoneID, route.ID)
 	if err != nil {
-		return errors.Wrap(err, "error deleting worker route")
+		return err.Wrap(err, "error deleting worker route")
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_worker_route.go
+++ b/cloudflare/resource_cloudflare_worker_route.go
@@ -41,7 +41,7 @@ func resourceCloudflareWorkerRouteCreate(ctx context.Context, d *schema.Resource
 
 	log.Printf("[INFO] Creating Cloudflare Worker Route from struct: %+v", route)
 
-	r, err := client.CreateWorkerRoute(context.Background(), zoneID, route)
+	r, err := client.CreateWorkerRoute(ctx, zoneID, route)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating worker route"))
 	}
@@ -64,7 +64,7 @@ func resourceCloudflareWorkerRouteRead(ctx context.Context, d *schema.ResourceDa
 
 	// There isn't a dedicated endpoint for retrieving a specific route, so we
 	// list all routes and find the target route by comparing IDs
-	resp, err := client.ListWorkerRoutes(context.Background(), zoneID)
+	resp, err := client.ListWorkerRoutes(ctx, zoneID)
 
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error reading worker routes"))
@@ -98,7 +98,7 @@ func resourceCloudflareWorkerRouteUpdate(ctx context.Context, d *schema.Resource
 
 	log.Printf("[INFO] Updating Cloudflare Worker Route from struct: %+v", route)
 
-	_, err := client.UpdateWorkerRoute(context.Background(), zoneID, route.ID, route)
+	_, err := client.UpdateWorkerRoute(ctx, zoneID, route.ID, route)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error updating worker route"))
 	}
@@ -113,7 +113,7 @@ func resourceCloudflareWorkerRouteDelete(ctx context.Context, d *schema.Resource
 
 	log.Printf("[INFO] Deleting Cloudflare Worker Route from zone %+v with id: %+v", zoneID, route.ID)
 
-	_, err := client.DeleteWorkerRoute(context.Background(), zoneID, route.ID)
+	_, err := client.DeleteWorkerRoute(ctx, zoneID, route.ID)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error deleting worker route"))
 	}

--- a/cloudflare/resource_cloudflare_worker_route.go
+++ b/cloudflare/resource_cloudflare_worker_route.go
@@ -14,10 +14,10 @@ import (
 func resourceCloudflareWorkerRoute() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareWorkerRouteSchema(),
-		Create: resourceCloudflareWorkerRouteCreate,
-		Read:   resourceCloudflareWorkerRouteRead,
-		Update: resourceCloudflareWorkerRouteUpdate,
-		Delete: resourceCloudflareWorkerRouteDelete,
+		CreateContext: resourceCloudflareWorkerRouteCreate,
+		ReadContext: resourceCloudflareWorkerRouteRead,
+		UpdateContext: resourceCloudflareWorkerRouteUpdate,
+		DeleteContext: resourceCloudflareWorkerRouteDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareWorkerRouteImport,
 		},

--- a/cloudflare/resource_cloudflare_worker_route.go
+++ b/cloudflare/resource_cloudflare_worker_route.go
@@ -46,7 +46,7 @@ func resourceCloudflareWorkerRouteCreate(ctx context.Context, d *schema.Resource
 	}
 
 	if r.ID == "" {
-		return fmt.Errorf("failed to find id in Create response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find id in Create response; resource was empty"))
 	}
 
 	d.SetId(r.ID)

--- a/cloudflare/resource_cloudflare_worker_route_test.go
+++ b/cloudflare/resource_cloudflare_worker_route_test.go
@@ -211,7 +211,6 @@ func testAccCheckCloudflareWorkerRouteDestroy(s *terraform.State) error {
 		if route.ID != "" {
 			return fmt.Errorf("worker route with id %s still exists", route.ID)
 		}
-
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_worker_script.go
+++ b/cloudflare/resource_cloudflare_worker_script.go
@@ -105,12 +105,12 @@ func resourceCloudflareWorkerScriptCreate(ctx context.Context, d *schema.Resourc
 	// make sure that the worker does not already exist
 	r, _ := client.DownloadWorker(context.Background(), &scriptData.Params)
 	if r.WorkerScript.Script != "" {
-		return fmt.Errorf("script already exists")
+		return diag.FromErr(fmt.Errorf("script already exists"))
 	}
 
 	scriptBody := d.Get("content").(string)
 	if scriptBody == "" {
-		return fmt.Errorf("script content cannot be empty")
+		return diag.FromErr(fmt.Errorf("script content cannot be empty"))
 	}
 
 	log.Printf("[INFO] Creating Cloudflare Worker Script from struct: %+v", &scriptData.Params)
@@ -204,23 +204,23 @@ func resourceCloudflareWorkerScriptRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err := d.Set("content", r.Script); err != nil {
-		return fmt.Errorf("cannot set content: %v", err)
+		return diag.FromErr(fmt.Errorf("cannot set content: %v", err))
 	}
 
 	if err := d.Set("kv_namespace_binding", kvNamespaceBindings); err != nil {
-		return fmt.Errorf("cannot set kv namespace bindings (%s): %v", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("cannot set kv namespace bindings (%s): %v", d.Id(), err))
 	}
 
 	if err := d.Set("plain_text_binding", plainTextBindings); err != nil {
-		return fmt.Errorf("cannot set plain text bindings (%s): %v", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("cannot set plain text bindings (%s): %v", d.Id(), err))
 	}
 
 	if err := d.Set("secret_text_binding", secretTextBindings); err != nil {
-		return fmt.Errorf("cannot set secret text bindings (%s): %v", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("cannot set secret text bindings (%s): %v", d.Id(), err))
 	}
 
 	if err := d.Set("webassembly_binding", webAssemblyBindings); err != nil {
-		return fmt.Errorf("cannot set webassembly bindings (%s): %v", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("cannot set webassembly bindings (%s): %v", d.Id(), err))
 	}
 
 	return nil
@@ -236,7 +236,7 @@ func resourceCloudflareWorkerScriptUpdate(ctx context.Context, d *schema.Resourc
 
 	scriptBody := d.Get("content").(string)
 	if scriptBody == "" {
-		return fmt.Errorf("script content cannot be empty")
+		return diag.FromErr(fmt.Errorf("script content cannot be empty"))
 	}
 
 	log.Printf("[INFO] Updating Cloudflare Worker Script from struct: %+v", &scriptData.Params)

--- a/cloudflare/resource_cloudflare_worker_script.go
+++ b/cloudflare/resource_cloudflare_worker_script.go
@@ -16,10 +16,10 @@ import (
 func resourceCloudflareWorkerScript() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareWorkerScriptSchema(),
-		Create: resourceCloudflareWorkerScriptCreate,
-		Read:   resourceCloudflareWorkerScriptRead,
-		Update: resourceCloudflareWorkerScriptUpdate,
-		Delete: resourceCloudflareWorkerScriptDelete,
+		CreateContext: resourceCloudflareWorkerScriptCreate,
+		ReadContext: resourceCloudflareWorkerScriptRead,
+		UpdateContext: resourceCloudflareWorkerScriptUpdate,
+		DeleteContext: resourceCloudflareWorkerScriptDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareWorkerScriptImport,
 		},

--- a/cloudflare/resource_cloudflare_worker_script.go
+++ b/cloudflare/resource_cloudflare_worker_script.go
@@ -52,7 +52,7 @@ type ScriptBindings map[string]cloudflare.WorkerBinding
 func getWorkerScriptBindings(ctx context.Context, scriptName string, client *cloudflare.API) (ScriptBindings, error) {
 	resp, err := client.ListWorkerBindings(ctx, &cloudflare.WorkerRequestParams{ScriptName: scriptName})
 	if err != nil {
-		return nil, fmt.Errorf("cannot list script bindings: %v", err)
+		return nil, fmt.Errorf("cannot list script bindings: %w", err)
 	}
 
 	bindings := make(ScriptBindings, len(resp.BindingList))
@@ -205,23 +205,23 @@ func resourceCloudflareWorkerScriptRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err := d.Set("content", r.Script); err != nil {
-		return diag.FromErr(fmt.Errorf("cannot set content: %v", err))
+		return diag.FromErr(fmt.Errorf("cannot set content: %w", err))
 	}
 
 	if err := d.Set("kv_namespace_binding", kvNamespaceBindings); err != nil {
-		return diag.FromErr(fmt.Errorf("cannot set kv namespace bindings (%s): %v", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("cannot set kv namespace bindings (%s): %w", d.Id(), err))
 	}
 
 	if err := d.Set("plain_text_binding", plainTextBindings); err != nil {
-		return diag.FromErr(fmt.Errorf("cannot set plain text bindings (%s): %v", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("cannot set plain text bindings (%s): %w", d.Id(), err))
 	}
 
 	if err := d.Set("secret_text_binding", secretTextBindings); err != nil {
-		return diag.FromErr(fmt.Errorf("cannot set secret text bindings (%s): %v", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("cannot set secret text bindings (%s): %w", d.Id(), err))
 	}
 
 	if err := d.Set("webassembly_binding", webAssemblyBindings); err != nil {
-		return diag.FromErr(fmt.Errorf("cannot set webassembly bindings (%s): %v", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("cannot set webassembly bindings (%s): %w", d.Id(), err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_worker_script_test.go
+++ b/cloudflare/resource_cloudflare_worker_script_test.go
@@ -141,7 +141,7 @@ func testAccCheckCloudflareWorkerScriptExists(n string, script *cloudflare.Worke
 		name := strings.Replace(n, "cloudflare_worker_script.", "", -1)
 		foundBindings, err := getWorkerScriptBindings(context.Background(), name, client)
 		if err != nil {
-			return fmt.Errorf("cannot list script bindings: %v", err)
+			return fmt.Errorf("cannot list script bindings: %w", err)
 		}
 
 		for _, binding := range bindings {

--- a/cloudflare/resource_cloudflare_worker_script_test.go
+++ b/cloudflare/resource_cloudflare_worker_script_test.go
@@ -139,7 +139,7 @@ func testAccCheckCloudflareWorkerScriptExists(n string, script *cloudflare.Worke
 		}
 
 		name := strings.Replace(n, "cloudflare_worker_script.", "", -1)
-		foundBindings, err := getWorkerScriptBindings(name, client)
+		foundBindings, err := getWorkerScriptBindings(context.Background(), name, client)
 		if err != nil {
 			return fmt.Errorf("cannot list script bindings: %v", err)
 		}

--- a/cloudflare/resource_cloudflare_workers_kv_namespace.go
+++ b/cloudflare/resource_cloudflare_workers_kv_namespace.go
@@ -23,7 +23,7 @@ func resourceCloudflareWorkersKVNamespace() *schema.Resource {
 	}
 }
 
-func resourceCloudflareWorkersKVNamespaceCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkersKVNamespaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	req := &cloudflare.WorkersKVNamespaceRequest{
@@ -34,7 +34,7 @@ func resourceCloudflareWorkersKVNamespaceCreate(d *schema.ResourceData, meta int
 
 	r, err := client.CreateWorkersKVNamespace(context.Background(), req)
 	if err != nil {
-		return errors.Wrap(err, "error creating workers kv namespace")
+		return err.Wrap(err, "error creating workers kv namespace")
 	}
 
 	if r.Result.ID == "" {
@@ -48,13 +48,13 @@ func resourceCloudflareWorkersKVNamespaceCreate(d *schema.ResourceData, meta int
 	return nil
 }
 
-func resourceCloudflareWorkersKVNamespaceRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkersKVNamespaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	namespaceID := d.Id()
 
 	resp, err := client.ListWorkersKVNamespaces(context.Background())
 	if err != nil {
-		return errors.Wrap(err, "error reading workers kv namespaces")
+		return err.Wrap(err, "error reading workers kv namespaces")
 	}
 
 	var namespace cloudflare.WorkersKVNamespace
@@ -73,7 +73,7 @@ func resourceCloudflareWorkersKVNamespaceRead(d *schema.ResourceData, meta inter
 	return nil
 }
 
-func resourceCloudflareWorkersKVNamespaceUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkersKVNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	namespace := &cloudflare.WorkersKVNamespaceRequest{
@@ -84,20 +84,20 @@ func resourceCloudflareWorkersKVNamespaceUpdate(d *schema.ResourceData, meta int
 
 	_, err := client.UpdateWorkersKVNamespace(context.Background(), d.Id(), namespace)
 	if err != nil {
-		return errors.Wrap(err, "error updating workers kv namespace")
+		return err.Wrap(err, "error updating workers kv namespace")
 	}
 
 	return nil
 }
 
-func resourceCloudflareWorkersKVNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareWorkersKVNamespaceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	log.Printf("[INFO] Deleting Cloudflare Workers KV Namespace with id: %+v", d.Id())
 
 	_, err := client.DeleteWorkersKVNamespace(context.Background(), d.Id())
 	if err != nil {
-		return errors.Wrap(err, "error deleting workers kv namespace")
+		return err.Wrap(err, "error deleting workers kv namespace")
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_workers_kv_namespace.go
+++ b/cloudflare/resource_cloudflare_workers_kv_namespace.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareWorkersKVNamespace() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareWorkersKVNamespaceSchema(),
-		Create: resourceCloudflareWorkersKVNamespaceCreate,
-		Read:   resourceCloudflareWorkersKVNamespaceRead,
-		Update: resourceCloudflareWorkersKVNamespaceUpdate,
-		Delete: resourceCloudflareWorkersKVNamespaceDelete,
+		CreateContext: resourceCloudflareWorkersKVNamespaceCreate,
+		ReadContext: resourceCloudflareWorkersKVNamespaceRead,
+		UpdateContext: resourceCloudflareWorkersKVNamespaceUpdate,
+		DeleteContext: resourceCloudflareWorkersKVNamespaceDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareWorkersKVNamespaceImport,
 		},

--- a/cloudflare/resource_cloudflare_workers_kv_namespace.go
+++ b/cloudflare/resource_cloudflare_workers_kv_namespace.go
@@ -38,7 +38,7 @@ func resourceCloudflareWorkersKVNamespaceCreate(ctx context.Context, d *schema.R
 	}
 
 	if r.Result.ID == "" {
-		return fmt.Errorf("failed to find id in Create response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find id in Create response; resource was empty"))
 	}
 
 	d.SetId(r.Result.ID)

--- a/cloudflare/resource_cloudflare_workers_kv_namespace.go
+++ b/cloudflare/resource_cloudflare_workers_kv_namespace.go
@@ -117,7 +117,7 @@ func resourceCloudflareWorkersKVNamespaceImport(ctx context.Context, d *schema.R
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("error finding workers kv namespace %q: %s", d.Id(), err)
+		return nil, fmt.Errorf("error finding workers kv namespace %q: %w", d.Id(), err)
 	}
 
 	d.Set("title", title)

--- a/cloudflare/resource_cloudflare_workers_kv_namespace.go
+++ b/cloudflare/resource_cloudflare_workers_kv_namespace.go
@@ -33,7 +33,7 @@ func resourceCloudflareWorkersKVNamespaceCreate(ctx context.Context, d *schema.R
 
 	log.Printf("[Info] Creating Cloudflare Workers KV Namespace from struct: %+v", req)
 
-	r, err := client.CreateWorkersKVNamespace(context.Background(), req)
+	r, err := client.CreateWorkersKVNamespace(ctx, req)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating workers kv namespace"))
 	}
@@ -83,7 +83,7 @@ func resourceCloudflareWorkersKVNamespaceUpdate(ctx context.Context, d *schema.R
 
 	log.Printf("[INFO] Updating Cloudflare Workers KV Namespace from struct %+v", namespace)
 
-	_, err := client.UpdateWorkersKVNamespace(context.Background(), d.Id(), namespace)
+	_, err := client.UpdateWorkersKVNamespace(ctx, d.Id(), namespace)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error updating workers kv namespace"))
 	}
@@ -96,7 +96,7 @@ func resourceCloudflareWorkersKVNamespaceDelete(ctx context.Context, d *schema.R
 
 	log.Printf("[INFO] Deleting Cloudflare Workers KV Namespace with id: %+v", d.Id())
 
-	_, err := client.DeleteWorkersKVNamespace(context.Background(), d.Id())
+	_, err := client.DeleteWorkersKVNamespace(ctx, d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error deleting workers kv namespace"))
 	}

--- a/cloudflare/resource_cloudflare_workers_kv_namespace.go
+++ b/cloudflare/resource_cloudflare_workers_kv_namespace.go
@@ -6,19 +6,20 @@ import (
 	"log"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 )
 
 func resourceCloudflareWorkersKVNamespace() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareWorkersKVNamespaceSchema(),
+		Schema:        resourceCloudflareWorkersKVNamespaceSchema(),
 		CreateContext: resourceCloudflareWorkersKVNamespaceCreate,
-		ReadContext: resourceCloudflareWorkersKVNamespaceRead,
+		ReadContext:   resourceCloudflareWorkersKVNamespaceRead,
 		UpdateContext: resourceCloudflareWorkersKVNamespaceUpdate,
 		DeleteContext: resourceCloudflareWorkersKVNamespaceDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareWorkersKVNamespaceImport,
+			StateContext: resourceCloudflareWorkersKVNamespaceImport,
 		},
 	}
 }
@@ -34,7 +35,7 @@ func resourceCloudflareWorkersKVNamespaceCreate(ctx context.Context, d *schema.R
 
 	r, err := client.CreateWorkersKVNamespace(context.Background(), req)
 	if err != nil {
-		return err.Wrap(err, "error creating workers kv namespace")
+		return diag.FromErr(errors.Wrap(err, "error creating workers kv namespace"))
 	}
 
 	if r.Result.ID == "" {
@@ -54,7 +55,7 @@ func resourceCloudflareWorkersKVNamespaceRead(ctx context.Context, d *schema.Res
 
 	resp, err := client.ListWorkersKVNamespaces(context.Background())
 	if err != nil {
-		return err.Wrap(err, "error reading workers kv namespaces")
+		return diag.FromErr(errors.Wrap(err, "error reading workers kv namespaces"))
 	}
 
 	var namespace cloudflare.WorkersKVNamespace
@@ -84,7 +85,7 @@ func resourceCloudflareWorkersKVNamespaceUpdate(ctx context.Context, d *schema.R
 
 	_, err := client.UpdateWorkersKVNamespace(context.Background(), d.Id(), namespace)
 	if err != nil {
-		return err.Wrap(err, "error updating workers kv namespace")
+		return diag.FromErr(errors.Wrap(err, "error updating workers kv namespace"))
 	}
 
 	return nil
@@ -97,13 +98,13 @@ func resourceCloudflareWorkersKVNamespaceDelete(ctx context.Context, d *schema.R
 
 	_, err := client.DeleteWorkersKVNamespace(context.Background(), d.Id())
 	if err != nil {
-		return err.Wrap(err, "error deleting workers kv namespace")
+		return diag.FromErr(errors.Wrap(err, "error deleting workers kv namespace"))
 	}
 
 	return nil
 }
 
-func resourceCloudflareWorkersKVNamespaceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareWorkersKVNamespaceImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*cloudflare.API)
 
 	namespaces, err := client.ListWorkersKVNamespaces(context.Background())

--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -76,10 +76,10 @@ var ratePlans = map[string]subscriptionData{
 func resourceCloudflareZone() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareZoneSchema(),
-		Create: resourceCloudflareZoneCreate,
-		Read:   resourceCloudflareZoneRead,
-		Update: resourceCloudflareZoneUpdate,
-		Delete: resourceCloudflareZoneDelete,
+		CreateContext: resourceCloudflareZoneCreate,
+		ReadContext: resourceCloudflareZoneRead,
+		UpdateContext: resourceCloudflareZoneUpdate,
+		DeleteContext: resourceCloudflareZoneDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -101,7 +101,7 @@ func resourceCloudflareZoneCreate(ctx context.Context, d *schema.ResourceData, m
 	zone, err := client.CreateZone(context.Background(), zoneName, jumpstart, account, zoneType)
 
 	if err != nil {
-		return fmt.Errorf("error creating zone %q: %s", zoneName, err)
+		return diag.FromErr(fmt.Errorf("error creating zone %q: %s", zoneName, err))
 	}
 
 	d.SetId(zone.ID)
@@ -111,7 +111,7 @@ func resourceCloudflareZoneCreate(ctx context.Context, d *schema.ResourceData, m
 			_, err := client.ZoneSetPaused(context.Background(), zone.ID, paused.(bool))
 
 			if err != nil {
-				return fmt.Errorf("error updating zone_id %q: %s", zone.ID, err)
+				return diag.FromErr(fmt.Errorf("error updating zone_id %q: %s", zone.ID, err))
 			}
 		}
 	}
@@ -125,7 +125,7 @@ func resourceCloudflareZoneCreate(ctx context.Context, d *schema.ResourceData, m
 	if ztype, ok := d.GetOk("type"); ok {
 		_, err := client.ZoneSetType(context.Background(), zone.ID, ztype.(string))
 		if err != nil {
-			return fmt.Errorf("error setting type on zone ID %q: %s", zone.ID, err)
+			return diag.FromErr(fmt.Errorf("error setting type on zone ID %q: %s", zone.ID, err))
 		}
 	}
 
@@ -147,7 +147,7 @@ func resourceCloudflareZoneRead(ctx context.Context, d *schema.ResourceData, met
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding Zone %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding Zone %q: %s", d.Id(), err))
 	}
 
 	// In the cases where the zone isn't completely setup yet, we need to
@@ -186,7 +186,7 @@ func resourceCloudflareZoneUpdate(ctx context.Context, d *schema.ResourceData, m
 		_, err := client.ZoneSetPaused(context.Background(), zoneID, paused.(bool))
 
 		if err != nil {
-			return fmt.Errorf("error setting paused for zone ID %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error setting paused for zone ID %q: %s", zoneID, err))
 		}
 	}
 
@@ -194,7 +194,7 @@ func resourceCloudflareZoneUpdate(ctx context.Context, d *schema.ResourceData, m
 		_, err := client.ZoneSetType(context.Background(), zoneID, ztype.(string))
 
 		if err != nil {
-			return fmt.Errorf("error setting type for on zone ID %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error setting type for on zone ID %q: %s", zoneID, err))
 		}
 	}
 
@@ -230,7 +230,7 @@ func resourceCloudflareZoneDelete(ctx context.Context, d *schema.ResourceData, m
 	_, err := client.DeleteZone(context.Background(), zoneID)
 
 	if err != nil {
-		return fmt.Errorf("error deleting Cloudflare Zone: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Zone: %s", err))
 	}
 
 	return nil
@@ -255,12 +255,12 @@ func setRatePlan(client *cloudflare.API, zoneID, planID string, isNewPlan bool, 
 		// HTTP call to set it.
 		if ratePlans[planID].ID != planIDFree {
 			if err := client.ZoneSetPlan(context.Background(), zoneID, ratePlans[planID].Name); err != nil {
-				return fmt.Errorf("error setting plan %s for zone %q: %s", planID, zoneID, err)
+				return diag.FromErr(fmt.Errorf("error setting plan %s for zone %q: %s", planID, zoneID, err))
 			}
 		}
 	} else {
 		if err := client.ZoneUpdatePlan(context.Background(), zoneID, ratePlans[planID].Name); err != nil {
-			return fmt.Errorf("error updating plan %s for zone %q: %s", planID, zoneID, err)
+			return diag.FromErr(fmt.Errorf("error updating plan %s for zone %q: %s", planID, zoneID, err))
 		}
 	}
 

--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -86,7 +86,7 @@ func resourceCloudflareZone() *schema.Resource {
 	}
 }
 
-func resourceCloudflareZoneCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	zoneName := d.Get("zone").(string)
@@ -118,7 +118,7 @@ func resourceCloudflareZoneCreate(d *schema.ResourceData, meta interface{}) erro
 
 	if plan, ok := d.GetOk("plan"); ok {
 		if err := setRatePlan(client, zone.ID, plan.(string), true, d); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
@@ -132,7 +132,7 @@ func resourceCloudflareZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	return resourceCloudflareZoneRead(d, meta)
 }
 
-func resourceCloudflareZoneRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Id()
 
@@ -173,7 +173,7 @@ func resourceCloudflareZoneRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceCloudflareZoneUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Id()
 	zone, _ := client.ZoneDetails(context.Background(), zoneID)
@@ -214,14 +214,14 @@ func resourceCloudflareZoneUpdate(d *schema.ResourceData, meta interface{}) erro
 		planID := newPlan.(string)
 
 		if err := setRatePlan(client, zoneID, planID, wasFreePlan, d); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
 	return resourceCloudflareZoneRead(d, meta)
 }
 
-func resourceCloudflareZoneDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Id()
 

--- a/cloudflare/resource_cloudflare_zone.go
+++ b/cloudflare/resource_cloudflare_zone.go
@@ -102,7 +102,7 @@ func resourceCloudflareZoneCreate(ctx context.Context, d *schema.ResourceData, m
 	zone, err := client.CreateZone(ctx, zoneName, jumpstart, account, zoneType)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating zone %q: %s", zoneName, err))
+		return diag.FromErr(fmt.Errorf("error creating zone %q: %w", zoneName, err))
 	}
 
 	d.SetId(zone.ID)
@@ -112,7 +112,7 @@ func resourceCloudflareZoneCreate(ctx context.Context, d *schema.ResourceData, m
 			_, err := client.ZoneSetPaused(ctx, zone.ID, paused.(bool))
 
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("error updating zone_id %q: %s", zone.ID, err))
+				return diag.FromErr(fmt.Errorf("error updating zone_id %q: %w", zone.ID, err))
 			}
 		}
 	}
@@ -126,7 +126,7 @@ func resourceCloudflareZoneCreate(ctx context.Context, d *schema.ResourceData, m
 	if ztype, ok := d.GetOk("type"); ok {
 		_, err := client.ZoneSetType(ctx, zone.ID, ztype.(string))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error setting type on zone ID %q: %s", zone.ID, err))
+			return diag.FromErr(fmt.Errorf("error setting type on zone ID %q: %w", zone.ID, err))
 		}
 	}
 
@@ -148,7 +148,7 @@ func resourceCloudflareZoneRead(ctx context.Context, d *schema.ResourceData, met
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding Zone %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding Zone %q: %w", d.Id(), err))
 	}
 
 	// In the cases where the zone isn't completely setup yet, we need to
@@ -187,7 +187,7 @@ func resourceCloudflareZoneUpdate(ctx context.Context, d *schema.ResourceData, m
 		_, err := client.ZoneSetPaused(ctx, zoneID, paused.(bool))
 
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error setting paused for zone ID %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error setting paused for zone ID %q: %w", zoneID, err))
 		}
 	}
 
@@ -195,7 +195,7 @@ func resourceCloudflareZoneUpdate(ctx context.Context, d *schema.ResourceData, m
 		_, err := client.ZoneSetType(ctx, zoneID, ztype.(string))
 
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error setting type for on zone ID %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error setting type for on zone ID %q: %w", zoneID, err))
 		}
 	}
 
@@ -231,7 +231,7 @@ func resourceCloudflareZoneDelete(ctx context.Context, d *schema.ResourceData, m
 	_, err := client.DeleteZone(ctx, zoneID)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Zone: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Zone: %w", err))
 	}
 
 	return nil
@@ -256,12 +256,12 @@ func setRatePlan(ctx context.Context, client *cloudflare.API, zoneID, planID str
 		// HTTP call to set it.
 		if ratePlans[planID].ID != planIDFree {
 			if err := client.ZoneSetPlan(ctx, zoneID, ratePlans[planID].Name); err != nil {
-				return fmt.Errorf("error setting plan %s for zone %q: %s", planID, zoneID, err)
+				return fmt.Errorf("error setting plan %s for zone %q: %w", planID, zoneID, err)
 			}
 		}
 	} else {
 		if err := client.ZoneUpdatePlan(ctx, zoneID, ratePlans[planID].Name); err != nil {
-			return fmt.Errorf("error updating plan %s for zone %q: %s", planID, zoneID, err)
+			return fmt.Errorf("error updating plan %s for zone %q: %w", planID, zoneID, err)
 		}
 	}
 

--- a/cloudflare/resource_cloudflare_zone_cache_variants.go
+++ b/cloudflare/resource_cloudflare_zone_cache_variants.go
@@ -33,54 +33,54 @@ func resourceCloudflareZoneCacheVariantsRead(ctx context.Context, d *schema.Reso
 			d.SetId("")
 			return nil
 		} else {
-			return fmt.Errorf("Error reading cache variants for zone %q: %w", d.Id(), err)
+			return diag.FromErr(fmt.Errorf("Error reading cache variants for zone %q: %w", d.Id(), err))
 		}
 	}
 
 	value := zoneCacheVariants.Value
 
 	if err := d.Set("avif", value.Avif); err != nil {
-		return fmt.Errorf("failed to set avif: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to set avif: %w", err))
 	}
 
 	if err := d.Set("bmp", value.Bmp); err != nil {
-		return fmt.Errorf("failed to set bmp: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to set bmp: %w", err))
 	}
 
 	if err := d.Set("gif", value.Gif); err != nil {
-		return fmt.Errorf("failed to set gif: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to set gif: %w", err))
 	}
 
 	if err := d.Set("jpeg", value.Jpeg); err != nil {
-		return fmt.Errorf("failed to set jpeg: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to set jpeg: %w", err))
 	}
 
 	if err := d.Set("jpg", value.Jpg); err != nil {
-		return fmt.Errorf("failed to set jpg: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to set jpg: %w", err))
 	}
 
 	if err := d.Set("jp2", value.Jp2); err != nil {
-		return fmt.Errorf("failed to set jp2: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to set jp2: %w", err))
 	}
 
 	if err := d.Set("jpg2", value.Jpg2); err != nil {
-		return fmt.Errorf("failed to set jpg2: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to set jpg2: %w", err))
 	}
 
 	if err := d.Set("png", value.Png); err != nil {
-		return fmt.Errorf("failed to set png: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to set png: %w", err))
 	}
 
 	if err := d.Set("tif", value.Tif); err != nil {
-		return fmt.Errorf("failed to set tif: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to set tif: %w", err))
 	}
 
 	if err := d.Set("tiff", value.Tiff); err != nil {
-		return fmt.Errorf("failed to set tiff: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to set tiff: %w", err))
 	}
 
 	if err := d.Set("webp", value.Webp); err != nil {
-		return fmt.Errorf("failed to set webp: %w", err)
+		return diag.FromErr(fmt.Errorf("failed to set webp: %w", err))
 	}
 
 	return nil
@@ -98,7 +98,7 @@ func resourceCloudflareZoneCacheVariantsUpdate(ctx context.Context, d *schema.Re
 	_, err := client.UpdateZoneCacheVariants(context.Background(), d.Id(), variantsValue)
 
 	if err != nil {
-		return fmt.Errorf("error setting cache variants for zone %q: %w", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error setting cache variants for zone %q: %w", d.Id(), err))
 	}
 
 	return resourceCloudflareZoneCacheVariantsRead(d, meta)
@@ -112,7 +112,7 @@ func resourceCloudflareZoneCacheVariantsDelete(ctx context.Context, d *schema.Re
 	err := client.DeleteZoneCacheVariants(context.Background(), d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error deleting cache variants for zone %v: %w", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error deleting cache variants for zone %v: %w", d.Id(), err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_zone_cache_variants.go
+++ b/cloudflare/resource_cloudflare_zone_cache_variants.go
@@ -20,7 +20,7 @@ func resourceCloudflareZoneCacheVariants() *schema.Resource {
 	}
 }
 
-func resourceCloudflareZoneCacheVariantsRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneCacheVariantsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	log.Printf("[INFO] Reading Zone Cache Variants in zone %q", d.Id())
@@ -86,7 +86,7 @@ func resourceCloudflareZoneCacheVariantsRead(d *schema.ResourceData, meta interf
 	return nil
 }
 
-func resourceCloudflareZoneCacheVariantsUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneCacheVariantsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	zoneID := d.Get("zone_id").(string)
@@ -104,7 +104,7 @@ func resourceCloudflareZoneCacheVariantsUpdate(d *schema.ResourceData, meta inte
 	return resourceCloudflareZoneCacheVariantsRead(d, meta)
 }
 
-func resourceCloudflareZoneCacheVariantsDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneCacheVariantsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	log.Printf("[INFO] Deleting Zone Cache Variants for zone ID: %q", d.Id())

--- a/cloudflare/resource_cloudflare_zone_cache_variants.go
+++ b/cloudflare/resource_cloudflare_zone_cache_variants.go
@@ -26,7 +26,7 @@ func resourceCloudflareZoneCacheVariantsRead(ctx context.Context, d *schema.Reso
 
 	log.Printf("[INFO] Reading Zone Cache Variants in zone %q", d.Id())
 
-	zoneCacheVariants, err := client.ZoneCacheVariants(context.Background(), d.Id())
+	zoneCacheVariants, err := client.ZoneCacheVariants(ctx, d.Id())
 
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP status 404") {
@@ -96,7 +96,7 @@ func resourceCloudflareZoneCacheVariantsUpdate(ctx context.Context, d *schema.Re
 	variantsValue := cacheVariantsValuesFromResource(d)
 	log.Printf("[INFO] Setting Zone Cache Variants to struct: %+v for zone ID: %q", variantsValue, d.Id())
 
-	_, err := client.UpdateZoneCacheVariants(context.Background(), d.Id(), variantsValue)
+	_, err := client.UpdateZoneCacheVariants(ctx, d.Id(), variantsValue)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error setting cache variants for zone %q: %w", d.Id(), err))
@@ -110,7 +110,7 @@ func resourceCloudflareZoneCacheVariantsDelete(ctx context.Context, d *schema.Re
 
 	log.Printf("[INFO] Deleting Zone Cache Variants for zone ID: %q", d.Id())
 
-	err := client.DeleteZoneCacheVariants(context.Background(), d.Id())
+	err := client.DeleteZoneCacheVariants(ctx, d.Id())
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting cache variants for zone %v: %w", d.Id(), err))

--- a/cloudflare/resource_cloudflare_zone_cache_variants.go
+++ b/cloudflare/resource_cloudflare_zone_cache_variants.go
@@ -7,14 +7,15 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareZoneCacheVariants() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareZoneCacheVariantsSchema(),
+		Schema:        resourceCloudflareZoneCacheVariantsSchema(),
 		CreateContext: resourceCloudflareZoneCacheVariantsUpdate,
-		ReadContext: resourceCloudflareZoneCacheVariantsRead,
+		ReadContext:   resourceCloudflareZoneCacheVariantsRead,
 		UpdateContext: resourceCloudflareZoneCacheVariantsUpdate,
 		DeleteContext: resourceCloudflareZoneCacheVariantsDelete,
 	}
@@ -101,7 +102,7 @@ func resourceCloudflareZoneCacheVariantsUpdate(ctx context.Context, d *schema.Re
 		return diag.FromErr(fmt.Errorf("error setting cache variants for zone %q: %w", d.Id(), err))
 	}
 
-	return resourceCloudflareZoneCacheVariantsRead(d, meta)
+	return resourceCloudflareZoneCacheVariantsRead(ctx, d, meta)
 }
 
 func resourceCloudflareZoneCacheVariantsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/cloudflare/resource_cloudflare_zone_cache_variants.go
+++ b/cloudflare/resource_cloudflare_zone_cache_variants.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareZoneCacheVariants() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareZoneCacheVariantsSchema(),
-		Create: resourceCloudflareZoneCacheVariantsUpdate,
-		Read:   resourceCloudflareZoneCacheVariantsRead,
-		Update: resourceCloudflareZoneCacheVariantsUpdate,
-		Delete: resourceCloudflareZoneCacheVariantsDelete,
+		CreateContext: resourceCloudflareZoneCacheVariantsUpdate,
+		ReadContext: resourceCloudflareZoneCacheVariantsRead,
+		UpdateContext: resourceCloudflareZoneCacheVariantsUpdate,
+		DeleteContext: resourceCloudflareZoneCacheVariantsDelete,
 	}
 }
 

--- a/cloudflare/resource_cloudflare_zone_dnssec.go
+++ b/cloudflare/resource_cloudflare_zone_dnssec.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -20,13 +21,13 @@ const (
 
 func resourceCloudflareZoneDNSSEC() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareZoneDNSSECSchema(),
+		Schema:        resourceCloudflareZoneDNSSECSchema(),
 		CreateContext: resourceCloudflareZoneDNSSECCreate,
-		ReadContext: resourceCloudflareZoneDNSSECRead,
+		ReadContext:   resourceCloudflareZoneDNSSECRead,
 		UpdateContext: resourceCloudflareZoneDNSSECUpdate,
 		DeleteContext: resourceCloudflareZoneDNSSECDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }
@@ -53,7 +54,7 @@ func resourceCloudflareZoneDNSSECCreate(ctx context.Context, d *schema.ResourceD
 
 	d.SetId(zoneID)
 
-	return resourceCloudflareZoneDNSSECRead(d, meta)
+	return resourceCloudflareZoneDNSSECRead(ctx, d, meta)
 }
 
 func resourceCloudflareZoneDNSSECRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -94,7 +95,7 @@ func resourceCloudflareZoneDNSSECRead(ctx context.Context, d *schema.ResourceDat
 
 // Just returning remote state since changing the zone ID would force a new resource
 func resourceCloudflareZoneDNSSECUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return resourceCloudflareZoneRead(d, meta)
+	return resourceCloudflareZoneRead(ctx, d, meta)
 }
 
 func resourceCloudflareZoneDNSSECDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/cloudflare/resource_cloudflare_zone_dnssec.go
+++ b/cloudflare/resource_cloudflare_zone_dnssec.go
@@ -39,12 +39,12 @@ func resourceCloudflareZoneDNSSECCreate(ctx context.Context, d *schema.ResourceD
 
 	log.Printf("[INFO] Creating Cloudflare Zone DNSSEC: name %s", zoneID)
 
-	currentDNSSEC, err := client.ZoneDNSSECSetting(context.Background(), zoneID)
+	currentDNSSEC, err := client.ZoneDNSSECSetting(ctx, zoneID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err))
 	}
 	if currentDNSSEC.Status != DNSSECStatusActive && currentDNSSEC.Status != DNSSECStatusPending {
-		_, err := client.UpdateZoneDNSSEC(context.Background(), zoneID, cloudflare.ZoneDNSSECUpdateOptions{Status: DNSSECStatusActive})
+		_, err := client.UpdateZoneDNSSEC(ctx, zoneID, cloudflare.ZoneDNSSECUpdateOptions{Status: DNSSECStatusActive})
 
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error creating zone DNSSEC %q: %s", zoneID, err))
@@ -68,7 +68,7 @@ func resourceCloudflareZoneDNSSECRead(ctx context.Context, d *schema.ResourceDat
 		zoneID = d.Id()
 	}
 
-	dnssec, err := client.ZoneDNSSECSetting(context.Background(), zoneID)
+	dnssec, err := client.ZoneDNSSECSetting(ctx, zoneID)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err))
 	}
@@ -105,7 +105,7 @@ func resourceCloudflareZoneDNSSECDelete(ctx context.Context, d *schema.ResourceD
 
 	log.Printf("[INFO] Deleting Cloudflare Zone DNSSEC: id %s", zoneID)
 
-	_, err := client.UpdateZoneDNSSEC(context.Background(), zoneID, cloudflare.ZoneDNSSECUpdateOptions{Status: DNSSECStatusDisabled})
+	_, err := client.UpdateZoneDNSSEC(ctx, zoneID, cloudflare.ZoneDNSSECUpdateOptions{Status: DNSSECStatusDisabled})
 
 	if err != nil {
 		if strings.Contains(err.Error(), "DNSSEC is already disabled") {

--- a/cloudflare/resource_cloudflare_zone_dnssec.go
+++ b/cloudflare/resource_cloudflare_zone_dnssec.go
@@ -41,15 +41,14 @@ func resourceCloudflareZoneDNSSECCreate(ctx context.Context, d *schema.ResourceD
 
 	currentDNSSEC, err := client.ZoneDNSSECSetting(ctx, zoneID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err))
+		return diag.FromErr(fmt.Errorf("error finding Zone DNSSEC %q: %w", zoneID, err))
 	}
 	if currentDNSSEC.Status != DNSSECStatusActive && currentDNSSEC.Status != DNSSECStatusPending {
 		_, err := client.UpdateZoneDNSSEC(ctx, zoneID, cloudflare.ZoneDNSSECUpdateOptions{Status: DNSSECStatusActive})
 
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error creating zone DNSSEC %q: %s", zoneID, err))
+			return diag.FromErr(fmt.Errorf("error creating zone DNSSEC %q: %w", zoneID, err))
 		}
-
 	}
 
 	d.SetId(zoneID)
@@ -70,7 +69,7 @@ func resourceCloudflareZoneDNSSECRead(ctx context.Context, d *schema.ResourceDat
 
 	dnssec, err := client.ZoneDNSSECSetting(ctx, zoneID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err))
+		return diag.FromErr(fmt.Errorf("error finding Zone DNSSEC %q: %w", zoneID, err))
 	}
 
 	if dnssec.Status == DNSSECStatusDisabled {
@@ -113,7 +112,7 @@ func resourceCloudflareZoneDNSSECDelete(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Zone DNSSEC: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Zone DNSSEC: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_zone_dnssec.go
+++ b/cloudflare/resource_cloudflare_zone_dnssec.go
@@ -31,7 +31,7 @@ func resourceCloudflareZoneDNSSEC() *schema.Resource {
 	}
 }
 
-func resourceCloudflareZoneDNSSECCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneDNSSECCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	zoneID := d.Get("zone_id").(string)
@@ -56,7 +56,7 @@ func resourceCloudflareZoneDNSSECCreate(d *schema.ResourceData, meta interface{}
 	return resourceCloudflareZoneDNSSECRead(d, meta)
 }
 
-func resourceCloudflareZoneDNSSECRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneDNSSECRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	zoneID := d.Get("zone_id").(string)
@@ -93,11 +93,11 @@ func resourceCloudflareZoneDNSSECRead(d *schema.ResourceData, meta interface{}) 
 }
 
 // Just returning remote state since changing the zone ID would force a new resource
-func resourceCloudflareZoneDNSSECUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneDNSSECUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return resourceCloudflareZoneRead(d, meta)
 }
 
-func resourceCloudflareZoneDNSSECDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneDNSSECDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
 	zoneID := d.Get("zone_id").(string)

--- a/cloudflare/resource_cloudflare_zone_dnssec.go
+++ b/cloudflare/resource_cloudflare_zone_dnssec.go
@@ -40,13 +40,13 @@ func resourceCloudflareZoneDNSSECCreate(ctx context.Context, d *schema.ResourceD
 
 	currentDNSSEC, err := client.ZoneDNSSECSetting(context.Background(), zoneID)
 	if err != nil {
-		return fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err))
 	}
 	if currentDNSSEC.Status != DNSSECStatusActive && currentDNSSEC.Status != DNSSECStatusPending {
 		_, err := client.UpdateZoneDNSSEC(context.Background(), zoneID, cloudflare.ZoneDNSSECUpdateOptions{Status: DNSSECStatusActive})
 
 		if err != nil {
-			return fmt.Errorf("error creating zone DNSSEC %q: %s", zoneID, err)
+			return diag.FromErr(fmt.Errorf("error creating zone DNSSEC %q: %s", zoneID, err))
 		}
 
 	}
@@ -69,11 +69,11 @@ func resourceCloudflareZoneDNSSECRead(ctx context.Context, d *schema.ResourceDat
 
 	dnssec, err := client.ZoneDNSSECSetting(context.Background(), zoneID)
 	if err != nil {
-		return fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error finding Zone DNSSEC %q: %s", zoneID, err))
 	}
 
 	if dnssec.Status == DNSSECStatusDisabled {
-		return fmt.Errorf("zone DNSSEC %q: already disabled", zoneID)
+		return diag.FromErr(fmt.Errorf("zone DNSSEC %q: already disabled", zoneID))
 	}
 
 	d.Set("zone_id", zoneID)
@@ -112,7 +112,7 @@ func resourceCloudflareZoneDNSSECDelete(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error deleting Cloudflare Zone DNSSEC: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Zone DNSSEC: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_zone_dnssec.go
+++ b/cloudflare/resource_cloudflare_zone_dnssec.go
@@ -21,10 +21,10 @@ const (
 func resourceCloudflareZoneDNSSEC() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareZoneDNSSECSchema(),
-		Create: resourceCloudflareZoneDNSSECCreate,
-		Read:   resourceCloudflareZoneDNSSECRead,
-		Update: resourceCloudflareZoneDNSSECUpdate,
-		Delete: resourceCloudflareZoneDNSSECDelete,
+		CreateContext: resourceCloudflareZoneDNSSECCreate,
+		ReadContext: resourceCloudflareZoneDNSSECRead,
+		UpdateContext: resourceCloudflareZoneDNSSECUpdate,
+		DeleteContext: resourceCloudflareZoneDNSSECDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/cloudflare/resource_cloudflare_zone_lockdown.go
+++ b/cloudflare/resource_cloudflare_zone_lockdown.go
@@ -23,7 +23,7 @@ func resourceCloudflareZoneLockdown() *schema.Resource {
 	}
 }
 
-func resourceCloudflareZoneLockdownCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneLockdownCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -72,7 +72,7 @@ func resourceCloudflareZoneLockdownCreate(d *schema.ResourceData, meta interface
 	return resourceCloudflareZoneLockdownRead(d, meta)
 }
 
-func resourceCloudflareZoneLockdownRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneLockdownRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -115,7 +115,7 @@ func resourceCloudflareZoneLockdownRead(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceCloudflareZoneLockdownUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneLockdownUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
@@ -160,7 +160,7 @@ func resourceCloudflareZoneLockdownUpdate(d *schema.ResourceData, meta interface
 	return resourceCloudflareZoneLockdownRead(d, meta)
 }
 
-func resourceCloudflareZoneLockdownDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudflareZoneLockdownDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 

--- a/cloudflare/resource_cloudflare_zone_lockdown.go
+++ b/cloudflare/resource_cloudflare_zone_lockdown.go
@@ -58,11 +58,11 @@ func resourceCloudflareZoneLockdownCreate(ctx context.Context, d *schema.Resourc
 	r, err = client.CreateZoneLockdown(context.Background(), zoneID, newZoneLockdown)
 
 	if err != nil {
-		return fmt.Errorf("error creating zone lockdown for zone ID %q: %s", zoneID, err)
+		return diag.FromErr(fmt.Errorf("error creating zone lockdown for zone ID %q: %s", zoneID, err))
 	}
 
 	if r.Result.ID == "" {
-		return fmt.Errorf("failed to find id in Create response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find id in Create response; resource was empty"))
 	}
 
 	d.SetId(r.Result.ID)
@@ -87,7 +87,7 @@ func resourceCloudflareZoneLockdownRead(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error finding zone lockdown %q: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error finding zone lockdown %q: %s", d.Id(), err))
 	}
 
 	log.Printf("[DEBUG] Cloudflare Zone Lockdown read configuration: %#v", zoneLockdownResponse)
@@ -146,11 +146,11 @@ func resourceCloudflareZoneLockdownUpdate(ctx context.Context, d *schema.Resourc
 	r, err := client.UpdateZoneLockdown(context.Background(), zoneID, d.Id(), newZoneLockdown)
 
 	if err != nil {
-		return fmt.Errorf("error updating zone lockdown for zone %q: %s", d.Get("zone").(string), err)
+		return diag.FromErr(fmt.Errorf("error updating zone lockdown for zone %q: %s", d.Get("zone").(string), err))
 	}
 
 	if r.Result.ID == "" {
-		return fmt.Errorf("failed to find id in Update response; resource was empty")
+		return diag.FromErr(fmt.Errorf("failed to find id in Update response; resource was empty"))
 	}
 
 	d.SetId(r.Result.ID)
@@ -169,7 +169,7 @@ func resourceCloudflareZoneLockdownDelete(ctx context.Context, d *schema.Resourc
 	_, err := client.DeleteZoneLockdown(context.Background(), zoneID, d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error deleting Cloudflare Zone Lockdown: %s", err)
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Zone Lockdown: %s", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_zone_lockdown.go
+++ b/cloudflare/resource_cloudflare_zone_lockdown.go
@@ -59,7 +59,7 @@ func resourceCloudflareZoneLockdownCreate(ctx context.Context, d *schema.Resourc
 	r, err = client.CreateZoneLockdown(ctx, zoneID, newZoneLockdown)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating zone lockdown for zone ID %q: %s", zoneID, err))
+		return diag.FromErr(fmt.Errorf("error creating zone lockdown for zone ID %q: %w", zoneID, err))
 	}
 
 	if r.Result.ID == "" {
@@ -88,7 +88,7 @@ func resourceCloudflareZoneLockdownRead(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error finding zone lockdown %q: %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error finding zone lockdown %q: %w", d.Id(), err))
 	}
 
 	log.Printf("[DEBUG] Cloudflare Zone Lockdown read configuration: %#v", zoneLockdownResponse)
@@ -147,7 +147,7 @@ func resourceCloudflareZoneLockdownUpdate(ctx context.Context, d *schema.Resourc
 	r, err := client.UpdateZoneLockdown(ctx, zoneID, d.Id(), newZoneLockdown)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating zone lockdown for zone %q: %s", d.Get("zone").(string), err))
+		return diag.FromErr(fmt.Errorf("error updating zone lockdown for zone %q: %w", d.Get("zone").(string), err))
 	}
 
 	if r.Result.ID == "" {
@@ -170,7 +170,7 @@ func resourceCloudflareZoneLockdownDelete(ctx context.Context, d *schema.Resourc
 	_, err := client.DeleteZoneLockdown(ctx, zoneID, d.Id())
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Zone Lockdown: %s", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Zone Lockdown: %w", err))
 	}
 
 	return nil

--- a/cloudflare/resource_cloudflare_zone_lockdown.go
+++ b/cloudflare/resource_cloudflare_zone_lockdown.go
@@ -56,7 +56,7 @@ func resourceCloudflareZoneLockdownCreate(ctx context.Context, d *schema.Resourc
 
 	var r *cloudflare.ZoneLockdownResponse
 
-	r, err = client.CreateZoneLockdown(context.Background(), zoneID, newZoneLockdown)
+	r, err = client.CreateZoneLockdown(ctx, zoneID, newZoneLockdown)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating zone lockdown for zone ID %q: %s", zoneID, err))
@@ -77,7 +77,7 @@ func resourceCloudflareZoneLockdownRead(ctx context.Context, d *schema.ResourceD
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
 
-	zoneLockdownResponse, err := client.ZoneLockdown(context.Background(), zoneID, d.Id())
+	zoneLockdownResponse, err := client.ZoneLockdown(ctx, zoneID, d.Id())
 
 	log.Printf("[DEBUG] zoneLockdownResponse: %#v", zoneLockdownResponse)
 	log.Printf("[DEBUG] zoneLockdownResponse error: %#v", err)
@@ -144,7 +144,7 @@ func resourceCloudflareZoneLockdownUpdate(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[INFO] Updating Cloudflare Zone Lockdown from struct: %+v", newZoneLockdown)
 
-	r, err := client.UpdateZoneLockdown(context.Background(), zoneID, d.Id(), newZoneLockdown)
+	r, err := client.UpdateZoneLockdown(ctx, zoneID, d.Id(), newZoneLockdown)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating zone lockdown for zone %q: %s", d.Get("zone").(string), err))
@@ -167,7 +167,7 @@ func resourceCloudflareZoneLockdownDelete(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[INFO] Deleting Cloudflare Zone Lockdown: id %s for zone %s", d.Id(), zoneID)
 
-	_, err := client.DeleteZoneLockdown(context.Background(), zoneID, d.Id())
+	_, err := client.DeleteZoneLockdown(ctx, zoneID, d.Id())
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Zone Lockdown: %s", err))

--- a/cloudflare/resource_cloudflare_zone_lockdown.go
+++ b/cloudflare/resource_cloudflare_zone_lockdown.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceCloudflareZoneLockdown() *schema.Resource {
 	return &schema.Resource{
-		Schema: resourceCloudflareZoneLockdownSchema(),
+		Schema:        resourceCloudflareZoneLockdownSchema(),
 		CreateContext: resourceCloudflareZoneLockdownCreate,
-		ReadContext: resourceCloudflareZoneLockdownRead,
+		ReadContext:   resourceCloudflareZoneLockdownRead,
 		UpdateContext: resourceCloudflareZoneLockdownUpdate,
 		DeleteContext: resourceCloudflareZoneLockdownDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudflareZoneLockdownImport,
+			StateContext: resourceCloudflareZoneLockdownImport,
 		},
 	}
 }
@@ -69,7 +70,7 @@ func resourceCloudflareZoneLockdownCreate(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[INFO] Cloudflare Zone Lockdown ID: %s", d.Id())
 
-	return resourceCloudflareZoneLockdownRead(d, meta)
+	return resourceCloudflareZoneLockdownRead(ctx, d, meta)
 }
 
 func resourceCloudflareZoneLockdownRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -157,7 +158,7 @@ func resourceCloudflareZoneLockdownUpdate(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[INFO] Cloudflare Zone Lockdown ID: %s", d.Id())
 
-	return resourceCloudflareZoneLockdownRead(d, meta)
+	return resourceCloudflareZoneLockdownRead(ctx, d, meta)
 }
 
 func resourceCloudflareZoneLockdownDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -187,7 +188,7 @@ func expandZoneLockdownConfig(configs *schema.Set) []cloudflare.ZoneLockdownConf
 	return configArray
 }
 
-func resourceCloudflareZoneLockdownImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudflareZoneLockdownImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	// split the id so we can lookup
 	idAttr := strings.SplitN(d.Id(), "/", 2)
 	var zoneID string
@@ -204,7 +205,7 @@ func resourceCloudflareZoneLockdownImport(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] zoneID: %s", zoneID)
 	log.Printf("[DEBUG] Resource ID : %s", zoneLockdownID)
 
-	resourceCloudflareZoneLockdownRead(d, meta)
+	resourceCloudflareZoneLockdownRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/cloudflare/resource_cloudflare_zone_lockdown.go
+++ b/cloudflare/resource_cloudflare_zone_lockdown.go
@@ -13,10 +13,10 @@ import (
 func resourceCloudflareZoneLockdown() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareZoneLockdownSchema(),
-		Create: resourceCloudflareZoneLockdownCreate,
-		Read:   resourceCloudflareZoneLockdownRead,
-		Update: resourceCloudflareZoneLockdownUpdate,
-		Delete: resourceCloudflareZoneLockdownDelete,
+		CreateContext: resourceCloudflareZoneLockdownCreate,
+		ReadContext: resourceCloudflareZoneLockdownRead,
+		UpdateContext: resourceCloudflareZoneLockdownUpdate,
+		DeleteContext: resourceCloudflareZoneLockdownDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudflareZoneLockdownImport,
 		},

--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -19,10 +19,10 @@ import (
 func resourceCloudflareZoneSettingsOverride() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceCloudflareZoneSettingsOverrideSchema(),
-		Create: resourceCloudflareZoneSettingsOverrideCreate,
-		Read:   resourceCloudflareZoneSettingsOverrideRead,
-		Update: resourceCloudflareZoneSettingsOverrideUpdate,
-		Delete: resourceCloudflareZoneSettingsOverrideDelete,
+		CreateContext: resourceCloudflareZoneSettingsOverrideCreate,
+		ReadContext: resourceCloudflareZoneSettingsOverrideRead,
+		UpdateContext: resourceCloudflareZoneSettingsOverrideUpdate,
+		DeleteContext: resourceCloudflareZoneSettingsOverrideDelete,
 	}
 }
 

--- a/cloudflare/resource_cloudflare_zone_settings_override.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override.go
@@ -261,7 +261,6 @@ func resourceCloudflareZoneSettingsOverrideUpdate(ctx context.Context, d *schema
 	client := meta.(*cloudflare.API)
 
 	if cfg, ok := d.GetOkExists("settings"); ok && cfg != nil && len(cfg.([]interface{})) > 0 {
-
 		readOnlySettings := expandInterfaceToStringList(d.Get("readonly_settings"))
 		zoneSettings, err := expandOverriddenZoneSettings(d, "settings", readOnlySettings)
 		if err != nil {
@@ -297,11 +296,9 @@ func expandOverriddenZoneSettings(d *schema.ResourceData, settingsKey string, re
 	keyFormat := fmt.Sprintf("%s.0.%%s", settingsKey)
 
 	for k := range resourceCloudflareZoneSettingsSchema {
-
 		// we only update if the user set the value non-empty before, and its different from the read value
 		// note that if user removes an attribute, we don't do anything
 		if settingValue, ok := d.GetOkExists(fmt.Sprintf(keyFormat, k)); ok && d.HasChange(fmt.Sprintf(keyFormat, k)) {
-
 			zoneSettingValue, err := expandZoneSetting(d, keyFormat, k, settingValue, readOnlySettings)
 			if err != nil {
 				return zoneSettings, err
@@ -319,15 +316,12 @@ func expandOverriddenZoneSettings(d *schema.ResourceData, settingsKey string, re
 				}
 				zoneSettings = append(zoneSettings, newZoneSetting)
 			}
-
 		}
-
 	}
 	return zoneSettings, nil
 }
 
 func expandZoneSetting(d *schema.ResourceData, keyFormatString, k string, settingValue interface{}, readOnlySettings []string) (interface{}, error) {
-
 	if contains(readOnlySettings, k) {
 		return nil, fmt.Errorf("invalid zone setting %q (value: %v) found - cannot be set as it is read only", k, settingValue)
 	}
@@ -350,7 +344,6 @@ func expandZoneSetting(d *schema.ResourceData, keyFormatString, k string, settin
 			if len(listValue) > 0 && listValue != nil {
 				zoneSettingValue = listValue[0].(map[string]interface{})
 			}
-
 		}
 	case "security_header":
 		{
@@ -373,7 +366,6 @@ func resourceCloudflareZoneSettingsOverrideDelete(ctx context.Context, d *schema
 	client := meta.(*cloudflare.API)
 
 	if cfg, ok := d.GetOkExists("settings"); ok && cfg != nil && len(cfg.([]interface{})) > 0 {
-
 		readOnlySettings := expandInterfaceToStringList(d.Get("readonly_settings"))
 
 		zoneSettings, err := expandRevertibleZoneSettings(d, readOnlySettings)
@@ -409,7 +401,6 @@ func expandRevertibleZoneSettings(d *schema.ResourceData, readOnlySettings []str
 	keyFormat := fmt.Sprintf("%s.0.%%s", "initial_settings")
 
 	for k := range resourceCloudflareZoneSettingsSchema {
-
 		initialKey := fmt.Sprintf("initial_settings.0.%s", k)
 		initialVal := d.Get(initialKey)
 		currentKey := fmt.Sprintf("settings.0.%s", k)
@@ -420,7 +411,6 @@ func expandRevertibleZoneSettings(d *schema.ResourceData, readOnlySettings []str
 
 		// if the value was never set we don't need to revert it
 		if currentVal, ok := d.GetOk(currentKey); ok && !schemaValueEquals(initialVal, currentVal) {
-
 			zoneSettingValue, err := expandZoneSetting(d, keyFormat, k, initialVal, readOnlySettings)
 			if err != nil {
 				return zoneSettings, err
@@ -433,7 +423,6 @@ func expandRevertibleZoneSettings(d *schema.ResourceData, readOnlySettings []str
 				}
 				zoneSettings = append(zoneSettings, newZoneSetting)
 			}
-
 		}
 	}
 	return zoneSettings, nil

--- a/cloudflare/resource_cloudflare_zone_settings_override_test.go
+++ b/cloudflare/resource_cloudflare_zone_settings_override_test.go
@@ -133,11 +133,11 @@ func testAccGetInitialZoneSettings(t *testing.T, zoneID string, settings map[str
 			t.Fatalf("Zone settings not found")
 		}
 
-		if err = updateZoneSettingsResponseWithSingleZoneSettings(foundZone, zoneID, client); err != nil {
+		if err = updateZoneSettingsResponseWithSingleZoneSettings(context.Background(), foundZone, zoneID, client); err != nil {
 			return err
 		}
 
-		if err = updateZoneSettingsResponseWithUniversalSSLSettings(foundZone, zoneID, client); err != nil {
+		if err = updateZoneSettingsResponseWithUniversalSSLSettings(context.Background(), foundZone, zoneID, client); err != nil {
 			return err
 		}
 
@@ -161,11 +161,11 @@ func testAccCheckInitialZoneSettings(zoneID string, initialSettings map[string]i
 			return fmt.Errorf("Zone settings not found")
 		}
 
-		if err = updateZoneSettingsResponseWithSingleZoneSettings(foundZone, zoneID, client); err != nil {
+		if err = updateZoneSettingsResponseWithSingleZoneSettings(context.Background(), foundZone, zoneID, client); err != nil {
 			return err
 		}
 
-		if err = updateZoneSettingsResponseWithUniversalSSLSettings(foundZone, zoneID, client); err != nil {
+		if err = updateZoneSettingsResponseWithUniversalSSLSettings(context.Background(), foundZone, zoneID, client); err != nil {
 			return err
 		}
 

--- a/cloudflare/schema_cloudflare_access_application.go
+++ b/cloudflare/schema_cloudflare_access_application.go
@@ -167,7 +167,6 @@ func convertCORSSchemaToStruct(d *schema.ResourceData) (*cloudflare.AccessApplic
 	if _, ok := d.GetOk("cors_headers"); ok {
 		if allowedMethods, ok := d.GetOk("cors_headers.0.allowed_methods"); ok {
 			CORSConfig.AllowedMethods = expandInterfaceToStringList(allowedMethods.(*schema.Set).List())
-
 		}
 
 		if allowedHeaders, ok := d.GetOk("cors_headers.0.allowed_headers"); ok {

--- a/cloudflare/schema_cloudflare_teams_proxy_endpoints.go
+++ b/cloudflare/schema_cloudflare_teams_proxy_endpoints.go
@@ -3,7 +3,6 @@ package cloudflare
 import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 func resourceCloudflareTeamsProxyEndpointSchema() map[string]*schema.Schema {
-
 	return map[string]*schema.Schema{
 		"account_id": {
 			Type:     schema.TypeString,

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -2,7 +2,6 @@ package cloudflare
 
 import (
 	"bytes"
-	"context"
 	"crypto/md5"
 	"fmt"
 	"hash/crc32"
@@ -11,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -133,21 +131,6 @@ func stringFromBool(status bool) string {
 		return "on"
 	}
 	return "off"
-}
-
-func getAccountIDFromZoneID(d *schema.ResourceData, client *cloudflare.API) (string, error) {
-	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		zoneID := d.Get("zone_id").(string)
-		zone, err := client.ZoneDetails(ctx, zoneID)
-		if err != nil {
-			return "", fmt.Errorf("error retrieving zone for zone_id %q: %s", zoneID, err)
-		}
-		accountID = zone.Account.ID
-	}
-
-	d.Set("account_id", accountID)
-	return accountID, nil
 }
 
 // AccessIdentifier represents the identifier provided in a resource

--- a/cloudflare/utils.go
+++ b/cloudflare/utils.go
@@ -139,7 +139,7 @@ func getAccountIDFromZoneID(d *schema.ResourceData, client *cloudflare.API) (str
 	accountID := d.Get("account_id").(string)
 	if accountID == "" {
 		zoneID := d.Get("zone_id").(string)
-		zone, err := client.ZoneDetails(context.Background(), zoneID)
+		zone, err := client.ZoneDetails(ctx, zoneID)
 		if err != nil {
 			return "", fmt.Errorf("error retrieving zone for zone_id %q: %s", zoneID, err)
 		}

--- a/cloudflare/validators.go
+++ b/cloudflare/validators.go
@@ -70,7 +70,7 @@ func validateStringIP(v interface{}, k string) (warnings []string, errors []erro
 // handle here but there _could_ be edge cases.
 func validateURL(v interface{}, k string) (s []string, errors []error) {
 	if _, err := url.ParseRequestURI(v.(string)); err != nil {
-		errors = append(errors, fmt.Errorf("%q: %s", k, err))
+		errors = append(errors, fmt.Errorf("%q: %w", k, err))
 	}
 	return
 }

--- a/docs/data-handling-and-processing.md
+++ b/docs/data-handling-and-processing.md
@@ -11,7 +11,7 @@ func resourceExampleRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 
     if err := d.Set("my_attr", attr); err != nil {
-      return fmt.Errorf("failed to set my_attr: %s", err)
+      return fmt.Errorf("failed to set my_attr: %w", err)
     }
 
     return nil

--- a/docs/data-handling-and-processing.md
+++ b/docs/data-handling-and-processing.md
@@ -5,7 +5,7 @@
 You should also include error handling for `d.Set` calls that are not using simple (string, number, boolean) values to catch any schema mismatches.
 
 ```go
-func resourceExampleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
     // ... snip
     // assuming `attr` is a map or list of types.
 


### PR DESCRIPTION
Updates the provider to make use of [Terraform diagnostics](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/diag) and reusing the `context.Context` passed in by the provider instead of spawning a new one. 

Closes #1187