### PR TITLE
Update default instructions to configure the provider

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -33,8 +33,7 @@ terraform {
 }
 
 provider "cloudflare" {
-  email   = var.cloudflare_email
-  api_key = var.cloudflare_api_key
+  api_token = var.cloudflare_api_token
 }
 
 # Create a record


### PR DESCRIPTION
`api_token` is preferred over `email` + `api_key`