### PR TITLE
Allow r2 logpush destinations without ownership validation

### DIFF
--- a/.changelog/1597.txt
+++ b/.changelog/1597.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_logpush_job: allow r2 logpush destinations without ownership validation
+```

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -43,7 +43,7 @@ func getJobFromResource(d *schema.ResourceData) (cloudflare.LogpushJob, *AccessI
 
 	destConf := d.Get("destination_conf").(string)
 	ownershipChallenge := d.Get("ownership_challenge").(string)
-	var re = regexp.MustCompile(`^((datadog|splunk|https)://|s3://.+endpoint=)`)
+	var re = regexp.MustCompile(`^((datadog|splunk|https|r2)://|s3://.+endpoint=)`)
 
 	if ownershipChallenge == "" && !re.MatchString(destConf) {
 		return cloudflare.LogpushJob{}, identifier, fmt.Errorf("ownership_challenge must be set for the provided destination_conf")


### PR DESCRIPTION
Allow users to create logpush jobs with Cloudflare R2 as a destination. Documentation for this feature is coming soon.