### PR TITLE
Fix possible panic during resourceCloudflareSpectrumApplicationRead

### DIFF
--- a/.changelog/1599.txt
+++ b/.changelog/1599.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
+```release-note:bug
 resource/cloudflare_spectrum_application: prevent the provider from panicing when the API does not return `edge_ips.connectivity`
 ```

--- a/.changelog/1599.txt
+++ b/.changelog/1599.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/cloudflare_spectrum_application: prevent the provider from panicing when the API does not return `edge_ips.connectivity`
+resource/cloudflare_spectrum_application: prevent panic when configuration does not include `edge_ips.connectivity`
 ```

--- a/.changelog/1599.txt
+++ b/.changelog/1599.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_spectrum_application: prevent the provider from panicing when the API does not return `edge_ips.connectivity`
+```

--- a/cloudflare/resource_cloudflare_spectrum_application.go
+++ b/cloudflare/resource_cloudflare_spectrum_application.go
@@ -114,8 +114,11 @@ func resourceCloudflareSpectrumApplicationRead(ctx context.Context, d *schema.Re
 		if err := d.Set("edge_ips", flattenEdgeIPs(application.EdgeIPs)); err != nil {
 			log.Printf("[WARN] Error setting Edge IPs on spectrum application %q: %s", d.Id(), err)
 		}
-		if err := d.Set("edge_ip_connectivity", application.EdgeIPs.Connectivity.String()); err != nil {
-			log.Printf("[WARN] Error setting Edge IP connectivity on spectrum application %q: %s", d.Id(), err)
+
+		if application.EdgeIPs.Connectivity != nil {
+			if err := d.Set("edge_ip_connectivity", application.EdgeIPs.Connectivity.String()); err != nil {
+				log.Printf("[WARN] Error setting Edge IP connectivity on spectrum application %q: %s", d.Id(), err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes a panic in `resourceCloudflareSpectrumApplicationRead` where `application.EdgeIPs.Connectivity` [could be nil](https://github.com/cloudflare/cloudflare-go/blob/09d35580ec7809ed09a3b12739426fb428c3871f/spectrum.go#L179). This is impacting our team from upgrading to the latest provider version. We were previously on: `v3.4.0`.

Relavent logs:
```
Stack trace from the terraform-provider-cloudflare_v3.14.0 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xba37c0]

goroutine 279 [running]:
github.com/cloudflare/terraform-provider-cloudflare/cloudflare.resourceCloudflareSpectrumApplicationRead(0xc00072e080, {0xdada00?, 0xc0004a8480})
        github.com/cloudflare/terraform-provider-cloudflare/cloudflare/resource_cloudflare_spectrum_application.go:116 +0x10e0
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xf05178?, {0xf05178?, 0xc00043f1d0?}, 0xd?, {0xdada00?, 0xc0004a8480?})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.14.0/helper/schema/resource.go:712 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000457340, {0xf05178, 0xc00043f1d0}, 0xc0004531e0, {0xdada00, 0xc0004a8480})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.14.0/helper/schema/resource.go:1015 +0x585
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc000187230, {0xf050d0?, 0xc00071b840?}, 0xc00071b8c0)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.14.0/helper/schema/grpc_provider.go:613 +0x497
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadResource(0xc000388a00, {0xf05178?, 0xc0004030e0?}, 0xc000791aa0)
        github.com/hashicorp/terraform-plugin-go@v0.9.0/tfprotov5/tf5server/server.go:746 +0x438
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler({0xd80140?, 0xc000388a00}, {0xf05178, 0xc0004030e0}, 0xc000791a40, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.9.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:349 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0001ae8c0, {0xf07c00, 0xc000374d00}, 0xc0008959e0, 0xc000460f60, 0x14002f0, 0x0)
        google.golang.org/grpc@v1.45.0/server.go:1282 +0xccf
google.golang.org/grpc.(*Server).handleStream(0xc0001ae8c0, {0xf07c00, 0xc000374d00}, 0xc0008959e0, 0x0)
        google.golang.org/grpc@v1.45.0/server.go:1619 +0xa1b
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        google.golang.org/grpc@v1.45.0/server.go:921 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.45.0/server.go:919 +0x28a

Error: The terraform-provider-cloudflare_v3.14.0 plugin crashed!
```

It appears this regression was introduced here: https://github.com/cloudflare/terraform-provider-cloudflare/pull/1515/files#diff-98e27307f62b90eef57324e5dfb984be43e94aa8fcec759596265dd981f168efR116