### PR TITLE
fix(#1360): Fix lifecycle of access_rule update

### DIFF
--- a/.changelog/1600.txt
+++ b/.changelog/1600.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_access_rule: Fix lifecycle of access_rule update
+```

--- a/cloudflare/schema_cloudflare_access_rule.go
+++ b/cloudflare/schema_cloudflare_access_rule.go
@@ -26,7 +26,7 @@ func resourceCloudflareAccessRuleSchema() map[string]*schema.Schema {
 			Type:             schema.TypeList,
 			MaxItems:         1,
 			Required:         true,
-                        ForceNew:         true,
+			ForceNew:         true,
 			DiffSuppressFunc: configurationDiffSuppress,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{

--- a/cloudflare/schema_cloudflare_access_rule.go
+++ b/cloudflare/schema_cloudflare_access_rule.go
@@ -26,18 +26,20 @@ func resourceCloudflareAccessRuleSchema() map[string]*schema.Schema {
 			Type:             schema.TypeList,
 			MaxItems:         1,
 			Required:         true,
-			ForceNew:         true,
+                        ForceNew:         true,
 			DiffSuppressFunc: configurationDiffSuppress,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"target": {
 						Type:         schema.TypeString,
 						Required:     true,
+						ForceNew:     true,
 						ValidateFunc: validation.StringInSlice([]string{"ip", "ip6", "ip_range", "asn", "country"}, false),
 					},
 					"value": {
 						Type:     schema.TypeString,
 						Required: true,
+						ForceNew: true,
 					},
 				},
 			},


### PR DESCRIPTION
According to documentation, to modify an existing Access Rule,
need to create a new Access Rule and delete the existing one.