### PR TITLE
fix(#1360): Fix lifecycle of access_rule update

### DIFF
--- a/.changelog/1601.txt
+++ b/.changelog/1601.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_access_rule: Fix lifecycle of access_rule update
+```

--- a/cloudflare/schema_cloudflare_access_rule.go
+++ b/cloudflare/schema_cloudflare_access_rule.go
@@ -33,11 +33,13 @@ func resourceCloudflareAccessRuleSchema() map[string]*schema.Schema {
 					"target": {
 						Type:         schema.TypeString,
 						Required:     true,
+						ForceNew:     true,
 						ValidateFunc: validation.StringInSlice([]string{"ip", "ip6", "ip_range", "asn", "country"}, false),
 					},
 					"value": {
 						Type:     schema.TypeString,
 						Required: true,
+						ForceNew: true,
 					},
 				},
 			},


### PR DESCRIPTION
According to documentation, to modify an existing Access Rule,
need to create a new Access Rule and delete the existing one.