### PR TITLE
add support for setting `frequency` on `cloudflare_logpush_job`

### DIFF
--- a/.changelog/1634.txt
+++ b/.changelog/1634.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_logpush_job: add support for specifying `frequency`
+```

--- a/cloudflare/resource_cloudflare_logpush_job.go
+++ b/cloudflare/resource_cloudflare_logpush_job.go
@@ -57,6 +57,7 @@ func getJobFromResource(d *schema.ResourceData) (cloudflare.LogpushJob, *AccessI
 		LogpullOptions:     d.Get("logpull_options").(string),
 		DestinationConf:    destConf,
 		OwnershipChallenge: ownershipChallenge,
+		Frequency:          d.Get("frequency").(string),
 	}
 
 	return job, identifier, nil
@@ -98,6 +99,7 @@ func resourceCloudflareLogpushJobRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("logpull_options", job.LogpullOptions)
 	d.Set("destination_conf", job.DestinationConf)
 	d.Set("ownership_challenge", d.Get("ownership_challenge"))
+	d.Set("frequency", job.Frequency)
 
 	return nil
 }

--- a/cloudflare/schema_cloudflare_logpush_job.go
+++ b/cloudflare/schema_cloudflare_logpush_job.go
@@ -42,5 +42,11 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"frequency": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "high",
+			ValidateFunc: validation.StringInSlice([]string{"high", "low"}, false),
+		},
 	}
 }

--- a/website/docs/r/logpush_job.html.markdown
+++ b/website/docs/r/logpush_job.html.markdown
@@ -19,6 +19,37 @@ have:
   `cloudflare_logpush_ownership_challenge` resource.
 - `cloudflare_logpush_job`: Create and manage the Logpush Job itself.
 
+
+## Example Usage (Cloudflare R2)
+
+When using Cloudflare R2, no ownership challenge is required.
+
+```hcl
+data "cloudflare_api_token_permission_groups" "all" {}
+
+resource "cloudflare_api_token" "logpush_r2_token" {
+  name = "logpush_r2_token"
+
+  policy {
+    permission_groups = [
+      data.cloudflare_api_token_permission_groups.all.permissions["Workers R2 Storage Write"],
+    ]
+    resources = {
+      "com.cloudflare.api.account.*" = "*"
+    }
+  }
+}
+
+resource "cloudflare_logpush_job" "http_requests" {
+  enabled          = true
+  zone_id          = var.zone_id
+  name             = "http_requests"
+  logpull_options  = "fields=ClientIP,ClientRequestHost,ClientRequestMethod,ClientRequestURI,EdgeEndTimestamp,EdgeResponseBytes,EdgeResponseStatus,EdgeStartTimestamp,RayID&timestamps=rfc3339"
+  destination_conf = "r2://cloudflare-logs/http_requests/date={DATE}?account-id=${var.account_id}&access-key-id=${cloudflare_api_token.logpush_r2_token.id}&secret-access-key=${sha256(cloudflare_api_token.logpush_r2_token.value)}"
+  dataset          = "http_requests"
+}
+```
+
 ## Example Usage (with AWS provider)
 
 Please see
@@ -74,6 +105,7 @@ resource "cloudflare_logpush_job" "example_job" {
   destination_conf = "s3://my-bucket-path?region=us-west-2"
   ownership_challenge = "0000000000000"
   dataset = "http_requests"
+  frequency = "high"
 }
 ```
 
@@ -92,6 +124,7 @@ The following arguments are supported:
 * `ownership_challenge` - (Optional) Ownership challenge token to prove destination ownership, required when destination is Amazon S3, Google Cloud Storage,
   Microsoft Azure or Sumo Logic. See [Developer documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#usage).
 * `enabled` - (Optional) Whether to enable the job.
+* `frequency` - (Optional) `"high"` or `"low"`. A higher frequency will result in logs being pushed on faster with smaller files. `"low"` frequency will push logs less often with larger files. 
 
 ## Import
 


### PR DESCRIPTION
Allows for setting the `frequency` on `cloudflare_logpush_job`'s. There are currently two valid choices, `high` and `low`.
These were added to `cloudflare/cloudflare-go` in https://github.com/cloudflare/cloudflare-go/pull/876