### PR TITLE
handle panic on parse workers kv id

### DIFF
--- a/.changelog/1635.txt
+++ b/.changelog/1635.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_workers_kv: handle invalid id during terraform import
+```


### PR DESCRIPTION
Currently the provider panics when an invalid id is used to import a `cloudflare_workers_kv` resource.

For example `e8b09ec03fe84a7db31416f050c1d75c_test` instead of `e8b09ec03fe84a7db31416f050c1d75c/test` will attempt to access an index out of range.

This change will throw an error explaining the issue and the id that is causing the panic instead of the provider panicking.