### PR TITLE
Waitingroom event bugfix

### DIFF
--- a/.changelog/1648.txt
+++ b/.changelog/1648.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_waiting_room_event: handle time pointer for nullable struct member
+```

--- a/internal/provider/resource_cloudflare_waiting_room_event.go
+++ b/internal/provider/resource_cloudflare_waiting_room_event.go
@@ -56,7 +56,7 @@ func expandWaitingRoomEvent(d *schema.ResourceData) (cloudflare.WaitingRoomEvent
 		Name:                  d.Get("name").(string),
 		EventStartTime:        eventStartTime,
 		EventEndTime:          eventEndTime,
-		PrequeueStartTime:     &prequeueStartTime,
+		PrequeueStartTime:     prequeueStartTime,
 		Description:           d.Get("description").(string),
 		QueueingMethod:        d.Get("queueing_method").(string),
 		ShuffleAtEventStart:   d.Get("shuffle_at_event_start").(bool),

--- a/internal/provider/resource_cloudflare_waiting_room_event.go
+++ b/internal/provider/resource_cloudflare_waiting_room_event.go
@@ -45,14 +45,13 @@ func expandWaitingRoomEvent(d *schema.ResourceData) (cloudflare.WaitingRoomEvent
 	var prequeueStartTime *time.Time
 	if t, ok := d.GetOk("prequeue_start_time"); ok {
 		prequeueStartTimeValue, err := time.Parse(time.RFC3339, t.(string))
-		prequeueStartTime = &prequeueStartTimeValue
+		prequeueStartTime = cloudflare.TimePtr(prequeueStartTimeValue)
 		if err != nil {
 			return cloudflare.WaitingRoomEvent{}, err
 		}
 	}
 
 	return cloudflare.WaitingRoomEvent{
-		ID:                    d.Id(),
 		Name:                  d.Get("name").(string),
 		EventStartTime:        eventStartTime,
 		EventEndTime:          eventEndTime,
@@ -147,6 +146,7 @@ func resourceCloudflareWaitingRoomEventRead(ctx context.Context, d *schema.Resou
 
 func resourceCloudflareWaitingRoomEventUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
+	waitingRoomEventID := d.Id()
 	waitingRoomID := d.Get("waiting_room_id").(string)
 	zoneID := d.Get("zone_id").(string)
 	waitingRoomEventName := d.Get("name").(string)
@@ -154,6 +154,7 @@ func resourceCloudflareWaitingRoomEventUpdate(ctx context.Context, d *schema.Res
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error building waiting room event %q: %w", waitingRoomEventName, err))
 	}
+	waitingRoomEvent.ID = waitingRoomEventID
 
 	_, err = client.ChangeWaitingRoomEvent(ctx, zoneID, waitingRoomID, waitingRoomEvent)
 

--- a/internal/provider/resource_cloudflare_waiting_room_event.go
+++ b/internal/provider/resource_cloudflare_waiting_room_event.go
@@ -42,15 +42,17 @@ func expandWaitingRoomEvent(d *schema.ResourceData) (cloudflare.WaitingRoomEvent
 		return cloudflare.WaitingRoomEvent{}, err
 	}
 
-	prequeueStartTime := time.Time{}
+	var prequeueStartTime *time.Time
 	if t, ok := d.GetOk("prequeue_start_time"); ok {
-		prequeueStartTime, err = time.Parse(time.RFC3339, t.(string))
+		prequeueStartTimeValue, err := time.Parse(time.RFC3339, t.(string))
+		prequeueStartTime = &prequeueStartTimeValue
 		if err != nil {
 			return cloudflare.WaitingRoomEvent{}, err
 		}
 	}
 
 	return cloudflare.WaitingRoomEvent{
+		ID:                    d.Id(),
 		Name:                  d.Get("name").(string),
 		EventStartTime:        eventStartTime,
 		EventEndTime:          eventEndTime,

--- a/internal/provider/resource_cloudflare_waiting_room_event.go
+++ b/internal/provider/resource_cloudflare_waiting_room_event.go
@@ -110,7 +110,7 @@ func resourceCloudflareWaitingRoomEventRead(ctx context.Context, d *schema.Resou
 	d.Set("event_end_time", waitingRoomEvent.EventEndTime.Format(time.RFC3339))
 	d.Set("session_duration", waitingRoomEvent.SessionDuration)
 
-	if !waitingRoomEvent.PrequeueStartTime.IsZero() {
+	if waitingRoomEvent.PrequeueStartTime != nil {
 		d.Set("prequeue_start_time", waitingRoomEvent.PrequeueStartTime.Format(time.RFC3339))
 	}
 


### PR DESCRIPTION
- Set ID on waiting room event expansion. 
cloudflare-go uses the id in the struct to create the path for the API request so it must be set. (https://github.com/cloudflare/cloudflare-go/blob/master/waiting_room.go#L342) 
- Propagating changes to use time pointer for PrequeueStartTime. (https://github.com/cloudflare/cloudflare-go/pull/878)