### PR TITLE
Fix Go module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cloudflare/terraform-provider-cloudflare
+module github.com/cloudflare/terraform-provider-cloudflare/v3
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/provider"
+	"github.com/cloudflare/terraform-provider-cloudflare/v3/internal/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 


### PR DESCRIPTION
The following commands are failing:
`go get github.com/cloudflare/terraform-provider-cloudflare@v3.15.0`
`go get github.com/cloudflare/terraform-provider-cloudflare/v3@v3.15.0`

For both you get:
`go: github.com/cloudflare/terraform-provider-cloudflare@v3.15.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/cloudflare/terraform-provider-cloudflare/v3")`

[The manual says](https://therootcompany.com/blog/bump-go-package-to-v2/) that you must change a package name to make it work.