### PR TITLE
Require block vs argument

### DIFF
--- a/website/docs/r/access_group.html.markdown
+++ b/website/docs/r/access_group.html.markdown
@@ -35,7 +35,7 @@ resource "cloudflare_access_group" "test_group" {
     email = ["test@example.com"]
   }
 
-  require = {
+  require {
     ip = [var.office_ip]
   }
 }


### PR DESCRIPTION
Fixes error in example:
An argument named "require" is not expected here. Did you mean to define a block of type "require"?