### PR TITLE
tools: update existing changelog missing comments if present

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,7 +1,5 @@
 name: Changelog check
-on:
-  pull_request_target:
-    types: [opened]
+on: [pull_request]
 
 jobs:
   changelog-check:

--- a/tools/cmd/changelog-check/main.go
+++ b/tools/cmd/changelog-check/main.go
@@ -6,7 +6,9 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
 )
@@ -14,6 +16,7 @@ import (
 const (
 	changelogEntryFileFormat      = ".changelog/%d.txt"
 	changelogProcessDocumentation = "https://github.com/cloudflare/terraform-provider-cloudflare/blob/master/contributing/changelog-process.md"
+	changelogDetectedMessage      = "changelog detected :white_check_mark:"
 )
 
 var (
@@ -83,21 +86,38 @@ func main() {
 		}
 	}
 
-	if changelogEntryPresent {
-		log.Printf("changelog found for %d, skipping remainder of checks\n", prNo)
-		os.Exit(0)
+	comments, _, _ := client.Issues.ListComments(ctx, owner, repo, prNo, &github.IssueListCommentsOptions{})
+	for _, comment := range comments {
+		if strings.Contains(comment.GetBody(), "no changelog entry is attached to") {
+			if changelogEntryPresent {
+				client.Issues.EditComment(ctx, owner, repo, *comment.ID, &github.IssueComment{
+					Body: cloudflare.StringPtr(changelogDetectedMessage),
+				})
+				os.Exit(0)
+			}
+			log.Println("no change in status of changelog checks; exiting")
+			os.Exit(1)
+		}
 	}
 
-	body := "Oops! It looks like no changelog entry is attached to" +
-		" this PR. Please include a release note as described in " +
-		changelogProcessDocumentation + ".\n\nExample: " +
-		"\n\n~~~\n```release-note:TYPE\nRelease note" +
-		"\n```\n~~~\n\n" +
-		"If you do not require a release note to be included, please add the `workflow/skip-changelog-entry` label."
+	// if changelogEntryPresent {
+	// 	_, _, _ = client.Issues.CreateComment(ctx, owner, repo, prNo, &github.IssueComment{
+	// 		Body: cloudflare.StringPtr(changelogDetectedMessage),
+	// 	})
+	// 	log.Printf("changelog found for %d, skipping remainder of checks\n", prNo)
+	// 	os.Exit(0)
+	// }
 
-	_, _, _ = client.Issues.CreateComment(ctx, owner, repo, prNo, &github.IssueComment{
-		Body: &body,
-	})
+	// body := "Oops! It looks like no changelog entry is attached to" +
+	// 	" this PR. Please include a release note as described in " +
+	// 	changelogProcessDocumentation + ".\n\nExample: " +
+	// 	"\n\n~~~\n```release-note:TYPE\nRelease note" +
+	// 	"\n```\n~~~\n\n" +
+	// 	"If you do not require a release note to be included, please add the `workflow/skip-changelog-entry` label."
+
+	// _, _, _ = client.Issues.CreateComment(ctx, owner, repo, prNo, &github.IssueComment{
+	// 	Body: &body,
+	// })
 
 	os.Exit(1)
 }

--- a/tools/cmd/maintainer-only-file-check/main.go
+++ b/tools/cmd/maintainer-only-file-check/main.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	maintainers         = []string{"dependabot[bot]", "jacobbednarz", "patryk"}
-	goDependencyMessage = "This project handles dependency version bumps (including upstream changes from cloudflare-go) independently of the standard PR process using automation. This allows the dependency upgrades to land without causing merge conflicts in multiple branches and handled in a consistent way. The exception to this is security related dependency upgrades but they should be co-ordinated with the maintainer team privately.\n\nPlease remove the changes to the go.mod or go.sum files from this PR in order to proceed with review and merging."
+	goDependencyMessage = "This project handles dependency version bumps (including upstream changes from cloudflare-go) independently of the standard PR process using automation. This allows the dependency upgrades to land without causing merge conflicts in multiple branches and handled in a consistent way. The exception to this is security related dependency upgrades but they should be co-ordinated with the maintainer team privately.\n\nPlease remove the changes to the `go.mod` or `go.sum` files from this PR in order to proceed with review and merging."
 	changelogMessage    = "This pull request contains a CHANGELOG.md file which should only be modified by maintainers.\n\nIf you are looking to include a CHANGELOG entry, you should use the process documented at https://github.com/cloudflare/terraform-provider-cloudflare/blob/master/contributing/changelog-process.md instead.\n\nIn order for this pull request to be merged, you need remove the modifications to CHANGELOG.md."
 )
 


### PR DESCRIPTION
Updates the changelog checker to update the existing comment should a
changelog entry be found on subsequent runs to avoid confusion with it
hanging around after changes being made.