### PR TITLE
LogpushJob.Filter is optional

### DIFF
--- a/.changelog/1712.txt
+++ b/.changelog/1712.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_logpush_job: Fix for optional `filter` attribute
+```

--- a/internal/provider/resource_cloudflare_logpush_job.go
+++ b/internal/provider/resource_cloudflare_logpush_job.go
@@ -81,7 +81,7 @@ func getJobFromResource(d *schema.ResourceData) (cloudflare.LogpushJob, *AccessI
 		if err != nil {
 			return job, identifier, err
 		}
-		job.Filter = jobFilter
+		job.Filter = &jobFilter
 	}
 
 	return job, identifier, nil
@@ -118,13 +118,15 @@ func resourceCloudflareLogpushJobRead(ctx context.Context, d *schema.ResourceDat
 		return nil
 	}
 
-	if job.Filter.Where.Validate() == nil {
-		filterstr, err := json.Marshal(job.Filter)
+	var filter string
+
+	if job.Filter != nil {
+		b, err := json.Marshal(job.Filter)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 
-		d.Set("filter", string(filterstr))
+		filter = string(b)
 	}
 
 	d.Set("name", job.Name)
@@ -133,6 +135,7 @@ func resourceCloudflareLogpushJobRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("destination_conf", job.DestinationConf)
 	d.Set("ownership_challenge", d.Get("ownership_challenge"))
 	d.Set("frequency", job.Frequency)
+	d.Set("filter", filter)
 
 	return nil
 }


### PR DESCRIPTION
> **Note** depends on the new release of cloudflare-go

this PR changes the usage of LogpushJob.Filter after the fix in cloudflare/cloudflare-go#937

* set pointer instead of copying struct to create LogpushJob from resource
* check nil pointer when creating resource from LogpushJob
