### PR TITLE
resource_cloudflare_record: Add DiffSuppressFunc to value param

### DIFF
--- a/.changelog/1713.txt
+++ b/.changelog/1713.txt
@@ -1,0 +1,3 @@
+``release-note:enhancement
+resource/cloudflare_record: ensure trailing `.` in `value` don't cause surious diffs
+```

--- a/internal/provider/schema_cloudflare_record.go
+++ b/internal/provider/schema_cloudflare_record.go
@@ -42,6 +42,9 @@ func resourceCloudflareRecordSchema() map[string]*schema.Schema {
 			Optional:      true,
 			Computed:      true,
 			ConflictsWith: []string{"data"},
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				return strings.TrimSuffix(old, ".") == strings.TrimSuffix(new, ".")
+			},
 		},
 
 		"data": {


### PR DESCRIPTION
Fixes: #154

When a trailing period is passed to the cloudflare_record resource,
we get a perpetual diff that looks as follows:

```
~ value: "_dbdxxx05384ca.hnyhpvdqhv.acm-validations.aws" => "_dbdxxxf205384ca.hnyhpvdqhv.acm-validations.aws."
```

We should ensure that we are adhering to the following RFCs where it
states that an FQDN can have a trailing `.`

Therefore, we can now use a DiffSuppressFunc to check that the old
value with the final `.` removed and the new value with the `.`
removed are the same and if they are then we don't need to cause a
diff