### PR TITLE
validate logpush job name

### DIFF
--- a/.changelog/1717.txt
+++ b/.changelog/1717.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_logpush_job: validate name attribute
+```

--- a/internal/provider/schema_cloudflare_logpush_job.go
+++ b/internal/provider/schema_cloudflare_logpush_job.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -27,9 +28,10 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 			Description: "Whether to enable the job.",
 		},
 		"name": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "The name of the logpush job to create. Must match the regular expression `^[a-zA-Z0-9\\-\\.]*$`.",
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9.-]+$`), "must contain only alphanumeric characters, hyphens, and periods"),
+			Description:  "The name of the logpush job to create.",
 		},
 		"dataset": {
 			Type:         schema.TypeString,


### PR DESCRIPTION
when terraforming a `cloudflare_logpush_job` an invalid `name` attribute will successfully plan, but fail to apply

this PR adds validation using the appropriate regex so that it can be caught during plan instead
