### PR TITLE
support for cloudflare_logpush_job kind attribute

### DIFF
--- a/.changelog/1718.txt
+++ b/.changelog/1718.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_logpush_job: adds support for `kind` attribute
+```

--- a/internal/provider/resource_cloudflare_logpush_job.go
+++ b/internal/provider/resource_cloudflare_logpush_job.go
@@ -63,6 +63,7 @@ func getJobFromResource(d *schema.ResourceData) (cloudflare.LogpushJob, *AccessI
 	job := cloudflare.LogpushJob{
 		ID:                 id,
 		Enabled:            d.Get("enabled").(bool),
+		Kind:               d.Get("kind").(string),
 		Name:               d.Get("name").(string),
 		Dataset:            d.Get("dataset").(string),
 		LogpullOptions:     d.Get("logpull_options").(string),
@@ -130,6 +131,7 @@ func resourceCloudflareLogpushJobRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	d.Set("name", job.Name)
+	d.Set("kind", job.Kind)
 	d.Set("enabled", job.Enabled)
 	d.Set("logpull_options", job.LogpullOptions)
 	d.Set("destination_conf", job.DestinationConf)

--- a/internal/provider/schema_cloudflare_logpush_job.go
+++ b/internal/provider/schema_cloudflare_logpush_job.go
@@ -27,6 +27,12 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Whether to enable the job.",
 		},
+		"kind": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"edge", "instant-logs", ""}, false),
+			Description:  `The kind of logpush job to create. Valid values are "edge", "instant-logs", or "".`,
+		},
 		"name": {
 			Type:         schema.TypeString,
 			Optional:     true,

--- a/internal/provider/schema_cloudflare_logpush_job.go
+++ b/internal/provider/schema_cloudflare_logpush_job.go
@@ -31,7 +31,7 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Optional:     true,
 			ValidateFunc: validation.StringInSlice([]string{"edge", "instant-logs", ""}, false),
-			Description:  `The kind of logpush job to create. Valid values are "edge", "instant-logs", or "".`,
+			Description:  fmt.Sprintf("The kind of logpush job to create. %s", renderAvailableDocumentationValuesStringSlice([]string{"edge", "instant-logs", ""})),
 		},
 		"name": {
 			Type:         schema.TypeString,


### PR DESCRIPTION
depends on cloudflare/cloudflare-go#936 ~- which is awaiting public api (documentation)~

adds the `kind` attribute to the `cloudflare_logpush_job` resource