### PR TITLE
Handle missing/empty filter in terraform

### DIFF
--- a/.changelog/1723.txt
+++ b/.changelog/1723.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_logpush_job: fix unmarhalling job with empty/no filter
+```

--- a/internal/provider/resource_cloudflare_logpush_job.go
+++ b/internal/provider/resource_cloudflare_logpush_job.go
@@ -72,7 +72,7 @@ func getJobFromResource(d *schema.ResourceData) (cloudflare.LogpushJob, *AccessI
 	}
 
 	filter := d.Get("filter")
-	if filter != nil {
+	if filter != "" {
 		var jobFilter cloudflare.LogpushJobFilters
 		if err := json.Unmarshal([]byte(filter.(string)), &jobFilter); err != nil {
 			return cloudflare.LogpushJob{}, identifier, err


### PR DESCRIPTION
in addition to the previous fix for marshalling an empty filter (in cloudflare-go), the terraform provider needs to be fixed for a different problem 

the current implementation attempts to unmarshal an empty string as JSON - which fails

the Get will return "", so we test that instead
