### PR TITLE
update waitingroom parameter defaults

### DIFF
--- a/.changelog/1766.txt
+++ b/.changelog/1766.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_waiting_room: Fix default waiting room session duration and path
+```

--- a/.changelog/1766.txt
+++ b/.changelog/1766.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/cloudflare_waiting_room: Fix default waiting room session duration and path
+resource/cloudflare_waiting_room: fix default waiting room `session_duration` and `path` values
 ```

--- a/docs/resources/waiting_room.md
+++ b/docs/resources/waiting_room.md
@@ -40,10 +40,10 @@ resource "cloudflare_waiting_room" "example" {
 - `description` (String) A description to add more details about the waiting room.
 - `disable_session_renewal` (Boolean) Disables automatic renewal of session cookies.
 - `json_response_enabled` (Boolean) If true, requests to the waiting room with the header `Accept: application/json` will receive a JSON response object.
-- `path` (String) The path within the host to enable the waiting room on.
+- `path` (String) The path within the host to enable the waiting room on. Defaults to `/`.
 - `queue_all` (Boolean) If queue_all is true, then all traffic will be sent to the waiting room.
 - `queueing_method` (String) The queueing method used by the waiting room. Available values: `fifo`, `random`, `passthrough`, `reject`. Defaults to `fifo`.
-- `session_duration` (Number) Lifetime of a cookie (in minutes) set by Cloudflare for users who get access to the origin.
+- `session_duration` (Number) Lifetime of a cookie (in minutes) set by Cloudflare for users who get access to the origin. Defaults to `5`.
 - `suspended` (Boolean) Suspends the waiting room.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/internal/provider/schema_cloudflare_waiting_room.go
+++ b/internal/provider/schema_cloudflare_waiting_room.go
@@ -64,6 +64,7 @@ func resourceCloudflareWaitingRoomSchema() map[string]*schema.Schema {
 			Description: "The path within the host to enable the waiting room on.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Default:     "/",
 		},
 
 		"total_active_users": {
@@ -128,6 +129,7 @@ func resourceCloudflareWaitingRoomSchema() map[string]*schema.Schema {
 			Description: "Lifetime of a cookie (in minutes) set by Cloudflare for users who get access to the origin.",
 			Type:        schema.TypeInt,
 			Optional:    true,
+			Default:     5,
 		},
 
 		"json_response_enabled": {


### PR DESCRIPTION
Update Waiting Room default values for some parameters.
This prevents constant state drift when a parameter isn't set. 