### PR TITLE
Log zoneID as d.Get(zone) might return nil

### DIFF
--- a/.changelog/1777.txt
+++ b/.changelog/1777.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_zone_lockdown: Fix crash when logging upstream error message
+```

--- a/internal/provider/resource_cloudflare_zone_lockdown.go
+++ b/internal/provider/resource_cloudflare_zone_lockdown.go
@@ -147,7 +147,7 @@ func resourceCloudflareZoneLockdownUpdate(ctx context.Context, d *schema.Resourc
 	r, err := client.UpdateZoneLockdown(ctx, zoneID, d.Id(), newZoneLockdown)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating zone lockdown for zone %q: %w", d.Get("zone").(string), err))
+		return diag.FromErr(fmt.Errorf("error updating zone lockdown for zone %q: %w", zoneID, err))
 	}
 
 	if r.Result.ID == "" {


### PR DESCRIPTION
This should fix https://github.com/cloudflare/terraform-provider-cloudflare/issues/1776 where the provider crashes when an error is encountered.