### PR TITLE
remove healthcheck notification properties

### DIFF
--- a/.changelog/1789.txt
+++ b/.changelog/1789.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/cloudflare_healthcheck: deprecates `notification_email_addresses` and `notification_suspended` in favour of `cloudflare_notification_policy`
+```

--- a/docs/resources/healthcheck.md
+++ b/docs/resources/healthcheck.md
@@ -89,8 +89,6 @@ resource "cloudflare_healthcheck" "tcp_health_check" {
 - `header` (Block Set) The HTTP request headers to send in the health check. It is recommended you set a Host header by default. The User-Agent header cannot be overridden. (see [below for nested schema](#nestedblock--header))
 - `interval` (Number) The interval between each health check. Shorter intervals may give quicker notifications if the origin status changes, but will increase the load on the origin as we check from multiple locations. Defaults to `60`.
 - `method` (String) The HTTP method to use for the health check. Available values: `connection_established`, `GET`, `HEAD`.
-- `notification_email_addresses` (List of String, Deprecated) A list of email addresses we want to send the notifications to. Deprecated, use cloudflare_notification_policy instead.
-- `notification_suspended` (Boolean, Deprecated) Whether the notifications are suspended or not. Useful for maintenance periods. Defaults to `false`.
 - `path` (String) The endpoint path to health check against. Defaults to `/`.
 - `port` (Number) Port number to connect to for the health check. Defaults to `80`.
 - `retries` (Number) The number of retries to attempt in case of a timeout before marking the origin as unhealthy. Retries are attempted immediately. Defaults to `2`.

--- a/internal/provider/resource_cloudflare_healthcheck.go
+++ b/internal/provider/resource_cloudflare_healthcheck.go
@@ -59,7 +59,6 @@ func resourceCloudflareHealthcheckRead(ctx context.Context, d *schema.ResourceDa
 		d.Set("expected_body", healthcheck.HTTPConfig.ExpectedBody)
 		d.Set("follow_redirects", healthcheck.HTTPConfig.FollowRedirects)
 		d.Set("allow_insecure", healthcheck.HTTPConfig.AllowInsecure)
-		d.Set("notification_email_addresses", healthcheck.Notification.EmailAddresses)
 
 		if err := d.Set("header", flattenHealthcheckHeader(healthcheck.HTTPConfig.Header)); err != nil {
 			tflog.Warn(ctx, fmt.Sprintf("Error setting header for standalone healthcheck %q: %s", d.Id(), err))
@@ -69,7 +68,6 @@ func resourceCloudflareHealthcheckRead(ctx context.Context, d *schema.ResourceDa
 	d.Set("name", healthcheck.Name)
 	d.Set("description", healthcheck.Description)
 	d.Set("suspended", healthcheck.Suspended)
-	d.Set("notification_suspended", healthcheck.Notification.Suspended)
 	d.Set("address", healthcheck.Address)
 	d.Set("consecutive_fails", healthcheck.ConsecutiveFails)
 	d.Set("consecutive_successes", healthcheck.ConsecutiveSuccesses)
@@ -184,14 +182,6 @@ func healthcheckSetStruct(d *schema.ResourceData) (cloudflare.Healthcheck, error
 
 	if region, ok := d.GetOk("check_regions"); ok {
 		healthcheck.CheckRegions = expandInterfaceToStringList(region)
-	}
-
-	if notificationSuspended, ok := d.GetOk("notification_suspended"); ok {
-		healthcheck.Notification.Suspended = notificationSuspended.(bool)
-	}
-
-	if notificationEmailAddresses, ok := d.GetOk("notification_email_addresses"); ok {
-		healthcheck.Notification.EmailAddresses = expandInterfaceToStringList(notificationEmailAddresses)
 	}
 
 	switch healthcheck.Type {

--- a/internal/provider/schema_cloudflare_healthcheck.go
+++ b/internal/provider/schema_cloudflare_healthcheck.go
@@ -153,22 +153,6 @@ func resourceCloudflareHealthcheckSchema() map[string]*schema.Schema {
 				},
 			},
 		},
-		"notification_suspended": {
-			Description: "Whether the notifications are suspended or not. Useful for maintenance periods.",
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Deprecated:  "Use `cloudflare_notification_policy` instead.",
-		},
-		"notification_email_addresses": {
-			Description: "A list of email addresses we want to send the notifications to. Deprecated, use cloudflare_notification_policy instead.",
-			Type:        schema.TypeList,
-			Optional:    true,
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-			Deprecated: "Use `cloudflare_notification_policy` instead.",
-		},
 		"created_on": {
 			Description: "Creation time.",
 			Type:        schema.TypeString,


### PR DESCRIPTION
Remove `notification_email_addresses` and `notification_suspended` properties from `cloudflare_healthcheck` to finish legacy notification deprecation.