### PR TITLE
Adds API Token TTL

### DIFF
--- a/.changelog/1792.txt
+++ b/.changelog/1792.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_api_token: add support for `not_before` and `expires_on`
+```

--- a/examples/resources/cloudflare_api_token/resource.tf
+++ b/examples/resources/cloudflare_api_token/resource.tf
@@ -13,6 +13,8 @@ resource "cloudflare_api_token" "api_token_create" {
     resources = {
       "com.cloudflare.api.user.${var.user_id}" = "*"
     }
+    not_before = "2018-07-01T05:20:00Z"
+    expires_on = "2020-01-01T00:00:00Z"
   }
 
   condition {

--- a/internal/provider/resource_cloudflare_api_token.go
+++ b/internal/provider/resource_cloudflare_api_token.go
@@ -168,8 +168,14 @@ func resourceCloudflareApiTokenRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("status", t.Status)
 	d.Set("issued_on", t.IssuedOn.Format(time.RFC3339Nano))
 	d.Set("modified_on", t.ModifiedOn.Format(time.RFC3339Nano))
-	d.Set("expires_on", t.ExpiresOn.Format(time.RFC3339Nano))
-	d.Set("not_before", t.ExpiresOn.Format(time.RFC3339Nano))
+
+	if t.ExpiresOn != nil {
+		d.Set("expires_on", t.ExpiresOn.Format(time.RFC3339Nano))
+	}
+
+	if t.NotBefore != nil {
+		d.Set("not_before", t.NotBefore.Format(time.RFC3339Nano))
+	}
 
 	var ipIn []string
 	var ipNotIn []string
@@ -203,7 +209,7 @@ func resourceCloudflareApiTokenUpdate(ctx context.Context, d *schema.ResourceDat
 
 	tflog.Info(ctx, fmt.Sprintf("Updating Cloudflare API Token: name %s", name))
 
-	t, err := client.UpdateAPIToken(ctx, tokenID, t)
+	_, err := client.UpdateAPIToken(ctx, tokenID, t)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Cloudflare API Token %q: %w", name, err))
 	}

--- a/internal/provider/resource_cloudflare_api_token.go
+++ b/internal/provider/resource_cloudflare_api_token.go
@@ -60,9 +60,14 @@ func buildAPIToken(d *schema.ResourceData) cloudflare.APIToken {
 			token.Condition.RequestIP.NotIn = ipsNotIn
 		}
 	}
-
-	token.NotBefore = d.Get("not_before").(*time.Time) 
-	token.ExpiresOn = d.Get("expires_on").(*time.Time)
+	if before, ok := d.GetOk("not_before"); ok {
+		notBefore, _ := time.Parse(time.RFC3339Nano, before.(string))
+		token.NotBefore = &notBefore
+	}
+	if expires, ok := d.GetOk("not_before"); ok {
+		expiresOn, _ := time.Parse(time.RFC3339Nano, expires.(string))
+		token.ExpiresOn = &expiresOn
+	}
 
 	return token
 }

--- a/internal/provider/resource_cloudflare_api_token.go
+++ b/internal/provider/resource_cloudflare_api_token.go
@@ -64,7 +64,7 @@ func buildAPIToken(d *schema.ResourceData) cloudflare.APIToken {
 		notBefore, _ := time.Parse(time.RFC3339Nano, before.(string))
 		token.NotBefore = &notBefore
 	}
-	if expires, ok := d.GetOk("not_before"); ok {
+	if expires, ok := d.GetOk("expires_on"); ok {
 		expiresOn, _ := time.Parse(time.RFC3339Nano, expires.(string))
 		token.ExpiresOn = &expiresOn
 	}

--- a/internal/provider/resource_cloudflare_api_token.go
+++ b/internal/provider/resource_cloudflare_api_token.go
@@ -61,6 +61,9 @@ func buildAPIToken(d *schema.ResourceData) cloudflare.APIToken {
 		}
 	}
 
+	token.NotBefore = d.Get("not_before").(*time.Time) 
+	token.ExpiresOn = d.Get("expires_on").(*time.Time)
+
 	return token
 }
 
@@ -160,6 +163,8 @@ func resourceCloudflareApiTokenRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("status", t.Status)
 	d.Set("issued_on", t.IssuedOn.Format(time.RFC3339Nano))
 	d.Set("modified_on", t.ModifiedOn.Format(time.RFC3339Nano))
+	d.Set("expires_on", t.ExpiresOn.Format(time.RFC3339Nano))
+	d.Set("not_before", t.ExpiresOn.Format(time.RFC3339Nano))
 
 	var ipIn []string
 	var ipNotIn []string

--- a/internal/provider/resource_cloudflare_api_token_test.go
+++ b/internal/provider/resource_cloudflare_api_token_test.go
@@ -293,7 +293,7 @@ func testAccCloudflareAPITokenWithTTL(rnd string, permissionID string) string {
 			resources = { "com.cloudflare.api.account.zone.*" = "*" }
 		}
 
-		not_before = "2018-07-01T05:20:00Z"
+		not_before = "2018-07-01"
 		expires_on = "2020-01-01T00:00:00Z"
 	}
 `, rnd, permissionID)

--- a/internal/provider/resource_cloudflare_api_token_test.go
+++ b/internal/provider/resource_cloudflare_api_token_test.go
@@ -275,7 +275,7 @@ func TestAccAPIToken_TokenTTL(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "not_before", "2018-07-01T05:20:00Z"),
-					resource.TestCheckResourceAttr(name, "expires_on", "2020-01-01T00:00:00Z"),
+					resource.TestCheckResourceAttr(name, "expires_on", "2032-01-01T00:00:00Z"),
 				),
 			},
 		},
@@ -294,7 +294,7 @@ func testAccCloudflareAPITokenWithTTL(rnd string, permissionID string) string {
 		}
 
 		not_before = "2018-07-01T05:20:00Z"
-		expires_on = "2020-01-01T00:00:00Z"
+		expires_on = "2032-01-01T00:00:00Z"
 	}
 `, rnd, permissionID)
 }

--- a/internal/provider/resource_cloudflare_api_token_test.go
+++ b/internal/provider/resource_cloudflare_api_token_test.go
@@ -293,7 +293,7 @@ func testAccCloudflareAPITokenWithTTL(rnd string, permissionID string) string {
 			resources = { "com.cloudflare.api.account.zone.*" = "*" }
 		}
 
-		not_before = "2018-07-01"
+		not_before = "2018-07-01T05:20:00Z"
 		expires_on = "2020-01-01T00:00:00Z"
 	}
 `, rnd, permissionID)

--- a/internal/provider/resource_cloudflare_api_token_test.go
+++ b/internal/provider/resource_cloudflare_api_token_test.go
@@ -251,3 +251,50 @@ func testAPITokenConfigAllowDeny(resourceID, permissionID, zoneID string, allowA
 		}
 		`, resourceID, permissionID, add)
 }
+
+func TestAccAPIToken_TokenTTL(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
+	// endpoint does not yet support the API tokens without an explicit scope.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		defer func(apiToken string) {
+			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
+		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
+		os.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := generateRandomResourceName()
+	name := "cloudflare_api_token." + rnd
+	permissionID := "82e64a83756745bbbb1c9c2701bf816b" // DNS read
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareAPITokenWithTTL(rnd, permissionID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "not_before", "2018-07-01T05:20:00Z"),
+					resource.TestCheckResourceAttr(name, "expires_on", "2020-01-01T00:00:00Z"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareAPITokenWithTTL(rnd string, permissionID string) string {
+	return fmt.Sprintf(`
+	resource "cloudflare_api_token" "%[1]s" {
+		name = "%[1]s"
+
+		policy {
+			effect = "allow"
+			permission_groups = [ "%[2]s" ]
+			resources = { "com.cloudflare.api.account.zone.*" = "*" }
+		}
+
+		not_before = "2018-07-01T05:20:00Z"
+		expires_on = "2020-01-01T00:00:00Z"
+	}
+`, rnd, permissionID)
+}

--- a/internal/provider/schema_cloudflare_api_token.go
+++ b/internal/provider/schema_cloudflare_api_token.go
@@ -77,6 +77,18 @@ func resourceCloudflareApiTokenSchema() map[string]*schema.Schema {
 				},
 			},
 		},
+		"not_before": {
+			Type: schema.TypeString,
+			ValidateFunc: validation.IsRFC3339Time,
+			Description: "The time before which the token MUST NOT be accepted for processing",
+			Optional: true,
+		},
+		"expires_on": {
+			Type: schema.TypeString,
+			ValidateFunc: validation.IsRFC3339Time,
+			Description: "The expiration time on or after which the token MUST NOT be accepted for processing",
+			Optional: true,
+		},
 		"value": {
 			Type:        schema.TypeString,
 			Computed:    true,

--- a/internal/provider/schema_cloudflare_api_token.go
+++ b/internal/provider/schema_cloudflare_api_token.go
@@ -78,16 +78,16 @@ func resourceCloudflareApiTokenSchema() map[string]*schema.Schema {
 			},
 		},
 		"not_before": {
-			Type: schema.TypeString,
+			Type:         schema.TypeString,
 			ValidateFunc: validation.IsRFC3339Time,
-			Description: "The time before which the token MUST NOT be accepted for processing",
-			Optional: true,
+			Description:  "The time before which the token MUST NOT be accepted for processing",
+			Optional:     true,
 		},
 		"expires_on": {
-			Type: schema.TypeString,
+			Type:         schema.TypeString,
 			ValidateFunc: validation.IsRFC3339Time,
-			Description: "The expiration time on or after which the token MUST NOT be accepted for processing",
-			Optional: true,
+			Description:  "The expiration time on or after which the token MUST NOT be accepted for processing",
+			Optional:     true,
 		},
 		"value": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
Adds the ability to set `not_before` and `expires_on` when creating API Tokens.

Resolves #1603