### PR TITLE
Fetch/modify `origin_max_http_version` as a single setting

### DIFF
--- a/.changelog/1805.txt
+++ b/.changelog/1805.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_zone_settings_override: Fetch/modify `origin_max_http_version` as a single setting.
+```

--- a/internal/provider/resource_cloudflare_zone_settings_override.go
+++ b/internal/provider/resource_cloudflare_zone_settings_override.go
@@ -31,6 +31,7 @@ var fetchAsSingleSetting = []string{
 	"h2_prioritization",
 	"image_resizing",
 	"early_hints",
+	"origin_max_http_version",
 }
 
 func resourceCloudflareZoneSettingsOverrideCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/resource_cloudflare_zone_settings_override_test.go
+++ b/internal/provider/resource_cloudflare_zone_settings_override_test.go
@@ -38,6 +38,7 @@ func TestAccCloudflareZoneSettingsOverride_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "settings.0.security_level", "high"),
 					resource.TestCheckResourceAttr(name, "settings.0.early_hints", "on"),
 					resource.TestCheckResourceAttr(name, "settings.0.h2_prioritization", "on"),
+					resource.TestCheckResourceAttr(name, "settings.0.origin_max_http_version", "2"),
 					resource.TestCheckResourceAttr(name, "settings.0.zero_rtt", "off"),
 					resource.TestCheckResourceAttr(name, "settings.0.universal_ssl", "off"),
 					resource.TestCheckResourceAttr(name, "settings.0.ciphers.#", "2"),
@@ -201,6 +202,7 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
 		opportunistic_encryption = "on"
 		automatic_https_rewrites = "on"
 		h2_prioritization = "on"
+		origin_max_http_version = "2"
 		universal_ssl = "off"
 		minify {
 			css = "on"


### PR DESCRIPTION
Unfortunately, https://api.cloudflare.com/#zone-settings-get-all-zone-settings does not include `origin_max_http_version`, so need to add it to `fetchAsSingleSetting` so that it is handled as a one-off.