### PR TITLE
Removed always_online action from page rules

### DIFF
--- a/.changelog/1817.txt
+++ b/.changelog/1817.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/cloudflare_page_rule: Removed `always_online` from page rules since this action has been decommissioned from page rules
+```

--- a/docs/resources/page_rule.md
+++ b/docs/resources/page_rule.md
@@ -41,7 +41,6 @@ The following arguments are supported:
 
 Action blocks support the following:
 
-- `always_online` - (Optional) Whether this action is `"on"` or `"off"`.
 - `always_use_https` - (Optional) Boolean of whether this action is enabled. Default: false.
 - `automatic_https_rewrites` - (Optional) Whether this action is `"on"` or `"off"`.
 - `browser_cache_ttl` - (Optional) The Time To Live for the browser cache. `0` means 'Respect Existing Headers'

--- a/internal/provider/resource_cloudflare_page_rule.go
+++ b/internal/provider/resource_cloudflare_page_rule.go
@@ -217,7 +217,6 @@ func resourceCloudflarePageRuleDelete(ctx context.Context, d *schema.ResourceDat
 }
 
 var pageRuleAPIOnOffFields = []string{
-	"always_online",
 	"automatic_https_rewrites",
 	"browser_check",
 	"cache_by_device_type",

--- a/internal/provider/schema_cloudflare_page_rule.go
+++ b/internal/provider/schema_cloudflare_page_rule.go
@@ -28,13 +28,6 @@ func resourceCloudflarePageRuleSchema() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				SchemaVersion: 1,
 				Schema: map[string]*schema.Schema{
-					// on/off options
-					"always_online": {
-						Type:         schema.TypeString,
-						Optional:     true,
-						ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
-					},
-
 					// may get api errors trying to set this
 					"automatic_https_rewrites": {
 						Type:         schema.TypeString,

--- a/templates/resources/page_rule.md
+++ b/templates/resources/page_rule.md
@@ -41,7 +41,6 @@ The following arguments are supported:
 
 Action blocks support the following:
 
-- `always_online` - (Optional) Whether this action is `"on"` or `"off"`.
 - `always_use_https` - (Optional) Boolean of whether this action is enabled. Default: false.
 - `automatic_https_rewrites` - (Optional) Whether this action is `"on"` or `"off"`.
 - `browser_cache_ttl` - (Optional) The Time To Live for the browser cache. `0` means 'Respect Existing Headers'


### PR DESCRIPTION
Removed `always_online` from page rules since this action has been decommissioned from page rules