### PR TITLE
browser_cache_ttl: keep validation values in sync with public API

### DIFF
--- a/internal/provider/schema_cloudflare_zone_settings_override.go
+++ b/internal/provider/schema_cloudflare_zone_settings_override.go
@@ -76,7 +76,7 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 		Type:     schema.TypeInt,
 		Optional: true,
 		Computed: true,
-		ValidateFunc: validation.IntInSlice([]int{0, 30, 60, 300, 1200, 1800, 3600, 7200, 10800, 14400, 18000, 28800,
+		ValidateFunc: validation.IntInSlice([]int{0, 30, 60, 120, 300, 1200, 1800, 3600, 7200, 10800, 14400, 18000, 28800,
 			43200, 57600, 72000, 86400, 172800, 259200, 345600, 432000, 691200, 1382400, 2073600, 2678400, 5356800,
 			16070400, 31536000}),
 		// minimum TTL available depends on the plan level of the zone.


### PR DESCRIPTION
The validation values for changing browser cache TTL setting got out of sync and the value `120` was missing. This caused some HTTP Application clones to fail. This PR aims to sync these values with the public API.

- https://api.cloudflare.com/#zone-settings-change-browser-cache-ttl-setting