### PR TITLE
Update docs to reflect that Go 1.18 is needed for development.

### DIFF
--- a/.changelog/1847.txt
+++ b/.changelog/1847.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-Update workstation setup documentationto reflect newer required Go version
+update local setup documentation to reflect newer required Go version
 ```

--- a/.changelog/1847.txt
+++ b/.changelog/1847.txt
@@ -1,0 +1,3 @@
+```release-note:note
+Update workstation setup documentationto reflect newer required Go version
+```

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -3,12 +3,12 @@
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.14+ (to run acceptance tests)
-- [Go](https://golang.org/doc/install) 1.17 (to build the provider plugin)
+- [Go](https://golang.org/doc/install) 1.18 (to build the provider plugin)
 
 ## Quick Start
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org)
-installed on your machine (version 1.17+ is *required*). You'll also need to
+installed on your machine (version 1.18+ is *required*). You'll also need to
 correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well
 as adding `$GOPATH/bin` to your `$PATH`.
 
@@ -62,8 +62,8 @@ will use instead of the version from the remote registry.
 
 ## Pulling in unreleased changes from Go library (cloudflare-go)
 
-In some scenarios, you may be wanting to make changes in `cloudflare-go` and have 
-them reflected in the Terraform provider before they are released upstream. To do 
+In some scenarios, you may be wanting to make changes in `cloudflare-go` and have
+them reflected in the Terraform provider before they are released upstream. To do
 this, you can update the `go.mod` file locally (do not commit it) using `go mod replace`.
 
 ```


### PR DESCRIPTION
Ran into this when using 1.17.15 and running `make test`:

```
# github.com/hashicorp/terraform-plugin-go/internal/logging
../../go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.0/internal/logging/protocol.go:31:62: undefined: any
../../go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.0/internal/logging/protocol_data.go:139:71: undefined: any
note: module requires Go 1.18
```