### PR TITLE
fix Access test assertions

### DIFF
--- a/internal/provider/resource_cloudflare_access_application_test.go
+++ b/internal/provider/resource_cloudflare_access_application_test.go
@@ -474,6 +474,12 @@ resource "cloudflare_access_application" "%[1]s" {
 
 func testAccCloudflareAccessApplicationConfigWithAutoRedirectToIdentity(rnd, zoneID, domain string) string {
 	return fmt.Sprintf(`
+resource "cloudflare_access_identity_provider" "%[1]s" {
+  zone_id = "%[2]s"
+  name    = "%[1]s"
+  type    = "onetimepin"
+}
+
 resource "cloudflare_access_application" "%[1]s" {
   zone_id                   = "%[2]s"
   name                      = "%[1]s"
@@ -481,6 +487,8 @@ resource "cloudflare_access_application" "%[1]s" {
   type                      = "self_hosted"
   session_duration          = "24h"
   auto_redirect_to_identity = true
+
+  depends_on = ["cloudflare_access_identity_provider.%[1]s"]
 }
 `, rnd, zoneID, domain)
 }

--- a/internal/provider/resource_cloudflare_teams_location.go
+++ b/internal/provider/resource_cloudflare_teams_location.go
@@ -30,7 +30,7 @@ func resourceCloudflareTeamsLocationRead(ctx context.Context, d *schema.Resource
 
 	location, err := client.TeamsLocation(ctx, accountID, d.Id())
 	if err != nil {
-		if strings.Contains(err.Error(), "HTTP status 400") {
+		if strings.Contains(err.Error(), "Location ID is invalid") {
 			tflog.Info(ctx, fmt.Sprintf("Teams Location %s no longer exists", d.Id()))
 			d.SetId("")
 			return nil

--- a/internal/provider/resource_cloudflare_teams_location_test.go
+++ b/internal/provider/resource_cloudflare_teams_location_test.go
@@ -27,6 +27,7 @@ func TestAccCloudflareTeamsLocationBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheck(t)
 			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,

--- a/internal/provider/resource_cloudflare_teams_proxy_endpoints.go
+++ b/internal/provider/resource_cloudflare_teams_proxy_endpoints.go
@@ -30,7 +30,7 @@ func resourceCloudflareTeamsProxyEndpointRead(ctx context.Context, d *schema.Res
 
 	endpoint, err := client.TeamsProxyEndpoint(ctx, accountID, d.Id())
 	if err != nil {
-		if strings.Contains(err.Error(), "HTTP status 400") {
+		if strings.Contains(err.Error(), "Proxy Endpoint ID is invalid") {
 			tflog.Info(ctx, fmt.Sprintf("Teams Proxy Endpoint %s no longer exists", d.Id()))
 			d.SetId("")
 			return nil

--- a/internal/provider/resource_cloudflare_teams_proxy_endpoints_test.go
+++ b/internal/provider/resource_cloudflare_teams_proxy_endpoints_test.go
@@ -28,6 +28,7 @@ func TestAccCloudflareTeamsProxyEndpoint_Basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheck(t)
 			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,


### PR DESCRIPTION
Updates the "not found" matchers in `Read` operations to correctly identify missing resources.