### PR TITLE
Fix typo in cloudflare_zone for jump_start description

### DIFF
--- a/docs/resources/zone.md
+++ b/docs/resources/zone.md
@@ -34,7 +34,7 @@ resource "cloudflare_zone" "example" {
 ### Optional
 
 - `account_id` (String) Account ID to manage the zone resource in.
-- `jump_start` (Boolean) Wwhether to scan for DNS records on creation. Ignored after zone is created.
+- `jump_start` (Boolean) Whether to scan for DNS records on creation. Ignored after zone is created.
 - `paused` (Boolean) Whether this zone is paused (traffic bypasses Cloudflare). Defaults to `false`.
 - `plan` (String) The name of the commercial plan to apply to the zone. Available values: `free`, `pro`, `business`, `enterprise`, `partners_free`, `partners_pro`, `partners_business`, `partners_enterprise`.
 - `type` (String) A full zone implies that DNS is hosted with Cloudflare. A partial zone is typically a partner-hosted zone or a CNAME setup. Available values: `full`, `partial`. Defaults to `full`.

--- a/internal/provider/schema_cloudflare_zone.go
+++ b/internal/provider/schema_cloudflare_zone.go
@@ -24,7 +24,7 @@ func resourceCloudflareZoneSchema() map[string]*schema.Schema {
 		"jump_start": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Description: "Wwhether to scan for DNS records on creation. Ignored after zone is created.",
+			Description: "Whether to scan for DNS records on creation. Ignored after zone is created.",
 		},
 		"paused": {
 			Type:        schema.TypeBool,


### PR DESCRIPTION
Fixes small typo in docs for `cloudflare_zone`