### PR TITLE
resource/cloudflare_access_rule: allow using user level resources

### DIFF
--- a/internal/provider/schema_cloudflare_access_rule.go
+++ b/internal/provider/schema_cloudflare_access_rule.go
@@ -10,20 +10,18 @@ import (
 func resourceCloudflareAccessRuleSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"account_id": {
-			Description:  "The account identifier to target for the resource.",
-			Type:         schema.TypeString,
-			Optional:     true,
-			ForceNew:     true,
-			Computed:     true,
-			ExactlyOneOf: []string{"account_id", "zone_id"},
+			Description: "The account identifier to target for the resource.",
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+			Computed:    true,
 		},
 		"zone_id": {
-			Description:  "The zone identifier to target for the resource.",
-			Type:         schema.TypeString,
-			Optional:     true,
-			ForceNew:     true,
-			Computed:     true,
-			ExactlyOneOf: []string{"account_id", "zone_id"},
+			Description: "The zone identifier to target for the resource.",
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+			Computed:    true,
 		},
 		"mode": {
 			Type:         schema.TypeString,


### PR DESCRIPTION
Allow omitting `account_id` or `zone_id` for the semi-deprecated user level resources. This will instead be cleaned up in 4.x

Closes #1881