### PR TITLE
update go scripts `working-directory`

### DIFF
--- a/.github/workflows/maintainer-only-files.yml
+++ b/.github/workflows/maintainer-only-files.yml
@@ -16,7 +16,8 @@ jobs:
         with:
           go-version: ^1.18
       - run: make tools
-      - run: go run tools/cmd/maintainer-only-file-check/main.go ${{ github.event.pull_request.number }}
+      - run: go run cmd/maintainer-only-file-check/main.go ${{ github.event.pull_request.number }}
+        working-directory: ./tools
         env:
           GITHUB_OWNER: cloudflare
           GITHUB_REPO: terraform-provider-cloudflare

--- a/.github/workflows/terraform-log-check.yml
+++ b/.github/workflows/terraform-log-check.yml
@@ -16,7 +16,8 @@ jobs:
         with:
           go-version: ^1.18
       - run: make tools
-      - run: go run tools/cmd/tf-log-check/main.go ${{ github.event.issue.number }}
+      - run: go run cmd/tf-log-check/main.go ${{ github.event.issue.number }}
+        working-directory: ./tools
         env:
           GITHUB_OWNER: cloudflare
           GITHUB_REPO: terraform-provider-cloudflare


### PR DESCRIPTION
Since the Go modules have been split, we need to set the `working-directory` to ensure it is operating in the correct context.