### PR TITLE
provider: allow individual setting of x-auth-service-key in the configuration

### DIFF
--- a/.changelog/1923.txt
+++ b/.changelog/1923.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider: allow individual setting of x-auth-service-key
+```


### PR DESCRIPTION
Permits setting the service key when that is the only source of authentication offered.