### PR TITLE
Fix array manipulation bug with the zone settings resource.

### DIFF
--- a/.changelog/1925.txt
+++ b/.changelog/1925.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_zone_settings_override: Fix array manipulation bug related to single zone settings
+```

--- a/internal/provider/resource_cloudflare_zone_settings_override.go
+++ b/internal/provider/resource_cloudflare_zone_settings_override.go
@@ -229,11 +229,9 @@ func updateSingleZoneSettings(ctx context.Context, zoneSettings []cloudflare.Zon
 		}
 	}
 
-	// precondition: indexesToCut is in ascending order
 	offset := 0
 	for _, indexToCut := range indexesToCut {
 		adjustedIndexToCut := indexToCut - offset
-		// loop postcondition: len(zoneSettings) decreases by 1 each iteration
 		zoneSettings = append(zoneSettings[:adjustedIndexToCut], zoneSettings[adjustedIndexToCut+1:]...)
 		offset += 1
 	}

--- a/internal/provider/resource_cloudflare_zone_settings_override.go
+++ b/internal/provider/resource_cloudflare_zone_settings_override.go
@@ -229,8 +229,13 @@ func updateSingleZoneSettings(ctx context.Context, zoneSettings []cloudflare.Zon
 		}
 	}
 
+	// precondition: indexesToCut is in ascending order
+	offset := 0
 	for _, indexToCut := range indexesToCut {
-		zoneSettings = append(zoneSettings[:indexToCut], zoneSettings[indexToCut+1:]...)
+		adjustedIndexToCut := indexToCut - offset
+		// loop postcondition: len(zoneSettings) decreases by 1 each iteration
+		zoneSettings = append(zoneSettings[:adjustedIndexToCut], zoneSettings[adjustedIndexToCut+1:]...)
+		offset += 1
 	}
 	return zoneSettings, nil
 }


### PR DESCRIPTION
This PR addresses a potential bug with the `cloudflare_zone_settings_override` resource. I was reviewing the implementation before provisioning it, and I encountered a bit of array manipulation code that might contain a bug. I haven't observed a problem in practice, but out of caution, I don't want to apply this resource until I'm sure it won't cause any problems for my zone.

The potential bug relates to how zone settings that must be fetched as single zone settings are removed from the zone settings list. I think there's an off-by-one type of error happening as the zone settings array is mutated.

NOTE: the code in this PR has never been tested or even ran