### PR TITLE
resource/cloudflare_email_routing_catch_all: switch to a dedicated scheme

### DIFF
--- a/.changelog/1947.txt
+++ b/.changelog/1947.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_email_routing_catch_all: switch to a dedicated scheme to allow type = "drop"
+```

--- a/docs/resources/email_routing_catch_all.md
+++ b/docs/resources/email_routing_catch_all.md
@@ -40,7 +40,6 @@ resource "cloudflare_email_routing_catch_all" "example" {
 ### Optional
 
 - `enabled` (Boolean) Routing rule status.
-- `priority` (Number) Priority of the routing rule.
 
 ### Read-Only
 
@@ -52,8 +51,8 @@ resource "cloudflare_email_routing_catch_all" "example" {
 
 Required:
 
-- `type` (String) Type of supported action.
-- `value` (List of String) An array with items in the following form.
+- `type` (String) Type of supported action. Available values: `drop`, `forward`, `worker`.
+- `value` (List of String) A list with items in the following form.
 
 
 <a id="nestedblock--matcher"></a>
@@ -61,11 +60,6 @@ Required:
 
 Required:
 
-- `type` (String) Type of matcher.
-
-Optional:
-
-- `field` (String) Field for type matcher.
-- `value` (String) Value for matcher.
+- `type` (String) Type of matcher. Available values: `all`.
 
 

--- a/internal/provider/resource_cloudflare_email_routing_catch_all.go
+++ b/internal/provider/resource_cloudflare_email_routing_catch_all.go
@@ -12,7 +12,7 @@ import (
 
 func resourceCloudflareEmailRoutingCatchAll() *schema.Resource {
 	return &schema.Resource{
-		Schema:        resourceCloudflareEmailRoutingRuleSchema(),
+		Schema:        resourceCloudflareEmailRoutingCatchAllSchema(),
 		ReadContext:   resourceCloudflareEmailRoutingCatchAllRead,
 		CreateContext: resourceCloudflareEmailRoutingCatchAllUpdate,
 		UpdateContext: resourceCloudflareEmailRoutingCatchAllUpdate,

--- a/internal/provider/resource_cloudflare_email_routing_rule.go
+++ b/internal/provider/resource_cloudflare_email_routing_rule.go
@@ -27,11 +27,16 @@ func buildMatchersAndActions(d *schema.ResourceData) (matchers []cloudflare.Emai
 	if items, ok := d.GetOk("matcher"); ok {
 		for _, item := range items.(*schema.Set).List() {
 			matcher := item.(map[string]interface{})
-			matchers = append(matchers, cloudflare.EmailRoutingRuleMatcher{
+			matcherStruct := cloudflare.EmailRoutingRuleMatcher{
 				Type:  matcher["type"].(string),
-				Field: matcher["field"].(string),
-				Value: matcher["value"].(string),
-			})
+			}
+			if val, ok := matcher["field"]; ok {
+				matcherStruct.Field = val.(string)
+			}
+			if val, ok := matcher["value"]; ok {
+				matcherStruct.Value = val.(string)
+			}
+			matchers = append(matchers, matcherStruct)
 		}
 	}
 

--- a/internal/provider/schema_cloudflare_email_routing_catch_all.go
+++ b/internal/provider/schema_cloudflare_email_routing_catch_all.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceCloudflareEmailRoutingCatchAllSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"zone_id": {
+			Description: "The zone identifier to target for the resource.",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"tag": {
+			Description: "Routing rule identifier.",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"name": {
+			Description: "Routing rule name.",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"enabled": {
+			Description: "Routing rule status.",
+			Type:        schema.TypeBool,
+			Optional:    true,
+		},
+		"matcher": {
+			Description: "Matching patterns to forward to your actions.",
+			Type:        schema.TypeSet,
+			Required:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Description:  "Type of matcher.",
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice([]string{"all"}, true),
+					},
+				},
+			},
+		},
+		"action": {
+			Description: "List actions patterns.",
+			Type:        schema.TypeSet,
+			Required:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Description:  "Type of supported action.",
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice([]string{"drop", "forward", "worker"}, true),
+					},
+					"value": {
+						Description: "An array with items in the following form.",
+						Type:        schema.TypeList,
+						Required:    true,
+						Elem: &schema.Schema{
+							Type:         schema.TypeString,
+							ValidateFunc: validation.StringLenBetween(0, 90),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/provider/schema_cloudflare_email_routing_catch_all.go
+++ b/internal/provider/schema_cloudflare_email_routing_catch_all.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -34,7 +35,7 @@ func resourceCloudflareEmailRoutingCatchAllSchema() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"type": {
-						Description:  "Type of matcher.",
+						Description:  fmt.Sprintf("Type of matcher. %s", renderAvailableDocumentationValuesStringSlice([]string{"all"})),
 						Type:         schema.TypeString,
 						Required:     true,
 						ValidateFunc: validation.StringInSlice([]string{"all"}, true),
@@ -49,13 +50,13 @@ func resourceCloudflareEmailRoutingCatchAllSchema() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"type": {
-						Description:  "Type of supported action.",
+						Description:  fmt.Sprintf("Type of supported action. %s", renderAvailableDocumentationValuesStringSlice([]string{"drop", "forward", "worker"})),
 						Type:         schema.TypeString,
 						Required:     true,
 						ValidateFunc: validation.StringInSlice([]string{"drop", "forward", "worker"}, true),
 					},
 					"value": {
-						Description: "An array with items in the following form.",
+						Description: "A list with items in the following form.",
 						Type:        schema.TypeList,
 						Required:    true,
 						Elem: &schema.Schema{


### PR DESCRIPTION
Compared to a normal email routing rule, the catch-all rule:

* Does not have a priority
* For matchers, it accepts only type = "all", and there are no "field" and "value" properties
* For actions, it accepts type = "drop" besides "forward" and "worker"

Ref: https://api.cloudflare.com/#email-routing-routing-rules-update-routing-rule
Ref: https://api.cloudflare.com/#email-routing-routing-rules-update-catch-all-rule

Fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/1937