### PR TITLE
resource/cloudflare_custom_ssl: ensure `GeoRestrictions` is not nil before comparing it

### DIFF
--- a/.changelog/1964.txt
+++ b/.changelog/1964.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_custom_ssl: check GeoRestrictions is not nil before attempting to compare it
+```

--- a/internal/provider/resource_cloudflare_custom_ssl.go
+++ b/internal/provider/resource_cloudflare_custom_ssl.go
@@ -275,7 +275,7 @@ func flattenCustomSSLOptions(sslopt cloudflare.ZoneCustomSSLOptions) map[string]
 		"type":          sslopt.Type,
 	}
 
-	if sslopt.GeoRestrictions.Label != "" && sslopt.GeoRestrictions.Label != "custom" {
+	if sslopt.GeoRestrictions != nil && sslopt.GeoRestrictions.Label != "" && sslopt.GeoRestrictions.Label != "custom" {
 		data["geo_restrictions"] = sslopt.GeoRestrictions.Label
 	}
 


### PR DESCRIPTION
Closes #1232

Acceptance tests are passing

```
TF_ACC=1 go test $(go list ./...) -v -run "^TestAccCloudflareCustomSSL_" -count 1 -parallel 1 -timeout 120m -parallel 1
?       github.com/cloudflare/terraform-provider-cloudflare     [no test files]
=== RUN   TestAccCloudflareCustomSSL_Basic
--- PASS: TestAccCloudflareCustomSSL_Basic (15.21s)
=== RUN   TestAccCloudflareCustomSSL_WithEmptyGeoRestrictions
--- PASS: TestAccCloudflareCustomSSL_WithEmptyGeoRestrictions (14.15s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/provider   29.938s
```