### PR TITLE
resource/cloudflare_ruleset: add support for overriding all ruleset rule sensitivity levels

### DIFF
--- a/.changelog/1965.txt
+++ b/.changelog/1965.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_ruleset: add support for overriding sensitivity levels for ruleset rules
+```

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -709,6 +709,7 @@ Optional:
 - `categories` (Block List) List of tag-based overrides. (see [below for nested schema](#nestedblock--rules--action_parameters--overrides--categories))
 - `enabled` (Boolean, Deprecated) Defines if the current ruleset-level override enables or disables the ruleset.
 - `rules` (Block List) List of rule-based overrides. (see [below for nested schema](#nestedblock--rules--action_parameters--overrides--rules))
+- `sensitivity_level` (String) Sensitivity level to override for all ruleset rules. Available values: `default`, `medium`, `low`, `eoff`.
 - `status` (String) Defines if the current ruleset-level override enables or disables the ruleset. Available values: `enabled`, `disabled`. Defaults to `""`.
 
 <a id="nestedblock--rules--action_parameters--overrides--categories"></a>

--- a/internal/provider/resource_cloudflare_ruleset.go
+++ b/internal/provider/resource_cloudflare_ruleset.go
@@ -286,10 +286,11 @@ func buildStateFromRulesetRules(rules []cloudflare.RulesetRule) interface{} {
 				}
 
 				overrides = append(overrides, map[string]interface{}{
-					"categories": categoryBasedOverrides,
-					"rules":      idBasedOverrides,
-					"status":     apiEnabledToStatusFieldConversion(r.ActionParameters.Overrides.Enabled),
-					"action":     r.ActionParameters.Overrides.Action,
+					"categories":        categoryBasedOverrides,
+					"rules":             idBasedOverrides,
+					"status":            apiEnabledToStatusFieldConversion(r.ActionParameters.Overrides.Enabled),
+					"action":            r.ActionParameters.Overrides.Action,
+					"sensitivity_level": r.ActionParameters.Overrides.SensitivityLevel,
 				})
 			}
 
@@ -723,6 +724,10 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 
 							if val, ok := overrideParamValue.(map[string]interface{})["action"]; ok {
 								overrideConfiguration.Action = val.(string)
+							}
+
+							if val, ok := overrideParamValue.(map[string]interface{})["sensitivity_level"]; ok {
+								overrideConfiguration.SensitivityLevel = val.(string)
 							}
 
 							// Category based overrides

--- a/internal/provider/schema_cloudflare_ruleset.go
+++ b/internal/provider/schema_cloudflare_ruleset.go
@@ -263,8 +263,8 @@ func resourceCloudflareRulesetSchema() map[string]*schema.Schema {
 											"sensitivity_level": {
 												Type:         schema.TypeString,
 												Optional:     true,
-												ValidateFunc: validation.StringInSlice([]string{"high", "medium", "low", "eoff"}, false),
-												Description:  fmt.Sprintf("Sensitivity level to override for all ruleset rules. %s", renderAvailableDocumentationValuesStringSlice([]string{"high", "medium", "low", "eoff"})),
+												ValidateFunc: validation.StringInSlice([]string{"default", "medium", "low", "eoff"}, false),
+												Description:  fmt.Sprintf("Sensitivity level to override for all ruleset rules. %s", renderAvailableDocumentationValuesStringSlice([]string{"default", "medium", "low", "eoff"})),
 											},
 											"categories": {
 												Type:        schema.TypeList,

--- a/internal/provider/schema_cloudflare_ruleset.go
+++ b/internal/provider/schema_cloudflare_ruleset.go
@@ -260,6 +260,12 @@ func resourceCloudflareRulesetSchema() map[string]*schema.Schema {
 												ValidateFunc: validation.StringInSlice(cloudflare.RulesetRuleActionValues(), false),
 												Description:  fmt.Sprintf("Action to perform in the rule-level override. %s", renderAvailableDocumentationValuesStringSlice(cloudflare.RulesetRuleActionValues())),
 											},
+											"sensitivity_level": {
+												Type:         schema.TypeString,
+												Optional:     true,
+												ValidateFunc: validation.StringInSlice([]string{"high", "medium", "low", "eoff"}, false),
+												Description:  fmt.Sprintf("Sensitivity level to override for all ruleset rules. %s", renderAvailableDocumentationValuesStringSlice([]string{"high", "medium", "low", "eoff"})),
+											},
 											"categories": {
 												Type:        schema.TypeList,
 												Optional:    true,


### PR DESCRIPTION
Closes #1853

Acceptance tests are passing

```
TF_ACC=1 go test $(go list ./...) -v -run "^TestAccCloudflareRuleset_" -count 1 -parallel 1 -timeout 120m -parallel 1
?       github.com/cloudflare/terraform-provider-cloudflare     [no test files]
=== RUN   TestAccCloudflareRuleset_WAFBasic
=== PAUSE TestAccCloudflareRuleset_WAFBasic
=== RUN   TestAccCloudflareRuleset_WAFManagedRuleset
=== PAUSE TestAccCloudflareRuleset_WAFManagedRuleset
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetOWASP
=== PAUSE TestAccCloudflareRuleset_WAFManagedRulesetOWASP
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetOWASPBlockXSSWithAnomalyOver60
=== PAUSE TestAccCloudflareRuleset_WAFManagedRulesetOWASPBlockXSSWithAnomalyOver60
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetOWASPOnlyPL1
=== PAUSE TestAccCloudflareRuleset_WAFManagedRulesetOWASPOnlyPL1
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetDeployMultiple
=== PAUSE TestAccCloudflareRuleset_WAFManagedRulesetDeployMultiple
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithSkip
=== PAUSE TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithSkip
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithTopSkipAndLastSkip
=== PAUSE TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithTopSkipAndLastSkip
=== RUN   TestAccCloudflareRuleset_SkipPhaseAndProducts
=== PAUSE TestAccCloudflareRuleset_SkipPhaseAndProducts
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetWithCategoryAndRuleBasedOverrides
=== PAUSE TestAccCloudflareRuleset_WAFManagedRulesetWithCategoryAndRuleBasedOverrides
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetWithIDBasedOverrides
=== PAUSE TestAccCloudflareRuleset_WAFManagedRulesetWithIDBasedOverrides
=== RUN   TestAccCloudflareRuleset_MagicTransitUpdateWithHigherPriority
    provider_test.go:191: Skipping acceptance test as 0da42c8d2132a9ddaf714f9e7c920711 is not configured for Magic Transit
--- SKIP: TestAccCloudflareRuleset_MagicTransitUpdateWithHigherPriority (0.00s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetWithPayloadLogging
=== PAUSE TestAccCloudflareRuleset_WAFManagedRulesetWithPayloadLogging
=== RUN   TestAccCloudflareRuleset_RateLimit
=== PAUSE TestAccCloudflareRuleset_RateLimit
=== RUN   TestAccCloudflareRuleset_CustomErrors
=== PAUSE TestAccCloudflareRuleset_CustomErrors
=== RUN   TestAccCloudflareRuleset_RequestOrigin
=== PAUSE TestAccCloudflareRuleset_RequestOrigin
=== RUN   TestAccCloudflareRuleset_TransformationRuleURIPath
=== PAUSE TestAccCloudflareRuleset_TransformationRuleURIPath
=== RUN   TestAccCloudflareRuleset_TransformationRuleURIQuery
=== PAUSE TestAccCloudflareRuleset_TransformationRuleURIQuery
=== RUN   TestAccCloudflareRuleset_TransformHTTPResponseHeaders
=== PAUSE TestAccCloudflareRuleset_TransformHTTPResponseHeaders
=== RUN   TestAccCloudflareRuleset_TransformationRuleURIPathAndQueryCombination
=== PAUSE TestAccCloudflareRuleset_TransformationRuleURIPathAndQueryCombination
=== RUN   TestAccCloudflareRuleset_TransformationRuleRequestHeaders
=== PAUSE TestAccCloudflareRuleset_TransformationRuleRequestHeaders
=== RUN   TestAccCloudflareRuleset_TransformationRuleResponseHeaders
=== PAUSE TestAccCloudflareRuleset_TransformationRuleResponseHeaders
=== RUN   TestAccCloudflareRuleset_ActionParametersMultipleSkips
=== PAUSE TestAccCloudflareRuleset_ActionParametersMultipleSkips
=== RUN   TestAccCloudflareRuleset_ActionParametersOverridesAction
=== PAUSE TestAccCloudflareRuleset_ActionParametersOverridesAction
=== RUN   TestAccCloudflareRuleset_ActionParametersHTTPDDoSOverride
=== PAUSE TestAccCloudflareRuleset_ActionParametersHTTPDDoSOverride
=== RUN   TestAccCloudflareRuleset_ActionParametersOverrideAllRulesetRules
=== PAUSE TestAccCloudflareRuleset_ActionParametersOverrideAllRulesetRules
=== RUN   TestAccCloudflareRuleset_AccountLevelCustomWAFRule
=== PAUSE TestAccCloudflareRuleset_AccountLevelCustomWAFRule
=== RUN   TestAccCloudflareRuleset_ExposedCredentialCheck
=== PAUSE TestAccCloudflareRuleset_ExposedCredentialCheck
=== RUN   TestAccCloudflareRuleset_Logging
=== PAUSE TestAccCloudflareRuleset_Logging
=== RUN   TestAccCloudflareRuleset_ConditionallySetActionParameterVersion
=== PAUSE TestAccCloudflareRuleset_ConditionallySetActionParameterVersion
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetWithActionManagedChallenge
=== PAUSE TestAccCloudflareRuleset_WAFManagedRulesetWithActionManagedChallenge
=== RUN   TestAccCloudflareRuleset_LogCustomField
=== PAUSE TestAccCloudflareRuleset_LogCustomField
=== RUN   TestAccCloudflareRuleset_ActionParametersOverridesThrashingStatus
=== PAUSE TestAccCloudflareRuleset_ActionParametersOverridesThrashingStatus
=== RUN   TestAccCloudflareRuleset_CacheSettings
=== PAUSE TestAccCloudflareRuleset_CacheSettings
=== RUN   TestAccCloudflareRuleset_Config
=== PAUSE TestAccCloudflareRuleset_Config
=== RUN   TestAccCloudflareRuleset_Redirect
=== PAUSE TestAccCloudflareRuleset_Redirect
=== RUN   TestAccCloudflareRuleset_DynamicRedirect
=== PAUSE TestAccCloudflareRuleset_DynamicRedirect
=== CONT  TestAccCloudflareRuleset_WAFBasic
--- PASS: TestAccCloudflareRuleset_WAFBasic (9.84s)
=== CONT  TestAccCloudflareRuleset_TransformationRuleURIPathAndQueryCombination
--- PASS: TestAccCloudflareRuleset_TransformationRuleURIPathAndQueryCombination (8.98s)
=== CONT  TestAccCloudflareRuleset_DynamicRedirect
--- PASS: TestAccCloudflareRuleset_DynamicRedirect (9.27s)
=== CONT  TestAccCloudflareRuleset_Redirect
--- PASS: TestAccCloudflareRuleset_Redirect (12.17s)
=== CONT  TestAccCloudflareRuleset_Config
--- PASS: TestAccCloudflareRuleset_Config (15.32s)
=== CONT  TestAccCloudflareRuleset_CacheSettings
--- PASS: TestAccCloudflareRuleset_CacheSettings (30.01s)
=== CONT  TestAccCloudflareRuleset_ActionParametersOverridesThrashingStatus
--- PASS: TestAccCloudflareRuleset_ActionParametersOverridesThrashingStatus (51.49s)
=== CONT  TestAccCloudflareRuleset_LogCustomField
--- PASS: TestAccCloudflareRuleset_LogCustomField (8.83s)
=== CONT  TestAccCloudflareRuleset_WAFManagedRulesetWithActionManagedChallenge
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetWithActionManagedChallenge (16.95s)
=== CONT  TestAccCloudflareRuleset_ConditionallySetActionParameterVersion
--- PASS: TestAccCloudflareRuleset_ConditionallySetActionParameterVersion (14.94s)
=== CONT  TestAccCloudflareRuleset_Logging
--- PASS: TestAccCloudflareRuleset_Logging (8.72s)
=== CONT  TestAccCloudflareRuleset_ExposedCredentialCheck
--- PASS: TestAccCloudflareRuleset_ExposedCredentialCheck (8.88s)
=== CONT  TestAccCloudflareRuleset_AccountLevelCustomWAFRule
--- PASS: TestAccCloudflareRuleset_AccountLevelCustomWAFRule (10.93s)
=== CONT  TestAccCloudflareRuleset_ActionParametersOverrideAllRulesetRules
--- PASS: TestAccCloudflareRuleset_ActionParametersOverrideAllRulesetRules (8.99s)
=== CONT  TestAccCloudflareRuleset_ActionParametersHTTPDDoSOverride
--- PASS: TestAccCloudflareRuleset_ActionParametersHTTPDDoSOverride (9.26s)
=== CONT  TestAccCloudflareRuleset_ActionParametersOverridesAction
--- PASS: TestAccCloudflareRuleset_ActionParametersOverridesAction (9.34s)
=== CONT  TestAccCloudflareRuleset_ActionParametersMultipleSkips
--- PASS: TestAccCloudflareRuleset_ActionParametersMultipleSkips (10.32s)
=== CONT  TestAccCloudflareRuleset_TransformationRuleResponseHeaders
--- PASS: TestAccCloudflareRuleset_TransformationRuleResponseHeaders (9.02s)
=== CONT  TestAccCloudflareRuleset_TransformationRuleRequestHeaders
--- PASS: TestAccCloudflareRuleset_TransformationRuleRequestHeaders (8.89s)
=== CONT  TestAccCloudflareRuleset_WAFManagedRulesetWithCategoryAndRuleBasedOverrides
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetWithCategoryAndRuleBasedOverrides (8.98s)
=== CONT  TestAccCloudflareRuleset_TransformHTTPResponseHeaders
--- PASS: TestAccCloudflareRuleset_TransformHTTPResponseHeaders (8.11s)
=== CONT  TestAccCloudflareRuleset_TransformationRuleURIQuery
--- PASS: TestAccCloudflareRuleset_TransformationRuleURIQuery (9.12s)
=== CONT  TestAccCloudflareRuleset_TransformationRuleURIPath
--- PASS: TestAccCloudflareRuleset_TransformationRuleURIPath (8.55s)
=== CONT  TestAccCloudflareRuleset_RequestOrigin
--- PASS: TestAccCloudflareRuleset_RequestOrigin (8.58s)
=== CONT  TestAccCloudflareRuleset_CustomErrors
--- PASS: TestAccCloudflareRuleset_CustomErrors (8.71s)
=== CONT  TestAccCloudflareRuleset_RateLimit
--- PASS: TestAccCloudflareRuleset_RateLimit (8.72s)
=== CONT  TestAccCloudflareRuleset_WAFManagedRulesetWithPayloadLogging
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetWithPayloadLogging (9.60s)
=== CONT  TestAccCloudflareRuleset_WAFManagedRulesetWithIDBasedOverrides
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetWithIDBasedOverrides (10.03s)
=== CONT  TestAccCloudflareRuleset_WAFManagedRulesetDeployMultiple
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetDeployMultiple (17.97s)
=== CONT  TestAccCloudflareRuleset_SkipPhaseAndProducts
--- PASS: TestAccCloudflareRuleset_SkipPhaseAndProducts (14.08s)
=== CONT  TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithTopSkipAndLastSkip
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithTopSkipAndLastSkip (10.93s)
=== CONT  TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithSkip
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithSkip (10.43s)
=== CONT  TestAccCloudflareRuleset_WAFManagedRulesetOWASPBlockXSSWithAnomalyOver60
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetOWASPBlockXSSWithAnomalyOver60 (15.37s)
=== CONT  TestAccCloudflareRuleset_WAFManagedRulesetOWASPOnlyPL1
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetOWASPOnlyPL1 (9.74s)
=== CONT  TestAccCloudflareRuleset_WAFManagedRulesetOWASP
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetOWASP (9.27s)
=== CONT  TestAccCloudflareRuleset_WAFManagedRuleset
--- PASS: TestAccCloudflareRuleset_WAFManagedRuleset (9.01s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/provider   439.700s
```