### PR TITLE
resource/cloudflare_load_balancer_{monitor,pool}: add support for explicit `account_id`s

### DIFF
--- a/.changelog/1986.txt
+++ b/.changelog/1986.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/cloudflare_load_balancer_pool: support defining explicit `account_id` for resources
+```
+
+```release-note:enhancement
+resource/cloudflare_load_balancer_monitor: support defining explicit `account_id` for resources
+```

--- a/docs/resources/load_balancer_monitor.md
+++ b/docs/resources/load_balancer_monitor.md
@@ -53,6 +53,7 @@ resource "cloudflare_load_balancer_monitor" "tcp_monitor" {
 
 The following arguments are supported:
 
+- `account_id` (Optional) The account identifier to target for the resource.
 - `expected_body` - (Optional) A case-insensitive sub-string to look for in the response body. If this string is not found, the origin will be marked as unhealthy. Only valid if `type` is "http" or "https". Default: "".
 - `expected_codes` - (Optional) The expected HTTP response code or code range of the health check. Eg `2xx`. Only valid and required if `type` is "http" or "https".
 - `method` - (Optional) The method to use for the health check. Valid values are any valid HTTP verb if `type` is "http" or "https", or `connection_established` if `type` is "tcp". Default: "GET" if `type` is "http" or "https", "connection_established" if `type` is "tcp", and empty otherwise.

--- a/docs/resources/load_balancer_pool.md
+++ b/docs/resources/load_balancer_pool.md
@@ -52,6 +52,7 @@ resource "cloudflare_load_balancer_pool" "foo" {
 
 The following arguments are supported:
 
+- `account_id` (Optional) The account identifier to target for the resource.
 - `name` - (Required) A short name (tag) for the pool. Only alphanumeric characters, hyphens, and underscores are allowed.
 - `origins` - (Required) The list of origins within this pool. Traffic directed at this pool is balanced across all currently healthy origins, provided the pool itself is healthy. It's a complex value. See description below.
 - `check_regions` - (Optional) A list of regions (specified by region code) from which to run health checks. Empty means every Cloudflare data center (the default), but requires an Enterprise plan. Region codes can be found [here](https://developers.cloudflare.com/load-balancing/reference/region-mapping-api).

--- a/internal/provider/resource_cloudflare_load_balancer_monitor.go
+++ b/internal/provider/resource_cloudflare_load_balancer_monitor.go
@@ -94,7 +94,11 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(ctx context.Context, d *sch
 
 	tflog.Debug(ctx, fmt.Sprintf("Creating Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor))
 
-	r, err := client.CreateLoadBalancerMonitor(ctx, cloudflare.AccountIdentifier(client.AccountID), cloudflare.CreateLoadBalancerMonitorParams{LoadBalancerMonitor: loadBalancerMonitor})
+	accountID := d.Get("account_id").(string)
+	if accountID == "" {
+		accountID = client.AccountID
+	}
+	r, err := client.CreateLoadBalancerMonitor(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.CreateLoadBalancerMonitorParams{LoadBalancerMonitor: loadBalancerMonitor})
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating load balancer monitor"))
 	}
@@ -182,7 +186,11 @@ func resourceCloudflareLoadBalancerPoolMonitorUpdate(ctx context.Context, d *sch
 
 	tflog.Debug(ctx, fmt.Sprintf("Update Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor))
 
-	_, err := client.UpdateLoadBalancerMonitor(ctx, cloudflare.AccountIdentifier(client.AccountID), cloudflare.UpdateLoadBalancerMonitorParams{LoadBalancerMonitor: loadBalancerMonitor})
+	accountID := d.Get("account_id").(string)
+	if accountID == "" {
+		accountID = client.AccountID
+	}
+	_, err := client.UpdateLoadBalancerMonitor(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.UpdateLoadBalancerMonitorParams{LoadBalancerMonitor: loadBalancerMonitor})
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error modifying load balancer monitor"))
 	}
@@ -205,7 +213,11 @@ func expandLoadBalancerMonitorHeader(cfgSet interface{}) map[string][]string {
 func resourceCloudflareLoadBalancerPoolMonitorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
-	loadBalancerMonitor, err := client.GetLoadBalancerMonitor(ctx, cloudflare.AccountIdentifier(client.AccountID), d.Id())
+	accountID := d.Get("account_id").(string)
+	if accountID == "" {
+		accountID = client.AccountID
+	}
+	loadBalancerMonitor, err := client.GetLoadBalancerMonitor(ctx, cloudflare.AccountIdentifier(accountID), d.Id())
 	if err != nil {
 		var notFoundError *cloudflare.NotFoundError
 		if errors.As(err, &notFoundError) {
@@ -262,7 +274,11 @@ func resourceCloudflareLoadBalancerPoolMonitorDelete(ctx context.Context, d *sch
 
 	tflog.Info(ctx, fmt.Sprintf("Deleting Cloudflare Load Balancer Monitor: %s ", d.Id()))
 
-	err := client.DeleteLoadBalancerMonitor(ctx, cloudflare.AccountIdentifier(client.AccountID), d.Id())
+	accountID := d.Get("account_id").(string)
+	if accountID == "" {
+		accountID = client.AccountID
+	}
+	err := client.DeleteLoadBalancerMonitor(ctx, cloudflare.AccountIdentifier(accountID), d.Id())
 	if err != nil {
 		var notFoundError *cloudflare.NotFoundError
 		if errors.As(err, &notFoundError) {

--- a/internal/provider/resource_cloudflare_load_balancer_monitor_test.go
+++ b/internal/provider/resource_cloudflare_load_balancer_monitor_test.go
@@ -35,8 +35,7 @@ func testSweepCloudflareLoadBalancerMonitors(r string) error {
 		return errors.New("CLOUDFLARE_ACCOUNT_ID must be set")
 	}
 
-	client.AccountID = accountID
-	monitors, err := client.ListLoadBalancerMonitors(ctx, cloudflare.AccountIdentifier(client.AccountID), cloudflare.ListLoadBalancerMonitorParams{})
+	monitors, err := client.ListLoadBalancerMonitors(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListLoadBalancerMonitorParams{})
 	if err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Failed to fetch Cloudflare Load Balancer Monitors: %s", err))
 	}
@@ -49,7 +48,7 @@ func testSweepCloudflareLoadBalancerMonitors(r string) error {
 	for _, monitor := range monitors {
 		tflog.Info(ctx, fmt.Sprintf("Deleting Cloudflare Load Balancer Monitor ID: %s", monitor.ID))
 		//nolint:errcheck
-		client.DeleteLoadBalancerPool(ctx, cloudflare.AccountIdentifier(client.AccountID), monitor.ID)
+		client.DeleteLoadBalancerPool(ctx, cloudflare.AccountIdentifier(accountID), monitor.ID)
 	}
 
 	return nil
@@ -309,7 +308,7 @@ func testAccCheckCloudflareLoadBalancerMonitorDestroy(s *terraform.State) error 
 			continue
 		}
 
-		_, err := client.GetLoadBalancerMonitor(context.Background(), cloudflare.AccountIdentifier(client.AccountID), rs.Primary.ID)
+		_, err := client.GetLoadBalancerMonitor(context.Background(), cloudflare.AccountIdentifier(os.Getenv("CLOUDFLARE_ACCOUNT_ID")), rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Load balancer monitor still exists")
 		}
@@ -330,7 +329,7 @@ func testAccCheckCloudflareLoadBalancerMonitorExists(n string, load *cloudflare.
 		}
 
 		client := testAccProvider.Meta().(*cloudflare.API)
-		foundLoadBalancerMonitor, err := client.GetLoadBalancerMonitor(context.Background(), cloudflare.AccountIdentifier(client.AccountID), rs.Primary.ID)
+		foundLoadBalancerMonitor, err := client.GetLoadBalancerMonitor(context.Background(), cloudflare.AccountIdentifier(os.Getenv("CLOUDFLARE_ACCOUNT_ID")), rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -370,7 +369,7 @@ func testAccManuallyDeleteLoadBalancerMonitor(name string, loadBalancerMonitor *
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*cloudflare.API)
 		*initialId = loadBalancerMonitor.ID
-		err := client.DeleteLoadBalancerMonitor(context.Background(), cloudflare.AccountIdentifier(client.AccountID), loadBalancerMonitor.ID)
+		err := client.DeleteLoadBalancerMonitor(context.Background(), cloudflare.AccountIdentifier(os.Getenv("CLOUDFLARE_ACCOUNT_ID")), loadBalancerMonitor.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/provider/resource_cloudflare_load_balancer_pool.go
+++ b/internal/provider/resource_cloudflare_load_balancer_pool.go
@@ -72,7 +72,12 @@ func resourceCloudflareLoadBalancerPoolCreate(ctx context.Context, d *schema.Res
 
 	tflog.Debug(ctx, fmt.Sprintf("Creating Cloudflare Load Balancer Pool from struct: %+v", loadBalancerPool))
 
-	r, err := client.CreateLoadBalancerPool(ctx, cloudflare.AccountIdentifier(client.AccountID), cloudflare.CreateLoadBalancerPoolParams{LoadBalancerPool: loadBalancerPool})
+	accountID := d.Get("account_id").(string)
+	if accountID == "" {
+		accountID = client.AccountID
+	}
+
+	r, err := client.CreateLoadBalancerPool(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.CreateLoadBalancerPoolParams{LoadBalancerPool: loadBalancerPool})
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating load balancer pool"))
 	}
@@ -134,7 +139,11 @@ func resourceCloudflareLoadBalancerPoolUpdate(ctx context.Context, d *schema.Res
 
 	tflog.Debug(ctx, fmt.Sprintf("Updating Cloudflare Load Balancer Pool from struct: %+v", loadBalancerPool))
 
-	_, err := client.UpdateLoadBalancerPool(ctx, cloudflare.AccountIdentifier(client.AccountID), cloudflare.UpdateLoadBalancerPoolParams{LoadBalancer: loadBalancerPool})
+	accountID := d.Get("account_id").(string)
+	if accountID == "" {
+		accountID = client.AccountID
+	}
+	_, err := client.UpdateLoadBalancerPool(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.UpdateLoadBalancerPoolParams{LoadBalancer: loadBalancerPool})
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error updating load balancer pool"))
 	}
@@ -215,7 +224,12 @@ func expandLoadBalancerOrigins(originSet *schema.Set) (origins []cloudflare.Load
 func resourceCloudflareLoadBalancerPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
-	loadBalancerPool, err := client.GetLoadBalancerPool(ctx, cloudflare.AccountIdentifier(client.AccountID), d.Id())
+	accountID := d.Get("account_id").(string)
+	if accountID == "" {
+		accountID = client.AccountID
+	}
+
+	loadBalancerPool, err := client.GetLoadBalancerPool(ctx, cloudflare.AccountIdentifier(accountID), d.Id())
 	if err != nil {
 		var notFoundError *cloudflare.NotFoundError
 		if errors.As(err, &notFoundError) {
@@ -308,7 +322,11 @@ func resourceCloudflareLoadBalancerPoolDelete(ctx context.Context, d *schema.Res
 
 	tflog.Info(ctx, fmt.Sprintf("Deleting Cloudflare Load Balancer Pool: %s ", d.Id()))
 
-	err := client.DeleteLoadBalancerPool(ctx, cloudflare.AccountIdentifier(client.AccountID), d.Id())
+	accountID := d.Get("account_id").(string)
+	if accountID == "" {
+		accountID = client.AccountID
+	}
+	err := client.DeleteLoadBalancerPool(ctx, cloudflare.AccountIdentifier(accountID), d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error deleting Cloudflare Load Balancer Pool"))
 	}

--- a/internal/provider/resource_cloudflare_load_balancer_pool_test.go
+++ b/internal/provider/resource_cloudflare_load_balancer_pool_test.go
@@ -35,7 +35,6 @@ func testSweepCloudflareLoadBalancerPool(r string) error {
 		return errors.New("CLOUDFLARE_ACCOUNT_ID must be set")
 	}
 
-	client.AccountID = accountID
 	pools, err := client.ListLoadBalancerPools(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListLoadBalancerPoolParams{})
 	if err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Failed to fetch Cloudflare Load Balancer Pools: %s", err))
@@ -243,7 +242,7 @@ func testAccManuallyDeleteLoadBalancerPool(name string, loadBalancerPool *cloudf
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*cloudflare.API)
 		*initialId = loadBalancerPool.ID
-		err := client.DeleteLoadBalancerPool(context.Background(), cloudflare.AccountIdentifier(client.AccountID), loadBalancerPool.ID)
+		err := client.DeleteLoadBalancerPool(context.Background(), cloudflare.AccountIdentifier(os.Getenv("CLOUDFLARE_ACCOUNT_ID")), loadBalancerPool.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/provider/schema_cloudflare_load_balancer_monitor.go
+++ b/internal/provider/schema_cloudflare_load_balancer_monitor.go
@@ -7,6 +7,12 @@ import (
 
 func resourceCloudflareLoadBalancerMonitorSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"account_id": {
+			Description: "The account identifier to target for the resource.",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+
 		"description": {
 			Type:     schema.TypeString,
 			Optional: true,

--- a/internal/provider/schema_cloudflare_load_balancer_pool.go
+++ b/internal/provider/schema_cloudflare_load_balancer_pool.go
@@ -9,6 +9,12 @@ import (
 
 func resourceCloudflareLoadBalancerPoolSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"account_id": {
+			Description: "The account identifier to target for the resource.",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+
 		"name": {
 			Type:         schema.TypeString,
 			Required:     true,

--- a/templates/resources/load_balancer_monitor.md
+++ b/templates/resources/load_balancer_monitor.md
@@ -53,6 +53,7 @@ resource "cloudflare_load_balancer_monitor" "tcp_monitor" {
 
 The following arguments are supported:
 
+- `account_id` (Optional) The account identifier to target for the resource.
 - `expected_body` - (Optional) A case-insensitive sub-string to look for in the response body. If this string is not found, the origin will be marked as unhealthy. Only valid if `type` is "http" or "https". Default: "".
 - `expected_codes` - (Optional) The expected HTTP response code or code range of the health check. Eg `2xx`. Only valid and required if `type` is "http" or "https".
 - `method` - (Optional) The method to use for the health check. Valid values are any valid HTTP verb if `type` is "http" or "https", or `connection_established` if `type` is "tcp". Default: "GET" if `type` is "http" or "https", "connection_established" if `type` is "tcp", and empty otherwise.

--- a/templates/resources/load_balancer_pool.md
+++ b/templates/resources/load_balancer_pool.md
@@ -52,6 +52,7 @@ resource "cloudflare_load_balancer_pool" "foo" {
 
 The following arguments are supported:
 
+- `account_id` (Optional) The account identifier to target for the resource.
 - `name` - (Required) A short name (tag) for the pool. Only alphanumeric characters, hyphens, and underscores are allowed.
 - `origins` - (Required) The list of origins within this pool. Traffic directed at this pool is balanced across all currently healthy origins, provided the pool itself is healthy. It's a complex value. See description below.
 - `check_regions` - (Optional) A list of regions (specified by region code) from which to run health checks. Empty means every Cloudflare data center (the default), but requires an Enterprise plan. Region codes can be found [here](https://developers.cloudflare.com/load-balancing/reference/region-mapping-api).


### PR DESCRIPTION
Updates the resources to support defining explicit `account_id`s instead of relying on the client wide configuration.

Acceptance tests are passing

```
TF_ACC=1 go test $(go list ./...) -v -run "^TestAccCloudflareLoadBalancer(Pool|Monitor)_" -count 1 -parallel 1 -timeout 120m -parallel 1
?       github.com/cloudflare/terraform-provider-cloudflare     [no test files]
=== RUN   TestAccCloudflareLoadBalancerMonitor_Import
=== PAUSE TestAccCloudflareLoadBalancerMonitor_Import
=== RUN   TestAccCloudflareLoadBalancerPool_Import
=== PAUSE TestAccCloudflareLoadBalancerPool_Import
=== RUN   TestAccCloudflareLoadBalancerMonitor_Basic
--- PASS: TestAccCloudflareLoadBalancerMonitor_Basic (8.71s)
=== RUN   TestAccCloudflareLoadBalancerMonitor_FullySpecified
--- PASS: TestAccCloudflareLoadBalancerMonitor_FullySpecified (8.36s)
=== RUN   TestAccCloudflareLoadBalancerMonitor_EmptyExpectedBody
--- PASS: TestAccCloudflareLoadBalancerMonitor_EmptyExpectedBody (10.59s)
=== RUN   TestAccCloudflareLoadBalancerMonitor_TcpFullySpecified
--- PASS: TestAccCloudflareLoadBalancerMonitor_TcpFullySpecified (8.27s)
=== RUN   TestAccCloudflareLoadBalancerMonitor_PremiumTypes
--- PASS: TestAccCloudflareLoadBalancerMonitor_PremiumTypes (31.91s)
=== RUN   TestAccCloudflareLoadBalancerMonitor_NoRequired
--- PASS: TestAccCloudflareLoadBalancerMonitor_NoRequired (3.19s)
=== RUN   TestAccCloudflareLoadBalancerMonitor_Update
--- PASS: TestAccCloudflareLoadBalancerMonitor_Update (15.22s)
=== RUN   TestAccCloudflareLoadBalancerMonitor_CreateAfterManualDestroy
--- PASS: TestAccCloudflareLoadBalancerMonitor_CreateAfterManualDestroy (16.14s)
=== RUN   TestAccCloudflareLoadBalancerMonitor_ChangingHeadersCauseReplacement
--- PASS: TestAccCloudflareLoadBalancerMonitor_ChangingHeadersCauseReplacement (20.16s)
=== RUN   TestAccCloudflareLoadBalancerPool_Basic
=== PAUSE TestAccCloudflareLoadBalancerPool_Basic
=== RUN   TestAccCloudflareLoadBalancerPool_FullySpecified
=== PAUSE TestAccCloudflareLoadBalancerPool_FullySpecified
=== RUN   TestAccCloudflareLoadBalancerPool_CreateAfterManualDestroy
=== PAUSE TestAccCloudflareLoadBalancerPool_CreateAfterManualDestroy
=== CONT  TestAccCloudflareLoadBalancerMonitor_Import
--- PASS: TestAccCloudflareLoadBalancerMonitor_Import (12.91s)
=== CONT  TestAccCloudflareLoadBalancerPool_FullySpecified
--- PASS: TestAccCloudflareLoadBalancerPool_FullySpecified (9.05s)
=== CONT  TestAccCloudflareLoadBalancerPool_CreateAfterManualDestroy
--- PASS: TestAccCloudflareLoadBalancerPool_CreateAfterManualDestroy (17.19s)
=== CONT  TestAccCloudflareLoadBalancerPool_Basic
--- PASS: TestAccCloudflareLoadBalancerPool_Basic (9.36s)
=== CONT  TestAccCloudflareLoadBalancerPool_Import
--- PASS: TestAccCloudflareLoadBalancerPool_Import (11.27s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/provider   182.874s
```