### PR TITLE
Add support for app_launcher, dash_sso and warp types on access applications

### DIFF
--- a/.changelog/1988.txt
+++ b/.changelog/1988.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_access_application: add support for `app_launcher`, `biso`, `dash_sso` and `warp` to the schema
+```

--- a/docs/resources/access_application.md
+++ b/docs/resources/access_application.md
@@ -72,7 +72,7 @@ resource "cloudflare_access_application" "staging_app" {
 - `service_auth_401_redirect` (Boolean) Option to return a 401 status code in service authentication rules on failed requests. Defaults to `false`.
 - `session_duration` (String) How often a user will be forced to re-authorise. Must be in the format `48h` or `2h45m`. Defaults to `24h`.
 - `skip_interstitial` (Boolean) Option to skip the authorization interstitial when using the CLI. Defaults to `false`.
-- `type` (String) The application type. Available values: `self_hosted`, `saas`, `ssh`, `vnc`, `bookmark`. Defaults to `self_hosted`.
+- `type` (String) The application type. Available values: `app_launcher`, `bookmark`, `biso`, `dash_sso`, `saas`, `self_hosted`, `ssh`, `vnc`, `warp`. Defaults to `self_hosted`.
 - `zone_id` (String) The zone identifier to target for the resource. Conflicts with `account_id`.
 
 ### Read-Only

--- a/internal/provider/schema_cloudflare_access_application.go
+++ b/internal/provider/schema_cloudflare_access_application.go
@@ -46,8 +46,8 @@ func resourceCloudflareAccessApplicationSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Default:      "self_hosted",
-			ValidateFunc: validation.StringInSlice([]string{"self_hosted", "saas", "ssh", "vnc", "bookmark"}, false),
-			Description:  fmt.Sprintf("The application type. %s", renderAvailableDocumentationValuesStringSlice([]string{"self_hosted", "saas", "ssh", "vnc", "bookmark"})),
+			ValidateFunc: validation.StringInSlice([]string{"app_launcher", "bookmark", "biso", "dash_sso", "saas", "self_hosted", "ssh", "vnc", "warp"}, false),
+			Description:  fmt.Sprintf("The application type. %s", renderAvailableDocumentationValuesStringSlice([]string{"app_launcher", "bookmark", "biso", "dash_sso", "saas", "self_hosted", "ssh", "vnc", "warp"})),
 		},
 		"session_duration": {
 			Type:     schema.TypeString,


### PR DESCRIPTION
The current schema is missing a few types which can be imported by the provider but later on invalidated. This PR adds the following missing types:

* `app_launcher`
* `biso`
* `dash_sso`
* `warp`