### PR TITLE
Default value for root_dir in pages_project.md

### DIFF
--- a/docs/resources/pages_project.md
+++ b/docs/resources/pages_project.md
@@ -135,7 +135,7 @@ Optional:
 
 - `build_command` (String) Command used to build project.
 - `destination_dir` (String) Output directory of the build.
-- `root_dir` (String) Directory to run the command.
+- `root_dir` (String) Directory to run the command. Defaults to `/`.
 - `web_analytics_tag` (String) The classifying tag for analytics.
 - `web_analytics_token` (String) The auth token for analytics.
 


### PR DESCRIPTION
The simple description of the default value makes it much more clearer.
I've tested with `root_dir = "/"` and I got his value on Cloudflare console: `//`.

E.g.:
![image](https://user-images.githubusercontent.com/63248178/199072572-60db2e6a-766e-4b22-b933-5091460b31dc.png)
