### PR TITLE
Return early if CORS headers are nil

### DIFF
--- a/.changelog/2009.txt
+++ b/.changelog/2009.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+resource/access_application: Fix issue where empty CORS headers state causes
+panics
+```

--- a/.changelog/2009.txt
+++ b/.changelog/2009.txt
@@ -1,4 +1,0 @@
-```release-note:bug
-resource/access_application: Fix issue where empty CORS headers state causes
-panics
-```

--- a/.changelog/2010.txt
+++ b/.changelog/2010.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/access_application: Fix issue where empty CORS headers state causes panics
+```

--- a/internal/provider/schema_cloudflare_access_application.go
+++ b/internal/provider/schema_cloudflare_access_application.go
@@ -274,6 +274,10 @@ func convertCORSStructToSchema(d *schema.ResourceData, headers *cloudflare.Acces
 		return []interface{}{}
 	}
 
+	if headers == nil {
+		return []interface{}{}
+	}
+
 	m := map[string]interface{}{
 		"allow_all_methods": headers.AllowAllMethods,
 		"allow_all_headers": headers.AllowAllHeaders,


### PR DESCRIPTION
This fixes an issue with Access Applications where an empty `cors_headers` state with `null` fields causes panics. You can get into this state by applying a bad config:
```terraform
resource "cloudflare_access_application" "my_app" {
  account_id       = var.account_id
  name             = "My App"
  type             = "self_hosted"
  domain           = "https://example.com"
  cors_headers {}
}
```
which sets an empty state despite the API call failing:
```
            "cors_headers": [
              {
                "allow_all_headers": null,
                "allow_all_methods": null,
                "allow_all_origins": null,
                "allow_credentials": null,
                "allowed_headers": null,
                "allowed_methods": null,
                "allowed_origins": null,
                "max_age": null
              }
            ],
```
the `convertCORSStructToSchema` helper function will then incorrectly assume we have CORS headers to parse on every plan/apply since it detects it in our state, which causes the panic because our CORS headers come back `nil` from the API.

Closes https://github.com/cloudflare/terraform-provider-cloudflare/issues/1655