### PR TITLE
Fix origin ca docs

### DIFF
--- a/docs/resources/dlp_profile.md
+++ b/docs/resources/dlp_profile.md
@@ -9,7 +9,7 @@ description: |-
 
 # cloudflare_dlp_profile (Resource)
 
-Provides a Cloudflare DLP Profile resource. Data Loss Prevention profiles 
+Provides a Cloudflare DLP Profile resource. Data Loss Prevention profiles
 are a set of entries that can be matched in HTTP bodies or files.
 They are referenced in Zero Trust Gateway rules.
 

--- a/docs/resources/origin_ca_certificate.md
+++ b/docs/resources/origin_ca_certificate.md
@@ -8,7 +8,7 @@ description: Provides a Cloudflare Origin CA certificate resource.
 
 Provides a Cloudflare Origin CA certificate used to protect traffic to your origin without involving a third party Certificate Authority.
 
-**This resource requires you use your Origin CA Key as the [`api_user_service_key`](../index.html#api_user_service_key), in conjunction with an `api_token` or `email` and `api_key`.**
+**This resource requires you use your Origin CA Key as the [`api_user_service_key`](../index.html#api_user_service_key). No values should be specified for `api_token` or `email` and `api_key`.**
 
 ## Example Usage
 

--- a/templates/resources/origin_ca_certificate.md
+++ b/templates/resources/origin_ca_certificate.md
@@ -8,7 +8,7 @@ description: Provides a Cloudflare Origin CA certificate resource.
 
 Provides a Cloudflare Origin CA certificate used to protect traffic to your origin without involving a third party Certificate Authority.
 
-**This resource requires you use your Origin CA Key as the [`api_user_service_key`](../index.html#api_user_service_key), in conjunction with an `api_token` or `email` and `api_key`.**
+**This resource requires you use your Origin CA Key as the [`api_user_service_key`](../index.html#api_user_service_key). No values should be specified for `api_token` or `email` and `api_key`.**
 
 ## Example Usage
 


### PR DESCRIPTION
The documentation for resource `cloudflare_origin_ca_certificate` is wrong and contradicting `index.md` which states **"Must provide only one of `api_key`, `api_token`, `api_user_service_key`."**.