### PR TITLE
Keep order of edge IPs to be same

### DIFF
--- a/.changelog/2032.txt
+++ b/.changelog/2032.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/cloudflare_spectrum_application: Keep order of edge IPs to be same 
+resource/cloudflare_spectrum_application: ignore ordering of `edge_ips`
 ```

--- a/.changelog/2032.txt
+++ b/.changelog/2032.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_spectrum_application: Keep order of edge IPs to be same 
+```

--- a/internal/provider/resource_cloudflare_spectrum_application.go
+++ b/internal/provider/resource_cloudflare_spectrum_application.go
@@ -288,7 +288,7 @@ func applicationFromResource(d *schema.ResourceData) cloudflare.SpectrumApplicat
 			Type: cloudflare.SpectrumEdgeTypeStatic,
 		}
 		// connectivity = cloudflare.SpectrumConnectivityStatic
-		for _, value := range edgeIPs.([]interface{}) {
+		for _, value := range edgeIPs.(*schema.Set).List() {
 			application.EdgeIPs.IPs = append(application.EdgeIPs.IPs, net.ParseIP(value.(string)))
 		}
 	}

--- a/internal/provider/resource_cloudflare_spectrum_application_test.go
+++ b/internal/provider/resource_cloudflare_spectrum_application_test.go
@@ -262,29 +262,28 @@ func TestAccCloudflareSpectrumApplication_EdgeIPsMultiple(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudflareSpectrumApplicationConfigMultipleEdgeIPs(zoneID, domain, rnd, `"172.65.64.13", "172.65.64.14"`),
+				Config: testAccCheckCloudflareSpectrumApplicationConfigMultipleEdgeIPs(zoneID, domain, rnd, `"172.65.64.13", "172.65.64.49"`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
 					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
 					resource.TestCheckResourceAttr(name, "edge_ips.#", "2"),
 					resource.TestCheckTypeSetElemAttr(name, "edge_ips.*", "172.65.64.13"),
-					resource.TestCheckTypeSetElemAttr(name, "edge_ips.*", "172.65.64.14"),
+					resource.TestCheckTypeSetElemAttr(name, "edge_ips.*", "172.65.64.49"),
 				),
 			},
 			{
-				Config: testAccCheckCloudflareSpectrumApplicationConfigMultipleEdgeIPs(zoneID, domain, rnd, `"172.65.64.14", "172.65.64.13"`),
+				Config: testAccCheckCloudflareSpectrumApplicationConfigMultipleEdgeIPs(zoneID, domain, rnd, `"172.65.64.49", "172.65.64.13"`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
 					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
 					resource.TestCheckResourceAttr(name, "edge_ips.#", "2"),
 					resource.TestCheckTypeSetElemAttr(name, "edge_ips.*", "172.65.64.13"),
-					resource.TestCheckTypeSetElemAttr(name, "edge_ips.*", "172.65.64.14"),
+					resource.TestCheckTypeSetElemAttr(name, "edge_ips.*", "172.65.64.49"),
 				),
 			},
 		},
 	})
 }
-
 
 func testAccCheckCloudflareSpectrumApplicationExists(n string, spectrumApp *cloudflare.SpectrumApplication) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/internal/provider/schema_cloudflare_spectrum_application.go
+++ b/internal/provider/schema_cloudflare_spectrum_application.go
@@ -118,9 +118,9 @@ func resourceCloudflareSpectrumApplicationSchema() map[string]*schema.Schema {
 		},
 
 		"edge_ips": {
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeSet},
+			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 
 		"edge_ip_connectivity": {

--- a/internal/provider/schema_cloudflare_spectrum_application.go
+++ b/internal/provider/schema_cloudflare_spectrum_application.go
@@ -120,7 +120,7 @@ func resourceCloudflareSpectrumApplicationSchema() map[string]*schema.Schema {
 		"edge_ips": {
 			Type:     schema.TypeList,
 			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
+			Elem:     &schema.Schema{Type: schema.TypeSet},
 		},
 
 		"edge_ip_connectivity": {


### PR DESCRIPTION
When interacting with a Spectrum app that is uses static edge IPs, these changes will ensure the order returned to a user will be consistent.

Closes #1610