### PR TITLE
Fix null MX record creation

### DIFF
--- a/.changelog/2038.txt
+++ b/.changelog/2038.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_record: Fix null MX record creation
+```

--- a/internal/provider/resource_cloudflare_record.go
+++ b/internal/provider/resource_cloudflare_record.go
@@ -440,3 +440,14 @@ func suppressPriority(k, old, new string, d *schema.ResourceData) bool {
 	}
 	return false
 }
+
+func suppressTrailingDots(k, old, new string, d *schema.ResourceData) bool {
+	newTrimmed := strings.TrimSuffix(new, ".")
+
+	// Ensure to distinguish values consists of dots only.
+	if newTrimmed == "" {
+		return old == new
+	}
+
+	return strings.TrimSuffix(old, ".") == newTrimmed
+}

--- a/internal/provider/resource_cloudflare_record_test.go
+++ b/internal/provider/resource_cloudflare_record_test.go
@@ -535,6 +535,29 @@ func TestAccCloudflareRecord_HTTPS(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareRecord_MXNull(t *testing.T) {
+	t.Parallel()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_record.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCloudflareRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRecordNullMX(zoneID, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "value", "."),
+					resource.TestCheckResourceAttr(name, "priority", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestSuppressTrailingDots(t *testing.T) {
 	t.Parallel()
 
@@ -843,4 +866,16 @@ resource "cloudflare_record" "%[2]s" {
 	}
 	ttl = 300
 }`, zoneID, rnd)
+}
+
+func testAccCheckCloudflareRecordNullMX(zoneID, rnd string) string {
+	return fmt.Sprintf(`
+	resource "cloudflare_record" "%[1]s" {
+		zone_id  = "%[2]s"
+		type     = "MX"
+		name     = "%[1]s"
+		value    = "."
+		priority = 0
+	  }
+	`, rnd, zoneID)
 }

--- a/internal/provider/schema_cloudflare_record.go
+++ b/internal/provider/schema_cloudflare_record.go
@@ -38,13 +38,11 @@ func resourceCloudflareRecordSchema() map[string]*schema.Schema {
 		},
 
 		"value": {
-			Type:          schema.TypeString,
-			Optional:      true,
-			Computed:      true,
-			ConflictsWith: []string{"data"},
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				return strings.TrimSuffix(old, ".") == strings.TrimSuffix(new, ".")
-			},
+			Type:             schema.TypeString,
+			Optional:         true,
+			Computed:         true,
+			ConflictsWith:    []string{"data"},
+			DiffSuppressFunc: suppressTrailingDots,
 		},
 
 		"data": {


### PR DESCRIPTION
[This change](https://github.com/cloudflare/terraform-provider-cloudflare/commit/f739b461fe2a9d0cc25fba92dd08ccf2a8c3a4a2#diff-8cbcffce54a790f765698cff05bf5b6f0d6cb76d654a0be1f41e42079ed9f6a9R45) introduced in v3.18.0 prevents creating a null MX record, whose `value` argument only contains a single dot(`.`).

This PR contains the following changes.

- Compare raw `value` values when they only contains dot characters. It keeps the original behaivior when value contains non-dot characters.
- Extract DiffSupressFunc implementation as `suppressTrailingDots` function and add unit tests.

Closes #2037 