### PR TITLE
resource/cloudflare_origin_ca_certificate: trigger a replacement when `csr` is changed

### DIFF
--- a/.changelog/2055.txt
+++ b/.changelog/2055.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_origin_ca_certificate: trigger a replacement when `csr` is changed
+```

--- a/internal/provider/resource_cloudflare_origin_ca_certificate.go
+++ b/internal/provider/resource_cloudflare_origin_ca_certificate.go
@@ -19,7 +19,6 @@ func resourceCloudflareOriginCACertificate() *schema.Resource {
 	return &schema.Resource{
 		Schema:        resourceCloudflareOriginCACertificateSchema(),
 		CreateContext: resourceCloudflareOriginCACertificateCreate,
-		UpdateContext: resourceCloudflareOriginCACertificateCreate,
 		ReadContext:   resourceCloudflareOriginCACertificateRead,
 		DeleteContext: resourceCloudflareOriginCACertificateDelete,
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/schema_cloudflare_origin_ca_certificate.go
+++ b/internal/provider/schema_cloudflare_origin_ca_certificate.go
@@ -13,6 +13,7 @@ func resourceCloudflareOriginCACertificateSchema() map[string]*schema.Schema {
 		},
 		"csr": {
 			Type:         schema.TypeString,
+			ForceNew:     true,
 			Optional:     true,
 			ValidateFunc: validateCSR,
 		},


### PR DESCRIPTION
As commented in the #1007, this is the proposed fix.
I ran some tests with the provided terraform and it works as expected

Closes #1007