### PR TITLE
resource/cloudflare_list: Do not reapply changes if only list order changed

### DIFF
--- a/.changelog/2063.txt
+++ b/.changelog/2063.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_list: Do not reapply changes if only list order changed.
+```

--- a/internal/provider/resource_cloudflare_list_test.go
+++ b/internal/provider/resource_cloudflare_list_test.go
@@ -185,6 +185,26 @@ func TestAccCloudflareList_Update(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareList_UpdateUnordered(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the IP List
+	// endpoint does not yet support the API tokens.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	config := testAccCheckCloudflareListIPUpdateUnordered(accountID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		ProviderFactories: providerFactories,
+		Steps:             []resource.TestStep{{Config: config}},
+	})
+}
+
 func testAccCheckCloudflareListExists(n string, list *cloudflare.List) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -241,6 +261,38 @@ func testAccCheckCloudflareListIPUpdate(ID, name, description, accountID string)
       comment = "two"
     }
   }`, ID, name, description, accountID)
+}
+
+func testAccCheckCloudflareListIPUpdateUnordered(accountID string) string {
+	return fmt.Sprintf(`
+  variable "cloudflare_test_allowlist" {
+    description = "Temp Testing IP list"
+    type        = map(string)
+    default = {
+      "73.98.124.7"  = "ip_address_01"
+      "73.98.124.8"  = "ip_address_02"
+      "73.98.124.9"  = "ip_address_03"
+      "73.98.124.10" = "ip_address_04"
+      "73.98.124.11" = "ip_address_05"
+    }
+  }
+
+  resource "cloudflare_list" "test_allowlist" {
+    account_id  = "%s"
+    name        = "test_allowlist"
+    kind        = "ip"
+    description = "Testing IP list"
+
+    dynamic "item" {
+      for_each = var.cloudflare_test_allowlist
+      content {
+	value {
+	  ip = item.key
+	}
+	comment = item.value
+      }
+    }
+  }`, accountID)
 }
 
 func testAccCheckCloudflareListRedirectUpdate(ID, name, description, accountID string) string {

--- a/internal/provider/schema_cloudflare_list.go
+++ b/internal/provider/schema_cloudflare_list.go
@@ -34,7 +34,7 @@ func resourceCloudflareListSchema() map[string]*schema.Schema {
 			Required:     true,
 		},
 		"item": {
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem:     listItemElem,
 		},


### PR DESCRIPTION
Fixes #1827 

* resource/cloudflare_list: add test that dynamic lists apply cleanly

Add a failing test with the example from #1827.

The test framework checks that a subsequent terraform plan does not produce a
diff. This check fails since the list is reordered on each terraform apply.

* resource/cloudflare_list: use schema.TypeSet instead of schema.TypeList

Lists are unordered so using schema.TypeList leads to spurious updates.
Use schema.TypeSet instead to avoid these.

Refactor `buildListItemsCreateRequest` to traverse the Go data structure instead
of using `resource.GetOk`. We can't easily use "item.%d.value" with TypeSet
because its items are indexed by hash instead of position.

* add changelog