### PR TITLE
Suppress session_duration diffs for bookmark applications

### DIFF
--- a/.changelog/2076.txt
+++ b/.changelog/2076.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/access_application: fix issue where session_duration always showed a diff for bookmark apps
+```

--- a/internal/provider/schema_cloudflare_access_application.go
+++ b/internal/provider/schema_cloudflare_access_application.go
@@ -53,6 +53,16 @@ func resourceCloudflareAccessApplicationSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 			Default:  "24h",
+			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+				appType := d.Get("type").(string)
+				// Suppress the diff if it's a bookmark app type. Bookmarks don't have a session duration
+				// field which always creates a diff because of the default '24h' value.
+				if appType == "bookmark" {
+					return true
+				}
+
+				return oldValue == newValue
+			},
 			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 				v := val.(string)
 				_, err := time.ParseDuration(v)


### PR DESCRIPTION
Fixes a bug where bookmark apps were always showing a diff for the session_duration field. We default that field to be '24h' when empty, however, bookmark apps don't have a session_duration so TF always showed a diff.