### PR TITLE
Don't require edge_ttl.default in cache rules

### DIFF
--- a/internal/provider/schema_cloudflare_ruleset.go
+++ b/internal/provider/schema_cloudflare_ruleset.go
@@ -581,7 +581,7 @@ func resourceCloudflareRulesetSchema() map[string]*schema.Schema {
 											},
 											"default": {
 												Type:        schema.TypeInt,
-												Required:    true,
+												Optional:    true,
 												Description: "Default edge TTL",
 											},
 											"status_code_ttl": {


### PR DESCRIPTION
Currently, `default` is required, but not _allowed_ to be set when `mode` is set to `respect_origin`. I believe it should be optional; we'll still get an error when _not_ setting this in combination with mode `override_origin`.

Closes #2007