### PR TITLE
Update api shield

### DIFF
--- a/.changelog/2091.txt
+++ b/.changelog/2091.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_api_shield: allow for empty auth_id_characteristics
+```

--- a/internal/provider/resource_cloudflare_api_shield.go
+++ b/internal/provider/resource_cloudflare_api_shield.go
@@ -90,22 +90,15 @@ func resourceCloudflareAPIShieldDelete(ctx context.Context, d *schema.ResourceDa
 }
 
 func buildAPIShieldConfiguration(d *schema.ResourceData) (cloudflare.APIShield, error) {
-	var as cloudflare.APIShield
-
+	as := cloudflare.APIShield{}
 	configs, ok := d.Get("auth_id_characteristics").([]interface{})
-
 	if !ok {
 		return cloudflare.APIShield{}, errors.New("unable to create interface map type assertion for rule")
 	}
 
+	as.AuthIdCharacteristics = []cloudflare.AuthIdCharacteristics{}
 	for i := 0; i < len(configs); i++ {
-		if ok = (configs[i] != interface{}(nil)); ok {
-			as.AuthIdCharacteristics = append(as.AuthIdCharacteristics, cloudflare.AuthIdCharacteristics{Name: configs[i].(map[string]interface{})["name"].(string), Type: configs[i].(map[string]interface{})["type"].(string)})
-		}
-	}
-
-	if len(as.AuthIdCharacteristics) == 0 {
-		as.AuthIdCharacteristics = make([]cloudflare.AuthIdCharacteristics, 0)
+		as.AuthIdCharacteristics = append(as.AuthIdCharacteristics, cloudflare.AuthIdCharacteristics{Name: configs[i].(map[string]interface{})["name"].(string), Type: configs[i].(map[string]interface{})["type"].(string)})
 	}
 
 	return as, nil

--- a/internal/provider/resource_cloudflare_api_shield.go
+++ b/internal/provider/resource_cloudflare_api_shield.go
@@ -33,12 +33,12 @@ func resourceCloudflareAPIShieldCreate(ctx context.Context, d *schema.ResourceDa
 
 	as, err := buildAPIShieldConfiguration(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("failed to create API Shield Configuration")))
+		return diag.FromErr(errors.Wrap(err, "failed to create API Shield Configuration"))
 	}
 
 	_, err = client.UpdateAPIShieldConfiguration(ctx, cloudflare.ZoneIdentifier(zoneID), cloudflare.UpdateAPIShieldParams{AuthIdCharacteristics: as.AuthIdCharacteristics})
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("failed to create API Shield Configuration")))
+		return diag.FromErr(errors.Wrap(err, "failed to create API Shield Configuration"))
 	}
 
 	return resourceCloudflareAPIShieldRead(ctx, d, meta)
@@ -97,9 +97,14 @@ func buildAPIShieldConfiguration(d *schema.ResourceData) (cloudflare.APIShield, 
 	if !ok {
 		return cloudflare.APIShield{}, errors.New("unable to create interface map type assertion for rule")
 	}
-
-	for i := 0; i < len(configs); i++ {
-		as.AuthIdCharacteristics = append(as.AuthIdCharacteristics, cloudflare.AuthIdCharacteristics{Name: configs[i].(map[string]interface{})["name"].(string), Type: configs[i].(map[string]interface{})["type"].(string)})
+	if len(configs) == 0 {
+		as.AuthIdCharacteristics = make([]cloudflare.AuthIdCharacteristics, 0)
+	} else {
+		for i := 0; i < len(configs); i++ {
+			if ok = configs != nil; ok {
+				as.AuthIdCharacteristics = append(as.AuthIdCharacteristics, cloudflare.AuthIdCharacteristics{Name: configs[i].(map[string]interface{})["name"].(string), Type: configs[i].(map[string]interface{})["type"].(string)})
+			}
+		}
 	}
 
 	return as, nil

--- a/internal/provider/resource_cloudflare_api_shield.go
+++ b/internal/provider/resource_cloudflare_api_shield.go
@@ -97,14 +97,15 @@ func buildAPIShieldConfiguration(d *schema.ResourceData) (cloudflare.APIShield, 
 	if !ok {
 		return cloudflare.APIShield{}, errors.New("unable to create interface map type assertion for rule")
 	}
-	if len(configs) == 0 {
-		as.AuthIdCharacteristics = make([]cloudflare.AuthIdCharacteristics, 0)
-	} else {
-		for i := 0; i < len(configs); i++ {
-			if ok = configs != nil; ok {
-				as.AuthIdCharacteristics = append(as.AuthIdCharacteristics, cloudflare.AuthIdCharacteristics{Name: configs[i].(map[string]interface{})["name"].(string), Type: configs[i].(map[string]interface{})["type"].(string)})
-			}
+
+	for i := 0; i < len(configs); i++ {
+		if ok = (configs[i] != interface{}(nil)); ok {
+			as.AuthIdCharacteristics = append(as.AuthIdCharacteristics, cloudflare.AuthIdCharacteristics{Name: configs[i].(map[string]interface{})["name"].(string), Type: configs[i].(map[string]interface{})["type"].(string)})
 		}
+	}
+
+	if len(as.AuthIdCharacteristics) == 0 {
+		as.AuthIdCharacteristics = make([]cloudflare.AuthIdCharacteristics, 0)
 	}
 
 	return as, nil

--- a/internal/provider/resource_cloudflare_api_shield_test.go
+++ b/internal/provider/resource_cloudflare_api_shield_test.go
@@ -48,3 +48,13 @@ func testAccCloudflareAPIShieldSingleEntry(resourceName, rnd string, authChar cl
 	}
 `, resourceName, rnd, authChar.Name, authChar.Type)
 }
+
+func testAccCloudflareAPIShieldEmptyAuthIdCharacteristics(resourceName, rnd string, authChar cloudflare.AuthIdCharacteristics) string {
+	return fmt.Sprintf(`
+	resource "cloudflare_api_shield" "%[1]s" {
+		zone_id = "%[2]s"
+		auth_id_characteristics {
+		}
+	}
+	`)
+}

--- a/internal/provider/resource_cloudflare_api_shield_test.go
+++ b/internal/provider/resource_cloudflare_api_shield_test.go
@@ -35,6 +35,19 @@ func TestAccAPIShield_Basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccAPIShield_EmptyAuthIdCharacteristics(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
+	// endpoint does not yet support the API tokens without an explicit scope.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := generateRandomResourceName()
+	resourceID := "cloudflare_api_shield." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
@@ -43,6 +56,7 @@ func TestAccAPIShield_Basic(t *testing.T) {
 				Config: testAccCloudflareAPIShieldEmptyAuthIdCharacteristics(rnd, zoneID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceID, "zone_id", zoneID),
+					resource.TestCheckResourceAttr(resourceID, "auth_id_characteristics.#", "0"),
 				),
 			},
 		},

--- a/internal/provider/resource_cloudflare_api_shield_test.go
+++ b/internal/provider/resource_cloudflare_api_shield_test.go
@@ -35,6 +35,18 @@ func TestAccAPIShield_Basic(t *testing.T) {
 			},
 		},
 	})
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareAPIShieldEmptyAuthIdCharacteristics(rnd, zoneID, cloudflare.AuthIdCharacteristics{Name: "test-header", Type: "header"}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceID, "zone_id", zoneID),
+				),
+			},
+		},
+	})
 }
 
 func testAccCloudflareAPIShieldSingleEntry(resourceName, rnd string, authChar cloudflare.AuthIdCharacteristics) string {
@@ -53,8 +65,6 @@ func testAccCloudflareAPIShieldEmptyAuthIdCharacteristics(resourceName, rnd stri
 	return fmt.Sprintf(`
 	resource "cloudflare_api_shield" "%[1]s" {
 		zone_id = "%[2]s"
-		auth_id_characteristics {
-		}
 	}
-	`)
+	`, resourceName, rnd)
 }

--- a/internal/provider/resource_cloudflare_api_shield_test.go
+++ b/internal/provider/resource_cloudflare_api_shield_test.go
@@ -40,7 +40,7 @@ func TestAccAPIShield_Basic(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudflareAPIShieldEmptyAuthIdCharacteristics(rnd, zoneID, cloudflare.AuthIdCharacteristics{Name: "test-header", Type: "header"}),
+				Config: testAccCloudflareAPIShieldEmptyAuthIdCharacteristics(rnd, zoneID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceID, "zone_id", zoneID),
 				),
@@ -61,7 +61,7 @@ func testAccCloudflareAPIShieldSingleEntry(resourceName, rnd string, authChar cl
 `, resourceName, rnd, authChar.Name, authChar.Type)
 }
 
-func testAccCloudflareAPIShieldEmptyAuthIdCharacteristics(resourceName, rnd string, authChar cloudflare.AuthIdCharacteristics) string {
+func testAccCloudflareAPIShieldEmptyAuthIdCharacteristics(resourceName, rnd string) string {
 	return fmt.Sprintf(`
 	resource "cloudflare_api_shield" "%[1]s" {
 		zone_id = "%[2]s"

--- a/internal/provider/schema_cloudflare_api_shield.go
+++ b/internal/provider/schema_cloudflare_api_shield.go
@@ -17,19 +17,19 @@ func resourceCloudflareAPIShieldSchema() map[string]*schema.Schema {
 		},
 		"auth_id_characteristics": {
 			Description: "Characteristics define properties across which auth-ids can be computed in a privacy-preserving manner.",
-			Required:    true,
+			Optional:    true,
 			Type:        schema.TypeList,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"type": {
 						Description:  fmt.Sprintf("The type of characteristic. %s", renderAvailableDocumentationValuesStringSlice([]string{"header", "cookie"})),
-						Required:     true,
+						Optional:     true,
 						Type:         schema.TypeString,
 						ValidateFunc: validation.StringInSlice([]string{"header", "cookie"}, false),
 					},
 					"name": {
 						Description: "The name of the characteristic.",
-						Required:    true,
+						Optional:    true,
 						Type:        schema.TypeString,
 					},
 				},


### PR DESCRIPTION
update api shield to allow auth_id_characteristics to be empty or missing from the TF. When its missing we will send `auth_id_characteristics: []` to cloudflare-go to send on to the API. 