### PR TITLE
fix: makes allowed_idps type to set

### DIFF
--- a/.changelog/2094.txt
+++ b/.changelog/2094.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_access_application: makes allowed_idps type to set
+```

--- a/internal/provider/data_source_access_identity_provider_test.go
+++ b/internal/provider/data_source_access_identity_provider_test.go
@@ -61,7 +61,7 @@ func TestAccCloudflareAccessIdentityProviderDataSourceNotFound(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -100,7 +100,7 @@ func TestAccCloudflareAccessIdentityProviderDataSource_GitHub(t *testing.T) {
 	name := "data.cloudflare_access_identity_provider." + rnd
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -79,18 +79,6 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testAccessAccPreCheck(t *testing.T) {
-	testAccPreCheckEmail(t)
-	testAccPreCheckApiKey(t)
-	testAccPreCheckDomain(t)
-
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	if zoneID == "" && accountID == "" {
-		t.Fatal("CLOUDFLARE_ZONE_ID or CLOUDFLARE_ACCOUNT_ID must be set for this acceptance test")
-	}
-}
-
 func testAccPreCheckAltDomain(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_ALT_DOMAIN"); v == "" {
 		t.Fatal("CLOUDFLARE_ALT_DOMAIN must be set for this acceptance test")

--- a/internal/provider/resource_cloudflare_access_application.go
+++ b/internal/provider/resource_cloudflare_access_application.go
@@ -34,7 +34,6 @@ func resourceCloudflareAccessApplication() *schema.Resource {
 func resourceCloudflareAccessApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
-	allowedIDPList := expandInterfaceToStringList(d.Get("allowed_idps"))
 	appType := d.Get("type").(string)
 
 	newAccessApplication := cloudflare.AccessApplication{
@@ -54,8 +53,8 @@ func resourceCloudflareAccessApplicationCreate(ctx context.Context, d *schema.Re
 		ServiceAuth401Redirect:  cloudflare.BoolPtr(d.Get("service_auth_401_redirect").(bool)),
 	}
 
-	if len(allowedIDPList) > 0 {
-		newAccessApplication.AllowedIdps = allowedIDPList
+	if value, ok := d.GetOk("allowed_idps"); ok {
+		newAccessApplication.AllowedIdps = expandInterfaceToStringList(value.(*schema.Set).List())
 	}
 
 	if _, ok := d.GetOk("cors_headers"); ok {
@@ -150,7 +149,6 @@ func resourceCloudflareAccessApplicationRead(ctx context.Context, d *schema.Reso
 func resourceCloudflareAccessApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 
-	allowedIDPList := expandInterfaceToStringList(d.Get("allowed_idps"))
 	appType := d.Get("type").(string)
 
 	updatedAccessApplication := cloudflare.AccessApplication{
@@ -175,8 +173,8 @@ func resourceCloudflareAccessApplicationUpdate(ctx context.Context, d *schema.Re
 		updatedAccessApplication.Domain = d.Get("domain").(string)
 	}
 
-	if len(allowedIDPList) > 0 {
-		updatedAccessApplication.AllowedIdps = allowedIDPList
+	if value, ok := d.GetOk("allowed_idps"); ok {
+		updatedAccessApplication.AllowedIdps = expandInterfaceToStringList(value.(*schema.Set).List())
 	}
 
 	if _, ok := d.GetOk("cors_headers"); ok {

--- a/internal/provider/resource_cloudflare_access_application_test.go
+++ b/internal/provider/resource_cloudflare_access_application_test.go
@@ -25,8 +25,6 @@ func TestAccCloudflareAccessApplication_BasicZone(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -55,7 +53,6 @@ func TestAccCloudflareAccessApplication_BasicAccount(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -85,8 +82,6 @@ func TestAccCloudflareAccessApplication_WithCORS(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -118,8 +113,6 @@ func TestAccCloudflareAccessApplication_WithSaas(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -148,8 +141,6 @@ func TestAccCloudflareAccessApplication_WithAutoRedirectToIdentity(t *testing.T)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -176,8 +167,6 @@ func TestAccCloudflareAccessApplication_WithEnableBindingCookie(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -204,8 +193,6 @@ func TestAccCloudflareAccessApplication_WithCustomDenyFields(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -233,8 +220,6 @@ func TestAccCloudflareAccessApplication_WithADefinedIdps(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -263,8 +248,6 @@ func TestAccCloudflareAccessApplication_WithMultipleIdpsReordered(t *testing.T) 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -286,8 +269,6 @@ func TestAccCloudflareAccessApplication_WithHttpOnlyCookieAttribute(t *testing.T
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -314,8 +295,6 @@ func TestAccCloudflareAccessApplication_WithHTTPOnlyCookieAttributeSetToFalse(t 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -342,8 +321,6 @@ func TestAccCloudflareAccessApplication_WithSameSiteCookieAttribute(t *testing.T
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -370,8 +347,6 @@ func TestAccCloudflareAccessApplication_WithLogoURL(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -398,8 +373,6 @@ func TestAccCloudflareAccessApplication_WithSkipInterstitial(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -426,8 +399,6 @@ func TestAccCloudflareAccessApplication_WithAppLauncherVisible(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
@@ -740,7 +711,7 @@ func TestAccCloudflareAccessApplicationWithZoneID(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -770,7 +741,7 @@ func TestAccCloudflareAccessApplicationWithMissingCORSMethods(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -790,7 +761,7 @@ func TestAccCloudflareAccessApplicationWithMissingCORSOrigins(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -810,7 +781,7 @@ func TestAccCloudflareAccessApplicationWithInvalidSessionDuration(t *testing.T) 
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -830,7 +801,7 @@ func TestAccCloudflareAccessApplicationMisconfiguredCORSCredentialsAllowingAllOr
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -850,7 +821,7 @@ func TestAccCloudflareAccessApplicationMisconfiguredCORSCredentialsAllowingWildc
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,

--- a/internal/provider/resource_cloudflare_access_bookmark_test.go
+++ b/internal/provider/resource_cloudflare_access_bookmark_test.go
@@ -24,7 +24,7 @@ func TestAccCloudflareAccessBookmark_Basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessBookmarkDestroy,
@@ -45,7 +45,6 @@ func TestAccCloudflareAccessBookmark_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -116,7 +115,6 @@ func TestAccCloudflareAccessBookmark_WithZoneID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,

--- a/internal/provider/resource_cloudflare_access_ca_certificate_test.go
+++ b/internal/provider/resource_cloudflare_access_ca_certificate_test.go
@@ -20,7 +20,6 @@ func TestAccCloudflareAccessCACertificate_AccountLevel(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -48,7 +47,6 @@ func TestAccCloudflareAccessCACertificate_ZoneLevel(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,

--- a/internal/provider/resource_cloudflare_access_group_test.go
+++ b/internal/provider/resource_cloudflare_access_group_test.go
@@ -80,7 +80,6 @@ func TestAccCloudflareAccessGroupConfig_BasicZone(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -122,7 +121,7 @@ func TestAccCloudflareAccessGroupConfig_BasicAccount(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessGroupDestroy,
@@ -172,7 +171,6 @@ func TestAccCloudflareAccessGroup_Exclude(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -200,7 +198,6 @@ func TestAccCloudflareAccessGroup_Require(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -228,7 +225,6 @@ func TestAccCloudflareAccessGroup_FullConfig(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -259,7 +255,6 @@ func TestAccCloudflareAccessGroupWithIDP(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -288,7 +283,6 @@ func TestAccCloudflareAccessGroup_Updated(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -321,7 +315,6 @@ func TestAccCloudflareAccessGroup_CreateAfterManualDestroy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,

--- a/internal/provider/resource_cloudflare_access_identity_provider_test.go
+++ b/internal/provider/resource_cloudflare_access_identity_provider_test.go
@@ -61,7 +61,6 @@ func TestAccCloudflareAccessIdentityProvider_OneTimePin(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -79,7 +78,7 @@ func TestAccCloudflareAccessIdentityProvider_OneTimePin(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
@@ -103,7 +102,6 @@ func TestAccCloudflareAccessIdentityProvider_OAuth(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -130,7 +128,6 @@ func TestAccCloudflareAccessIdentityProvider_OAuthWithUpdate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -167,7 +164,6 @@ func TestAccCloudflareAccessIdentityProvider_SAML(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,

--- a/internal/provider/resource_cloudflare_access_keys_configuration_test.go
+++ b/internal/provider/resource_cloudflare_access_keys_configuration_test.go
@@ -23,7 +23,6 @@ func TestAccCloudflareAccessKeysConfiguration_WithKeyRotationIntervalDaysSet(t *
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
@@ -60,7 +59,6 @@ func TestAccCloudflareAccessKeysConfiguration_WithoutKeyRotationIntervalDaysSet(
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_cloudflare_access_mutual_tls_certificate_test.go
+++ b/internal/provider/resource_cloudflare_access_mutual_tls_certificate_test.go
@@ -75,7 +75,6 @@ func TestAccCloudflareAccessMutualTLSBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -118,7 +117,7 @@ func TestAccCloudflareAccessMutualTLSBasicWithZoneID(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessMutualTLSCertificateDestroy,

--- a/internal/provider/resource_cloudflare_access_organization_test.go
+++ b/internal/provider/resource_cloudflare_access_organization_test.go
@@ -16,7 +16,6 @@ func TestAccCloudflareAccessOrganization(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_cloudflare_access_policy_test.go
+++ b/internal/provider/resource_cloudflare_access_policy_test.go
@@ -24,7 +24,6 @@ func TestAccCloudflareAccessPolicy_ServiceToken(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -50,7 +49,6 @@ func TestAccCloudflareAccessPolicy_AnyServiceToken(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -75,7 +73,7 @@ func TestAccCloudflareAccessPolicy_WithZoneID(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
@@ -205,7 +203,6 @@ func TestAccCloudflareAccessPolicy_Group(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -263,7 +260,6 @@ func TestAccCloudflareAccessPolicy_MTLS(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -312,7 +308,6 @@ func TestAccCloudflareAccessPolicy_CommonName(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -361,7 +356,6 @@ func TestAccCloudflareAccessPolicy_EmailDomain(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -410,7 +404,6 @@ func TestAccCloudflareAccessPolicy_Emails(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -461,7 +454,6 @@ func TestAccCloudflareAccessPolicy_Everyone(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -510,7 +502,6 @@ func TestAccCloudflareAccessPolicy_IPs(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -561,7 +552,6 @@ func TestAccCloudflareAccessPolicy_AuthMethod(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -610,7 +600,6 @@ func TestAccCloudflareAccessPolicy_Geo(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -661,7 +650,6 @@ func TestAccCloudflareAccessPolicy_Okta(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -715,7 +703,6 @@ func TestAccCloudflareAccessPolicy_PurposeJustification(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -766,7 +753,6 @@ func TestAccCloudflareAccessPolicy_ApprovalGroup(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -835,7 +821,6 @@ func TestAccCloudflareAccessPolicy_ExternalEvaluation(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,

--- a/internal/provider/resource_cloudflare_access_service_tokens_test.go
+++ b/internal/provider/resource_cloudflare_access_service_tokens_test.go
@@ -25,7 +25,7 @@ func TestAccCloudflareAccessServiceTokenCreate(t *testing.T) {
 	resourceName := strings.Split(name, ".")[1]
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccessAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
@@ -42,7 +42,7 @@ func TestAccCloudflareAccessServiceTokenCreate(t *testing.T) {
 	})
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccessAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
@@ -73,7 +73,7 @@ func TestAccCloudflareAccessServiceTokenUpdate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -94,7 +94,7 @@ func TestAccCloudflareAccessServiceTokenUpdate(t *testing.T) {
 	})
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccessAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
@@ -132,7 +132,7 @@ func TestAccCloudflareAccessServiceTokenUpdate(t *testing.T) {
 // 	expirationTime := 365
 
 // 	resource.Test(t, resource.TestCase{
-// 		PreCheck:  func() { testAccessAccPreCheck(t) },
+// 		PreCheck:  func() { testAccPreCheck(t) },
 // 		ProviderFactories: providerFactories,
 // 		Steps: []resource.TestStep{
 // 			{
@@ -208,7 +208,7 @@ func TestAccCloudflareAccessServiceTokenDelete(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 			testAccPreCheckAccount(t)
 		},
 		ProviderFactories: providerFactories,
@@ -228,7 +228,7 @@ func TestAccCloudflareAccessServiceTokenDelete(t *testing.T) {
 	})
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccessAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessServiceTokenDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_cloudflare_device_policy_certificates_test.go
+++ b/internal/provider/resource_cloudflare_device_policy_certificates_test.go
@@ -21,7 +21,7 @@ func TestAccCloudflareDevicePolicyCertificatesCreate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareDevicePostureIntegrationDestroy,

--- a/internal/provider/resource_cloudflare_device_posture_integration_test.go
+++ b/internal/provider/resource_cloudflare_device_posture_integration_test.go
@@ -29,7 +29,7 @@ func TestAccCloudflareDevicePostureIntegrationCreate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 			testAccPreCheckWorkspaceOne(t)
 		},
 		ProviderFactories: providerFactories,

--- a/internal/provider/resource_cloudflare_device_posture_rule_test.go
+++ b/internal/provider/resource_cloudflare_device_posture_rule_test.go
@@ -25,7 +25,6 @@ func TestAccCloudflareDevicePostureRule_SerialNumber(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareDevicePostureRuleDestroy,
@@ -59,7 +58,6 @@ func TestAccCloudflareDevicePostureRule_OsVersion(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareDevicePostureRuleDestroy,
@@ -94,7 +92,6 @@ func TestAccCloudflareDevicePostureRule_LinuxOsDistro(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareDevicePostureRuleDestroy,
@@ -130,7 +127,6 @@ func TestAccCloudflareDevicePostureRule_DomainJoined(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareDevicePostureRuleDestroy,
@@ -164,7 +160,6 @@ func TestAccCloudflareDevicePostureRule_Firewall(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareDevicePostureRuleDestroy,
@@ -200,7 +195,6 @@ func TestAccCloudflareDevicePostureRule_DiskEncryption(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareDevicePostureRuleDestroy,

--- a/internal/provider/resource_cloudflare_device_settings_policy_test.go
+++ b/internal/provider/resource_cloudflare_device_settings_policy_test.go
@@ -30,7 +30,7 @@ func TestAccCloudflareDeviceSettingsPolicy_Create(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareDeviceSettingsPolicyDestroy,

--- a/internal/provider/resource_cloudflare_split_tunnel_test.go
+++ b/internal/provider/resource_cloudflare_split_tunnel_test.go
@@ -22,7 +22,7 @@ func TestAccCloudflareSplitTunnel_Include(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
@@ -62,7 +62,7 @@ func TestAccCloudflareSplitTunnel_ConflictingTunnelProperties(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
@@ -143,7 +143,7 @@ func TestAccCloudflareSplitTunnel_Exclude(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
@@ -172,7 +172,7 @@ func TestAccCloudflareSplitTunnel_IncludeTunnelOrdering(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_cloudflare_teams_accounts_test.go
+++ b/internal/provider/resource_cloudflare_teams_accounts_test.go
@@ -21,7 +21,7 @@ func TestAccCloudflareTeamsAccountConfigurationBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_cloudflare_teams_list_test.go
+++ b/internal/provider/resource_cloudflare_teams_list_test.go
@@ -27,7 +27,6 @@ func TestAccCloudflareTeamsList_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareTeamsListDestroy,
@@ -61,7 +60,6 @@ func TestAccCloudflareTeamsList_LottaListItems(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareTeamsListDestroy,
@@ -93,7 +91,6 @@ func TestAccCloudflareTeamsList_Reordered(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareTeamsListDestroy,

--- a/internal/provider/resource_cloudflare_teams_location_test.go
+++ b/internal/provider/resource_cloudflare_teams_location_test.go
@@ -25,7 +25,6 @@ func TestAccCloudflareTeamsLocationBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareTeamsLocationDestroy,

--- a/internal/provider/resource_cloudflare_teams_proxy_endpoints_test.go
+++ b/internal/provider/resource_cloudflare_teams_proxy_endpoints_test.go
@@ -26,7 +26,6 @@ func TestAccCloudflareTeamsProxyEndpoint_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareTeamsProxyEndpointDestroy,

--- a/internal/provider/resource_cloudflare_teams_rules_test.go
+++ b/internal/provider/resource_cloudflare_teams_rules_test.go
@@ -25,7 +25,7 @@ func TestAccCloudflareTeamsRuleBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareTeamsRuleDestroy,

--- a/internal/provider/resource_cloudflare_web3hostname_test.go
+++ b/internal/provider/resource_cloudflare_web3hostname_test.go
@@ -38,7 +38,7 @@ func TestAccCloudflareWeb3HostnameEthereum(t *testing.T) {
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccessAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
@@ -61,7 +61,7 @@ func TestAccCloudflareWeb3Hostname(t *testing.T) {
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccessAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/resource_cloudflare_workers_cron_trigger_test.go
+++ b/internal/provider/resource_cloudflare_workers_cron_trigger_test.go
@@ -15,7 +15,7 @@ func TestAccCloudflareWorkerCronTriggerBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccessAccPreCheck(t)
+			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/schema_cloudflare_access_application.go
+++ b/internal/provider/schema_cloudflare_access_application.go
@@ -162,7 +162,7 @@ func resourceCloudflareAccessApplicationSchema() map[string]*schema.Schema {
 			Description: "Option to provide increased security against compromised authorization tokens and CSRF attacks by requiring an additional \"binding\" cookie on requests.",
 		},
 		"allowed_idps": {
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,


### PR DESCRIPTION
Because order of cloudflare_access_application.allowed_idps is not stable, each time terraform plan shows diff. To avoid this, allowed_idps should be set type rather than list.
It might be Cloudflare API doesn't care an order of IDPs.
For example, after I apply a plan below, rerun apply, it shows same diff.

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # cloudflare_access_application.xxx will be updated in-place
  ~ resource "cloudflare_access_application" "xxx" {
      ~ allowed_idps               = [
          - "327a35a4-d355-43f0-a90e-0ee915d3c7f9",
            "c6efb857-e6e4-483a-91c9-f0f0c63ea16e",
          + "327a35a4-d355-43f0-a90e-0ee915d3c7f9",
        ]
        id                         = "fcb66895-7006-482b-94a4-85a9eb3e51df"
        name                       = "XXX"
        # (12 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
