### PR TITLE
allow edge_ttl->default to be optional

### DIFF
--- a/.changelog/2097.txt
+++ b/.changelog/2097.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: allow edge_ttl -> default to be optional
+```

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -614,11 +614,11 @@ Optional:
 
 Required:
 
-- `default` (Number) Default edge TTL.
 - `mode` (String) Mode of the edge TTL.
 
 Optional:
 
+- `default` (Number) Default edge TTL.
 - `status_code_ttl` (Block List) Edge TTL for the status codes. (see [below for nested schema](#nestedblock--rules--action_parameters--edge_ttl--status_code_ttl))
 
 <a id="nestedblock--rules--action_parameters--edge_ttl--status_code_ttl"></a>

--- a/internal/provider/schema_cloudflare_ruleset.go
+++ b/internal/provider/schema_cloudflare_ruleset.go
@@ -581,7 +581,7 @@ func resourceCloudflareRulesetSchema() map[string]*schema.Schema {
 											},
 											"default": {
 												Type:        schema.TypeInt,
-												Required:    true,
+												Optional:    true,
 												Description: "Default edge TTL",
 											},
 											"status_code_ttl": {


### PR DESCRIPTION
Closes https://github.com/cloudflare/terraform-provider-cloudflare/issues/2007

Ran into this issue myself. Allow `edge_ttl->default` to be Optional. There are checks in place in the API to ensure `default` exist when in `override_origin` mode. 