### PR TITLE
Migrate to v0.57.0 for cloudflare-go

### DIFF
--- a/.changelog/2104.txt
+++ b/.changelog/2104.txt
@@ -1,0 +1,3 @@
+```release-note:dependency
+provider: bumps cloudflare/cloudflare-go from 0.56.0 to 0.57.0
+```

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
-	github.com/cloudflare/cloudflare-go v0.56.0
+	github.com/cloudflare/cloudflare-go v0.57.0
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/cloudflare-go v0.56.0 h1:ipMEKt3/33fgv8CdHnxn9hba1HzJ67hf0VyCdprIaro=
-github.com/cloudflare/cloudflare-go v0.56.0/go.mod h1:Xv29BilsDBBZUneqqnSEJT4HRi1YMn4RvWitAVkESOI=
+github.com/cloudflare/cloudflare-go v0.57.0 h1:+MNQFoJ4IqtFFUj41aV5buB4f2vFyPMrQrgecH3XYxI=
+github.com/cloudflare/cloudflare-go v0.57.0/go.mod h1:cD8AqNMMaL1A0Sj9XKo3Xu9ZVHwHqgXJofb1ya210GQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
@@ -249,7 +249,7 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/urfave/cli/v2 v2.23.6/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
+github.com/urfave/cli/v2 v2.23.7/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/resource_cloudflare_workers_cron_trigger.go
+++ b/internal/provider/resource_cloudflare_workers_cron_trigger.go
@@ -31,7 +31,13 @@ func resourceCloudflareWorkerCronTriggerUpdate(ctx context.Context, d *schema.Re
 
 	scriptName := d.Get("script_name").(string)
 
-	_, err := client.UpdateWorkerCronTriggers(ctx, accountID, scriptName, transformSchemaToWorkerCronTriggerStruct(d))
+	crons := transformSchemaToWorkerCronTriggerStruct(d)
+	params := cloudflare.UpdateWorkerCronTriggersParams{
+		ScriptName: scriptName,
+		Crons:      crons,
+	}
+
+	_, err := client.UpdateWorkerCronTriggers(ctx, cloudflare.AccountIdentifier(accountID), params)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to update Worker Cron Trigger: %w", err))
 	}
@@ -46,7 +52,11 @@ func resourceCloudflareWorkerCronTriggerRead(ctx context.Context, d *schema.Reso
 	scriptName := d.Get("script_name").(string)
 	accountID := d.Get("account_id").(string)
 
-	s, err := client.ListWorkerCronTriggers(ctx, accountID, scriptName)
+	params := cloudflare.ListWorkerCronTriggersParams{
+		ScriptName: scriptName,
+	}
+
+	s, err := client.ListWorkerCronTriggers(ctx, cloudflare.AccountIdentifier(accountID), params)
 	if err != nil {
 		// If the script is removed, we also need to remove the triggers.
 		if strings.Contains(err.Error(), "workers.api.error.script_not_found") {
@@ -69,7 +79,11 @@ func resourceCloudflareWorkerCronTriggerDelete(ctx context.Context, d *schema.Re
 	scriptName := d.Get("script_name").(string)
 	accountID := d.Get("account_id").(string)
 
-	_, err := client.UpdateWorkerCronTriggers(ctx, accountID, scriptName, []cloudflare.WorkerCronTrigger{})
+	params := cloudflare.UpdateWorkerCronTriggersParams{
+		ScriptName: scriptName,
+		Crons:      []cloudflare.WorkerCronTrigger{},
+	}
+	_, err := client.UpdateWorkerCronTriggers(ctx, cloudflare.AccountIdentifier(accountID), params)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_cloudflare_workers_route.go
+++ b/internal/provider/resource_cloudflare_workers_route.go
@@ -26,23 +26,18 @@ func resourceCloudflareWorkerRoute() *schema.Resource {
 	}
 }
 
-func getRouteFromResource(d *schema.ResourceData) cloudflare.WorkerRoute {
-	route := cloudflare.WorkerRoute{
-		ID:      d.Id(),
+func resourceCloudflareWorkerRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+
+	params := cloudflare.CreateWorkerRouteParams{
 		Pattern: d.Get("pattern").(string),
 		Script:  d.Get("script_name").(string),
 	}
-	return route
-}
 
-func resourceCloudflareWorkerRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*cloudflare.API)
-	route := getRouteFromResource(d)
-	zoneID := d.Get("zone_id").(string)
+	tflog.Info(ctx, fmt.Sprintf("Creating Cloudflare Worker Route from struct: %+v", params))
 
-	tflog.Info(ctx, fmt.Sprintf("Creating Cloudflare Worker Route from struct: %+v", route))
-
-	r, err := client.CreateWorkerRoute(ctx, zoneID, route)
+	r, err := client.CreateWorkerRoute(ctx, cloudflare.ZoneIdentifier(zoneID), params)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating worker route"))
 	}
@@ -65,7 +60,7 @@ func resourceCloudflareWorkerRouteRead(ctx context.Context, d *schema.ResourceDa
 
 	// There isn't a dedicated endpoint for retrieving a specific route, so we
 	// list all routes and find the target route by comparing IDs
-	resp, err := client.ListWorkerRoutes(ctx, zoneID)
+	resp, err := client.ListWorkerRoutes(ctx, cloudflare.ZoneIdentifier(zoneID), cloudflare.ListWorkerRoutesParams{})
 
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error reading worker routes"))
@@ -87,7 +82,7 @@ func resourceCloudflareWorkerRouteRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	d.Set("pattern", route.Pattern)
-	d.Set("script_name", route.Script)
+	d.Set("script_name", route.ScriptName)
 
 	return nil
 }
@@ -95,11 +90,15 @@ func resourceCloudflareWorkerRouteRead(ctx context.Context, d *schema.ResourceDa
 func resourceCloudflareWorkerRouteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
-	route := getRouteFromResource(d)
+	params := cloudflare.UpdateWorkerRouteParams{
+		ID:      d.Id(),
+		Pattern: d.Get("pattern").(string),
+		Script:  d.Get("script_name").(string),
+	}
 
-	log.Printf("[INFO] Updating Cloudflare Worker Route from struct: %+v", route)
+	log.Printf("[INFO] Updating Cloudflare Worker Route from struct: %+v", params)
 
-	_, err := client.UpdateWorkerRoute(ctx, zoneID, route.ID, route)
+	_, err := client.UpdateWorkerRoute(ctx, cloudflare.ZoneIdentifier(zoneID), params)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error updating worker route"))
 	}
@@ -110,11 +109,10 @@ func resourceCloudflareWorkerRouteUpdate(ctx context.Context, d *schema.Resource
 func resourceCloudflareWorkerRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get("zone_id").(string)
-	route := getRouteFromResource(d)
 
-	log.Printf("[INFO] Deleting Cloudflare Worker Route from zone %+v with id: %+v", zoneID, route.ID)
+	log.Printf("[INFO] Deleting Cloudflare Worker Route from zone %+v with id: %+v", zoneID, d.Id())
 
-	_, err := client.DeleteWorkerRoute(ctx, zoneID, route.ID)
+	_, err := client.DeleteWorkerRoute(ctx, cloudflare.ZoneIdentifier(zoneID), d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error deleting worker route"))
 	}

--- a/internal/provider/resource_cloudflare_workers_route_test.go
+++ b/internal/provider/resource_cloudflare_workers_route_test.go
@@ -145,7 +145,7 @@ func getRouteFromApi(zoneID, routeId string) (cloudflare.WorkerRoute, error) {
 	}
 
 	client := testAccProvider.Meta().(*cloudflare.API)
-	resp, err := client.ListWorkerRoutes(context.Background(), zoneID)
+	resp, err := client.ListWorkerRoutes(context.Background(), cloudflare.ZoneIdentifier(zoneID), cloudflare.ListWorkerRoutesParams{})
 	if err != nil {
 		return cloudflare.WorkerRoute{}, err
 	}


### PR DESCRIPTION
This tackles the migration for the underlying API reference of cloudflare-go from v0.56.0 to v0.57.0. Additional modifications were required to handle changes to the Workers APIs in support of the upcoming v4.x release.

Implementation:

* Migration from DownloadWorker -> GetWorker
* Migration from UploadWorkerWithBindings -> UploadWorker
* Migration from DeleteWorker -> DeleteWorker (new parameter structure)
* Generally adding accountID to all workers calls
