### PR TITLE
Added custom_metadata support to custom hostnames

### DIFF
--- a/.changelog/2107.txt
+++ b/.changelog/2107.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_custom_hostname: add support for defining custom metadata
+```

--- a/docs/resources/custom_hostname.md
+++ b/docs/resources/custom_hostname.md
@@ -30,6 +30,7 @@ resource "cloudflare_custom_hostname" "example" {
 
 ### Optional
 
+- `custom_metadata` (Map of String) Custom metadata associated with custom hostname. Only supports primitive string values, all other values are accessible via the API directly.
 - `custom_origin_server` (String) The custom origin server used for certificates.
 - `custom_origin_sni` (String) The [custom origin SNI](https://developers.cloudflare.com/ssl/ssl-for-saas/hostname-specific-behavior/custom-origin) used for certificates.
 - `ssl` (Block List) SSL configuration of the certificate. (see [below for nested schema](#nestedblock--ssl))

--- a/internal/provider/resource_cloudflare_custom_hostname.go
+++ b/internal/provider/resource_cloudflare_custom_hostname.go
@@ -220,5 +220,11 @@ func buildCustomHostname(d *schema.ResourceData) cloudflare.CustomHostname {
 		}
 	}
 
+	// only supports a map with string values
+	if val, ok := d.GetOk("custom_metadata"); ok {
+		cm := val.(map[string]interface{})
+		ch.CustomMetadata = (*cloudflare.CustomMetadata)(&cm)
+	}
+
 	return ch
 }

--- a/internal/provider/schema_cloudflare_custom_hostname.go
+++ b/internal/provider/schema_cloudflare_custom_hostname.go
@@ -137,7 +137,7 @@ func resourceCloudflareCustomHostnameSchema() map[string]*schema.Schema {
 		"custom_metadata": {
 			Type:        schema.TypeMap,
 			Optional:    true,
-			Description: "Custom metadata associated with custom hostname. Only supports string values.",
+			Description: "Custom metadata associated with custom hostname. Only supports primitive string values, all other values are accessible via the API directly.",
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},

--- a/internal/provider/schema_cloudflare_custom_hostname.go
+++ b/internal/provider/schema_cloudflare_custom_hostname.go
@@ -134,6 +134,14 @@ func resourceCloudflareCustomHostnameSchema() map[string]*schema.Schema {
 				},
 			},
 		},
+		"custom_metadata": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Description: "Custom metadata associated with custom hostname. Only supports string values.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"status": {
 			Type:        schema.TypeString,
 			Computed:    true,


### PR DESCRIPTION
Only supports string values. For mixing types, having lists, nexted maps, etc. the API or cloudflare-go SDK would have to be used.