### PR TITLE
provider: update internal logging sink to use cloudflare-go logger

### DIFF
--- a/.changelog/2123.txt
+++ b/.changelog/2123.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+provider: use inbuilt cloudflare-go logger for HTTP interactions
+```
+
+```release-note:enhancement
+provider: `X-Auth-Email`, `X-Auth-Key`, `X-Auth-User-Service-Key` and `Authorization` values are now automatically redacted from debug logs
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,13 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
-	"os"
 	"regexp"
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
@@ -296,7 +293,6 @@ func New(version string) func() *schema.Provider {
 }
 
 func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
-
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		var diags diag.Diagnostics
 
@@ -307,13 +303,7 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		retryOpt := cloudflare.UsingRetryPolicy(d.Get("retries").(int), d.Get("min_backoff").(int), d.Get("max_backoff").(int))
 		options := []cloudflare.Option{limitOpt, retryOpt, baseURL}
 
-		if d.Get("api_client_logging").(bool) {
-			options = append(options, cloudflare.UsingLogger(log.New(os.Stderr, "", log.LstdFlags)))
-		}
-
-		c := cleanhttp.DefaultClient()
-		c.Transport = logging.NewTransport("Cloudflare", c.Transport)
-		options = append(options, cloudflare.HTTPClient(c))
+		options = append(options, cloudflare.Debug(logging.IsDebugOrHigher()))
 
 		ua := fmt.Sprintf("terraform/%s terraform-plugin-sdk/%s terraform-provider-cloudflare/%s", p.TerraformVersion, meta.SDKVersionString(), version)
 		options = append(options, cloudflare.UserAgent(ua))

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"log"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
@@ -24,10 +23,6 @@ func main() {
 		ProviderAddr: "registry.terraform.io/cloudflare/cloudflare",
 		Debug:        debugMode,
 	}
-
-	logFlags := log.Flags()
-	logFlags = logFlags &^ (log.Ldate | log.Ltime)
-	log.SetFlags(logFlags)
 
 	plugin.Serve(opts)
 }


### PR DESCRIPTION
As of cloudflare/cloudflare-go#1164 we have the ability to use the inbuilt logger for redacting sensitive HTTP headers.

Previously, we were discarding the provided logger due to instantiating a new `cleanhttp` client to use however, with this change we are now using the cloudflare-go logger for HTTP interactions inside the Terraform Core sink.

By default we redact the values found in the following HTTP headers (not the headers themselves) in the entire HTTP interaction:

- `X-Auth-Email`
- `X-Auth-Key`
- `X-Auth-User-Service-Key`
- `Authorization`

And here is an example of the logger in action for `TF_LOG=DEBUG`.

```
2023-01-05T06:49:41.208221+11:00 [DEBUG] cloudflare
GET /client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/access/apps/dec500cc-4eb3-4c64-b10d-1fce8f686339 HTTP/1.1
Host: api.cloudflare.com
User-Agent: terraform/1.3.6 terraform-plugin-sdk/2.10.1 terraform-provider-cloudflare/dev
Content-Type: application/json
X-Auth-Email: [redacted]
X-Auth-Key: [redacted]
Accept-Encoding: gzip

2023-01-05T06:49:41.208221+11:00 [DEBUG] cloudflare
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Cf-Cache-Status: DYNAMIC
Cf-Ray: 78467fb52e4baaf9-SYD
Connection: keep-alive

...

{
  "result": {
    "id": "dec500cc-4eb3-4c64-b10d-1fce8f686339",
    "uid": "dec500cc-4eb3-4c64-b10d-1fce8f686339",
    // ..
    "http_only_cookie_attribute": false
  },
  "success": true,
  "errors": [],
  "messages": []
}
```