### PR TITLE
allow for zero value for some action parameter attributes

### DIFF
--- a/.changelog/2129.txt
+++ b/.changelog/2129.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+cloudflare_ruleset: Let confugiration rules action params have false values
+```

--- a/internal/provider/resource_cloudflare_ruleset.go
+++ b/internal/provider/resource_cloudflare_ruleset.go
@@ -949,7 +949,7 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 							}
 						}
 					case "cache":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.cache", rulesCounter)); ok {
+						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.cache", rulesCounter)); ok {
 							rule.ActionParameters.Cache = cloudflare.BoolPtr(value.(bool))
 						}
 

--- a/internal/provider/resource_cloudflare_ruleset.go
+++ b/internal/provider/resource_cloudflare_ruleset.go
@@ -871,7 +871,7 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 							}
 						}
 					case "automatic_https_rewrites":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.automatic_https_rewrites", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.automatic_https_rewrites", rulesCounter)); ok {
 							rule.ActionParameters.AutomaticHTTPSRewrites = cloudflare.BoolPtr(value.(bool))
 						}
 					case "autominify":
@@ -884,62 +884,62 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 						}
 
 					case "bic":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.bic", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.bic", rulesCounter)); ok {
 							rule.ActionParameters.BrowserIntegrityCheck = cloudflare.BoolPtr(value.(bool))
 						}
 					case "disable_apps":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.disable_apps", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.disable_apps", rulesCounter)); ok {
 							rule.ActionParameters.DisableApps = cloudflare.BoolPtr(value.(bool))
 						}
 					case "disable_zaraz":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.disable_zaraz", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.disable_zaraz", rulesCounter)); ok {
 							rule.ActionParameters.DisableZaraz = cloudflare.BoolPtr(value.(bool))
 						}
 					case "disable_railgun":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.disable_zaraz", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.disable_zaraz", rulesCounter)); ok {
 							rule.ActionParameters.DisableRailgun = cloudflare.BoolPtr(value.(bool))
 						}
 					case "email_obfuscation":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.email_obfuscation", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.email_obfuscation", rulesCounter)); ok {
 							rule.ActionParameters.EmailObfuscation = cloudflare.BoolPtr(value.(bool))
 						}
 					case "mirage":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.mirage", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.mirage", rulesCounter)); ok {
 							rule.ActionParameters.Mirage = cloudflare.BoolPtr(value.(bool))
 						}
 					case "opportunistic_encryption":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.opportunistic_encryption", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.opportunistic_encryption", rulesCounter)); ok {
 							rule.ActionParameters.OpportunisticEncryption = cloudflare.BoolPtr(value.(bool))
 						}
 					case "polish":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.polish", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.polish", rulesCounter)); ok {
 							p, _ := cloudflare.PolishFromString(value.(string))
 							rule.ActionParameters.Polish = p
 						}
 					case "rocket_loader":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.rocket_loader", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.rocket_loader", rulesCounter)); ok {
 							rule.ActionParameters.RocketLoader = cloudflare.BoolPtr(value.(bool))
 						}
 					case "security_level":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.security_level", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.security_level", rulesCounter)); ok {
 							sl, _ := cloudflare.SecurityLevelFromString(value.(string))
 							rule.ActionParameters.SecurityLevel = sl
 						}
 					case "server_side_excludes":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.server_side_excludes", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.server_side_excludes", rulesCounter)); ok {
 							rule.ActionParameters.ServerSideExcludes = cloudflare.BoolPtr(value.(bool))
 						}
 					case "ssl":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.ssl", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.ssl", rulesCounter)); ok {
 							ssl, _ := cloudflare.SSLFromString(value.(string))
 							rule.ActionParameters.SSL = ssl
 						}
 					case "sxg":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.sxg", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.sxg", rulesCounter)); ok {
 							rule.ActionParameters.SXG = cloudflare.BoolPtr(value.(bool))
 						}
 					case "hotlink_protection":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.hotlink_protection", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.hotlink_protection", rulesCounter)); ok {
 							rule.ActionParameters.HotLinkProtection = cloudflare.BoolPtr(value.(bool))
 						}
 					case "sni":

--- a/internal/provider/resource_cloudflare_ruleset.go
+++ b/internal/provider/resource_cloudflare_ruleset.go
@@ -871,8 +871,8 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 							}
 						}
 					case "automatic_https_rewrites":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.automatic_https_rewrites", rulesCounter)); ok {
-							rule.ActionParameters.AutomaticHTTPSRewrites = cloudflare.BoolPtr(value.(bool))
+						if ok := verifyActionParameterRootAttributeExists(d, pKey, rulesCounter); ok {
+							rule.ActionParameters.AutomaticHTTPSRewrites = cloudflare.BoolPtr(pValue.(bool))
 						}
 					case "autominify":
 						for i := range pValue.([]interface{}) {
@@ -884,32 +884,32 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 						}
 
 					case "bic":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.bic", rulesCounter)); ok {
-							rule.ActionParameters.BrowserIntegrityCheck = cloudflare.BoolPtr(value.(bool))
+						if ok := verifyActionParameterRootAttributeExists(d, pKey, rulesCounter); ok {
+							rule.ActionParameters.BrowserIntegrityCheck = cloudflare.BoolPtr(pValue.(bool))
 						}
 					case "disable_apps":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.disable_apps", rulesCounter)); ok {
+						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.disable_apps", rulesCounter)); ok {
 							rule.ActionParameters.DisableApps = cloudflare.BoolPtr(value.(bool))
 						}
 					case "disable_zaraz":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.disable_zaraz", rulesCounter)); ok {
+						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.disable_zaraz", rulesCounter)); ok {
 							rule.ActionParameters.DisableZaraz = cloudflare.BoolPtr(value.(bool))
 						}
 					case "disable_railgun":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.disable_zaraz", rulesCounter)); ok {
+						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.disable_railgun", rulesCounter)); ok {
 							rule.ActionParameters.DisableRailgun = cloudflare.BoolPtr(value.(bool))
 						}
 					case "email_obfuscation":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.email_obfuscation", rulesCounter)); ok {
-							rule.ActionParameters.EmailObfuscation = cloudflare.BoolPtr(value.(bool))
+						if ok := verifyActionParameterRootAttributeExists(d, pKey, rulesCounter); ok {
+							rule.ActionParameters.EmailObfuscation = cloudflare.BoolPtr(pValue.(bool))
 						}
 					case "mirage":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.mirage", rulesCounter)); ok {
-							rule.ActionParameters.Mirage = cloudflare.BoolPtr(value.(bool))
+						if ok := verifyActionParameterRootAttributeExists(d, pKey, rulesCounter); ok {
+							rule.ActionParameters.Mirage = cloudflare.BoolPtr(pValue.(bool))
 						}
 					case "opportunistic_encryption":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.opportunistic_encryption", rulesCounter)); ok {
-							rule.ActionParameters.OpportunisticEncryption = cloudflare.BoolPtr(value.(bool))
+						if ok := verifyActionParameterRootAttributeExists(d, pKey, rulesCounter); ok {
+							rule.ActionParameters.OpportunisticEncryption = cloudflare.BoolPtr(pValue.(bool))
 						}
 					case "polish":
 						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.polish", rulesCounter)); ok {
@@ -917,8 +917,8 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 							rule.ActionParameters.Polish = p
 						}
 					case "rocket_loader":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.rocket_loader", rulesCounter)); ok {
-							rule.ActionParameters.RocketLoader = cloudflare.BoolPtr(value.(bool))
+						if ok := verifyActionParameterRootAttributeExists(d, pKey, rulesCounter); ok {
+							rule.ActionParameters.RocketLoader = cloudflare.BoolPtr(pValue.(bool))
 						}
 					case "security_level":
 						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.security_level", rulesCounter)); ok {
@@ -926,8 +926,8 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 							rule.ActionParameters.SecurityLevel = sl
 						}
 					case "server_side_excludes":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.server_side_excludes", rulesCounter)); ok {
-							rule.ActionParameters.ServerSideExcludes = cloudflare.BoolPtr(value.(bool))
+						if ok := verifyActionParameterRootAttributeExists(d, pKey, rulesCounter); ok {
+							rule.ActionParameters.ServerSideExcludes = cloudflare.BoolPtr(pValue.(bool))
 						}
 					case "ssl":
 						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.ssl", rulesCounter)); ok {
@@ -935,12 +935,12 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 							rule.ActionParameters.SSL = ssl
 						}
 					case "sxg":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.sxg", rulesCounter)); ok {
-							rule.ActionParameters.SXG = cloudflare.BoolPtr(value.(bool))
+						if ok := verifyActionParameterRootAttributeExists(d, pKey, rulesCounter); ok {
+							rule.ActionParameters.SXG = cloudflare.BoolPtr(pValue.(bool))
 						}
 					case "hotlink_protection":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.hotlink_protection", rulesCounter)); ok {
-							rule.ActionParameters.HotLinkProtection = cloudflare.BoolPtr(value.(bool))
+						if ok := verifyActionParameterRootAttributeExists(d, pKey, rulesCounter); ok {
+							rule.ActionParameters.HotLinkProtection = cloudflare.BoolPtr(pValue.(bool))
 						}
 					case "sni":
 						for i := range pValue.([]interface{}) {
@@ -1362,4 +1362,14 @@ func apiEnabledToStatusFieldConversion(s *bool) string {
 	} else {
 		return ""
 	}
+}
+
+func verifyActionParameterRootAttributeExists(d *schema.ResourceData, pKey string, rulesCounter int) bool {
+	if rules := d.GetRawConfig().GetAttr("rules"); !rules.IsNull() {
+		keyExists := rules.AsValueSlice()[rulesCounter].GetAttr("action_parameters").AsValueSlice()[0].GetAttr(pKey)
+		if !keyExists.IsNull() {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/provider/resource_cloudflare_ruleset.go
+++ b/internal/provider/resource_cloudflare_ruleset.go
@@ -912,7 +912,7 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 							rule.ActionParameters.OpportunisticEncryption = cloudflare.BoolPtr(value.(bool))
 						}
 					case "polish":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.polish", rulesCounter)); ok {
+						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.polish", rulesCounter)); ok {
 							p, _ := cloudflare.PolishFromString(value.(string))
 							rule.ActionParameters.Polish = p
 						}
@@ -921,7 +921,7 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 							rule.ActionParameters.RocketLoader = cloudflare.BoolPtr(value.(bool))
 						}
 					case "security_level":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.security_level", rulesCounter)); ok {
+						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.security_level", rulesCounter)); ok {
 							sl, _ := cloudflare.SecurityLevelFromString(value.(string))
 							rule.ActionParameters.SecurityLevel = sl
 						}
@@ -930,7 +930,7 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 							rule.ActionParameters.ServerSideExcludes = cloudflare.BoolPtr(value.(bool))
 						}
 					case "ssl":
-						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.ssl", rulesCounter)); ok {
+						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.ssl", rulesCounter)); ok {
 							ssl, _ := cloudflare.SSLFromString(value.(string))
 							rule.ActionParameters.SSL = ssl
 						}

--- a/internal/provider/resource_cloudflare_ruleset.go
+++ b/internal/provider/resource_cloudflare_ruleset.go
@@ -949,7 +949,7 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 							}
 						}
 					case "cache":
-						if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.cache", rulesCounter)); ok {
+						if value, ok := d.GetOkExists(fmt.Sprintf("rules.%d.action_parameters.0.cache", rulesCounter)); ok {
 							rule.ActionParameters.Cache = cloudflare.BoolPtr(value.(bool))
 						}
 

--- a/internal/provider/resource_cloudflare_ruleset_test.go
+++ b/internal/provider/resource_cloudflare_ruleset_test.go
@@ -1719,6 +1719,51 @@ func TestAccCloudflareRuleset_Config(t *testing.T) {
 		},
 	})
 }
+func TestAccCloudflareRuleset_ConfigDisabled(t *testing.T) {
+	t.Parallel()
+	rnd := generateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareRulesetConfigAllDisabled(rnd, "my basic config ruleset", zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "my basic config ruleset"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_config_settings"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "set_config"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", rnd+" set config rule"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.automatic_https_rewrites", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.autominify.0.html", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.autominify.0.css", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.autominify.0.js", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.bic", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.disable_apps", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.disable_zaraz", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.disable_railgun", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.email_obfuscation", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.mirage", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.opportunistic_encryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.polish", "off"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.rocket_loader", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.security_level", "off"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.server_side_excludes", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.ssl", "off"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.sxg", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.hotlink_protection", "false"),
+				),
+			},
+		},
+	})
+}
 func TestAccCloudflareRuleset_Redirect(t *testing.T) {
 	t.Parallel()
 	rnd := generateRandomResourceName()
@@ -1789,9 +1834,9 @@ func TestAccCloudflareRuleset_ConfigurationRulesSingleFalseValue(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudflareRulesetConfigurationRuleSingleKeyFalseValue(rnd, "test configuration rule", zoneID),
+				Config: testAccCheckCloudflareRulesetConfigurationRuleSingleKeyFalseValue(rnd, zoneID),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "test configuration rule"),
+					resource.TestCheckResourceAttr(resourceName, "name", rnd),
 					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
 					resource.TestCheckResourceAttr(resourceName, "phase", "http_config_settings"),
 
@@ -3093,26 +3138,66 @@ func testAccCloudflareRulesetConfigAllEnabled(rnd, accountID, zoneID string) str
     rules {
       action = "set_config"
       action_parameters {
-		automatic_https_rewrites = true
-		autominify {
-			html = true
-			css = true
-			js = true
-		}
-		bic = true
-		disable_apps = true
-		disable_zaraz = true
-		disable_railgun = true
-		email_obfuscation = true
-		mirage = true
-		opportunistic_encryption = true
-		polish = "off"
-		rocket_loader = true
-		security_level = "off"
-		server_side_excludes = true
-		ssl = "off"
-		sxg = true
-		hotlink_protection = true
+				automatic_https_rewrites = true
+				autominify {
+					html = true
+					css = true
+					js = true
+				}
+				bic = true
+				disable_apps = true
+				disable_zaraz = true
+				disable_railgun = true
+				email_obfuscation = true
+				mirage = true
+				opportunistic_encryption = true
+				polish = "off"
+				rocket_loader = true
+				security_level = "off"
+				server_side_excludes = true
+				ssl = "off"
+				sxg = true
+				hotlink_protection = true
+      }
+	  expression = "true"
+	  description = "%[1]s set config rule"
+	  enabled = true
+    }
+  }`, rnd, accountID, zoneID)
+}
+
+func testAccCloudflareRulesetConfigAllDisabled(rnd, accountID, zoneID string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+	zone_id     = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_config_settings"
+
+    rules {
+      action = "set_config"
+      action_parameters {
+				automatic_https_rewrites = false
+				autominify {
+					html = false
+					css = false
+					js = false
+				}
+				bic = false
+				disable_apps = false
+				disable_zaraz = false
+				disable_railgun = false
+				email_obfuscation = false
+				mirage = false
+				opportunistic_encryption = false
+				polish = "off"
+				rocket_loader = false
+				security_level = "off"
+				server_side_excludes = false
+				ssl = "off"
+				sxg = false
+				hotlink_protection = false
       }
 	  expression = "true"
 	  description = "%[1]s set config rule"
@@ -3204,12 +3289,12 @@ func testAccCheckCloudflareRulesetActionParametersOverrideSensitivityForAllRules
   }`, rnd, name, zoneID, zoneName)
 }
 
-func testAccCheckCloudflareRulesetConfigurationRuleSingleKeyFalseValue(rnd, name, zoneID string) string {
+func testAccCheckCloudflareRulesetConfigurationRuleSingleKeyFalseValue(rnd, zoneID string) string {
 	return fmt.Sprintf(`
 	resource "cloudflare_ruleset" "%[1]s" {
-		zone_id 		= "%[3]s"
-		name     		= "%[2]s"
-		description = "%[2]s ruleset description"
+		zone_id 		= "%[2]s"
+		name     		= "%[1]s"
+		description = "%[1]s ruleset description"
 		kind 				= "zone"
 		phase   		= "http_config_settings"
 		rules {
@@ -3221,5 +3306,5 @@ func testAccCheckCloudflareRulesetConfigurationRuleSingleKeyFalseValue(rnd, name
 				automatic_https_rewrites = false
 			}
 		}
-	}`, rnd, name, zoneID)
+	}`, rnd, zoneID)
 }


### PR DESCRIPTION
A bug arose while working on https://developers.cloudflare.com/version-management/ where boolean false values were being ignored by the provider. Specifically for this use case, Configuration Rules was throwing errors due to empty action_parameter blocks. These block were empty because they contained one key with a value of false.
example:
```
rules {
    action      = "set_config"
    description = "ssss"
    enabled     = true
    expression  = "(http.cookie eq \"s\")"
    action_parameters {
      automatic_https_rewrites = false
    }
  }
```

This change will make sure the value is set, and use that value vs checking if its a Zero value. 