### PR TITLE
docs: Update cloudflare_list example to use underscore in name

### DIFF
--- a/docs/resources/list.md
+++ b/docs/resources/list.md
@@ -17,7 +17,7 @@ across all zones within the same account.
 # IP list
 resource "cloudflare_list" "example" {
   account_id  = "f037e56e89293a057740de681ac9abbe"
-  name        = "example list"
+  name        = "example_list"
   description = "example IPs for a list"
   kind        = "ip"
 
@@ -39,7 +39,7 @@ resource "cloudflare_list" "example" {
 # Redirect list
 resource "cloudflare_list" "example" {
   account_id  = "f037e56e89293a057740de681ac9abbe"
-  name        = "example list"
+  name        = "example_list"
   description = "example redirects for a list"
   kind        = "redirect"
 

--- a/examples/resources/cloudflare_list/resource.tf
+++ b/examples/resources/cloudflare_list/resource.tf
@@ -1,7 +1,7 @@
 # IP list
 resource "cloudflare_list" "example" {
   account_id  = "f037e56e89293a057740de681ac9abbe"
-  name        = "example list"
+  name        = "example_list"
   description = "example IPs for a list"
   kind        = "ip"
 
@@ -23,7 +23,7 @@ resource "cloudflare_list" "example" {
 # Redirect list
 resource "cloudflare_list" "example" {
   account_id  = "f037e56e89293a057740de681ac9abbe"
-  name        = "example list"
+  name        = "example_list"
   description = "example redirects for a list"
   kind        = "redirect"
 


### PR DESCRIPTION
The Cloudflare API rejects lists that have whitespace characters in their name. This updates the example resources we have to use a name with an underscore instead.

The error I had gotten previously was
```
╷
│ Error: invalid value for name (List name must only contain lowercase letters, numbers and underscores)
│ 
│   with cloudflare_list.example,
│   on cfdata-staging.tf line 3, in resource "cloudflare_list" "example":
│    3:   name        = "example list"
│ 
╵
```