### PR TITLE
do not let edge_ttl: default be zero

### DIFF
--- a/.changelog/2143.txt
+++ b/.changelog/2143.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_ruleset: do not let edge_ttl: default be zero
+```

--- a/internal/provider/resource_cloudflare_ruleset.go
+++ b/internal/provider/resource_cloudflare_ruleset.go
@@ -959,7 +959,9 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 							for pKey, pValue := range pValue.([]interface{})[i].(map[string]interface{}) {
 								switch pKey {
 								case "default":
-									rule.ActionParameters.EdgeTTL.Default = cloudflare.UintPtr(uint(pValue.(int)))
+									if value, ok := d.GetOk(fmt.Sprintf("rules.%d.action_parameters.0.edge_ttl.0.default", rulesCounter)); ok {
+										rule.ActionParameters.EdgeTTL.Default = cloudflare.UintPtr(uint(value.(int)))
+									}
 								case "mode":
 									rule.ActionParameters.EdgeTTL.Mode = pValue.(string)
 								case "status_code_ttl":


### PR DESCRIPTION
before:
```
TF_ACC=1 go test $(go list ./...) -v -run "^TestAccCloudflareRuleset_CacheSettings" -count 1 -parallel 1 -timeout 120m -parallel 1
?       github.com/cloudflare/terraform-provider-cloudflare     [no test files]
=== RUN   TestAccCloudflareRuleset_CacheSettings
=== PAUSE TestAccCloudflareRuleset_CacheSettings
=== CONT  TestAccCloudflareRuleset_CacheSettings
    resource_cloudflare_ruleset_test.go:1675: Step 1/1 error: Error running apply: exit status 1

        Error: error creating ruleset kjukyzjsfl: default is useless in respect_origin mode, default cannot be 0

          with cloudflare_ruleset.kjukyzjsfl,
          on terraform_plugin_test.tf line 2, in resource "cloudflare_ruleset" "kjukyzjsfl":
           2:   resource "cloudflare_ruleset" "kjukyzjsfl" {
```

after:
```
TF_ACC=1 go test $(go list ./...) -v -run "^TestAccCloudflareRuleset_CacheSettings" -count 1 -parallel 1 -timeout 120m -parallel 1
?       github.com/cloudflare/terraform-provider-cloudflare     [no test files]
=== RUN   TestAccCloudflareRuleset_CacheSettings
=== PAUSE TestAccCloudflareRuleset_CacheSettings
=== CONT  TestAccCloudflareRuleset_CacheSettings
--- PASS: TestAccCloudflareRuleset_CacheSettings (12.49s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/provider   12.917s
```