### PR TITLE
remove internal reliance on `client.AccountID`

### DIFF
--- a/.changelog/2154.txt
+++ b/.changelog/2154.txt
@@ -1,0 +1,27 @@
+```release-note:breaking-change
+resource/cloudflare_workers_kv: no longer sets `client.AccountID` internally and relies on the resource provided value
+```
+
+```release-note:breaking-change
+resource/cloudflare_load_balancer_monitor: no longer sets `client.AccountID` internally and relies on the resource provided value
+```
+
+```release-note:breaking-change
+resource/cloudflare_workers_script: no longer sets `client.AccountID` internally and relies on the resource provided value
+```
+
+```release-note:breaking-change
+resource/cloudflare_workers_kv_namespace: no longer sets `client.AccountID` internally and relies on the resource provided value
+```
+
+```release-note:breaking-change
+resource/cloudflare_load_balancer_pool: no longer sets `client.AccountID` internally and relies on the resource provided value
+```
+
+```release-note:breaking-change
+resource/cloudflare_zone: no longer sets `client.AccountID` internally and relies on the resource provided value
+```
+
+```release-note:breaking-change
+resource/cloudflare_account_member: no longer sets `client.AccountID` internally and relies on the resource provided value
+```

--- a/internal/provider/resource_cloudflare_account_member.go
+++ b/internal/provider/resource_cloudflare_account_member.go
@@ -31,13 +31,7 @@ func resourceCloudflareAccountMember() *schema.Resource {
 
 func resourceCloudflareAccountMemberRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
-
-	var accountID string
-	if d.Get("account_id").(string) != "" {
-		accountID = d.Get("account_id").(string)
-	} else {
-		accountID = client.AccountID
-	}
+	accountID := d.Get("account_id").(string)
 
 	member, err := client.AccountMember(ctx, accountID, d.Id())
 	if err != nil {
@@ -65,15 +59,8 @@ func resourceCloudflareAccountMemberRead(ctx context.Context, d *schema.Resource
 
 func resourceCloudflareAccountMemberDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
-
+	accountID := d.Get("account_id").(string)
 	tflog.Debug(ctx, fmt.Sprintf("Deleting Cloudflare account member ID: %s", d.Id()))
-
-	var accountID string
-	if d.Get("account_id").(string) != "" {
-		accountID = d.Get("account_id").(string)
-	} else {
-		accountID = client.AccountID
-	}
 
 	err := client.DeleteAccountMember(ctx, accountID, d.Id())
 	if err != nil {
@@ -86,19 +73,12 @@ func resourceCloudflareAccountMemberDelete(ctx context.Context, d *schema.Resour
 func resourceCloudflareAccountMemberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	memberEmailAddress := d.Get("email_address").(string)
 	requestedMemberRoles := d.Get("role_ids").(*schema.Set).List()
-
+	accountID := d.Get("account_id").(string)
 	client := meta.(*cloudflare.API)
 
 	var accountMemberRoleIDs []string
 	for _, roleID := range requestedMemberRoles {
 		accountMemberRoleIDs = append(accountMemberRoleIDs, roleID.(string))
-	}
-
-	var accountID string
-	if d.Get("account_id").(string) != "" {
-		accountID = d.Get("account_id").(string)
-	} else {
-		accountID = client.AccountID
 	}
 
 	status := d.Get("status").(string)
@@ -121,13 +101,7 @@ func resourceCloudflareAccountMemberUpdate(ctx context.Context, d *schema.Resour
 	client := meta.(*cloudflare.API)
 	accountRoles := []cloudflare.AccountRole{}
 	memberRoles := d.Get("role_ids").(*schema.Set).List()
-
-	var accountID string
-	if d.Get("account_id").(string) != "" {
-		accountID = d.Get("account_id").(string)
-	} else {
-		accountID = client.AccountID
-	}
+	accountID := d.Get("account_id").(string)
 
 	for _, r := range memberRoles {
 		accountRole, _ := client.AccountRole(ctx, accountID, r.(string))

--- a/internal/provider/resource_cloudflare_load_balancer_monitor.go
+++ b/internal/provider/resource_cloudflare_load_balancer_monitor.go
@@ -102,9 +102,6 @@ func resourceCloudflareLoadBalancerPoolMonitorCreate(ctx context.Context, d *sch
 	tflog.Debug(ctx, fmt.Sprintf("Creating Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor))
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 	r, err := client.CreateLoadBalancerMonitor(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.CreateLoadBalancerMonitorParams{LoadBalancerMonitor: loadBalancerMonitor})
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating load balancer monitor"))
@@ -194,9 +191,6 @@ func resourceCloudflareLoadBalancerPoolMonitorUpdate(ctx context.Context, d *sch
 	tflog.Debug(ctx, fmt.Sprintf("Update Cloudflare Load Balancer Monitor from struct: %+v", loadBalancerMonitor))
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 	_, err := client.UpdateLoadBalancerMonitor(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.UpdateLoadBalancerMonitorParams{LoadBalancerMonitor: loadBalancerMonitor})
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error modifying load balancer monitor"))
@@ -221,9 +215,6 @@ func resourceCloudflareLoadBalancerPoolMonitorRead(ctx context.Context, d *schem
 	client := meta.(*cloudflare.API)
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 	loadBalancerMonitor, err := client.GetLoadBalancerMonitor(ctx, cloudflare.AccountIdentifier(accountID), d.Id())
 	if err != nil {
 		var notFoundError *cloudflare.NotFoundError
@@ -282,9 +273,6 @@ func resourceCloudflareLoadBalancerPoolMonitorDelete(ctx context.Context, d *sch
 	tflog.Info(ctx, fmt.Sprintf("Deleting Cloudflare Load Balancer Monitor: %s ", d.Id()))
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 	err := client.DeleteLoadBalancerMonitor(ctx, cloudflare.AccountIdentifier(accountID), d.Id())
 	if err != nil {
 		var notFoundError *cloudflare.NotFoundError

--- a/internal/provider/resource_cloudflare_load_balancer_pool.go
+++ b/internal/provider/resource_cloudflare_load_balancer_pool.go
@@ -78,9 +78,6 @@ func resourceCloudflareLoadBalancerPoolCreate(ctx context.Context, d *schema.Res
 	tflog.Debug(ctx, fmt.Sprintf("Creating Cloudflare Load Balancer Pool from struct: %+v", loadBalancerPool))
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 
 	r, err := client.CreateLoadBalancerPool(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.CreateLoadBalancerPoolParams{LoadBalancerPool: loadBalancerPool})
 	if err != nil {
@@ -145,9 +142,6 @@ func resourceCloudflareLoadBalancerPoolUpdate(ctx context.Context, d *schema.Res
 	tflog.Debug(ctx, fmt.Sprintf("Updating Cloudflare Load Balancer Pool from struct: %+v", loadBalancerPool))
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 	_, err := client.UpdateLoadBalancerPool(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.UpdateLoadBalancerPoolParams{LoadBalancer: loadBalancerPool})
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error updating load balancer pool"))
@@ -230,9 +224,6 @@ func resourceCloudflareLoadBalancerPoolRead(ctx context.Context, d *schema.Resou
 	client := meta.(*cloudflare.API)
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 
 	loadBalancerPool, err := client.GetLoadBalancerPool(ctx, cloudflare.AccountIdentifier(accountID), d.Id())
 	if err != nil {
@@ -328,9 +319,6 @@ func resourceCloudflareLoadBalancerPoolDelete(ctx context.Context, d *schema.Res
 	tflog.Info(ctx, fmt.Sprintf("Deleting Cloudflare Load Balancer Pool: %s ", d.Id()))
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 	err := client.DeleteLoadBalancerPool(ctx, cloudflare.AccountIdentifier(accountID), d.Id())
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error deleting Cloudflare Load Balancer Pool"))

--- a/internal/provider/resource_cloudflare_workers_kv.go
+++ b/internal/provider/resource_cloudflare_workers_kv.go
@@ -34,9 +34,6 @@ func resourceCloudflareWorkersKVRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 
 	value, err := client.GetWorkersKV(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.GetWorkersKVParams{
 		NamespaceID: namespaceID,
@@ -63,9 +60,6 @@ func resourceCloudflareWorkersKVUpdate(ctx context.Context, d *schema.ResourceDa
 	value := d.Get("value").(string)
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 
 	_, err := client.WriteWorkersKVEntry(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.WriteWorkersKVEntryParams{
 		NamespaceID: namespaceID,
@@ -91,9 +85,6 @@ func resourceCloudflareWorkersKVDelete(ctx context.Context, d *schema.ResourceDa
 	}
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 
 	tflog.Info(ctx, fmt.Sprintf("Deleting Cloudflare Workers KV with id: %+v", d.Id()))
 

--- a/internal/provider/resource_cloudflare_workers_kv_namespace.go
+++ b/internal/provider/resource_cloudflare_workers_kv_namespace.go
@@ -30,9 +30,6 @@ func resourceCloudflareWorkersKVNamespaceCreate(ctx context.Context, d *schema.R
 	client := meta.(*cloudflare.API)
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 
 	req := cloudflare.CreateWorkersKVNamespaceParams{
 		Title: d.Get("title").(string),
@@ -61,9 +58,6 @@ func resourceCloudflareWorkersKVNamespaceRead(ctx context.Context, d *schema.Res
 	namespaceID := d.Id()
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 
 	resp, _, err := client.ListWorkersKVNamespaces(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListWorkersKVNamespacesParams{})
 	if err != nil {
@@ -92,9 +86,6 @@ func resourceCloudflareWorkersKVNamespaceUpdate(ctx context.Context, d *schema.R
 	client := meta.(*cloudflare.API)
 
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 
 	_, err := client.UpdateWorkersKVNamespace(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.UpdateWorkersKVNamespaceParams{
 		NamespaceID: d.Id(),
@@ -110,9 +101,6 @@ func resourceCloudflareWorkersKVNamespaceUpdate(ctx context.Context, d *schema.R
 func resourceCloudflareWorkersKVNamespaceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 
 	tflog.Info(ctx, fmt.Sprintf("Deleting Cloudflare Workers KV Namespace with id: %+v", d.Id()))
 

--- a/internal/provider/resource_cloudflare_workers_kv_namespace_test.go
+++ b/internal/provider/resource_cloudflare_workers_kv_namespace_test.go
@@ -40,9 +40,6 @@ func testAccCloudflareWorkersKVNamespaceDestroy(s *terraform.State) error {
 		}
 
 		accountID := rs.Primary.Attributes["account_id"]
-		if accountID == "" {
-			accountID = client.AccountID
-		}
 
 		resp, _, err := client.ListWorkersKVNamespaces(context.Background(), cloudflare.AccountIdentifier(accountID), cloudflare.ListWorkersKVNamespacesParams{})
 		if err == nil {
@@ -75,9 +72,7 @@ func testAccCheckCloudflareWorkersKVNamespaceExists(title string, namespace *clo
 			return fmt.Errorf("not found: %s", title)
 		}
 		accountID := rs.Primary.Attributes["account_id"]
-		if accountID == "" {
-			accountID = client.AccountID
-		}
+
 		resp, _, err := client.ListWorkersKVNamespaces(context.Background(), cloudflare.AccountIdentifier(accountID), cloudflare.ListWorkersKVNamespacesParams{})
 		if err != nil {
 			return err

--- a/internal/provider/resource_cloudflare_workers_kv_test.go
+++ b/internal/provider/resource_cloudflare_workers_kv_test.go
@@ -120,9 +120,6 @@ func testAccCloudflareWorkersKVDestroy(s *terraform.State) error {
 		key := rs.Primary.Attributes["key"]
 
 		accountID := rs.Primary.Attributes["account_id"]
-		if accountID == "" {
-			accountID = client.AccountID
-		}
 
 		_, err := client.GetWorkersKV(context.Background(), cloudflare.AccountIdentifier(accountID), cloudflare.GetWorkersKVParams{NamespaceID: namespaceID, Key: key})
 

--- a/internal/provider/resource_cloudflare_workers_script.go
+++ b/internal/provider/resource_cloudflare_workers_script.go
@@ -125,10 +125,6 @@ func resourceCloudflareWorkerScriptCreate(ctx context.Context, d *schema.Resourc
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	if accountID == "" {
-		accountID = client.AccountID
-	}
-
 	scriptData, err := getScriptData(d, client)
 	if err != nil {
 		return diag.FromErr(err)
@@ -169,10 +165,6 @@ func resourceCloudflareWorkerScriptCreate(ctx context.Context, d *schema.Resourc
 func resourceCloudflareWorkerScriptRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
-
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 
 	scriptData, err := getScriptData(d, client)
 	if err != nil {
@@ -301,10 +293,6 @@ func resourceCloudflareWorkerScriptUpdate(ctx context.Context, d *schema.Resourc
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
 
-	if accountID == "" {
-		accountID = client.AccountID
-	}
-
 	scriptData, err := getScriptData(d, client)
 	if err != nil {
 		return diag.FromErr(err)
@@ -337,10 +325,6 @@ func resourceCloudflareWorkerScriptUpdate(ctx context.Context, d *schema.Resourc
 func resourceCloudflareWorkerScriptDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	accountID := d.Get("account_id").(string)
-
-	if accountID == "" {
-		accountID = client.AccountID
-	}
 
 	scriptData, err := getScriptData(d, client)
 	if err != nil {

--- a/internal/provider/resource_cloudflare_zone.go
+++ b/internal/provider/resource_cloudflare_zone.go
@@ -108,12 +108,7 @@ func resourceCloudflareZone() *schema.Resource {
 
 func resourceCloudflareZoneCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
-	var accountID string
-	if d.Get("account_id").(string) != "" {
-		accountID = d.Get("account_id").(string)
-	} else {
-		accountID = client.AccountID
-	}
+	accountID := d.Get("account_id").(string)
 	zoneName := d.Get("zone").(string)
 	jumpstart := d.Get("jump_start").(bool)
 	zoneType := d.Get("type").(string)


### PR DESCRIPTION
During the transition period of removing the global `account_id` configuraton, we handled both cases by implementing a conditional to catch when the resource level `account_id` was not provided. Now that we've removed the global `account_id`, we can remove the conditional.