### PR TITLE
resource/cloudflare_access_rule: remove ability to create user level rules

### DIFF
--- a/.changelog/2157.txt
+++ b/.changelog/2157.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/cloudflare_access_rule: require explicit `zone_id` or `account_id` and remove implicit fallback to user level rules
+```

--- a/docs/resources/access_rule.md
+++ b/docs/resources/access_rule.md
@@ -66,9 +66,9 @@ resource "cloudflare_access_rule" "office_network" {
 
 ### Optional
 
-- `account_id` (String) The account identifier to target for the resource. **Modifying this attribute will force creation of a new resource.**
+- `account_id` (String) The account identifier to target for the resource. Must provide only one of `account_id`, `zone_id`. **Modifying this attribute will force creation of a new resource.**
 - `notes` (String) A personal note about the rule. Typically used as a reminder or explanation for the rule.
-- `zone_id` (String) The zone identifier to target for the resource. **Modifying this attribute will force creation of a new resource.**
+- `zone_id` (String) The zone identifier to target for the resource. Must provide only one of `account_id`, `zone_id`. **Modifying this attribute will force creation of a new resource.**
 
 ### Read-Only
 

--- a/internal/provider/resource_cloudflare_access_rule.go
+++ b/internal/provider/resource_cloudflare_access_rule.go
@@ -66,10 +66,8 @@ func resourceCloudflareAccessRuleCreate(ctx context.Context, d *schema.ResourceD
 
 	if accountID != "" {
 		r, err = client.CreateAccountAccessRule(ctx, accountID, newRule)
-	} else if zoneID != "" {
-		r, err = client.CreateZoneAccessRule(ctx, zoneID, newRule)
 	} else {
-		r, err = client.CreateUserAccessRule(ctx, newRule)
+		r, err = client.CreateZoneAccessRule(ctx, zoneID, newRule)
 	}
 
 	if err != nil {
@@ -95,10 +93,8 @@ func resourceCloudflareAccessRuleRead(ctx context.Context, d *schema.ResourceDat
 
 	if accountID != "" {
 		accessRuleResponse, err = client.AccountAccessRule(ctx, accountID, d.Id())
-	} else if zoneID != "" {
-		accessRuleResponse, err = client.ZoneAccessRule(ctx, zoneID, d.Id())
 	} else {
-		accessRuleResponse, err = client.UserAccessRule(ctx, d.Id())
+		accessRuleResponse, err = client.ZoneAccessRule(ctx, zoneID, d.Id())
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("accessRuleResponse: %#v", accessRuleResponse))
@@ -155,10 +151,8 @@ func resourceCloudflareAccessRuleUpdate(ctx context.Context, d *schema.ResourceD
 
 	if accountID != "" {
 		_, err = client.UpdateAccountAccessRule(ctx, accountID, d.Id(), updatedRule)
-	} else if zoneID != "" {
-		_, err = client.UpdateZoneAccessRule(ctx, zoneID, d.Id(), updatedRule)
 	} else {
-		_, err = client.UpdateUserAccessRule(ctx, d.Id(), updatedRule)
+		_, err = client.UpdateZoneAccessRule(ctx, zoneID, d.Id(), updatedRule)
 	}
 
 	if err != nil {
@@ -179,10 +173,8 @@ func resourceCloudflareAccessRuleDelete(ctx context.Context, d *schema.ResourceD
 
 	if accountID != "" {
 		_, err = client.DeleteAccountAccessRule(ctx, accountID, d.Id())
-	} else if zoneID != "" {
-		_, err = client.DeleteZoneAccessRule(ctx, zoneID, d.Id())
 	} else {
-		_, err = client.DeleteUserAccessRule(ctx, d.Id())
+		_, err = client.DeleteZoneAccessRule(ctx, zoneID, d.Id())
 	}
 
 	if err != nil {

--- a/internal/provider/schema_cloudflare_access_rule.go
+++ b/internal/provider/schema_cloudflare_access_rule.go
@@ -10,18 +10,20 @@ import (
 func resourceCloudflareAccessRuleSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"account_id": {
-			Description: "The account identifier to target for the resource.",
-			Type:        schema.TypeString,
-			Optional:    true,
-			ForceNew:    true,
-			Computed:    true,
+			Description:  "The account identifier to target for the resource.",
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Computed:     true,
+			ExactlyOneOf: []string{"account_id", "zone_id"},
 		},
 		"zone_id": {
-			Description: "The zone identifier to target for the resource.",
-			Type:        schema.TypeString,
-			Optional:    true,
-			ForceNew:    true,
-			Computed:    true,
+			Description:  "The zone identifier to target for the resource.",
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Computed:     true,
+			ExactlyOneOf: []string{"account_id", "zone_id"},
 		},
 		"mode": {
 			Type:         schema.TypeString,


### PR DESCRIPTION
Prior to this commit, if you omitted `account_id` and `zone_id` it would create a user level access rule. This wasn't noted anywhere and caught a lot of people out prior to releasing the WAF.

Here, we are removing that and explicitly requiring a zone or account ID as in most cases, user level rules are the same as account level rules -- just have a different name externally.