### PR TITLE
Added note regarding "partial" setup DNS

### DIFF
--- a/docs/resources/zone.md
+++ b/docs/resources/zone.md
@@ -37,7 +37,7 @@ resource "cloudflare_zone" "example" {
 - `jump_start` (Boolean) Whether to scan for DNS records on creation. Ignored after zone is created.
 - `paused` (Boolean) Whether this zone is paused (traffic bypasses Cloudflare). Defaults to `false`.
 - `plan` (String) The name of the commercial plan to apply to the zone. Available values: `free`, `lite`, `pro`, `pro_plus`, `business`, `enterprise`, `partners_free`, `partners_pro`, `partners_business`, `partners_enterprise`.
-- `type` (String) A full zone implies that DNS is hosted with Cloudflare. A partial zone is typically a partner-hosted zone or a CNAME setup. Available values: `full`, `partial`. Defaults to `full`.
+- `type` (String) A full zone implies that DNS is hosted with Cloudflare. A partial zone is typically a partner-hosted zone or a CNAME setup. Available values: `full`, `partial`. Defaults to `full`. Note the `partial` type requires contacting the Cloudflare customer success or account team to be enabled.
 
 ### Read-Only
 


### PR DESCRIPTION
It's not obvious for customers that "partial" setup type will fail unless the account team or customer success added a specific enablement to the zone.