### PR TITLE
Preserve rule IDs when updating rulesets

### DIFF
--- a/.changelog/2172.txt
+++ b/.changelog/2172.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_ruleset: Preserve IDs of unmodified rules when updating rulesets
+```

--- a/internal/sdkv2provider/resource_cloudflare_ruleset.go
+++ b/internal/sdkv2provider/resource_cloudflare_ruleset.go
@@ -1322,11 +1322,10 @@ func buildRule(d *schema.ResourceData, resourceRule map[string]interface{}, rule
 	return rule
 }
 
-// receives the resource config and builds a ruleset rule array.
-func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.RulesetRule, error) {
+func buildRules(d *schema.ResourceData, value interface{}) ([]cloudflare.RulesetRule, error) {
 	var rulesetRules []cloudflare.RulesetRule
 
-	rules, ok := d.Get("rules").([]interface{})
+	rules, ok := value.([]interface{})
 	if !ok {
 		return nil, errors.New("unable to create interface array type assertion")
 	}
@@ -1343,6 +1342,13 @@ func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.Ruleset
 	}
 
 	return rulesetRules, nil
+}
+
+// receives the resource config and builds a ruleset rule array.
+func buildRulesetRulesFromResource(d *schema.ResourceData) ([]cloudflare.RulesetRule, error) {
+	value := d.Get("rules")
+
+	return buildRules(d, value)
 }
 
 // statusToAPIEnabledFieldConversion takes the "status" field from the Terraform


### PR DESCRIPTION
This PR improves updating `cloudflare_ruleset` resources to preserve the IDs of unmodified rules. Currently, when we update a ruleset, every rule is created from scratch and all rule IDs change. We can avoid that by including the IDs of rules that haven't been modified in the request body.

The implementation uses [ResourceData.GetChange](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema#ResourceData.GetChange) to retrieve the old and new values of the ruleset. Each rule in the two versions of the ruleset is serialized to JSON. We build a map to associate the JSON of each old rule with its ID. The map allows us to look up the new rules and find their IDs if they didn't change.

A ruleset can have rules that are identical except for their ID. We exclude the ID from the JSON lookup key and allow lookup keys to be associated with multiple IDs. We preserve the order of these IDs to ensure that each copy of a rule keeps its original ID.

**Note:** This PR extracts two functions from a large code region, which makes the overall diff hard to read. I've separated these refactorings into `refactor:` commits to make the PR easier to review. The core changes are in the single `feat:` commit.