### PR TITLE
Changing associated_hostnames from list to set for cloudflare_access_mutual_tls_certificate

### DIFF
--- a/.changelog/2174.txt
+++ b/.changelog/2174.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/cloudflare_access_mutual_tls_certificate: The `associated_hostnames` attribute is changing from a List to a Set.
+```

--- a/docs/resources/access_mutual_tls_certificate.md
+++ b/docs/resources/access_mutual_tls_certificate.md
@@ -44,7 +44,7 @@ resource "cloudflare_access_mutual_tls_certificate" "my_cert" {
 ### Optional
 
 - `account_id` (String) The account identifier to target for the resource. Conflicts with `zone_id`.
-- `associated_hostnames` (List of String) The hostnames that will be prompted for this certificate.
+- `associated_hostnames` (Set of String) The hostnames that will be prompted for this certificate.
 - `certificate` (String) The Root CA for your certificates.
 - `zone_id` (String) The zone identifier to target for the resource. Conflicts with `account_id`.
 

--- a/internal/sdkv2provider/schema_cloudflare_access_mutual_tls_certificate.go
+++ b/internal/sdkv2provider/schema_cloudflare_access_mutual_tls_certificate.go
@@ -32,7 +32,7 @@ func resourceCloudflareAccessMutualTLSCertificateSchema() map[string]*schema.Sch
 			Description: "The Root CA for your certificates.",
 		},
 		"associated_hostnames": {
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,


### PR DESCRIPTION
The `associated_hostnames` attribute of the `cloudflare_access_mutual_tls_certificate` resource is currently ordered whereas it should not be in my opinion. There is no consistency in the ordering of the hostnames that is returned by APIs. Therefore, shouldn't we replace the list by a set ?