### PR TITLE
Align cache_key_fields to API constraints

### DIFF
--- a/.changelog/2192.txt
+++ b/.changelog/2192.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_page_rule: make cache_key_fields optional to align with API constraints
+```

--- a/internal/sdkv2provider/schema_cloudflare_page_rule.go
+++ b/internal/sdkv2provider/schema_cloudflare_page_rule.go
@@ -283,11 +283,12 @@ func resourceCloudflarePageRuleSchema() map[string]*schema.Schema {
 						Type:     schema.TypeList,
 						Optional: true,
 						MaxItems: 1,
+						MinItems: 1,
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
 								"cookie": {
 									Type:     schema.TypeList,
-									Required: true,
+									Optional: true,
 									MinItems: 1,
 									MaxItems: 1,
 									Elem: &schema.Resource{
@@ -314,7 +315,7 @@ func resourceCloudflarePageRuleSchema() map[string]*schema.Schema {
 
 								"header": {
 									Type:     schema.TypeList,
-									Required: true,
+									Optional: true,
 									MinItems: 1,
 									MaxItems: 1,
 									Elem: &schema.Resource{
@@ -349,7 +350,7 @@ func resourceCloudflarePageRuleSchema() map[string]*schema.Schema {
 
 								"host": {
 									Type:     schema.TypeList,
-									Required: true,
+									Optional: true,
 									MinItems: 1,
 									MaxItems: 1,
 									Elem: &schema.Resource{
@@ -365,7 +366,7 @@ func resourceCloudflarePageRuleSchema() map[string]*schema.Schema {
 
 								"query_string": {
 									Type:     schema.TypeList,
-									Required: true,
+									Optional: true,
 									MinItems: 1,
 									MaxItems: 1,
 									Elem: &schema.Resource{
@@ -397,7 +398,7 @@ func resourceCloudflarePageRuleSchema() map[string]*schema.Schema {
 
 								"user": {
 									Type:     schema.TypeList,
-									Required: true,
+									Optional: true,
 									MinItems: 1,
 									MaxItems: 1,
 									Elem: &schema.Resource{


### PR DESCRIPTION
The schema is a little more strict than the API. The page rules API only cares if there's at least one "value" field. I've updated the schema to align the schema with the API.