### PR TITLE
ci: remove mac + windows jobs

### DIFF
--- a/.github/workflows/maintainer-only-files.yml
+++ b/.github/workflows/maintainer-only-files.yml
@@ -5,10 +5,7 @@ on:
 
 jobs:
   maintainer-only-files:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/terraform-log-check.yml
+++ b/.github/workflows/terraform-log-check.yml
@@ -9,10 +9,7 @@ on:
         required: true
 jobs:
   tf-log-check:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,12 +3,7 @@ on: [pull_request]
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code repository source code
         uses: actions/checkout@v3


### PR DESCRIPTION
We added MacOS and Windows runners after we had a dependency library incompatible upgrade occur. We haven't seen anything like this recently so let's remove it for now given our tight budget on GitHub Action runners.