### PR TITLE
Remove empty cookie, header fields from page rules - cache by custom key

### DIFF
--- a/.changelog/2208.txt
+++ b/.changelog/2208.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_page_rule: remove empty cookie and header fields when applying this resource
+```

--- a/internal/sdkv2provider/resource_cloudflare_page_rule.go
+++ b/internal/sdkv2provider/resource_cloudflare_page_rule.go
@@ -290,8 +290,24 @@ func transformFromCloudflarePageRuleAction(pageRuleAction *cloudflare.PageRuleAc
 
 		for sectionID, sectionValue := range pageRuleAction.Value.(map[string]interface{}) {
 			switch sectionID {
-			case "cookie", "header", "host", "user":
+			case "host", "user":
 				output[sectionID] = []interface{}{sectionValue}
+
+			case "cookie", "header":
+				fieldOutput := map[string]interface{}{}
+				for fieldID, fieldValue := range sectionValue.(map[string]interface{}) {
+					switch fieldValue.(type) {
+					case []interface{}:
+						if len(fieldValue.([]interface{})) > 0 {
+							fieldOutput[fieldID] = fieldValue
+						}
+					default:
+						fieldOutput[fieldID] = fieldValue
+					}
+				}
+				if len(fieldOutput) > 0 {
+					output[sectionID] = []interface{}{fieldOutput}
+				}
 
 			case "query_string":
 				fieldOutput := map[string]interface{}{}
@@ -422,11 +438,14 @@ func transformToCloudflarePageRuleAction(ctx context.Context, id string, value i
 
 				switch sectionID {
 				case "cookie", "header":
-					for fieldID, fieldValue := range sectionValue.([]interface{})[0].(map[string]interface{}) {
-						sectionOutput[fieldID] = fieldValue.(*schema.Set).List()
+					if len(sectionValue.([]interface{})) > 0 && sectionValue.([]interface{})[0] != nil {
+						for fieldID, fieldValue := range sectionValue.([]interface{})[0].(map[string]interface{}) {
+							sectionOutput[fieldID] = fieldValue.(*schema.Set).List()
+						}
+						output[sectionID] = sectionOutput
 					}
 				case "query_string":
-					if sectionValue.([]interface{})[0] != nil {
+					if len(sectionValue.([]interface{})) > 0 && sectionValue.([]interface{})[0] != nil {
 						for fieldID, fieldValue := range sectionValue.([]interface{})[0].(map[string]interface{}) {
 							switch fieldID {
 							case "exclude", "include":
@@ -464,12 +483,13 @@ func transformToCloudflarePageRuleAction(ctx context.Context, id string, value i
 
 					output[sectionID] = sectionOutput
 				default:
-					for fieldID, fieldValue := range sectionValue.([]interface{})[0].(map[string]interface{}) {
-						sectionOutput[fieldID] = fieldValue
+					if len(sectionValue.([]interface{})) > 0 {
+						for fieldID, fieldValue := range sectionValue.([]interface{})[0].(map[string]interface{}) {
+							sectionOutput[fieldID] = fieldValue
+						}
+						output[sectionID] = sectionOutput
 					}
 				}
-
-				output[sectionID] = sectionOutput
 			}
 
 			pageRuleAction.Value = output

--- a/internal/sdkv2provider/schema_cloudflare_page_rule.go
+++ b/internal/sdkv2provider/schema_cloudflare_page_rule.go
@@ -350,7 +350,7 @@ func resourceCloudflarePageRuleSchema() map[string]*schema.Schema {
 
 								"host": {
 									Type:     schema.TypeList,
-									Optional: true,
+									Required: true,
 									MinItems: 1,
 									MaxItems: 1,
 									Elem: &schema.Resource{
@@ -366,7 +366,7 @@ func resourceCloudflarePageRuleSchema() map[string]*schema.Schema {
 
 								"query_string": {
 									Type:     schema.TypeList,
-									Optional: true,
+									Required: true,
 									MinItems: 1,
 									MaxItems: 1,
 									Elem: &schema.Resource{
@@ -398,7 +398,7 @@ func resourceCloudflarePageRuleSchema() map[string]*schema.Schema {
 
 								"user": {
 									Type:     schema.TypeList,
-									Optional: true,
+									Required: true,
 									MinItems: 1,
 									MaxItems: 1,
 									Elem: &schema.Resource{


### PR DESCRIPTION
The following block is a valid `Cache by custom field` Page Rule:
```
{
    "status": "active",
    "priority": 12,
    "actions": [
        {
            "id": "cache_key_fields",
            "value": {
                "query_string": {
                    "include": "*",
                    "exclude": []
                },
                "header": {
                    "include": [],
                    "exclude": [],
                    "check_presence": []
                },
                "host": {
                    "resolved": false
                },
                "cookie": {
                    "include": [],
                    "check_presence": []
                },
                "user": {
                    "device_type": false,
                    "geo": false,
                    "lang": false
                }
            }
        }
    ],
    "targets": [
        {
            "target": "url",
            "constraint": {
                "operator": "matches",
                "value": "www.foo.bar/*"
            }
        }
    ]
}
```

cf-terraforming correctly generates
```
resource "cloudflare_page_rule" "{resource_id}" {
	zone_id = "{zone_id}"
	target = "www.foo.bar/*"
	actions {
    cache_key_fields {
      host {
        resolved = false
      }
      query_string {
        ignore = false
      }
      user {
        device_type = false
        geo         = false
        lang        = false
      }
    }
  }
}
```

and when I `terraform apply`, the provider will try to send the following request:
```
{
    "targets": [
        {
            "target": "url",
            "constraint": {
                "operator": "matches",
                "value": "tamasjozsa.net/*"
            }
        }
    ],
    "actions": [
        {
            "id": "cache_key_fields",
            "value": {
                "cookie": {},
                "header": {},
                "host": {
                    "resolved": false
                },
                "query_string": {
                    "include": "*"
                },
                "user": {
                    "device_type": false,
                    "geo": false,
                    "lang": false
                }
            }
        }
    ],
    "priority": 1,
    "status": "active",
    "modified_on": "0001-01-01T00:00:00Z",
    "created_on": "0001-01-01T00:00:00Z"
}
```

because of the `cookie` and `header` empty fields, Page Rules will respond
```
resource_cloudflare_page_rule_test.go:749: Step 1/1 error: Error running apply: exit status 1
Error: failed to create page rule: Page Rule validation failed: See messages for details. (1004)
.settings[0].value: cookie expects a non empty array.
```

This PR removes empty `cookie` and `header` fields.  

Closes #2062