### PR TITLE
When Pages project is renamed, correctly invalidate resource

### DIFF
--- a/.changelog/2216.txt
+++ b/.changelog/2216.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_pages_project: changing `name` will now correctly invalidate the resource state. Fixes #2202
+```

--- a/.changelog/2216.txt
+++ b/.changelog/2216.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/cloudflare_pages_project: changing `name` will now correctly invalidate the resource state. Fixes #2202
+resource/cloudflare_pages_project: changing `name` will now force recreation of the project
 ```

--- a/internal/sdkv2provider/schema_cloudflare_pages_domain.go
+++ b/internal/sdkv2provider/schema_cloudflare_pages_domain.go
@@ -13,6 +13,8 @@ func resourceCloudflarePagesDomainSchema() map[string]*schema.Schema {
 			Required:    true,
 			ForceNew:    true,
 		},
+		// Domain name is the unique identifier for this resource, we use this in the API calls.
+		// If this changes, `plan` will fail as it can't figure out the changes.
 		"domain": {
 			Description: "Custom domain.",
 			Type:        schema.TypeString,

--- a/internal/sdkv2provider/schema_cloudflare_pages_project.go
+++ b/internal/sdkv2provider/schema_cloudflare_pages_project.go
@@ -189,10 +189,13 @@ func resourceCloudflarePagesProjectSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Required:    true,
 		},
+		// Name is the unique identifier for this resource, we use this in the API calls.
+		// If this changes, `plan` will fail as it can't figure out the changes.
 		"name": {
 			Description: "Name of the project.",
 			Type:        schema.TypeString,
 			Required:    true,
+			ForceNew:    true,
 		},
 		"subdomain": {
 			Description: "The Cloudflare subdomain associated with the project.",


### PR DESCRIPTION
Fixes #2202 - Correctly invalidates resource when changing a Pages project name