### PR TITLE
Fix multiple emails in notification policy

### DIFF
--- a/.changelog/2248.txt
+++ b/.changelog/2248.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_notification_policy: ensure all emails are saved if multiple `email_integration` values specified
+```

--- a/internal/sdkv2provider/resource_cloudflare_notification_policy.go
+++ b/internal/sdkv2provider/resource_cloudflare_notification_policy.go
@@ -215,9 +215,9 @@ func getNotificationMechanisms(s *schema.Set) []cloudflare.NotificationMechanism
 
 func setNotificationMechanisms(md []cloudflare.NotificationMechanismData) *schema.Set {
 	mechanisms := make([]interface{}, 0)
-	data := make(map[string]interface{})
 
 	for _, m := range md {
+		data := make(map[string]interface{})
 		data["name"] = m.Name
 		data["id"] = m.ID
 		mechanisms = append(mechanisms, data)

--- a/internal/sdkv2provider/resource_cloudflare_notification_policy_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_notification_policy_test.go
@@ -39,6 +39,7 @@ func TestAccCloudflareNotificationPolicy_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "alert_type", "universal_ssl_event_type"),
 					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(resourceName, "email_integration.#", "2"),
 				),
 			},
 			{
@@ -49,6 +50,7 @@ func TestAccCloudflareNotificationPolicy_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "alert_type", "universal_ssl_event_type"),
 					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(resourceName, "email_integration.#", "2"),
 				),
 			},
 		},
@@ -67,6 +69,10 @@ func testCheckCloudflareNotificationPolicy(name, accountID string) string {
       name =  ""
       id   =  "test@example.com"
     }
+    email_integration {
+      name =  ""
+      id   =  "test2@example.com"
+    }
   }`, name, accountID)
 }
 
@@ -81,6 +87,10 @@ func testCheckCloudflareNotificationPolicyUpdated(resName, policyName, policyDes
     email_integration {
       name =  ""
       id   =  "test@example.com"
+    }
+    email_integration {
+      name =  ""
+      id   =  "test2@example.com"
     }
   }`, resName, policyName, policyDesc, accountID)
 }


### PR DESCRIPTION
Setting `data["id"]` only saves the last value as it keeps writing to the same map. Instead a new map should be created for each value.

Fixes: https://github.com/cloudflare/terraform-provider-cloudflare/issues/1917