### PR TITLE
Add ru-RU & fa-IR to default_template_language for WR

### DIFF
--- a/.changelog/2262.txt
+++ b/.changelog/2262.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_waiting_room: add 'ru-RU' and 'fa-IR' to default_template_language field
+```

--- a/docs/resources/waiting_room.md
+++ b/docs/resources/waiting_room.md
@@ -36,7 +36,7 @@ resource "cloudflare_waiting_room" "example" {
 ### Optional
 
 - `custom_page_html` (String) This is a templated html file that will be rendered at the edge.
-- `default_template_language` (String) The language to use for the default waiting room page. Available values: `de-DE`, `es-ES`, `en-US`, `fr-FR`, `id-ID`, `it-IT`, `ja-JP`, `ko-KR`, `nl-NL`, `pl-PL`, `pt-BR`, `tr-TR`, `zh-CN`, `zh-TW`. Defaults to `en-US`.
+- `default_template_language` (String) The language to use for the default waiting room page. Available values: `de-DE`, `es-ES`, `en-US`, `fr-FR`, `id-ID`, `it-IT`, `ja-JP`, `ko-KR`, `nl-NL`, `pl-PL`, `pt-BR`, `tr-TR`, `zh-CN`, `zh-TW`, `ru-RU`, `fa-IR`. Defaults to `en-US`.
 - `description` (String) A description to add more details about the waiting room.
 - `disable_session_renewal` (Boolean) Disables automatic renewal of session cookies.
 - `json_response_enabled` (Boolean) If true, requests to the waiting room with the header `Accept: application/json` will receive a JSON response object.

--- a/internal/sdkv2provider/schema_cloudflare_waiting_room.go
+++ b/internal/sdkv2provider/schema_cloudflare_waiting_room.go
@@ -25,6 +25,8 @@ var defaultTemplateLanguages = []string{
 	"tr-TR",
 	"zh-CN",
 	"zh-TW",
+	"ru-RU",
+	"fa-IR",
 }
 var waitingRoomQueueingMethod = []string{
 	"fifo",


### PR DESCRIPTION
Updated Waiting Room resource to allow for ru-RU and fa-IR locales to the list of default_template_langauge. 

closes WR-1165