### PR TITLE
DLP-810: Add support for DLP payload logging

### DIFF
--- a/.changelog/2267.txt
+++ b/.changelog/2267.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/cloudflare_teams_account: Add support for DLP payload logging public key
+```
+
+```release-note:enhancement
+resource/cloudflare_teams_rule: Add support for enabling DLP payload logging per-rule
+```

--- a/docs/resources/teams_account.md
+++ b/docs/resources/teams_account.md
@@ -75,6 +75,7 @@ resource "cloudflare_teams_account" "example" {
 - `block_page` (Block List, Max: 1) Configuration for a custom block page. (see [below for nested schema](#nestedblock--block_page))
 - `fips` (Block List, Max: 1) Configure compliance with Federal Information Processing Standards. (see [below for nested schema](#nestedblock--fips))
 - `logging` (Block List, Max: 1) (see [below for nested schema](#nestedblock--logging))
+- `payload_log` (Block List, Max: 1) Configuration for DLP Payload Logging. (see [below for nested schema](#nestedblock--payload_log))
 - `proxy` (Block List, Max: 1) Configuration block for specifying which protocols are proxied. (see [below for nested schema](#nestedblock--proxy))
 - `tls_decrypt_enabled` (Boolean) Indicator that decryption of TLS traffic is enabled.
 - `url_browser_isolation_enabled` (Boolean) Safely browse websites in Browser Isolation through a URL.
@@ -160,6 +161,14 @@ Required:
 - `log_blocks` (Boolean)
 
 
+
+
+<a id="nestedblock--payload_log"></a>
+### Nested Schema for `payload_log`
+
+Required:
+
+- `public_key` (String) Public key used to encrypt matched payloads.
 
 
 <a id="nestedblock--proxy"></a>

--- a/docs/resources/teams_rule.md
+++ b/docs/resources/teams_rule.md
@@ -66,6 +66,7 @@ Optional:
 - `l4override` (Block List, Max: 1) Settings to forward layer 4 traffic. (see [below for nested schema](#nestedblock--rule_settings--l4override))
 - `override_host` (String) The host to override matching DNS queries with.
 - `override_ips` (List of String) The IPs to override matching DNS queries with.
+- `payload_log` (Block List, Max: 1) Configure DLP Payload Logging settings for this rule. (see [below for nested schema](#nestedblock--rule_settings--payload_log))
 
 <a id="nestedblock--rule_settings--biso_admin_controls"></a>
 ### Nested Schema for `rule_settings.biso_admin_controls`
@@ -108,6 +109,14 @@ Required:
 
 - `ip` (String) Override IP to forward traffic to.
 - `port` (Number) Override Port to forward traffic to.
+
+
+<a id="nestedblock--rule_settings--payload_log"></a>
+### Nested Schema for `rule_settings.payload_log`
+
+Required:
+
+- `enabled` (Boolean) Enable or disable DLP Payload Logging for this rule.
 
 ## Import
 

--- a/internal/sdkv2provider/resource_cloudflare_teams_accounts.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_accounts.go
@@ -99,6 +99,15 @@ func resourceCloudflareTeamsAccountRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(fmt.Errorf("error parsing teams account device settings: %w", err))
 	}
 
+	payloadLogSettings, err := client.GetDLPPayloadLogSettings(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.GetDLPPayloadLogSettingsParams{})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error finding DLP Account config %q: %w", d.Id(), err))
+	}
+
+	if err := d.Set("payload_log", flattenPayloadLogSettings(&payloadLogSettings)); err != nil {
+		return diag.FromErr(fmt.Errorf("error parsing payload log settings: %w", err))
+	}
+
 	return nil
 }
 
@@ -110,6 +119,7 @@ func resourceCloudflareTeamsAccountUpdate(ctx context.Context, d *schema.Resourc
 	antivirusConfig := inflateAntivirusConfig(d.Get("antivirus"))
 	loggingConfig := inflateLoggingSettings(d.Get("logging"))
 	deviceConfig := inflateDeviceSettings(d.Get("proxy"))
+	payloadLogSettings := inflatePayloadLogSettings(d.Get("payload_log"))
 	updatedTeamsAccount := cloudflare.TeamsConfiguration{
 		Settings: cloudflare.TeamsAccountSettings{
 			Antivirus: antivirusConfig,
@@ -151,6 +161,12 @@ func resourceCloudflareTeamsAccountUpdate(ctx context.Context, d *schema.Resourc
 	if deviceConfig != nil {
 		if _, err := client.TeamsAccountDeviceUpdateConfiguration(ctx, accountID, *deviceConfig); err != nil {
 			return diag.FromErr(fmt.Errorf("error updating Teams Account proxy settings for account %q: %w", accountID, err))
+		}
+	}
+
+	if payloadLogSettings != nil {
+		if _, err := client.UpdateDLPPayloadLogSettings(ctx, cloudflare.AccountIdentifier(accountID), *payloadLogSettings); err != nil {
+			return diag.FromErr(fmt.Errorf("error updating DLP Account configuration for account %q: %w", accountID, err))
 		}
 	}
 
@@ -343,5 +359,24 @@ func inflateDeviceSettings(device interface{}) *cloudflare.TeamsDeviceSettings {
 	return &cloudflare.TeamsDeviceSettings{
 		GatewayProxyEnabled:    deviceSettings["tcp"].(bool),
 		GatewayProxyUDPEnabled: deviceSettings["udp"].(bool),
+	}
+}
+
+func flattenPayloadLogSettings(payloadLogSettings *cloudflare.DLPPayloadLogSettings) []interface{} {
+	return []interface{}{map[string]interface{}{
+		"public_key": payloadLogSettings.PublicKey,
+	}}
+}
+
+func inflatePayloadLogSettings(payloadLog interface{}) *cloudflare.DLPPayloadLogSettings {
+	payloadLogList := payloadLog.([]interface{})
+	if len(payloadLogList) != 1 {
+		return nil
+	}
+
+	payloadLogMap := payloadLogList[0].(map[string]interface{})
+	publicKey := payloadLogMap["public_key"].(string)
+	return &cloudflare.DLPPayloadLogSettings{
+		PublicKey: publicKey,
 	}
 }

--- a/internal/sdkv2provider/resource_cloudflare_teams_accounts_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_accounts_test.go
@@ -50,6 +50,7 @@ func TestAccCloudflareTeamsAccountConfigurationBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "logging.0.settings_by_rule_type.0.l4.0.log_blocks", "true"),
 					resource.TestCheckResourceAttr(name, "proxy.0.tcp", "true"),
 					resource.TestCheckResourceAttr(name, "proxy.0.udp", "false"),
+					resource.TestCheckResourceAttr(name, "payload_log.0.public_key", "EmpOvSXw8BfbrGCi0fhGiD/3yXk2SiV1Nzg2lru3oj0="),
 				),
 			},
 		},
@@ -100,6 +101,9 @@ resource "cloudflare_teams_account" "%[1]s" {
         log_blocks = true
       }
     }
+  }
+  payload_log {
+	public_key = "EmpOvSXw8BfbrGCi0fhGiD/3yXk2SiV1Nzg2lru3oj0="
   }
 }
 `, rnd, accountID)

--- a/internal/sdkv2provider/resource_cloudflare_teams_rules.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_rules.go
@@ -207,6 +207,7 @@ func flattenTeamsRuleSettings(settings *cloudflare.TeamsRuleSettings) []interfac
 		"add_headers":                        flattenTeamsAddHeaders(settings.AddHeaders),
 		"insecure_disable_dnssec_validation": settings.InsecureDisableDNSSECValidation,
 		"egress":                             flattenTeamsEgressSettings(settings.EgressSettings),
+		"payload_log":                        flattenTeamsDlpPayloadLogSettings(settings.PayloadLog),
 	}}
 }
 
@@ -233,6 +234,7 @@ func inflateTeamsRuleSettings(settings interface{}) *cloudflare.TeamsRuleSetting
 	addHeaders := inflateTeamsAddHeaders(settingsMap["add_headers"].(map[string]interface{}))
 	insecureDisableDNSSECValidation := settingsMap["insecure_disable_dnssec_validation"].(bool)
 	egressSettings := inflateTeamsEgressSettings(settingsMap["egress"].([]interface{}))
+	payloadLog := inflateTeamsDlpPayloadLogSettings(settingsMap["payload_log"].([]interface{}))
 
 	return &cloudflare.TeamsRuleSettings{
 		BlockPageEnabled:                enabled,
@@ -245,6 +247,7 @@ func inflateTeamsRuleSettings(settings interface{}) *cloudflare.TeamsRuleSetting
 		AddHeaders:                      addHeaders,
 		InsecureDisableDNSSECValidation: insecureDisableDNSSECValidation,
 		EgressSettings:                  egressSettings,
+		PayloadLog:                      payloadLog,
 	}
 }
 
@@ -391,6 +394,27 @@ func inflateTeamsEgressSettings(settings interface{}) *cloudflare.EgressSettings
 		Ipv4:         ipv4,
 		Ipv6Range:    ipv6,
 		Ipv4Fallback: ipv4Fallback,
+	}
+}
+
+func flattenTeamsDlpPayloadLogSettings(settings *cloudflare.TeamsDlpPayloadLogSettings) []interface{} {
+	if settings == nil {
+		return nil
+	}
+	return []interface{}{map[string]interface{}{
+		"enabled": settings.Enabled,
+	}}
+}
+
+func inflateTeamsDlpPayloadLogSettings(settings interface{}) *cloudflare.TeamsDlpPayloadLogSettings {
+	settingsList := settings.([]interface{})
+	if len(settingsList) != 1 {
+		return nil
+	}
+	settingsMap := settingsList[0].(map[string]interface{})
+	enabled := settingsMap["enabled"].(bool)
+	return &cloudflare.TeamsDlpPayloadLogSettings{
+		Enabled: enabled,
 	}
 }
 

--- a/internal/sdkv2provider/resource_cloudflare_teams_rules_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_rules_test.go
@@ -46,6 +46,7 @@ func TestAccCloudflareTeamsRuleBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "rule_settings.0.insecure_disable_dnssec_validation", "false"),
 					resource.TestCheckResourceAttr(name, "rule_settings.0.egress.0.ipv4", "203.0.113.1"),
 					resource.TestCheckResourceAttr(name, "rule_settings.0.egress.0.ipv6", "2001:db8::/32"),
+					resource.TestCheckResourceAttr(name, "rule_settings.0.payload_log.0.enabled", "true"),
 				),
 			},
 		},
@@ -69,6 +70,9 @@ resource "cloudflare_teams_rule" "%[1]s" {
 	egress {
 		ipv4 = "203.0.113.1"
 		ipv6 = "2001:db8::/32"
+	}
+	payload_log {
+		enabled = true
 	}
   }
 }

--- a/internal/sdkv2provider/schema_cloudflare_teams_accounts.go
+++ b/internal/sdkv2provider/schema_cloudflare_teams_accounts.go
@@ -71,6 +71,15 @@ func resourceCloudflareTeamsAccountSchema() map[string]*schema.Schema {
 			},
 			Description: "Configuration block for specifying which protocols are proxied.",
 		},
+		"payload_log": {
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: payloadLogSchema,
+			},
+			Description: "Configuration for DLP Payload Logging.",
+		},
 	}
 }
 
@@ -210,5 +219,13 @@ var loggingEnabledSchema = map[string]*schema.Schema{
 	"log_blocks": {
 		Type:     schema.TypeBool,
 		Required: true,
+	},
+}
+
+var payloadLogSchema = map[string]*schema.Schema{
+	"public_key": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Public key used to encrypt matched payloads.",
 	},
 }

--- a/internal/sdkv2provider/schema_cloudflare_teams_rules.go
+++ b/internal/sdkv2provider/schema_cloudflare_teams_rules.go
@@ -150,6 +150,23 @@ var teamsRuleSettings = map[string]*schema.Schema{
 		},
 		Description: "Configure how Proxy traffic egresses. Can be set for rules with Egress action and Egress filter. Can be omitted to indicate local egress via Warp IPs.",
 	},
+	"payload_log": {
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: payloadLogSettings,
+		},
+		Description: "Configure DLP Payload Logging settings for this rule.",
+	},
+}
+
+var payloadLogSettings = map[string]*schema.Schema{
+	"enabled": {
+		Type:        schema.TypeBool,
+		Required:    true,
+		Description: "Enable or disable DLP Payload Logging for this rule.",
+	},
 }
 
 var egressSettings = map[string]*schema.Schema{


### PR DESCRIPTION
Adds support for the DLP payload logging feature, both enabling it for an individual rule and setting the account-level public key setting. Both new options can be added into existing resources. While you need an entitlement to _set_ the public key, you don't need one to read it. Setting the key isn't attempted unless the `public_key {}` block is specified on the `cloudflare_teams_account` resource, so this shouldn't be a breaking change.