### PR TITLE
Fix issue where azure group rules would override each other

### DIFF
--- a/.changelog/2270.txt
+++ b/.changelog/2270.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/access_group: fixes an issue where Azure group rules with different identity provider ids would override each other
+resource/cloudflare_access_group: fixes an issue where Azure group rules with different identity provider ids would override each other
 ```

--- a/.changelog/2270.txt
+++ b/.changelog/2270.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/access_group: fixes an issue where Azure group rules with different identity provider ids would override each other
+```

--- a/internal/sdkv2provider/resource_cloudflare_access_group_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_group_test.go
@@ -148,6 +148,10 @@ func TestAccCloudflareAccessGroupConfig_BasicAccount(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "include.0.saml.0.attribute_value", "Value1"),
 					resource.TestCheckResourceAttr(name, "include.0.saml.1.attribute_name", "Name2"),
 					resource.TestCheckResourceAttr(name, "include.0.saml.1.attribute_value", "Value2"),
+					resource.TestCheckResourceAttr(name, "include.0.azure.0.id.0", "group1"),
+					resource.TestCheckResourceAttr(name, "include.0.azure.0.identity_provider_id", "1234"),
+					resource.TestCheckResourceAttr(name, "include.0.azure.1.id.0", "group2"),
+					resource.TestCheckResourceAttr(name, "include.0.azure.1.identity_provider_id", "5678"),
 				),
 			},
 			{
@@ -167,6 +171,10 @@ func TestAccCloudflareAccessGroupConfig_BasicAccount(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "include.0.saml.0.attribute_value", "Value1"),
 					resource.TestCheckResourceAttr(name, "include.0.saml.1.attribute_name", "Name2"),
 					resource.TestCheckResourceAttr(name, "include.0.saml.1.attribute_value", "Value2"),
+					resource.TestCheckResourceAttr(name, "include.0.azure.0.id.0", "group1"),
+					resource.TestCheckResourceAttr(name, "include.0.azure.0.identity_provider_id", "1234"),
+					resource.TestCheckResourceAttr(name, "include.0.azure.1.id.0", "group2"),
+					resource.TestCheckResourceAttr(name, "include.0.azure.1.identity_provider_id", "5678"),
 				),
 			},
 		},
@@ -377,6 +385,14 @@ resource "cloudflare_access_group" "%[1]s" {
     saml {
       attribute_name = "Name2"
       attribute_value = "Value2"
+    }
+    azure {
+      id = ["group1"]
+      identity_provider_id = "1234"
+    }
+    azure {
+      id = ["group2"]
+      identity_provider_id = "5678"
     }
   }
 }`, resourceName, email, identifier.Type, identifier.Value)


### PR DESCRIPTION
Fixes an issue where Azure group rules with different identity provider ids would clobber each other.