### PR TITLE
Support `sentinelone` type in the `cloudflare_device_posture_rule` schema

### DIFF
--- a/.changelog/2279.txt
+++ b/.changelog/2279.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/cloudflare_access_device_posture_rule: Add support for `sentinelone` type
+resource/cloudflare_device_posture_rule: Add support for `sentinelone` type.
 ```

--- a/.changelog/2279.txt
+++ b/.changelog/2279.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_access_device_posture_rule: Add support for `sentinelone` type
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 4.2.0 (Unreleased)
 
+ENHANCEMENTS:
+
+- `resource/cloudflare_access_device_posture_rule`: Add support for `sentinelone` type ([#2278](https://github.com/cloudflare/terraform-provider-cloudflare/issues/2278))
+
 ## 4.1.0 (March 8th, 2023)
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## 4.2.0 (Unreleased)
 
-ENHANCEMENTS:
-
-- `resource/cloudflare_access_device_posture_rule`: Add support for `sentinelone` type ([#2278](https://github.com/cloudflare/terraform-provider-cloudflare/issues/2278))
-
 ## 4.1.0 (March 8th, 2023)
 
 ENHANCEMENTS:

--- a/docs/resources/device_posture_rule.md
+++ b/docs/resources/device_posture_rule.md
@@ -39,7 +39,7 @@ resource "cloudflare_device_posture_rule" "eaxmple" {
 ### Required
 
 - `account_id` (String) The account identifier to target for the resource.
-- `type` (String) The device posture rule type. Available values: `serial_number`, `file`, `application`, `gateway`, `warp`, `domain_joined`, `os_version`, `disk_encryption`, `firewall`, `workspace_one`, `unique_client_id`, `crowdstrike_s2s`.
+- `type` (String) The device posture rule type. Available values: `serial_number`, `file`, `application`, `gateway`, `warp`, `domain_joined`, `os_version`, `disk_encryption`, `firewall`, `workspace_one`, `unique_client_id`, `crowdstrike_s2s`, `sentinelone`.
 
 ### Optional
 

--- a/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
@@ -18,8 +18,8 @@ func resourceCloudflareDevicePostureRuleSchema() map[string]*schema.Schema {
 		"type": {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: validation.StringInSlice([]string{"serial_number", "file", "application", "gateway", "warp", "domain_joined", "os_version", "disk_encryption", "firewall", "workspace_one", "unique_client_id", "crowdstrike_s2s"}, false),
-			Description:  fmt.Sprintf("The device posture rule type. %s", renderAvailableDocumentationValuesStringSlice([]string{"serial_number", "file", "application", "gateway", "warp", "domain_joined", "os_version", "disk_encryption", "firewall", "workspace_one", "unique_client_id", "crowdstrike_s2s"})),
+			ValidateFunc: validation.StringInSlice([]string{"serial_number", "file", "application", "gateway", "warp", "domain_joined", "os_version", "disk_encryption", "firewall", "workspace_one", "unique_client_id", "crowdstrike_s2s", "sentinelone"}, false),
+			Description:  fmt.Sprintf("The device posture rule type. %s", renderAvailableDocumentationValuesStringSlice([]string{"serial_number", "file", "application", "gateway", "warp", "domain_joined", "os_version", "disk_encryption", "firewall", "workspace_one", "unique_client_id", "crowdstrike_s2s", "sentinelone"})),
 		},
 		"name": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
Follow up PR for issue https://github.com/cloudflare/terraform-provider-cloudflare/issues/2278.

Adds support for the `sentinelone` device posture rule type (which is undocumented, but used by some posture rules created in the dashboard). No additional `input` schema modifications need to be made as `sentinelone` appears to be an alias for / accept the same parameters as the `application` type.