### PR TITLE
Support `check_disks` in the `device_posture_rule` input block schema

### DIFF
--- a/.changelog/2280.txt
+++ b/.changelog/2280.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_device_posture_rule: Support `check_disks` in the `input` block schema.
+```

--- a/docs/resources/device_posture_rule.md
+++ b/docs/resources/device_posture_rule.md
@@ -59,6 +59,7 @@ resource "cloudflare_device_posture_rule" "eaxmple" {
 
 Optional:
 
+- `check_disks` (List of String) Specific volume(s) to check for encryption.
 - `compliance_status` (String) The workspace one device compliance status. Available values: `compliant`, `noncompliant`.
 - `connection_id` (String) The workspace one connection id.
 - `domain` (String) The domain that the client must join.

--- a/docs/resources/device_posture_rule.md
+++ b/docs/resources/device_posture_rule.md
@@ -59,7 +59,7 @@ resource "cloudflare_device_posture_rule" "eaxmple" {
 
 Optional:
 
-- `check_disks` (List of String) Specific volume(s) to check for encryption.
+- `check_disks` (Set of String) Specific volume(s) to check for encryption.
 - `compliance_status` (String) The workspace one device compliance status. Available values: `compliant`, `noncompliant`.
 - `connection_id` (String) The workspace one connection id.
 - `domain` (String) The domain that the client must join.

--- a/internal/sdkv2provider/resource_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/resource_cloudflare_device_posture_rule.go
@@ -181,8 +181,7 @@ func setDevicePostureRuleInput(rule *cloudflare.DevicePostureRule, d *schema.Res
 			input.RequireAll = require_all.(bool)
 		}
 		if check_disks, ok := d.GetOk("input.0.check_disks"); ok {
-			values := check_disks.([]interface{})
-			input.CheckDisks = make([]string, len(values))
+			values := check_disks.(*schema.Set).List()
 			for _, value := range values {
 				input.CheckDisks = append(input.CheckDisks, value.(string))
 			}

--- a/internal/sdkv2provider/resource_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/resource_cloudflare_device_posture_rule.go
@@ -180,6 +180,13 @@ func setDevicePostureRuleInput(rule *cloudflare.DevicePostureRule, d *schema.Res
 		if require_all, ok := d.GetOk("input.0.require_all"); ok {
 			input.RequireAll = require_all.(bool)
 		}
+		if check_disks, ok := d.GetOk("input.0.check_disks"); ok {
+			values := check_disks.([]interface{})
+			input.CheckDisks = make([]string, len(values))
+			for _, value := range values {
+				input.CheckDisks = append(input.CheckDisks, value.(string))
+			}
+		}
 		if enabled, ok := d.GetOk("input.0.enabled"); ok {
 			input.Enabled = enabled.(bool)
 		}
@@ -260,6 +267,7 @@ func convertInputToSchema(input cloudflare.DevicePostureRuleInput) []map[string]
 		"sha256":             input.Sha256,
 		"running":            input.Running,
 		"require_all":        input.RequireAll,
+		"check_disks":        input.CheckDisks,
 		"enabled":            input.Enabled,
 		"version":            input.Version,
 		"os_distro_name":     input.OsDistroName,

--- a/internal/sdkv2provider/resource_cloudflare_device_posture_rule_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_device_posture_rule_test.go
@@ -182,7 +182,7 @@ func TestAccCloudflareDevicePostureRule_Firewall(t *testing.T) {
 	})
 }
 
-func TestAccCloudflareDevicePostureRule_DiskEncryption(t *testing.T) {
+func TestAccCloudflareDevicePostureRule_DiskEncryption_RequireAll(t *testing.T) {
 	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
 	// service does not yet support the API tokens and it results in
 	// misleading state error messages.
@@ -201,7 +201,7 @@ func TestAccCloudflareDevicePostureRule_DiskEncryption(t *testing.T) {
 		CheckDestroy:      testAccCheckCloudflareDevicePostureRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudflareDevicePostureRuleConfigDiskEncryption(rnd, accountID),
+				Config: testAccCloudflareDevicePostureRuleConfigDiskEncryptionRequireAll(rnd, accountID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
@@ -211,6 +211,43 @@ func TestAccCloudflareDevicePostureRule_DiskEncryption(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "expiration", "24h"),
 					resource.TestCheckResourceAttr(name, "match.0.platform", "mac"),
 					resource.TestCheckResourceAttr(name, "input.0.require_all", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareDevicePostureRule_DiskEncryption_CheckDisks(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_device_posture_rule.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCloudflareDevicePostureRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareDevicePostureRuleConfigDiskEncryptionCheckDisks(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "type", "disk_encryption"),
+					resource.TestCheckResourceAttr(name, "description", "My description"),
+					resource.TestCheckResourceAttr(name, "schedule", "24h"),
+					resource.TestCheckResourceAttr(name, "expiration", "24h"),
+					resource.TestCheckResourceAttr(name, "match.0.platform", "mac"),
+					resource.TestCheckResourceAttr(name, "input.0.require_all", "false"),
+					resource.TestCheckResourceAttr(name, "input.0.check_disks.0", "C"),
+					resource.TestCheckResourceAttr(name, "input.0.check_disks.1", "D"),
 				),
 			},
 		},
@@ -297,7 +334,7 @@ resource "cloudflare_device_posture_rule" "%[1]s" {
 `, rnd, accountID)
 }
 
-func testAccCloudflareDevicePostureRuleConfigDiskEncryption(rnd, accountID string) string {
+func testAccCloudflareDevicePostureRuleConfigDiskEncryptionRequireAll(rnd, accountID string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_device_posture_rule" "%[1]s" {
 	account_id                = "%[2]s"
@@ -311,6 +348,26 @@ resource "cloudflare_device_posture_rule" "%[1]s" {
 	}
 	input {
 		require_all = true
+	}
+}
+`, rnd, accountID)
+}
+
+func testAccCloudflareDevicePostureRuleConfigDiskEncryptionCheckDisks(rnd, accountID string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_device_posture_rule" "%[1]s" {
+	account_id                = "%[2]s"
+	name                      = "%[1]s"
+	type                      = "disk_encryption"
+	description               = "My description"
+	schedule                  = "24h"
+	expiration                = "24h"
+	match {
+		platform = "mac"
+	}
+	input {
+		require_all = false
+		check_disks = ["C", "D"]
 	}
 }
 `, rnd, accountID)

--- a/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
@@ -100,7 +100,7 @@ func resourceCloudflareDevicePostureRuleSchema() map[string]*schema.Schema {
 						Description: "True if all drives must be encrypted.",
 					},
 					"check_disks": {
-						Type: schema.TypeList,
+						Type: schema.TypeSet,
 						Elem: &schema.Schema{
 							Type: schema.TypeString,
 						},

--- a/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
@@ -99,6 +99,14 @@ func resourceCloudflareDevicePostureRuleSchema() map[string]*schema.Schema {
 						Computed:    true,
 						Description: "True if all drives must be encrypted.",
 					},
+					"check_disks": {
+						Type: schema.TypeList,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+						Optional:    true,
+						Description: "Specific volume(s) to check for encryption.",
+					},
 					"enabled": {
 						Type:        schema.TypeBool,
 						Optional:    true,


### PR DESCRIPTION
_**Note:** This PR is pending the https://github.com/cloudflare/cloudflare-go/pull/1197 enhancement to be released in v0.63.0 of the [cloudflare-go](https://github.com/cloudflare/cloudflare-go) library._

Implements the `check_disks` configuration value in the `input` nested schema for the `device_posture_rule` resource. This value accepts a list of strings, each of which is a discrete volume to check for encryption.

This PR additionally splits the `TestAccCloudflareDevicePostureRule_DiskEncryption` test into `_RequireAll` and `_CheckDisks`.

@jacobbednarz an additional PR may be required to remove `Computed` from the schema for `require_all` as this value is now user-configurable.

**Related Issues**
Closes https://github.com/cloudflare/terraform-provider-cloudflare/issues/1644