### PR TITLE
DLP-1010: Ignore 'not found' error when reading DLP payload log settings

### DIFF
--- a/.changelog/2284.txt
+++ b/.changelog/2284.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_teams_account: fixes an issue where accounts that had never configured DLP payload logging would error upon reading this resource
+```


### PR DESCRIPTION
Fixes the bug brought up in #2267 where reading the DLP payload log settings would error when the target account had never configured it before.