### PR TITLE
automatically lock issues/PRs after a milestone release

### DIFF
--- a/.github/workflows/milestone-closed.yml
+++ b/.github/workflows/milestone-closed.yml
@@ -20,3 +20,18 @@ jobs:
             Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading.
 
             For further feature requests or bug reports with this functionality, please create a [new GitHub issue](https://github.com/${{ github.repository }}/issues/new/choose) following the template. Thank you!
+  lock-closed-issues:
+    runs-on: ubuntu-latest
+    needs: comment-on-closed-milestone
+    steps:
+      - run: |
+          IFS=',' read -r -a issues <<< "$ISSUES"
+          for element in "${issues[@]}"
+          do
+              echo "Locking $element"
+              echo "no" | gh pr lock -r resolved $element
+              echo "no" | gh issue lock -r resolved $element
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUES: ${{ needs.comment-on-closed-milestone.outputs.ids }}


### PR DESCRIPTION
Updates the release process to automatically lock issues and PRs after a release to get folks to create new issues for problems instead of dogpiling.