### PR TITLE
Resource list item

### DIFF
--- a/docs/resources/list.md
+++ b/docs/resources/list.md
@@ -82,6 +82,7 @@ resource "cloudflare_list" "example" {
 
 - `description` (String) An optional description of the list.
 - `item` (Block Set) (see [below for nested schema](#nestedblock--item))
+- `ignore_inline_items` (Boolean) Will cause the resource to ignore item nested blocks. Useful when managing list items outside of Terraform or when using the `cloudflare_list_item` resource. Defaults to `false`.
 
 ### Read-Only
 

--- a/docs/resources/list_item.md
+++ b/docs/resources/list_item.md
@@ -1,0 +1,88 @@
+---
+page_title: "cloudflare_list_item Resource - Cloudflare"
+subcategory: ""
+description: |-
+  Provides Lists Items (IPs, Redirects) to be used in Edge Rules Engine
+  across all zones within the same account.
+---
+
+# cloudflare_list_item (Resource)
+
+Provides List Items (IPs, Redirects) to be used in Edge Rules Engine
+across all zones within the same account.
+
+~> The Cloudflare Terraform Provider supports list items being specified in-line when creating a `cloudflare_list` resource.  The `cloudflare_list_item` resource can only be used on lists that are created with no in-line items or lists managed outside of Terraform.
+
+## Example Usage
+
+```terraform
+# IP List Item
+resource "cloudflare_list" "example_ip_list" {
+  account_id  = "01234567890123456789012345678901"
+  name        = "example_list"
+  description = "example IPs for a list"
+  kind        = "ip"
+}
+
+resource "cloudflare_list_item" example_ip_item" {
+  account_id = "01234567890123456789012345678901"
+  list_id    = cloudflare_list.example_ip_list.id
+  comment    = "List Item Comment"
+  ip         = "192.0.2.0"
+}
+```
+```
+# Redirect List Item
+resource "cloudflare_list_item" "test_two" {
+  account_id = "01234567890123456789012345678901"
+  list_id    = cloudflare_list.example_ip_list.id
+  redirect {
+    source_url       = "https://source.tld"
+    target_url       = "https://target.tld"
+    status_code      = 302
+    subpath_matching = "enabled"
+  }
+}
+```
+
+
+## Schema
+
+### Required
+
+- `account_id` (String) The account identifier to target for the resource.
+- `list_id` (String) The list identifier to target for the resource.
+
+### Optional
+
+- `comment` (String) An optional description of the list.
+- `ip` (String) The IP address for lists of `kind = "ip"`.
+- `redirect` (Block Set) (see [below for nested schema](#nestedblock--redirect))
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
+
+<a id="nestedblock--redirect"></a>
+### Nested Schema for `redirect`
+
+Required:
+
+- `source_url` (String) The source url of the redirect.
+- `target_url` (String) The target url of the redirect.
+
+Optional:
+
+- `include_subdomains` (String) Whether the redirect also matches subdomains of the source url. Available values: `disabled`, `enabled`.
+- `preserve_path_suffix` (String) Whether to preserve the path suffix when doing subpath matching. Available values: `disabled`, `enabled`.
+- `preserve_query_string` (String) Whether the redirect target url should keep the query string of the request's url. Available values: `disabled`, `enabled`.
+- `status_code` (Number) The status code to be used when redirecting a request.
+- `subpath_matching` (String) Whether the redirect also matches subpaths of the source url. Available values: `disabled`, `enabled`.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+$ terraform import cloudflare_list_item.example <account_id>/<list_id>/<item_id>
+```

--- a/docs/resources/list_item.md
+++ b/docs/resources/list_item.md
@@ -11,17 +11,18 @@ description: |-
 Provides List Items (IPs, Redirects) to be used in Edge Rules Engine
 across all zones within the same account.
 
-~> The Cloudflare Terraform Provider supports list items being specified in-line when creating a `cloudflare_list` resource.  The `cloudflare_list_item` resource can only be used on lists that are created with no in-line items or lists managed outside of Terraform.
+~> The Cloudflare Terraform Provider supports list items being specified in-line when creating a `cloudflare_list` resource. The `cloudflare_list_item` resource can only be used on lists that are created with no in-line items or lists managed outside of Terraform. If managing a list via Terraform, set the `cloudflare_list` attribute `ignore_inline_items` to `true` when using the `cloudflare_list_item` resource as it will prevent the list resource from trying to reconcile an empty in-line item list.
 
 ## Example Usage
 
 ```terraform
 # IP List Item
 resource "cloudflare_list" "example_ip_list" {
-  account_id  = "01234567890123456789012345678901"
-  name        = "example_list"
-  description = "example IPs for a list"
-  kind        = "ip"
+  account_id          = "01234567890123456789012345678901"
+  name                = "example_list"
+  description         = "example IPs for a list"
+  kind                = "ip"
+  ignore_inline_items = true
 }
 
 resource "cloudflare_list_item" example_ip_item" {

--- a/internal/sdkv2provider/provider.go
+++ b/internal/sdkv2provider/provider.go
@@ -258,6 +258,7 @@ func New(version string) func() *schema.Provider {
 				"cloudflare_zone_lockdown":                          resourceCloudflareZoneLockdown(),
 				"cloudflare_zone_settings_override":                 resourceCloudflareZoneSettingsOverride(),
 				"cloudflare_zone":                                   resourceCloudflareZone(),
+				"cloudflare_list_item":                              resourceCloudflareListItem(),
 			},
 		}
 

--- a/internal/sdkv2provider/resource_cloudflare_list.go
+++ b/internal/sdkv2provider/resource_cloudflare_list.go
@@ -94,6 +94,10 @@ func resourceCloudflareListRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("description", list.Description)
 	d.Set("kind", list.Kind)
 
+	if d.Get("ignore_inline_items").(bool) {
+		return nil
+	}
+
 	items, err := client.ListListItems(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListListItemsParams{
 		ID: d.Id(),
 	})

--- a/internal/sdkv2provider/resource_cloudflare_list_item.go
+++ b/internal/sdkv2provider/resource_cloudflare_list_item.go
@@ -1,0 +1,217 @@
+package sdkv2provider
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pkg/errors"
+)
+
+func resourceCloudflareListItem() *schema.Resource {
+	return &schema.Resource{
+		Schema:        resourceCloudflareListItemSchema(),
+		CreateContext: resourceCloudflareListItemCreate,
+		ReadContext:   resourceCloudflareListItemRead,
+		UpdateContext: resourceCloudflareListItemUpdate,
+		DeleteContext: resourceCloudflareListItemDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCloudflareListItemImport,
+		},
+		Description: heredoc.Doc(`
+			Provides individual list items (IPs, Redirects) to be used in Edge Rules Engine
+			across all zones within the same account.
+		`),
+	}
+}
+
+func resourceCloudflareListItemCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get(consts.AccountIDSchemaKey).(string)
+	listID := d.Get("list_id").(string)
+	listItemType := listItemType(d)
+
+	list, err := client.GetList(ctx, cloudflare.AccountIdentifier(accountID), listID)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to find list with id %s: %w", listID, err))
+	}
+
+	if list.Kind != listItemType {
+		return diag.FromErr(fmt.Errorf("items of type %s can not be added to lists of type %s", listItemType, list.Kind))
+	}
+
+	createListItemResponse, err := client.CreateListItem(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListCreateItemParams{
+		ID:   listID,
+		Item: buildListItemCreateRequest(d),
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to create list item on list id %s: %w", listID, err))
+	}
+
+	newestItem := mostRecentlyCreatedItem(createListItemResponse)
+	d.SetId(newestItem.ID)
+
+	return nil
+}
+
+func resourceCloudflareListItemImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	attributes := strings.SplitN(d.Id(), "/", 3)
+
+	if len(attributes) != 3 {
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"accountID/listID/itemID\"", d.Id())
+	}
+
+	accountID, listID, itemID := attributes[0], attributes[1], attributes[2]
+	d.SetId(itemID)
+	d.Set(consts.AccountIDSchemaKey, accountID)
+	d.Set("list_id", listID)
+
+	resourceCloudflareListItemRead(ctx, d, meta)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceCloudflareListItemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get(consts.AccountIDSchemaKey).(string)
+	listID := d.Get("list_id").(string)
+
+	listItem, err := client.GetListItem(ctx, cloudflare.AccountIdentifier(accountID), listID, d.Id())
+	if err != nil {
+		if strings.Contains(err.Error(), "could not find item") {
+			tflog.Info(ctx, fmt.Sprintf("List item %s no longer exists", d.Id()))
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error reading List Item with ID %q", d.Id())))
+	}
+
+	d.Set("comment", listItem.Comment)
+
+	if listItem.IP != nil {
+		d.Set("ip", *listItem.IP)
+	}
+
+	if listItem.Redirect != nil {
+		optBoolToString := func(b *bool) string {
+			if b != nil {
+				switch *b {
+				case true:
+					return "enabled"
+				case false:
+					return "disabled"
+				}
+			}
+			return ""
+		}
+
+		d.Set("source_url", listItem.Redirect.SourceUrl)
+		d.Set("include_subdomains", optBoolToString(listItem.Redirect.IncludeSubdomains))
+		d.Set("target_url", listItem.Redirect.TargetUrl)
+		d.Set("status_code", listItem.Redirect.StatusCode)
+		d.Set("preserve_query_string", optBoolToString(listItem.Redirect.PreserveQueryString))
+		d.Set("subpath_matching", optBoolToString(listItem.Redirect.SubpathMatching))
+		d.Set("preserve_path_suffix", optBoolToString(listItem.Redirect.PreservePathSuffix))
+	}
+
+	return nil
+}
+
+func resourceCloudflareListItemUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// The API does not currently support in-place update of list items
+	dr := resourceCloudflareListItemDelete(ctx, d, meta)
+	if dr != nil {
+		return dr
+	}
+
+	cr := resourceCloudflareListItemCreate(ctx, d, meta)
+	if cr != nil {
+		return cr
+	}
+
+	return resourceCloudflareListItemRead(ctx, d, meta)
+}
+
+func resourceCloudflareListItemDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get(consts.AccountIDSchemaKey).(string)
+	listID := d.Get("list_id").(string)
+
+	_, err := client.DeleteListItems(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListDeleteItemsParams{
+		ID: listID,
+		Items: cloudflare.ListItemDeleteRequest{
+			Items: []cloudflare.ListItemDeleteItemRequest{{ID: d.Id()}},
+		},
+	})
+	if err != nil {
+		return diag.FromErr(errors.Wrap(err, fmt.Sprintf("error removing List Item %s from list %s", listID, d.Id())))
+	}
+
+	return nil
+}
+
+func listItemType(d *schema.ResourceData) string {
+	if _, ok := d.GetOk("ip"); ok {
+		return "ip"
+	}
+
+	return "redirect"
+}
+
+func buildListItemCreateRequest(d *schema.ResourceData) cloudflare.ListItemCreateRequest {
+	itemType := listItemType(d)
+
+	request := cloudflare.ListItemCreateRequest{
+		Comment: d.Get("comment").(string),
+	}
+
+	if itemType == "ip" {
+		request.IP = cloudflare.StringPtr(d.Get("ip").(string))
+		return request
+	}
+
+	// itemType must be 'redirect'
+
+	stringToOptBool := func(r map[string]interface{}, s string) *bool {
+		switch r[s] {
+		case "enabled":
+			return cloudflare.BoolPtr(true)
+		case "disabled":
+			return cloudflare.BoolPtr(false)
+		default:
+			return nil
+		}
+	}
+
+	redirect := d.Get("redirect").([]interface{})[0].(map[string]interface{})
+	request.Redirect = &cloudflare.Redirect{
+		SourceUrl: redirect["source_url"].(string),
+		TargetUrl: redirect["target_url"].(string),
+	}
+
+	if value, ok := redirect["status_code"]; ok && value != 0 {
+		request.Redirect.StatusCode = cloudflare.IntPtr(value.(int))
+	}
+
+	request.Redirect.IncludeSubdomains = stringToOptBool(redirect, "include_subdomains")
+	request.Redirect.PreserveQueryString = stringToOptBool(redirect, "preserve_query_string")
+	request.Redirect.SubpathMatching = stringToOptBool(redirect, "subpath_matching")
+	request.Redirect.PreservePathSuffix = stringToOptBool(redirect, "preserve_path_suffix")
+
+	return request
+}
+
+func mostRecentlyCreatedItem(createListItemResponse []cloudflare.ListItem) cloudflare.ListItem {
+	sort.Slice(createListItemResponse, func(i, j int) bool {
+		return createListItemResponse[i].CreatedOn.After(*createListItemResponse[j].CreatedOn)
+	})
+
+	return createListItemResponse[0]
+}

--- a/internal/sdkv2provider/resource_cloudflare_list_item_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_list_item_test.go
@@ -1,0 +1,154 @@
+package sdkv2provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccCloudflareListItem_Exists(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	var ListItem cloudflare.ListItem
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareIPListItem(rnd, rnd, rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareListItemExists(name, &ListItem),
+					resource.TestCheckResourceAttr(
+						name, "ip", "192.0.2.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareListItem_Update(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	var listItem cloudflare.ListItem
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareIPListItem(rnd, rnd, rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareListItemExists(name, &listItem),
+					resource.TestCheckResourceAttr(
+						name, "ip", "192.0.2.0"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareIPListItem(rnd, rnd, rnd+"-updated", accountID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareListItemExists(name, &listItem),
+					resource.TestCheckResourceAttr(name, "comment", rnd+"-updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareListItem_BadListItemType(t *testing.T) {
+	rnd := generateRandomResourceName()
+	// name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckCloudflareBadListItemType(rnd, rnd, rnd, accountID),
+				ExpectError: regexp.MustCompile(" can not be added to lists of type "),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareIPListItem(ID, name, comment, accountID string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_list" "list_name" {
+    account_id          = "%[4]s"
+    name                = "%[2]s"
+    description         = "list named %[2]s"
+    kind                = "ip"
+	ignore_inline_items = true
+  }
+  
+  resource "cloudflare_list_item" "%[1]s" {
+    account_id = "%[4]s"
+	list_id    = cloudflare_list.list_name.id
+	ip         = "192.0.2.0"
+	comment    = "%[3]s"
+  } `, ID, name, comment, accountID)
+}
+
+func testAccCheckCloudflareListItemExists(n string, listItem *cloudflare.ListItem) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+		listRS := s.RootModule().Resources["cloudflare_list.list_name"]
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No List ID is set")
+		}
+
+		client := testAccProvider.Meta().(*cloudflare.API)
+		foundList, err := client.GetListItem(context.Background(), cloudflare.AccountIdentifier(accountID), listRS.Primary.ID, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*listItem = foundList
+
+		return nil
+	}
+}
+
+func testAccCheckCloudflareBadListItemType(ID, name, comment, accountID string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_list" "list_name" {
+    account_id          = "%[4]s"
+    name                = "%[2]s"
+    description         = "list named %[2]s"
+    kind                = "redirect"
+	ignore_inline_items = true
+  }
+  
+  resource "cloudflare_list_item" "%[1]s" {
+    account_id = "%[4]s"
+	list_id    = cloudflare_list.list_name.id
+	ip         = "192.0.2.0"
+	comment    = "%[3]s"
+  } `, ID, name, comment, accountID)
+}

--- a/internal/sdkv2provider/resource_cloudflare_list_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_list_test.go
@@ -38,6 +38,7 @@ func TestAccCloudflareList_Exists(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						name, "name", rnd),
 				),
+				Destroy: false,
 			},
 		},
 	})

--- a/internal/sdkv2provider/schema_cloudflare_list.go
+++ b/internal/sdkv2provider/schema_cloudflare_list.go
@@ -39,6 +39,12 @@ func resourceCloudflareListSchema() map[string]*schema.Schema {
 			Optional: true,
 			Elem:     listItemElem,
 		},
+		"ignore_inline_items": {
+			Description: "Set to true if not managing list items in line.",
+			Type:        schema.TypeBool,
+			Default:     false,
+			Optional:    true,
+		},
 	}
 }
 

--- a/internal/sdkv2provider/schema_cloudflare_list_item.go
+++ b/internal/sdkv2provider/schema_cloudflare_list_item.go
@@ -1,0 +1,82 @@
+package sdkv2provider
+
+import (
+	"fmt"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceCloudflareListItemSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		consts.AccountIDSchemaKey: {
+			Description: "The account identifier to target for the resource.",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"list_id": {
+			Description: "The list identifier to target for the resource.",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"ip": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ExactlyOneOf: []string{"ip", "redirect"},
+		},
+		"redirect": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"source_url": {
+						Description: "The source url of the redirect.",
+						Type:        schema.TypeString,
+						Required:    true,
+					},
+					"target_url": {
+						Description: "The target url of the redirect.",
+						Type:        schema.TypeString,
+						Required:    true,
+					},
+					"include_subdomains": {
+						Description:  fmt.Sprintf("Whether the redirect also matches subdomains of the source url. %s", renderAvailableDocumentationValuesStringSlice([]string{"disabled", "enabled"})),
+						Type:         schema.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice([]string{"disabled", "enabled"}, false),
+					},
+					"subpath_matching": {
+						Description:  fmt.Sprintf("Whether the redirect also matches subpaths of the source url. %s", renderAvailableDocumentationValuesStringSlice([]string{"disabled", "enabled"})),
+						Type:         schema.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice([]string{"disabled", "enabled"}, false),
+					},
+					"status_code": {
+						Description: "The status code to be used when redirecting a request.",
+						Type:        schema.TypeInt,
+						Optional:    true,
+					},
+					"preserve_query_string": {
+						Description:  fmt.Sprintf("Whether the redirect target url should keep the query string of the request's url. %s", renderAvailableDocumentationValuesStringSlice([]string{"disabled", "enabled"})),
+						Type:         schema.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice([]string{"disabled", "enabled"}, false),
+					},
+					"preserve_path_suffix": {
+						Description:  fmt.Sprintf("Whether to preserve the path suffix when doing subpath matching. %s", renderAvailableDocumentationValuesStringSlice([]string{"disabled", "enabled"})),
+						Type:         schema.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice([]string{"disabled", "enabled"}, false),
+					},
+				},
+			},
+		},
+		"comment": {
+			Description: "An optional comment for the item.",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+	}
+}


### PR DESCRIPTION
Resource: `cloudflare_list_item`
Addresses: https://github.com/cloudflare/terraform-provider-cloudflare/issues/2283

New `cloudflare_list_item` resource to allow managing list items independently of (not inline) the `cloudflare_list` resource.  

