### PR TITLE
add import `cloudflare_tunnel_config`

### DIFF
--- a/.changelog/2298.txt
+++ b/.changelog/2298.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_tunnel_config: add support for import of `cloudflare_tunnel_config`
+```

--- a/docs/resources/tunnel_config.md
+++ b/docs/resources/tunnel_config.md
@@ -139,3 +139,11 @@ Optional:
 Optional:
 
 - `enabled` (Boolean) Whether WARP routing is enabled.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+$ terraform import cloudflare_tunnel_config.example <account_id>/<tunnel_id>
+```

--- a/examples/resources/cloudflare_tunnel_config/import.sh
+++ b/examples/resources/cloudflare_tunnel_config/import.sh
@@ -1,0 +1,1 @@
+$ terraform import cloudflare_tunnel_config.example <account_id>/<tunnel_id>

--- a/internal/sdkv2provider/resource_cloudflare_tunnel_config_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_tunnel_config_test.go
@@ -129,6 +129,12 @@ func TestAccCloudflareTunnelConfig_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "config.0.ingress_rule.1.service", "https://10.0.0.3:8081"),
 				),
 			},
+			{
+				ResourceName:        name,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", zoneID),
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
 		},
 	})
 }
@@ -152,6 +158,12 @@ func TestAccCloudflareTunnelConfig_Short(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "config.0.ingress_rule.#", "1"),
 					resource.TestCheckResourceAttr(name, "config.0.ingress_rule.0.service", "https://10.0.0.1:8081"),
 				),
+			},
+			{
+				ResourceName:        name,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", zoneID),
+				ImportState:         true,
+				ImportStateVerify:   true,
 			},
 		},
 	})

--- a/templates/resources/tunnel_config.md.tmpl
+++ b/templates/resources/tunnel_config.md.tmpl
@@ -16,3 +16,11 @@ description: |-
 {{ tffile (printf "%s%s%s" "examples/resources/" .Name "/resource.tf") }}
 
 {{ .SchemaMarkdown | trimspace }}
+
+{{ if .HasImport -}}
+## Import
+
+Import is supported using the following syntax:
+
+{{ codefile "shell" (printf "%s%s%s" "examples/resources/" .Name "/import.sh") }}
+{{- end }}


### PR DESCRIPTION
Thanks for the great OSS.

I am using `cloudflare_tunnel_config` in production.
I have added implementation and documentation to import existing resources.

Implemented with reference to `cloudflare_tunnel`.

```
$ TESTARGS='-run "TestAccCloudflareTunnelConfig" -count 1 -parallel 1' make testacc
TF_ACC=1 go test $(go list ./...) -v -run "TestAccCloudflareTunnelConfig" -count 1 -parallel 1 -timeout 120m -parallel 1
?       github.com/cloudflare/terraform-provider-cloudflare     [no test files]
?       github.com/cloudflare/terraform-provider-cloudflare/internal/acctest    [no test files]
?       github.com/cloudflare/terraform-provider-cloudflare/internal/consts     [no test files]
?       github.com/cloudflare/terraform-provider-cloudflare/internal/framework/expanders        [no test files]
?       github.com/cloudflare/terraform-provider-cloudflare/internal/framework/flatteners       [no test files]
?       github.com/cloudflare/terraform-provider-cloudflare/internal/framework/modifiers/defaults       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/framework/provider 0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/framework/service/example  0.003s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/framework/service/rulesets 0.008s [no tests to run]
=== RUN   TestAccCloudflareTunnelConfig_Full
--- PASS: TestAccCloudflareTunnelConfig_Full (15.17s)
=== RUN   TestAccCloudflareTunnelConfig_Short
--- PASS: TestAccCloudflareTunnelConfig_Short (14.48s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider      29.656s
?       github.com/cloudflare/terraform-provider-cloudflare/internal/utils      [no test files]
```