### PR TITLE
add `compatibility_date` to `cloudflare_workers_script`

### DIFF
--- a/.changelog/2300.txt
+++ b/.changelog/2300.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_worker_script: Add `compatibility_date` attribute
+```

--- a/docs/resources/worker_script.md
+++ b/docs/resources/worker_script.md
@@ -78,6 +78,7 @@ resource "cloudflare_worker_script" "my_script" {
 - `analytics_engine_binding` (Block Set) (see [below for nested schema](#nestedblock--analytics_engine_binding))
 - `kv_namespace_binding` (Block Set) (see [below for nested schema](#nestedblock--kv_namespace_binding))
 - `module` (Boolean) Whether to upload Worker as a module.
+- `compatibility_date` (String) The date to use for the compatibility flag. This is used to determine which version of the Workers runtime to use. The date must be in the format `YYYY-MM-DD`.
 - `plain_text_binding` (Block Set) (see [below for nested schema](#nestedblock--plain_text_binding))
 - `queue_binding` (Block Set) (see [below for nested schema](#nestedblock--queue_binding))
 - `r2_bucket_binding` (Block Set) (see [below for nested schema](#nestedblock--r2_bucket_binding))

--- a/internal/sdkv2provider/resource_cloudflare_workers_script.go
+++ b/internal/sdkv2provider/resource_cloudflare_workers_script.go
@@ -158,10 +158,11 @@ func resourceCloudflareWorkerScriptCreate(ctx context.Context, d *schema.Resourc
 	parseWorkerBindings(d, bindings)
 
 	_, err = client.UploadWorker(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.CreateWorkerParams{
-		ScriptName: scriptData.Params.ScriptName,
-		Script:     scriptBody,
-		Module:     d.Get("module").(bool),
-		Bindings:   bindings,
+		ScriptName:        scriptData.Params.ScriptName,
+		Script:            scriptBody,
+		CompatibilityDate: d.Get("compatibility_date").(string),
+		Module:            d.Get("module").(bool),
+		Bindings:          bindings,
 	})
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating worker script"))
@@ -330,10 +331,11 @@ func resourceCloudflareWorkerScriptUpdate(ctx context.Context, d *schema.Resourc
 	parseWorkerBindings(d, bindings)
 
 	_, err = client.UploadWorker(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.CreateWorkerParams{
-		ScriptName: scriptData.Params.ScriptName,
-		Script:     scriptBody,
-		Module:     d.Get("module").(bool),
-		Bindings:   bindings,
+		ScriptName:        scriptData.Params.ScriptName,
+		Script:            scriptBody,
+		CompatibilityDate: d.Get("compatibility_date").(string),
+		Module:            d.Get("module").(bool),
+		Bindings:          bindings,
 	})
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error updating worker script"))

--- a/internal/sdkv2provider/resource_cloudflare_workers_script_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_workers_script_test.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
-	scriptContent1 = `addEventListener('fetch', event => {event.respondWith(new Response('test 1'))});`
-	scriptContent2 = `addEventListener('fetch', event => {event.respondWith(new Response('test 2'))});`
-	moduleContent  = `export default { fetch() { return new Response('Hello world'); }, };`
-	encodedWasm    = "AGFzbQEAAAAGgYCAgAAA" // wat source: `(module)`, so literally just an empty wasm module
+	scriptContent1    = `addEventListener('fetch', event => {event.respondWith(new Response('test 1'))});`
+	scriptContent2    = `addEventListener('fetch', event => {event.respondWith(new Response('test 2'))});`
+	moduleContent     = `export default { fetch() { return new Response('Hello world'); }, };`
+	encodedWasm       = "AGFzbQEAAAAGgYCAgAAA" // wat source: `(module)`, so literally just an empty wasm module
+	compatibilityDate = "2023-03-19"
 )
 
 func TestAccCloudflareWorkerScript_MultiScriptEnt(t *testing.T) {
@@ -85,6 +86,7 @@ func TestAccCloudflareWorkerScript_ModuleUpload(t *testing.T) {
 					testAccCheckCloudflareWorkerScriptExists(name, &script, nil),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "content", moduleContent),
+					resource.TestCheckResourceAttr(name, "compatibility_date", compatibilityDate),
 				),
 			},
 		},
@@ -194,7 +196,8 @@ resource "cloudflare_worker_script" "%[1]s" {
   name = "%[1]s"
   content = "%[2]s"
   module = true
-}`, rnd, moduleContent, accountID)
+	compatibility_date = "%[4]s"
+}`, rnd, moduleContent, accountID, compatibilityDate)
 }
 
 func testAccCheckCloudflareWorkerScriptExists(n string, script *cloudflare.WorkerScript, bindings []string) resource.TestCheckFunc {

--- a/internal/sdkv2provider/schema_cloudflare_workers_script.go
+++ b/internal/sdkv2provider/schema_cloudflare_workers_script.go
@@ -154,6 +154,11 @@ func resourceCloudflareWorkerScriptSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Whether to upload Worker as a module.",
 		},
+		"compatibility_date": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The date to use for the compatibility flag.",
+		},
 		"plain_text_binding": {
 			Type:     schema.TypeSet,
 			Optional: true,


### PR DESCRIPTION
Hello, thank you for this repo.

Currently, I deploy a worker without compatibility_date and FormData doesn't support File. I need to publish again with wrangler to have the compatibility_date.

I have added the attribute `compatibility_date`.

Closes #1869