### PR TITLE
ci: ensure doc generation runs after changelog

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -9,7 +9,7 @@ on:
       - completed
   workflow_dispatch:
 jobs:
-  GenerateChangelog:
+  generate-changelog:
     if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -8,6 +8,7 @@ jobs:
   make-docs:
     if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    needs: generate-changelog
     steps:
       - uses: actions/checkout@v3
       - run: make docs


### PR DESCRIPTION
To prevent races between the two, we want the registry docs to be dependant on the changelog completing first.