### PR TITLE
resource/cloudflare_notification_policy_webhooks: `url` triggers recreation

### DIFF
--- a/.changelog/2302.txt
+++ b/.changelog/2302.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_notification_policy_webhooks: ensure `url` triggers recreation, not in-place updates
+```

--- a/docs/resources/notification_policy_webhooks.md
+++ b/docs/resources/notification_policy_webhooks.md
@@ -30,7 +30,7 @@ resource "cloudflare_notification_policy_webhooks" "example" {
 ### Optional
 
 - `secret` (String) An optional secret can be provided that will be passed in the `cf-webhook-auth` header when dispatching a webhook notification. Secrets are not returned in any API response body. Refer to the [documentation](https://api.cloudflare.com/#notification-webhooks-create-webhook) for more details.
-- `url` (String) The URL of the webhook destinations.
+- `url` (String) The URL of the webhook destinations. **Modifying this attribute will force creation of a new resource.**
 
 ### Read-Only
 

--- a/internal/sdkv2provider/schema_cloudflare_notification_policy_webhooks.go
+++ b/internal/sdkv2provider/schema_cloudflare_notification_policy_webhooks.go
@@ -20,6 +20,7 @@ func resourceCloudflareNotificationPolicyWebhookSchema() map[string]*schema.Sche
 		"url": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			ForceNew:    true,
 			Description: "The URL of the webhook destinations.",
 		},
 		"secret": {


### PR DESCRIPTION
Updates `url` to force a new resource instead of updating in place.

Closes #2266