### PR TITLE
tools/sync-github-issue-to-jira: introduce initial issue sync support

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -1,0 +1,36 @@
+name: Sync issues internally
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: The issue to target
+        required: true
+jobs:
+  internal-issue-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'tools/go.mod'
+      - run: make tools
+      - name: Set the issue number to sync
+        run: |
+          if [ -n "${{ github.event.inputs.issue_number }}" ]; then
+              echo "issue_number=${{ github.event.inputs.issue_number }}" >> $GITHUB_ENV
+          else
+              echo "issue_number=${{ github.event.issue.number }}" >> $GITHUB_ENV
+          fi
+      - run: go run cmd/sync-github-issue-to-jira/main.go ${{ env.issue_number }}
+        working-directory: ./tools
+        env:
+          GITHUB_OWNER: cloudflare
+          GITHUB_REPO: terraform-provider-cloudflare
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JIRA_HOSTNAME: ${{ secrets.JIRA_HOSTNAME }}
+          JIRA_AUTH_TOKEN: ${{ secrets.JIRA_AUTH_TOKEN }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/tools/cmd/sync-github-issue-to-jira/main.go
+++ b/tools/cmd/sync-github-issue-to-jira/main.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+type serviceOwner struct {
+	manager  string
+	teamName string
+}
+
+type IssueName struct {
+	Name string `json:"name"`
+}
+
+type IssueValue struct {
+	Value string `json:"value"`
+}
+
+type IssueKey struct {
+	Key string `json:"key"`
+}
+
+type IssueFields struct {
+	Project     IssueKey     `json:"project"`
+	Summary     string       `json:"summary"`
+	Description string       `json:"description"`
+	Teams       []IssueValue `json:"customfield_13100"`
+	EngOwner    IssueName    `json:"customfield_16304"`
+	MyTeam      IssueValue   `json:"customfield_14803"`
+	SLA         IssueValue   `json:"customfield_15031"`
+	IssueType   IssueName    `json:"issuetype"`
+}
+
+type InternalIssue struct {
+	Fields IssueFields `json:"fields"`
+}
+
+type IssueCreationResponse struct {
+	ID   string `json:"id"`
+	Key  string `json:"key"`
+	Self string `json:"self"`
+}
+
+var (
+	// Label used to determine if the issue meets all the criteria and is ready
+	// to be synced.
+	acceptedLabel = "triage/accepted"
+
+	// List of services that we permit syncing internally.
+	allowedServiceLabels = []string{"provider/internals", "service/zones"}
+
+	// Mapping of service label to owning internal team.
+	serviceOwnership = map[string]serviceOwner{
+		"provider/internals": serviceOwner{
+			teamName: "API & Zones",
+			manager:  "rupalim",
+		},
+		"service/zones": serviceOwner{
+			teamName: "API & Zones",
+			manager:  "rupalim",
+		},
+	}
+)
+
+func main() {
+	ctx := context.Background()
+	if len(os.Args) < 2 {
+		log.Fatalf("Usage: sync-github-issue-to-jira <GitHub issue number>\n")
+	}
+	iss := os.Args[1]
+	issueNumber, err := strconv.Atoi(iss)
+	if err != nil {
+		log.Fatalf("error parsing issue %q as a number: %s", iss, err)
+	}
+
+	githubRepositoryOwner := os.Getenv("GITHUB_OWNER")
+	githubRepositoryName := os.Getenv("GITHUB_REPO")
+	githubAccessToken := os.Getenv("GITHUB_TOKEN")
+	jiraHostname := os.Getenv("JIRA_HOSTNAME")
+	jiraAuthToken := os.Getenv("JIRA_AUTH_TOKEN")
+	accessClientID := os.Getenv("CF_ACCESS_CLIENT_ID")
+	accessClientSecret := os.Getenv("CF_ACCESS_CLIENT_SECRET")
+
+	if githubRepositoryOwner == "" {
+		log.Fatal("GITHUB_OWNER not set")
+	}
+
+	if githubRepositoryName == "" {
+		log.Fatal("GITHUB_REPO not set")
+	}
+
+	if githubAccessToken == "" {
+		log.Fatal("GITHUB_TOKEN not set")
+	}
+
+	if jiraHostname == "" {
+		log.Fatal("JIRA_HOSTNAME not set")
+	}
+
+	if jiraAuthToken == "" {
+		log.Fatal("JIRA_AUTH_TOKEN not set")
+	}
+
+	if accessClientID == "" {
+		log.Fatal("CF_ACCESS_CLIENT_ID not set")
+	}
+
+	if accessClientSecret == "" {
+		log.Fatal("CF_ACCESS_CLIENT_SECRET not set")
+	}
+
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: githubAccessToken},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	client := github.NewClient(tc)
+
+	issue, _, err := client.Issues.Get(ctx, githubRepositoryOwner, githubRepositoryName, issueNumber)
+	if err != nil {
+		log.Fatalf("error retrieving issue %s/%s#%d: %s", githubRepositoryOwner, githubRepositoryName, issueNumber, err)
+	}
+
+	if !hasLabel(issue, acceptedLabel) {
+		log.Printf("issue is not marked as ready for syncing using %s, skipping", acceptedLabel)
+		os.Exit(0)
+	}
+
+	serviceLabel := getOwnershipLabel(issue)
+	if serviceLabel == "" {
+		fmt.Println("no service owner detected; exiting without creating a new JIRA issue")
+		os.Exit(0)
+	}
+
+	serviceOwner := serviceOwnership[serviceLabel]
+
+	newIssue := InternalIssue{Fields: IssueFields{
+		Project:     IssueKey{Key: "CUSTESC"},
+		Summary:     *issue.Title,
+		Description: jirafyBodyMarkdown(*issue.Body),
+		Teams:       []IssueValue{{Value: serviceOwner.teamName}},
+		EngOwner:    IssueName{Name: serviceOwner.manager},
+		SLA:         IssueValue{Value: "Pro / Free"},
+		MyTeam:      IssueValue{Value: "Other"},
+		IssueType:   IssueName{Name: "Bug"},
+	}}
+
+	res, err := json.Marshal(newIssue)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	url := fmt.Sprintf("https://%s/rest/api/latest/issue/", jiraHostname)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(res))
+	if err != nil {
+		log.Fatalf("failed to build HTTP request: %s", err)
+	}
+
+	req.Header.Set("authorization", "Basic "+jiraAuthToken)
+	req.Header.Set("cf-access-client-id", accessClientID)
+	req.Header.Set("cf-access-client-secret", accessClientSecret)
+	req.Header.Set("content-type", "application/json")
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("failed to read response body: %s", err)
+	}
+
+	var createdIssue IssueCreationResponse
+	json.Unmarshal([]byte(body), &createdIssue)
+
+	if resp.StatusCode != http.StatusCreated {
+		fmt.Println(fmt.Sprintf("failed to create new JIRA issue"))
+		os.Exit(1)
+	}
+
+	fmt.Println(fmt.Sprintf("successfully created internal JIRA issue: %s", createdIssue.Key))
+
+	os.Exit(0)
+}
+
+func hasLabel(issue *github.Issue, label string) bool {
+	for _, l := range issue.Labels {
+		if *l.Name == label {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getOwnershipLabel(issue *github.Issue) string {
+	for _, l := range issue.Labels {
+		if strings.Contains(*l.Name, "service/") || strings.Contains(*l.Name, "provider/internals") {
+			return *l.Name
+		}
+	}
+
+	return ""
+}
+
+// jirafyBodyMarkdown takes GitHub markdown and makes it palatable for JIRA
+// with reasonable formatting.
+func jirafyBodyMarkdown(s string) string {
+	s = strings.ReplaceAll(s, "- [X] ", "✅ ")
+	s = strings.ReplaceAll(s, "###", "h3.")
+	s = strings.ReplaceAll(s, "```hcl", "{code}")
+	s = strings.ReplaceAll(s, "```", "{code}")
+
+	return s
+}


### PR DESCRIPTION
Introduces automation that will allow syncing GitHub issues into our internal issue tracker.