### PR TITLE
when geo_restrictions aren't set, set as nil and not empty string

### DIFF
--- a/.changelog/2319.txt
+++ b/.changelog/2319.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_custom_ssl: fix json sent to API when geo_restrictions are not used
+```

--- a/internal/sdkv2provider/resource_cloudflare_custom_ssl.go
+++ b/internal/sdkv2provider/resource_cloudflare_custom_ssl.go
@@ -245,8 +245,12 @@ func expandToZoneCustomSSLOptions(ctx context.Context, d *schema.ResourceData) (
 			for id, value := range cert.(map[string]interface{}) {
 				var newValue interface{}
 				if id == "geo_restrictions" {
-					newValue = cloudflare.ZoneCustomSSLGeoRestrictions{
-						Label: value.(string),
+					if value == "" {
+						newValue = nil
+					} else {
+						newValue = cloudflare.ZoneCustomSSLGeoRestrictions{
+							Label: value.(string),
+						}
 					}
 				} else {
 					newValue = value.(string)


### PR DESCRIPTION
previously, we would send `geo_restrictions":{"label":""}`, now we won't send anything at all.

Closes #2318
Closes #1472

