### PR TITLE
Update origin_ca_certificate.md

### DIFF
--- a/docs/resources/origin_ca_certificate.md
+++ b/docs/resources/origin_ca_certificate.md
@@ -22,7 +22,6 @@ resource "tls_private_key" "example" {
 }
 
 resource "tls_cert_request" "example" {
-  key_algorithm   = tls_private_key.example.algorithm
   private_key_pem = tls_private_key.example.private_key_pem
 
   subject {


### PR DESCRIPTION
tls_cert_request's key_algorithm is a read-only attribute, you can't assign a value to it. See: https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request#read-only