### PR TITLE
resource/cloudflare_ruleset: ensure custom keys via query strings are known

### DIFF
--- a/.changelog/2388.txt
+++ b/.changelog/2388.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: ensure custom cache keys using query parameters are defined as known values for state handling
+```

--- a/internal/framework/service/rulesets/resource.go
+++ b/internal/framework/service/rulesets/resource.go
@@ -527,12 +527,20 @@ func toRulesetResourceModel(zoneID, accountID basetypes.StringValue, in cloudfla
 						include, _ := basetypes.NewSetValueFrom(context.Background(), types.StringType, ruleResponse.ActionParameters.CacheKey.CustomKey.Query.Include)
 						exclude, _ := basetypes.NewSetValueFrom(context.Background(), types.StringType, ruleResponse.ActionParameters.CacheKey.CustomKey.Query.Exclude)
 
-						if ruleResponse.ActionParameters.CacheKey.CustomKey.Query.Include != nil && ruleResponse.ActionParameters.CacheKey.CustomKey.Query.Include.All {
-							include, _ = basetypes.NewSetValueFrom(context.Background(), types.StringType, []string{"*"})
+						if ruleResponse.ActionParameters.CacheKey.CustomKey.Query.Include != nil {
+							if ruleResponse.ActionParameters.CacheKey.CustomKey.Query.Include.All {
+								include, _ = basetypes.NewSetValueFrom(context.Background(), types.StringType, []string{"*"})
+							} else {
+								include, _ = basetypes.NewSetValueFrom(context.Background(), types.StringType, ruleResponse.ActionParameters.CacheKey.CustomKey.Query.Include.List)
+							}
 						}
 
-						if ruleResponse.ActionParameters.CacheKey.CustomKey.Query.Exclude != nil && ruleResponse.ActionParameters.CacheKey.CustomKey.Query.Exclude.All {
-							exclude, _ = basetypes.NewSetValueFrom(context.Background(), types.StringType, []string{"*"})
+						if ruleResponse.ActionParameters.CacheKey.CustomKey.Query.Exclude != nil {
+							if ruleResponse.ActionParameters.CacheKey.CustomKey.Query.Exclude.All {
+								exclude, _ = basetypes.NewSetValueFrom(context.Background(), types.StringType, []string{"*"})
+							} else {
+								exclude, _ = basetypes.NewSetValueFrom(context.Background(), types.StringType, ruleResponse.ActionParameters.CacheKey.CustomKey.Query.Exclude.List)
+							}
 						}
 
 						key.QueryString = []*ActionParameterCacheKeyCustomKeyQueryStringModel{{


### PR DESCRIPTION
Updates the state handling to ensure that all query string parameters are known to the state handler when defining explicit query parameters as part of the custom cache key.

Closes #2360