### PR TITLE
Adds support for new_status filter for cloudflare_notification_policy tunnel_health_event

### DIFF
--- a/.changelog/2390.txt
+++ b/.changelog/2390.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_notification_policy: Fix missing new_status filter required by tunnel_health_event policies
+```

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -117,6 +117,7 @@ Optional:
 - `limit` (Set of String) A numerical limit. Example: `100`.
 - `megabits_per_second` (Set of String) Megabits per second threshold for dos alert.
 - `new_health` (Set of String) Health status to alert on for pool or origin.
+- `new_status` (Set of String) Tunnel health status to alert on.
 - `packets_per_second` (Set of String) Packets per second threshold for dos alert.
 - `pool_id` (Set of String) Load balancer pool identifier.
 - `product` (Set of String) Product name. Available values: `worker_requests`, `worker_durable_objects_requests`, `worker_durable_objects_duration`, `worker_durable_objects_data_transfer`, `worker_durable_objects_stored_data`, `worker_durable_objects_storage_deletes`, `worker_durable_objects_storage_writes`, `worker_durable_objects_storage_reads`.

--- a/internal/sdkv2provider/schema_cloudflare_notification_policy.go
+++ b/internal/sdkv2provider/schema_cloudflare_notification_policy.go
@@ -367,6 +367,14 @@ func notificationPolicyFilterSchema() *schema.Schema {
 					Optional:    true,
 					Description: fmt.Sprintf("The incident impact level that will trigger the dispatch of a notification. %s", renderAvailableDocumentationValuesStringSlice(notificationPolicyIncidentImpactLevels)),
 				},
+				"new_status": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+					Optional:    true,
+					Description: "Tunnel health status to alert on.",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Adds missing filter which is required for creating `tunnel_health_event` policies with `cloudflare_notification_policy`. Fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/2276.