### PR TITLE
Add support for max upload params in Logpush jobs

### DIFF
--- a/.changelog/2394.txt
+++ b/.changelog/2394.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_logpush_job: add max upload parameters
+```

--- a/docs/resources/logpush_job.md
+++ b/docs/resources/logpush_job.md
@@ -121,6 +121,9 @@ resource "cloudflare_logpush_job" "example_job" {
 - `frequency` (String) A higher frequency will result in logs being pushed on faster with smaller files. `low` frequency will push logs less often with larger files. Available values: `high`, `low`. Defaults to `high`.
 - `kind` (String) The kind of logpush job to create. Available values: `edge`, `instant-logs`, `""`.
 - `logpull_options` (String) Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpush options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options).
+- `max_upload_bytes` (Number) The maximum uncompressed file size of a batch of logs. Value must be between 5MB and 1GB.
+- `max_upload_interval_seconds` (Number) The maximum interval in seconds for log batches. Value must be between 30 and 300.
+- `max_upload_records` (Number) The maximum number of log lines per batch. Value must be between 1000 and 1,000,000.
 - `name` (String) The name of the logpush job to create.
 - `ownership_challenge` (String) Ownership challenge token to prove destination ownership, required when destination is Amazon S3, Google Cloud Storage, Microsoft Azure or Sumo Logic. See [Developer documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#usage).
 - `zone_id` (String) The zone identifier to target for the resource. Must provide only one of `account_id`, `zone_id`.

--- a/internal/sdkv2provider/resource_cloudflare_logpush_job.go
+++ b/internal/sdkv2provider/resource_cloudflare_logpush_job.go
@@ -66,15 +66,18 @@ func getJobFromResource(d *schema.ResourceData) (cloudflare.LogpushJob, *AccessI
 	}
 
 	job := cloudflare.LogpushJob{
-		ID:                 id,
-		Enabled:            d.Get("enabled").(bool),
-		Kind:               d.Get("kind").(string),
-		Name:               d.Get("name").(string),
-		Dataset:            d.Get("dataset").(string),
-		LogpullOptions:     d.Get("logpull_options").(string),
-		DestinationConf:    destConf,
-		OwnershipChallenge: ownershipChallenge,
-		Frequency:          d.Get("frequency").(string),
+		ID:                       id,
+		Enabled:                  d.Get("enabled").(bool),
+		Kind:                     d.Get("kind").(string),
+		Name:                     d.Get("name").(string),
+		Dataset:                  d.Get("dataset").(string),
+		LogpullOptions:           d.Get("logpull_options").(string),
+		DestinationConf:          destConf,
+		OwnershipChallenge:       ownershipChallenge,
+		Frequency:                d.Get("frequency").(string),
+		MaxUploadBytes:           d.Get("max_upload_bytes").(int),
+		MaxUploadRecords:         d.Get("max_upload_records").(int),
+		MaxUploadIntervalSeconds: d.Get("max_upload_interval_seconds").(int),
 	}
 
 	filter := d.Get("filter")
@@ -144,6 +147,9 @@ func resourceCloudflareLogpushJobRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("ownership_challenge", d.Get("ownership_challenge"))
 	d.Set("frequency", job.Frequency)
 	d.Set("filter", filter)
+	d.Set("max_upload_bytes", job.MaxUploadBytes)
+	d.Set("max_upload_records", job.MaxUploadRecords)
+	d.Set("max_upload_interval_seconds", job.MaxUploadIntervalSeconds)
 
 	return nil
 }

--- a/internal/sdkv2provider/schema_cloudflare_logpush_job.go
+++ b/internal/sdkv2provider/schema_cloudflare_logpush_job.go
@@ -102,5 +102,23 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.StringInSlice([]string{"high", "low"}, false),
 			Description:  fmt.Sprintf("A higher frequency will result in logs being pushed on faster with smaller files. `low` frequency will push logs less often with larger files. %s", renderAvailableDocumentationValuesStringSlice([]string{"high", "low"})),
 		},
+		"max_upload_bytes": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntBetween(5000000, 1000000000),
+			Description:  fmt.Sprint("The maximum uncompressed file size of a batch of logs. Value must be between 5MB and 1GB."),
+		},
+		"max_upload_records": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntBetween(1000, 1000000),
+			Description:  fmt.Sprint("The maximum number of log lines per batch. Value must be between 1000 and 1,000,000."),
+		},
+		"max_upload_interval_seconds": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntBetween(30, 300),
+			Description:  fmt.Sprint("The maximum interval in seconds for log batches. Value must be between 30 and 300."),
+		},
 	}
 }


### PR DESCRIPTION
Documented here https://developers.cloudflare.com/logs/get-started/api-configuration/#max-upload-parameters

Requires release of `cloudflare-go` to add library support for this