### PR TITLE
 fix random_steering pool weights sent to the API on update from existing value

### DIFF
--- a/.changelog/2403.txt
+++ b/.changelog/2403.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_load_balancer: fixes random_steering being unset on value updates
+```

--- a/internal/sdkv2provider/resource_cloudflare_load_balancer.go
+++ b/internal/sdkv2provider/resource_cloudflare_load_balancer.go
@@ -807,7 +807,7 @@ func expandRandomSteering(set interface{}) *cloudflare.RandomSteering {
 	var cfRandomSteering cloudflare.RandomSteering
 
 	if l := set.(*schema.Set).List(); len(l) > 0 {
-		for k, v := range l[0].(map[string]interface{}) {
+		for k, v := range l[len(l)-1].(map[string]interface{}) {
 			switch k {
 			case "pool_weights":
 				poolWeights := make(map[string]float64)


### PR DESCRIPTION
Hiya :wave: 

This PR looks to fix a rather nasty bug of when using load balancer pool weights. 

On creation of the weights, everything is as expected, however on subsequent updates/applies, even though the `terraform plan` and state looks correct, a default empty `"random_steering": {}` is sent to the API, removing any weights entirely. 

This results in scenarios when changing pool weights for 2 pools from (0.98, 0.02) -> (0.95, 0.05) unexpectedly going to 50/50 on apply. 

The `d.GetOk("random_steering")` that calls `expandRandomSteering` returns 1 entry (the desired values) in the set when no existing steering weights exist, and 2 when it does. The first is a default empty value in this scenario and causes the bug.This means that a second apply after the issue does "resolve" and sync to state until the next change. 

This change to always get the last value in the set fixes the issue. I have added a covering update scenario test case that fails without this change. 

Closes #2099
