### PR TITLE
Add device posture, zt network sessions, to logpush job

### DIFF
--- a/.changelog/2405.txt
+++ b/.changelog/2405.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+ resource/cloudflare_logpush_job: add support for `device_posture_results` and `zero_trust_network_sessions`.
+ ```

--- a/docs/resources/logpush_job.md
+++ b/docs/resources/logpush_job.md
@@ -110,7 +110,7 @@ resource "cloudflare_logpush_job" "example_job" {
 
 ### Required
 
-- `dataset` (String) The kind of the dataset to use with the logpush job. Available values: `access_requests`, `firewall_events`, `http_requests`, `spectrum_events`, `nel_reports`, `audit_logs`, `gateway_dns`, `gateway_http`, `gateway_network`, `dns_logs`, `network_analytics_logs`, `workers_trace_events`.
+- `dataset` (String) The kind of the dataset to use with the logpush job. Available values: `access_requests`, `firewall_events`, `http_requests`, `spectrum_events`, `nel_reports`, `audit_logs`, `gateway_dns`, `gateway_http`, `gateway_network`, `dns_logs`, `network_analytics_logs`, `workers_trace_events`, `device_posture_results`, `zero_trust_network_sessions`.
 - `destination_conf` (String) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included. See [Logpush destination documentation](https://developers.cloudflare.com/logs/reference/logpush-api-configuration#destination).
 
 ### Optional

--- a/internal/sdkv2provider/schema_cloudflare_logpush_job.go
+++ b/internal/sdkv2provider/schema_cloudflare_logpush_job.go
@@ -57,7 +57,7 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 				"network_analytics_logs",
 				"workers_trace_events",
 				"device_posture_results",
-				"zero_trust_network_sessions"
+				"zero_trust_network_sessions",
 			}, false),
 			Description: fmt.Sprintf(
 				"The kind of the dataset to use with the logpush job. %s",
@@ -75,7 +75,7 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 					"network_analytics_logs",
 					"workers_trace_events",
 					"device_posture_results",
-					"zero_trust_network_sessions"
+					"zero_trust_network_sessions",
 				}),
 			),
 		},

--- a/internal/sdkv2provider/schema_cloudflare_logpush_job.go
+++ b/internal/sdkv2provider/schema_cloudflare_logpush_job.go
@@ -56,6 +56,8 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 				"dns_logs",
 				"network_analytics_logs",
 				"workers_trace_events",
+				"device_posture_results",
+				"zero_trust_network_sessions"
 			}, false),
 			Description: fmt.Sprintf(
 				"The kind of the dataset to use with the logpush job. %s",
@@ -72,6 +74,8 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 					"dns_logs",
 					"network_analytics_logs",
 					"workers_trace_events",
+					"device_posture_results",
+					"zero_trust_network_sessions"
 				}),
 			),
 		},


### PR DESCRIPTION
Hello! I will add a changelog entry as well. This PR intends to add device posture and zero trust network sessions as supported logpush job types according to docs: 

https://developers.cloudflare.com/logs/reference/log-fields/account/device_posture_results/

https://developers.cloudflare.com/logs/reference/log-fields/account/zero_trust_network_sessions/

Thanks!