### PR TITLE
resource/cloudflare_ruleset: allow `FromValue.PreserveQueryString` to be nullable

### DIFF
--- a/.changelog/2414.txt
+++ b/.changelog/2414.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: allow `FromValue.PreserveQueryString` to be nullable and handled correctly
+```

--- a/internal/framework/service/rulesets/resource.go
+++ b/internal/framework/service/rulesets/resource.go
@@ -657,13 +657,18 @@ func toRulesetResourceModel(ctx context.Context, zoneID, accountID basetypes.Str
 
 			if ruleResponse.ActionParameters.FromValue != nil {
 				rule.ActionParameters[0].FromValue = []*ActionParameterFromValueModel{{
-					StatusCode:          flatteners.Int64(int64(ruleResponse.ActionParameters.FromValue.StatusCode)),
-					PreserveQueryString: flatteners.Bool(&ruleResponse.ActionParameters.FromValue.PreserveQueryString),
+					StatusCode: flatteners.Int64(int64(ruleResponse.ActionParameters.FromValue.StatusCode)),
 					TargetURL: []*ActionParameterFromValueTargetURLModel{{
 						Value:      flatteners.String(ruleResponse.ActionParameters.FromValue.TargetURL.Value),
 						Expression: flatteners.String(ruleResponse.ActionParameters.FromValue.TargetURL.Expression),
 					}},
 				}}
+
+				if !reflect.ValueOf(ruleResponse.ActionParameters.FromValue.PreserveQueryString).IsNil() {
+					rule.ActionParameters[0].FromValue[0].PreserveQueryString = flatteners.Bool(ruleResponse.ActionParameters.FromValue.PreserveQueryString)
+				} else {
+					rule.ActionParameters[0].FromValue[0].PreserveQueryString = types.BoolNull()
+				}
 			}
 
 			if len(ruleResponse.ActionParameters.Algorithms) > 0 {
@@ -1222,7 +1227,7 @@ func (r *RulesModel) toRulesetRule(ctx context.Context) cloudflare.RulesetRule {
 			}
 
 			if !ap.FromValue[0].PreserveQueryString.IsNull() {
-				from.PreserveQueryString = ap.FromValue[0].PreserveQueryString.ValueBool()
+				from.PreserveQueryString = cloudflare.BoolPtr(ap.FromValue[0].PreserveQueryString.ValueBool())
 			}
 
 			from.TargetURL.Expression = ap.FromValue[0].TargetURL[0].Expression.ValueString()


### PR DESCRIPTION
Updates the `FromValue.PreserveQueryString` handling in the request + state handler to use the changes from cloudflare/cloudflare-go#1275 and allows conditional handling of null in resources.

Depends on cloudflare/cloudflare-go#1275
Closes #2408