### PR TITLE
resource/cloudflare_ruleset: handle 0 values for edge cache TTLs by status

### DIFF
--- a/.changelog/2415.txt
+++ b/.changelog/2415.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: allow using `0` as an edge TTL value without conflicting with Go types for zeros
+```

--- a/internal/framework/service/rulesets/resource.go
+++ b/internal/framework/service/rulesets/resource.go
@@ -574,9 +574,17 @@ func toRulesetResourceModel(ctx context.Context, zoneID, accountID basetypes.Str
 							From: flatteners.Int64(int64(cloudflare.Uint(sct.StatusCodeRange.From))),
 						})
 					}
+
+					var sctValue basetypes.Int64Value
+					if sct.Value != nil {
+						sctValue = types.Int64Value(int64(cloudflare.Int(sct.Value)))
+					} else {
+						sctValue = types.Int64Null()
+					}
+
 					statusCodeTTLs = append(statusCodeTTLs, &ActionParameterEdgeTTLStatusCodeTTLModel{
 						StatusCode:      flatteners.Int64(int64(cloudflare.Uint(sct.StatusCodeValue))),
-						Value:           flatteners.Int64(int64(cloudflare.Int(sct.Value))),
+						Value:           sctValue,
 						StatusCodeRange: sctrange,
 					})
 				}


### PR DESCRIPTION
Allows use of 0 as an edge TTL status without conflicting with Go type zeros.