### PR TITLE
fix: unexpected crashes when setting target_host_name with a filters attribute

### DIFF
--- a/.changelog/2425.txt
+++ b/.changelog/2425.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/cloudflare_notification_policy: Fix unexpected crashes when setting target_host_name with a filters attribute
+resource/cloudflare_notification_policy: Fix unexpected crashes when setting target_hostname with a filters attribute
 ```

--- a/.changelog/2425.txt
+++ b/.changelog/2425.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_notification_policy: Fix unexpected crashes when setting target_host_name with a filters attribute
+```

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -119,7 +119,7 @@ Optional:
 - `services` (Set of String)
 - `slo` (Set of String) A numerical limit. Example: `99.9`.
 - `status` (Set of String) Status to alert on.
-- `target_host_name` (Set of String) Target host to alert on for dos.
+- `target_hostname` (Set of String) Target host to alert on for dos.
 - `target_zone_name` (Set of String) Target domain to alert on.
 - `zones` (Set of String) A list of zone identifiers.
 

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -119,7 +119,7 @@ Optional:
 - `services` (Set of String)
 - `slo` (Set of String) A numerical limit. Example: `99.9`.
 - `status` (Set of String) Status to alert on.
-- `target_host` (Set of String) Target host to alert on for dos.
+- `target_host_name` (Set of String) Target host to alert on for dos.
 - `target_zone_name` (Set of String) Target domain to alert on.
 - `zones` (Set of String) A list of zone identifiers.
 

--- a/internal/sdkv2provider/schema_cloudflare_notification_policy.go
+++ b/internal/sdkv2provider/schema_cloudflare_notification_policy.go
@@ -267,7 +267,7 @@ func notificationPolicyFilterSchema() *schema.Schema {
 					Optional:    true,
 					Description: "Target domain to alert on.",
 				},
-				"target_host": {
+				"target_host_name": {
 					Type: schema.TypeSet,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,

--- a/internal/sdkv2provider/schema_cloudflare_notification_policy.go
+++ b/internal/sdkv2provider/schema_cloudflare_notification_policy.go
@@ -267,7 +267,7 @@ func notificationPolicyFilterSchema() *schema.Schema {
 					Optional:    true,
 					Description: "Target domain to alert on.",
 				},
-				"target_host_name": {
+				"target_hostname": {
 					Type: schema.TypeSet,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,


### PR DESCRIPTION
fixed unexpected crashes when setting target_host_name with a filters attribute

Fixes: #2260 