### PR TITLE
Improve error handling in account delete function

### DIFF
--- a/.changelog/2436.txt
+++ b/.changelog/2436.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_account: provide account ID for error handling in `resourceCloudflareAccountDelete`
+```

--- a/internal/sdkv2provider/resource_cloudflare_access_keys_configuration.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_keys_configuration.go
@@ -93,7 +93,7 @@ func resourceCloudflareKeysConfigurationImport(ctx context.Context, d *schema.Re
 	d.Set(consts.AccountIDSchemaKey, accountID)
 
 	if err := resourceCloudflareAccessKeysConfigurationRead(ctx, d, meta); err != nil {
-		return nil, fmt.Errorf("diagnostic error occurred: %v", err)
+		return nil, errors.New(err[0].Summary)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/internal/sdkv2provider/resource_cloudflare_access_keys_configuration.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_keys_configuration.go
@@ -92,6 +92,9 @@ func resourceCloudflareKeysConfigurationImport(ctx context.Context, d *schema.Re
 	d.SetId(accountID)
 	d.Set(consts.AccountIDSchemaKey, accountID)
 
-	resourceCloudflareAccessKeysConfigurationRead(ctx, d, meta)
+	if err := resourceCloudflareAccessKeysConfigurationRead(ctx, d, meta); err != nil {
+		return nil, fmt.Errorf("diagnostic error occurred: %v", err)
+	}
+
 	return []*schema.ResourceData{d}, nil
 }

--- a/internal/sdkv2provider/resource_cloudflare_account.go
+++ b/internal/sdkv2provider/resource_cloudflare_account.go
@@ -118,7 +118,7 @@ func resourceCloudflareAccountDelete(ctx context.Context, d *schema.ResourceData
 	err := client.DeleteAccount(ctx, accountID)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Account: %w", err))
+		return diag.FromErr(fmt.Errorf("error deleting Cloudflare Account %q: %w", accountID, err))
 	}
 
 	return nil


### PR DESCRIPTION
This commit surfaces some additional information (the account ID) on account 
deletion failure cases.

I encountered some strange behaviour (that ended up being my fault) that
led to me digging through this module. Thought I'd leave it in a better place than
I found it as I found a couple of minor issues.

Closes #2437