### PR TITLE
Suggest a better default value for root_dir in pages_project docs

### DIFF
--- a/.changelog/2440.txt
+++ b/.changelog/2440.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_pages_project: suggest a better default value for root_dir
+```

--- a/docs/resources/pages_project.md
+++ b/docs/resources/pages_project.md
@@ -147,7 +147,7 @@ Optional:
 
 - `build_command` (String) Command used to build project.
 - `destination_dir` (String) Output directory of the build.
-- `root_dir` (String) Directory to run the command.
+- `root_dir` (String) Your project's root directory, where Cloudflare runs the build command. If your site is not in a subdirectory, leave this path value empty.
 - `web_analytics_tag` (String) The classifying tag for analytics.
 - `web_analytics_token` (String) The auth token for analytics.
 

--- a/docs/resources/pages_project.md
+++ b/docs/resources/pages_project.md
@@ -31,7 +31,7 @@ resource "cloudflare_pages_project" "build_config" {
   build_config {
     build_command       = "npm run build"
     destination_dir     = "build"
-    root_dir            = "/"
+    root_dir            = ""
     web_analytics_tag   = "cee1c73f6e4743d0b5e6bb1a0bcaabcc"
     web_analytics_token = "021e1057c18547eca7b79f2516f06o7x"
   }

--- a/docs/resources/pages_project.md
+++ b/docs/resources/pages_project.md
@@ -31,7 +31,7 @@ resource "cloudflare_pages_project" "build_config" {
   build_config {
     build_command       = "npm run build"
     destination_dir     = "build"
-    root_dir            = ""
+    root_dir            = "/"
     web_analytics_tag   = "cee1c73f6e4743d0b5e6bb1a0bcaabcc"
     web_analytics_token = "021e1057c18547eca7b79f2516f06o7x"
   }

--- a/examples/resources/cloudflare_pages_project/resource.tf
+++ b/examples/resources/cloudflare_pages_project/resource.tf
@@ -13,7 +13,7 @@ resource "cloudflare_pages_project" "build_config" {
   build_config {
     build_command       = "npm run build"
     destination_dir     = "build"
-    root_dir            = "/"
+    root_dir            = ""
     web_analytics_tag   = "cee1c73f6e4743d0b5e6bb1a0bcaabcc"
     web_analytics_token = "021e1057c18547eca7b79f2516f06o7x"
   }

--- a/internal/sdkv2provider/schema_cloudflare_pages_project.go
+++ b/internal/sdkv2provider/schema_cloudflare_pages_project.go
@@ -21,7 +21,7 @@ func resourceCloudflarePagesProjectSchema() map[string]*schema.Schema {
 			},
 			"root_dir": {
 				Type:        schema.TypeString,
-				Description: "Directory to run the command.",
+				Description: "Your project's root directory, where Cloudflare runs the build command. If your site is not in a subdirectory, leave this path value empty.",
 				Optional:    true,
 			},
 			"web_analytics_tag": {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/2439

`root_dir = "/"` results in a Pages project that has `root_dir` of `//` (double slash).