### PR TITLE
Adds additional validation for TTLs for cloudflare_ruleset action_parameters

### DIFF
--- a/.changelog/2454.txt
+++ b/.changelog/2454.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: Validation of ttls for action_parameters with edge_ttl or browser_ttl mode of override_origin
+```

--- a/internal/framework/service/rulesets/errors.go
+++ b/internal/framework/service/rulesets/errors.go
@@ -1,0 +1,5 @@
+package rulesets
+
+const (
+	errInvalidConfiguration = "invalid configuration"
+)

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -459,14 +459,17 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 										NestedObject: schema.NestedBlockObject{
 											Attributes: map[string]schema.Attribute{
 												"mode": schema.StringAttribute{
-													Optional:            true,
+													Required:            true,
+													Validators:          []validator.String{stringvalidator.OneOf("override_origin", "respect_origin")},
 													MarkdownDescription: "Mode of the edge TTL.",
 												},
 												"default": schema.Int64Attribute{
 													Optional:            true,
+													Validators:          []validator.Int64{int64validator.AtLeast(1)},
 													MarkdownDescription: "Default edge TTL",
 												},
 											},
+											Validators: []validator.Object{EdgeTTLValidator{}},
 											Blocks: map[string]schema.Block{
 												"status_code_ttl": schema.ListNestedBlock{
 													MarkdownDescription: "Edge TTL for the status codes.",
@@ -518,14 +521,17 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 										NestedObject: schema.NestedBlockObject{
 											Attributes: map[string]schema.Attribute{
 												"mode": schema.StringAttribute{
-													Optional:            true,
+													Required:            true,
+													Validators:          []validator.String{stringvalidator.OneOf("override_origin", "respect_origin")},
 													MarkdownDescription: "Mode of the browser TTL.",
 												},
 												"default": schema.Int64Attribute{
 													Optional:            true,
-													MarkdownDescription: "Default browser TTL.",
+													Validators:          []validator.Int64{int64validator.AtLeast(1)},
+													MarkdownDescription: "Default browser TTL. This value is required when override_origin is set",
 												},
 											},
+											Validators: []validator.Object{BrowserTTLValidator{}},
 										},
 										Validators: []validator.List{
 											listvalidator.SizeAtMost(1),

--- a/internal/framework/service/rulesets/validators.go
+++ b/internal/framework/service/rulesets/validators.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 type sbfmDeprecationWarningValidator struct{}
@@ -34,5 +35,77 @@ func (v sbfmDeprecationWarningValidator) ValidateString(ctx context.Context, req
 		)
 
 		return
+	}
+}
+
+type RulesetActionParameterEdgeTTL struct {
+	Mode       basetypes.StringValue `tfsdk:"mode"`
+	Default    basetypes.Int64Value  `tfsdk:"default"`
+	StatusCode basetypes.ListValue   `tfsdk:"status_code_ttl"`
+}
+
+type EdgeTTLValidator struct{}
+
+func (v EdgeTTLValidator) Description(ctx context.Context) string {
+	return fmt.Sprintf("ttl values are required when the override_origin mode is set")
+}
+
+func (v EdgeTTLValidator) MarkdownDescription(ctx context.Context) string {
+	return fmt.Sprintf("ttl values are required when the override_origin mode is set")
+}
+
+func (v EdgeTTLValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	var parameter RulesetActionParameterEdgeTTL
+
+	diag := req.ConfigValue.As(ctx, &parameter, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true, UnhandledUnknownAsEmpty: true})
+	resp.Diagnostics.Append(diag...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if parameter.Mode.ValueString() == "override_origin" {
+		if parameter.Default.ValueInt64() <= 0 {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				errInvalidConfiguration,
+				fmt.Sprintf("using mode '%s' requires setting a default for ttl", parameter.Mode.ValueString()),
+			)
+		}
+	}
+}
+
+type RulesetActionParameterBrowserTTL struct {
+	Mode    basetypes.StringValue `tfsdk:"mode"`
+	Default basetypes.Int64Value  `tfsdk:"default"`
+}
+
+type BrowserTTLValidator struct{}
+
+func (v BrowserTTLValidator) Description(ctx context.Context) string {
+	return fmt.Sprintf("ttl values are required when the override_origin mode is set")
+}
+
+func (v BrowserTTLValidator) MarkdownDescription(ctx context.Context) string {
+	return fmt.Sprintf("ttl values are required when the override_origin mode is set")
+}
+
+func (v BrowserTTLValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	var parameter RulesetActionParameterBrowserTTL
+
+	diag := req.ConfigValue.As(ctx, &parameter, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true, UnhandledUnknownAsEmpty: true})
+	resp.Diagnostics.Append(diag...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if parameter.Mode.ValueString() == "override_origin" {
+		if parameter.Default.ValueInt64() <= 0 {
+
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				errInvalidConfiguration,
+				fmt.Sprintf("using mode '%s' requires setting a default for ttl", parameter.Mode.ValueString()),
+			)
+		}
 	}
 }

--- a/internal/framework/service/rulesets/validators_test.go
+++ b/internal/framework/service/rulesets/validators_test.go
@@ -24,7 +24,7 @@ func TestEdgeTTLValidation(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
 
-		t.Run("and override_origin mode is specified...", func(t *testing.T) {
+		t.Run("override_origin mode is specified", func(t *testing.T) {
 			t.Parallel()
 
 			t.Run("errors when no ttl is passed", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestEdgeTTLValidation(t *testing.T) {
 			})
 		})
 
-		t.Run("and respect_origin mode is specified", func(t *testing.T) {
+		t.Run("respect_origin mode is specified", func(t *testing.T) {
 			t.Parallel()
 
 			t.Run("passes with ttl values", func(t *testing.T) {
@@ -106,7 +106,7 @@ func TestBrowserTTLValidation(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
 
-		t.Run("and override_origin mode is specified...", func(t *testing.T) {
+		t.Run("override_origin mode is specified", func(t *testing.T) {
 			t.Parallel()
 
 			t.Run("errors when no ttl is passed", func(t *testing.T) {
@@ -159,7 +159,7 @@ func TestBrowserTTLValidation(t *testing.T) {
 			})
 		})
 
-		t.Run("and respect_origin mode is specified", func(t *testing.T) {
+		t.Run("respect_origin mode is specified", func(t *testing.T) {
 			t.Parallel()
 
 			t.Run("passes with ttl values", func(t *testing.T) {

--- a/internal/framework/service/rulesets/validators_test.go
+++ b/internal/framework/service/rulesets/validators_test.go
@@ -1,0 +1,323 @@
+package rulesets
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestEdgeTTLValidation(t *testing.T) {
+	t.Parallel()
+
+	var edgeValidator EdgeTTLValidator
+	t.Run("when validating edge ttl", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+
+		t.Run("and override_origin mode is specified...", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("errors when no ttl is passed", func(t *testing.T) {
+				t.Parallel()
+
+				resp := &validator.ObjectResponse{}
+				req := constructEdgeTTLObjectRequest("override_origin", nil)
+				edgeValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: diag.Diagnostics{
+						diag.NewAttributeErrorDiagnostic(path.Root("edge_ttl"), "invalid configuration", "using mode 'override_origin' requires setting a default for ttl"),
+					},
+				}
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+
+			t.Run("errors when invalid ttl is passed", func(t *testing.T) {
+				t.Parallel()
+
+				resp := &validator.ObjectResponse{}
+				req := constructEdgeTTLObjectRequest("override_origin", big.NewFloat(-1))
+				edgeValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: diag.Diagnostics{
+						diag.NewAttributeErrorDiagnostic(path.Root("edge_ttl"), "invalid configuration", "using mode 'override_origin' requires setting a default for ttl"),
+					},
+				}
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+
+			t.Run("passes valid ttl values", func(t *testing.T) {
+				t.Parallel()
+
+				resp := &validator.ObjectResponse{}
+				req := constructEdgeTTLObjectRequest("override_origin", big.NewFloat(10))
+				edgeValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: nil,
+				}
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+		})
+
+		t.Run("and respect_origin mode is specified", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("passes with ttl values", func(t *testing.T) {
+				t.Parallel()
+
+				resp := &validator.ObjectResponse{}
+				req := constructEdgeTTLObjectRequest("respect_origin", big.NewFloat(1))
+				edgeValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: nil,
+				}
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+		})
+	})
+}
+
+func TestBrowserTTLValidation(t *testing.T) {
+	t.Parallel()
+
+	var browserValidator BrowserTTLValidator
+	t.Run("when validating browser ttl", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+
+		t.Run("and override_origin mode is specified...", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("errors when no ttl is passed", func(t *testing.T) {
+				t.Parallel()
+
+				resp := &validator.ObjectResponse{}
+				req := constructBrowserTTLObjectRequest("override_origin", nil)
+				browserValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: diag.Diagnostics{
+						diag.NewAttributeErrorDiagnostic(path.Root("browser_ttl"), "invalid configuration", "using mode 'override_origin' requires setting a default for ttl"),
+					},
+				}
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+
+			t.Run("errors when invalid ttl is passed", func(t *testing.T) {
+				t.Parallel()
+
+				resp := &validator.ObjectResponse{}
+				req := constructBrowserTTLObjectRequest("override_origin", big.NewFloat(-1))
+				browserValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: diag.Diagnostics{
+						diag.NewAttributeErrorDiagnostic(path.Root("browser_ttl"), "invalid configuration", "using mode 'override_origin' requires setting a default for ttl"),
+					},
+				}
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+
+			t.Run("passes valid ttl values", func(t *testing.T) {
+				t.Parallel()
+
+				resp := &validator.ObjectResponse{}
+				req := constructBrowserTTLObjectRequest("override_origin", big.NewFloat(10))
+				browserValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: nil,
+				}
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+		})
+
+		t.Run("and respect_origin mode is specified", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("passes with ttl values", func(t *testing.T) {
+				t.Parallel()
+
+				resp := &validator.ObjectResponse{}
+				req := constructBrowserTTLObjectRequest("respect_origin", big.NewFloat(1))
+				browserValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: nil,
+				}
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+		})
+	})
+}
+
+func constructStatusTTLObject() (tftypes.Value, attr.Value, types.ListType) {
+	tftype := tftypes.NewValue(
+		tftypes.List{
+			ElementType: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"status_code": tftypes.Number,
+					"value":       tftypes.Number,
+				},
+			},
+		},
+		[]tftypes.Value{tftypes.NewValue(
+			tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+				"status_code": tftypes.Number,
+				"value":       tftypes.Number,
+			}},
+			map[string]tftypes.Value{
+				"status_code": tftypes.NewValue(
+					tftypes.Number,
+					100,
+				),
+				"value": tftypes.NewValue(
+					tftypes.Number,
+					100,
+				),
+			},
+		)},
+	)
+
+	attributes, _ := types.ListValue(
+		types.ObjectType{
+			AttrTypes: map[string]attr.Type{"status_code": types.Int64Type, "value": types.Int64Type},
+		},
+		[]attr.Value{
+			types.ObjectValueMust(
+				map[string]attr.Type{"status_code": types.Int64Type, "value": types.Int64Type},
+				map[string]attr.Value{"status_code": types.Int64Value(100), "value": types.Int64Value(100)},
+			),
+		},
+	)
+
+	listType := types.ListType{
+		ElemType: types.ObjectType{
+			AttrTypes: map[string]attr.Type{"status_code": types.Int64Type, "value": types.Int64Type},
+		},
+	}
+	return tftype, attributes, listType
+}
+
+func constructEdgeTTLObjectRequest(mode string, ttl *big.Float) validator.ObjectRequest {
+	var objectValue basetypes.ObjectValue
+
+	statusCodeTfTypes, statusCodeAttr, listType := constructStatusTTLObject()
+	if ttl == nil {
+		objectValue = types.ObjectValueMust(
+			map[string]attr.Type{"mode": types.StringType, "status_code_ttl": listType, "default": types.Int64Type},
+			map[string]attr.Value{"mode": types.StringValue(mode), "status_code_ttl": statusCodeAttr, "default": types.Int64Null()},
+		)
+	} else {
+		intTTL, _ := ttl.Int64()
+		objectValue = types.ObjectValueMust(
+			map[string]attr.Type{"mode": types.StringType, "status_code_ttl": listType, "default": types.Int64Type},
+			map[string]attr.Value{"mode": types.StringValue(mode), "status_code_ttl": statusCodeAttr, "default": types.Int64Value(intTTL)},
+		)
+	}
+
+	return validator.ObjectRequest{
+		Path:        path.Root("edge_ttl"),
+		ConfigValue: objectValue,
+		Config: tfsdk.Config{
+			Raw: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"mode":    tftypes.String,
+						"default": tftypes.Number,
+						"status_code_ttl": tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"status_code": tftypes.Number,
+									"value":       tftypes.Number,
+								},
+							},
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"mode": tftypes.NewValue(
+						tftypes.String,
+						mode,
+					),
+					"default": tftypes.NewValue(
+						tftypes.Number,
+						ttl,
+					),
+					"status_code_ttl": statusCodeTfTypes,
+				},
+			),
+		},
+	}
+}
+
+func constructBrowserTTLObjectRequest(mode string, ttl *big.Float) validator.ObjectRequest {
+	var objectValue basetypes.ObjectValue
+
+	if ttl == nil {
+		objectValue = types.ObjectValueMust(
+			map[string]attr.Type{"mode": types.StringType, "default": types.Int64Type},
+			map[string]attr.Value{"mode": types.StringValue(mode), "default": types.Int64Null()},
+		)
+	} else {
+		intTTL, _ := ttl.Int64()
+		objectValue = types.ObjectValueMust(
+			map[string]attr.Type{"mode": types.StringType, "default": types.Int64Type},
+			map[string]attr.Value{"mode": types.StringValue(mode), "default": types.Int64Value(intTTL)},
+		)
+	}
+
+	return validator.ObjectRequest{
+		Path:        path.Root("browser_ttl"),
+		ConfigValue: objectValue,
+		Config: tfsdk.Config{
+			Raw: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"mode":    tftypes.String,
+						"default": tftypes.Number,
+					},
+				},
+				map[string]tftypes.Value{
+					"mode": tftypes.NewValue(
+						tftypes.String,
+						mode,
+					),
+					"default": tftypes.NewValue(
+						tftypes.Number,
+						ttl,
+					),
+				},
+			),
+		},
+	}
+}


### PR DESCRIPTION
This adds new validation for the schema that enforces TTL values for specific modes within the cloudflare_ruleset action parameters. This applies to the browser_ttl and edge_ttl blocks within the action_parameters schema. The validation will serialize the existing values into a type that is a 1:1 match of the schema and then will determine if the default value for the ttl is greater than zero for the configured rule.

Implementation:

* Custom object validator for Browser TTL block within action_parameters for cloudflare_ruleset
* Custom object validator for Edge TTL block within action_parameters for cloudflare_ruleset