### PR TITLE
resource/cloudflare_list: remove `IsIPAddress` validation

### DIFF
--- a/.changelog/2486.txt
+++ b/.changelog/2486.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_list: remove `IsIPAddress` validation that doesn't take into account CIDR notation
+```

--- a/internal/sdkv2provider/schema_cloudflare_list.go
+++ b/internal/sdkv2provider/schema_cloudflare_list.go
@@ -53,9 +53,8 @@ var listItemElem = &schema.Resource{
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"ip": {
-						Type:         schema.TypeString,
-						Optional:     true,
-						ValidateFunc: validation.IsIPAddress,
+						Type:     schema.TypeString,
+						Optional: true,
 					},
 					"redirect": {
 						Type:     schema.TypeList,

--- a/internal/sdkv2provider/schema_cloudflare_list_item.go
+++ b/internal/sdkv2provider/schema_cloudflare_list_item.go
@@ -33,6 +33,7 @@ func resourceCloudflareListItemSchema() map[string]*schema.Schema {
 			Description:  "Autonomous system number to include in the list",
 			ExactlyOneOf: []string{"ip", "redirect", "hostname", "asn"},
 			ForceNew:     true,
+			ValidateFunc: validation.IntAtLeast(1),
 		},
 		"hostname": {
 			Type:         schema.TypeList,


### PR DESCRIPTION
This was added in 4.7.0 after seeing some incorrect API payloads but the internals of the validation do not take into account a possible CIDR.

Closes #2485