### PR TITLE
Ignore invalid full wildcards for cache_rule cache_key includes/excludes

### DIFF
--- a/.changelog/2492.txt
+++ b/.changelog/2492.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: removes ability to set wildcards for include and exclude, provides guidance on proper values to use instead
+```

--- a/.changelog/2492.txt
+++ b/.changelog/2492.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-resource/cloudflare_ruleset: removes ability to set wildcards for include and exclude, provides guidance on proper values to use instead
+```release-note:enhancement
+resource/cloudflare_ruleset: applies additional validation to cache key rules for using wildcards in `include` and `exclude`, provides guidance on proper values to use instead
 ```

--- a/internal/framework/service/rulesets/errors.go
+++ b/internal/framework/service/rulesets/errors.go
@@ -2,4 +2,5 @@ package rulesets
 
 const (
 	errInvalidConfiguration = "invalid configuration"
+	errInvalidValue = "invalid value"
 )

--- a/internal/framework/service/rulesets/errors.go
+++ b/internal/framework/service/rulesets/errors.go
@@ -2,5 +2,5 @@ package rulesets
 
 const (
 	errInvalidConfiguration = "invalid configuration"
-	errInvalidValue = "invalid value"
+	errInvalidValue         = "invalid value"
 )

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -586,6 +586,7 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 																			MarkdownDescription: "List of query string parameters to include in the custom key.",
 																			Validators: []validator.Set{
 																				setvalidator.ConflictsWith(path.Expression(path.MatchRelative().AtParent().AtName("exclude"))),
+																				InvalidWildCardValidator{},
 																			},
 																		},
 																		"exclude": schema.SetAttribute{
@@ -594,6 +595,7 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 																			MarkdownDescription: "List of query string parameters to exclude from the custom key.",
 																			Validators: []validator.Set{
 																				setvalidator.ConflictsWith(path.Expression(path.MatchRelative().AtParent().AtName("include"))),
+																				InvalidWildCardValidator{},
 																			},
 																		},
 																	},


### PR DESCRIPTION
Wildcards for the include and exclude values for cache keys need to be set using the ignore rules. Setting the value using include or exclude can cause unexpected behaviors. This addresses this outstanding bug by adding new validation to the schema.

Implementation:

* Adds new validation to the query_key schema for cache_key in cache_rules