### PR TITLE
utils/ephemeral_certs: add a helper for generating TLS certificates

### DIFF
--- a/internal/utils/ephemeral_certs.go
+++ b/internal/utils/ephemeral_certs.go
@@ -1,0 +1,90 @@
+package utils
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"math/big"
+	"os"
+	"time"
+)
+
+func publicKey(priv interface{}) interface{} {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey
+	case *ecdsa.PrivateKey:
+		return &k.PublicKey
+	default:
+		return nil
+	}
+}
+
+func pemBlockForKey(priv interface{}) *pem.Block {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
+	case *ecdsa.PrivateKey:
+		b, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to marshal ECDSA private key: %v", err)
+			os.Exit(2)
+		}
+		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}
+	default:
+		return nil
+	}
+}
+
+// GenerateEphemeralCertAndKey generates an ephemeral TLS certificate and
+// private key to use in tests that are not actually used for real traffic.
+// In most cases, this will not generate a usable combination but is enough for
+// test assertions. This method *should not* be considered suitable for real
+// certificates.
+func GenerateEphemeralCertAndKey(hostnames []string) (certificate string, key string, err error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+	template := x509.Certificate{
+		DNSNames:     hostnames,
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour * 1),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)
+	if err != nil {
+		return "", "", err
+	}
+
+	out := &bytes.Buffer{}
+	err = pem.Encode(out, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	if err != nil {
+		return "", "", err
+	}
+
+	certificate = out.String()
+	out.Reset()
+	err = pem.Encode(out, pemBlockForKey(priv))
+	if err != nil {
+		return "", "", err
+	}
+
+	key = out.String()
+
+	return certificate, key, nil
+}

--- a/internal/utils/ephemeral_certs_test.go
+++ b/internal/utils/ephemeral_certs_test.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateEphemeralCertAndKey(t *testing.T) {
+	cert, key, err := GenerateEphemeralCertAndKey([]string{"example.com"})
+
+	assert.NotEqual(t, "", cert)
+	assert.NotEqual(t, "", key)
+	assert.Equal(t, nil, err)
+	assert.Contains(t, cert, "BEGIN CERTIFICATE", "failed to find certificate delimiter in output")
+	assert.Contains(t, key, "BEGIN EC PRIVATE KEY", "failed to find private key delimiter in output")
+}


### PR DESCRIPTION
Introduces a way for us to generate *intentionally* insecure certificates (usually accompanied by the `bundle_method=force` attributes) for the test suite to generate TLS certificates to use in resources.

This *should not* be used for actual certificates or where security is important.