### PR TITLE
resource/cloudflare_custom_hostname: use values from user provided config for certificates

### DIFF
--- a/.changelog/2494.txt
+++ b/.changelog/2494.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/cloudflare_custom_hostname: use user provided values for state management when the API response isn't provided
+```
+
+```release-note:enhancement
+resource/cloudflare_custom_hostname: add support for `bundle_method` TLS configuration
+```

--- a/docs/resources/custom_hostname.md
+++ b/docs/resources/custom_hostname.md
@@ -33,7 +33,7 @@ resource "cloudflare_custom_hostname" "example" {
 - `custom_metadata` (Map of String) Custom metadata associated with custom hostname. Only supports primitive string values, all other values are accessible via the API directly.
 - `custom_origin_server` (String) The custom origin server used for certificates.
 - `custom_origin_sni` (String) The [custom origin SNI](https://developers.cloudflare.com/ssl/ssl-for-saas/hostname-specific-behavior/custom-origin) used for certificates.
-- `ssl` (Block List) SSL configuration of the certificate. (see [below for nested schema](#nestedblock--ssl))
+- `ssl` (Block List) SSL properties used when creating the custom hostname. (see [below for nested schema](#nestedblock--ssl))
 - `wait_for_ssl_pending_validation` (Boolean) Whether to wait for a custom hostname SSL sub-object to reach status `pending_validation` during creation. Defaults to `false`.
 
 ### Read-Only
@@ -48,6 +48,7 @@ resource "cloudflare_custom_hostname" "example" {
 
 Optional:
 
+- `bundle_method` (String) A ubiquitous bundle has the highest probability of being verified everywhere, even by clients using outdated or unusual trust stores. An optimal bundle uses the shortest chain and newest intermediates. And the force bundle verifies the chain, but does not otherwise modify it. Available values: `ubiquitous`, `optimal`, `force`.
 - `certificate_authority` (String)
 - `custom_certificate` (String) If a custom uploaded certificate is used.
 - `custom_key` (String) The key for a custom uploaded certificate.

--- a/internal/sdkv2provider/resource_cloudflare_custom_hostname.go
+++ b/internal/sdkv2provider/resource_cloudflare_custom_hostname.go
@@ -65,6 +65,10 @@ func resourceCloudflareCustomHostnameRead(ctx context.Context, d *schema.Resourc
 				"early_hints":     customHostname.SSL.Settings.EarlyHints,
 			}},
 		}
+
+		if val, ok := d.GetOk("ssl.0.bundle_method"); ok {
+			ssl["bundle_method"] = val.(string)
+		}
 		if !reflect.ValueOf(customHostname.SSL.ValidationErrors).IsNil() {
 			errors := []map[string]interface{}{}
 			for _, e := range customHostname.SSL.ValidationErrors {
@@ -205,6 +209,7 @@ func buildCustomHostname(d *schema.ResourceData) cloudflare.CustomHostname {
 
 	if _, ok := d.GetOk("ssl"); ok {
 		ch.SSL = &cloudflare.CustomHostnameSSL{
+			BundleMethod:         d.Get("ssl.0.bundle_method").(string),
 			Method:               d.Get("ssl.0.method").(string),
 			Type:                 d.Get("ssl.0.type").(string),
 			Wildcard:             cloudflare.BoolPtr(d.Get("ssl.0.wildcard").(bool)),

--- a/internal/sdkv2provider/resource_cloudflare_custom_hostname.go
+++ b/internal/sdkv2provider/resource_cloudflare_custom_hostname.go
@@ -50,13 +50,9 @@ func resourceCloudflareCustomHostnameRead(ctx context.Context, d *schema.Resourc
 
 	if !reflect.ValueOf(customHostname.SSL).IsNil() {
 		ssl := map[string]interface{}{
-			"type":                  customHostname.SSL.Type,
-			"method":                customHostname.SSL.Method,
 			"wildcard":              customHostname.SSL.Wildcard,
 			"status":                customHostname.SSL.Status,
 			"certificate_authority": customHostname.SSL.CertificateAuthority,
-			"custom_certificate":    customHostname.SSL.CustomCertificate,
-			"custom_key":            customHostname.SSL.CustomKey,
 			"settings": []map[string]interface{}{{
 				"http2":           customHostname.SSL.Settings.HTTP2,
 				"tls13":           customHostname.SSL.Settings.TLS13,
@@ -69,6 +65,23 @@ func resourceCloudflareCustomHostnameRead(ctx context.Context, d *schema.Resourc
 		if val, ok := d.GetOk("ssl.0.bundle_method"); ok {
 			ssl["bundle_method"] = val.(string)
 		}
+
+		if val, ok := d.GetOk("ssl.0.method"); ok {
+			ssl["method"] = val.(string)
+		}
+
+		if val, ok := d.GetOk("ssl.0.type"); ok {
+			ssl["type"] = val.(string)
+		}
+
+		if val, ok := d.GetOk("ssl.0.custom_certificate"); ok {
+			ssl["custom_certificate"] = val.(string)
+		}
+
+		if val, ok := d.GetOk("ssl.0.custom_key"); ok {
+			ssl["custom_key"] = val.(string)
+		}
+
 		if !reflect.ValueOf(customHostname.SSL.ValidationErrors).IsNil() {
 			errors := []map[string]interface{}{}
 			for _, e := range customHostname.SSL.ValidationErrors {

--- a/internal/sdkv2provider/resource_cloudflare_custom_hostname_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_custom_hostname_test.go
@@ -9,6 +9,7 @@ import (
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -73,6 +74,42 @@ func TestAccCloudflareCustomHostname_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
 					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("%s.%s", rnd, domain)),
 					resource.TestCheckResourceAttr(resourceName, "ssl.0.method", "txt"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.value"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification_http.http_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification_http.http_body"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareCustomHostname_WithCertificate(t *testing.T) {
+	t.Parallel()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := generateRandomResourceName()
+	resourceName := "cloudflare_custom_hostname." + rnd
+
+	cert, key, err := utils.GenerateEphemeralCertAndKey([]string{rnd + "." + domain})
+	if err != nil {
+		t.Error(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareCustomHostnameWithCertificate(zoneID, rnd, domain, cert, key),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.method", "http"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.type", "dv"),
+					resource.TestCheckResourceAttrSet(resourceName, "ssl.0.custom_certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "ssl.0.custom_key"),
 					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.value"),
 					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.type"),
 					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.name"),
@@ -526,4 +563,24 @@ func testAccCheckCloudflareCustomHostnameWithCustomMetadata(zoneID, rnd, domain 
 		}
 	}
 	`, zoneID, rnd, domain)
+}
+
+func testAccCheckCloudflareCustomHostnameWithCertificate(zoneID, rnd, domain, cert, key string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_custom_hostname" "%[2]s" {
+  zone_id = "%[1]s"
+  hostname = "%[2]s.%[3]s"
+  ssl {
+    method             = "http"
+    type               = "dv"
+	bundle_method      = "force"
+	custom_certificate = <<EOT
+%[4]s
+	EOT
+    custom_key = <<EOT
+%[5]s
+	EOT
+  }
+}
+`, zoneID, rnd, domain, cert, key)
 }

--- a/internal/sdkv2provider/schema_cloudflare_custom_hostname.go
+++ b/internal/sdkv2provider/schema_cloudflare_custom_hostname.go
@@ -36,13 +36,19 @@ func resourceCloudflareCustomHostnameSchema() map[string]*schema.Schema {
 		"ssl": {
 			Type:        schema.TypeList,
 			Optional:    true,
-			Description: "SSL configuration of the certificate.",
+			Description: "SSL properties used when creating the custom hostname.",
 			Elem: &schema.Resource{
 				SchemaVersion: 1,
 				Schema: map[string]*schema.Schema{
 					"status": {
 						Type:     schema.TypeString,
 						Computed: true,
+					},
+					"bundle_method": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice([]string{"ubiquitous", "optimal", "force"}, false),
+						Description:  fmt.Sprintf("A ubiquitous bundle has the highest probability of being verified everywhere, even by clients using outdated or unusual trust stores. An optimal bundle uses the shortest chain and newest intermediates. And the force bundle verifies the chain, but does not otherwise modify it. %s", renderAvailableDocumentationValuesStringSlice([]string{"ubiquitous", "optimal", "force"})),
 					},
 					"method": {
 						Type:         schema.TypeString,


### PR DESCRIPTION
- Adds support for `bundle_method` for TLS configuration
- Handle empty values from the API for state management

Depends on #2493
Depends on cloudflare/cloudflare-go#1298

Closes #2411