### PR TITLE
resource/cloudflare_origin_ca_certificate: make `csr` required to match API requirements

### DIFF
--- a/.changelog/2496.txt
+++ b/.changelog/2496.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_origin_ca_certificate: mark `csr` as Required
+```

--- a/docs/resources/origin_ca_certificate.md
+++ b/docs/resources/origin_ca_certificate.md
@@ -44,12 +44,12 @@ resource "cloudflare_origin_ca_certificate" "example" {
 
 ### Required
 
+- `csr` (String) The Certificate Signing Request. Must be newline-encoded. **Modifying this attribute will force creation of a new resource.**
 - `hostnames` (Set of String) A list of hostnames or wildcard names bound to the certificate. **Modifying this attribute will force creation of a new resource.**
 - `request_type` (String) The signature type desired on the certificate. Available values: `origin-rsa`, `origin-ecc`, `keyless-certificate`. **Modifying this attribute will force creation of a new resource.**
 
 ### Optional
 
-- `csr` (String) The Certificate Signing Request. Must be newline-encoded. **Modifying this attribute will force creation of a new resource.**
 - `min_days_for_renewal` (Number) Number of days prior to the expiry to trigger a renewal of the certificate if a Terraform operation is run.
 - `requested_validity` (Number) The number of days for which the certificate should be valid. Available values: `7`, `30`, `90`, `365`, `730`, `1095`, `5475`. **Modifying this attribute will force creation of a new resource.**
 

--- a/internal/sdkv2provider/schema_cloudflare_origin_ca_certificate.go
+++ b/internal/sdkv2provider/schema_cloudflare_origin_ca_certificate.go
@@ -17,7 +17,7 @@ func resourceCloudflareOriginCACertificateSchema() map[string]*schema.Schema {
 		"csr": {
 			Type:         schema.TypeString,
 			ForceNew:     true,
-			Optional:     true,
+			Required:     true,
 			ValidateFunc: validateCSR,
 			Description:  "The Certificate Signing Request. Must be newline-encoded.",
 		},


### PR DESCRIPTION
Corrects the schema to rectify some functional drift between the API requirements and what the schema enforces.

Closes #2465