### PR TITLE
resource/cloudflare_certificate_pack: handle deletion via UI

### DIFF
--- a/.changelog/2497.txt
+++ b/.changelog/2497.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_certificate_pack: handle UI deletion scenarios for HTTP 404s and `status = "deleted"` responses
+```

--- a/internal/sdkv2provider/resource_cloudflare_certificate_pack.go
+++ b/internal/sdkv2provider/resource_cloudflare_certificate_pack.go
@@ -104,6 +104,12 @@ func resourceCloudflareCertificatePackRead(ctx context.Context, d *schema.Resour
 
 	certificatePack, err := client.CertificatePack(ctx, zoneID, d.Id())
 	if err != nil {
+		var notFoundError *cloudflare.NotFoundError
+		if errors.As(err, &notFoundError) || certificatePack.Status == "deleted" {
+			tflog.Warn(ctx, fmt.Sprintf("removing certificate pack from state because it is not found in the API"))
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(errors.Wrap(err, "failed to fetch certificate pack"))
 	}
 


### PR DESCRIPTION
The deletion policy for certificate packs is a little different and for a short period of time following deletion, the URL does not return a 404 like most other resources. Instead, it will return a HTTP 200 with the `status` field set to deleted. This isn't standard handling so we'll explicitly account for both of these scenarios.

Closes #2461