### PR TITLE
resource/cloudflare_device_posture_rule: fix schema value for `issue_count`

### DIFF
--- a/docs/resources/device_posture_rule.md
+++ b/docs/resources/device_posture_rule.md
@@ -67,7 +67,7 @@ Optional:
 - `enabled` (Boolean) True if the firewall must be enabled.
 - `exists` (Boolean) Checks if the file should exist.
 - `id` (String) The Teams List id.
-- `issue_config` (String) The Number of Issues for kolide.
+- `issue_count` (String) The number of issues for kolide.
 - `operator` (String) The version comparison operator. Available values: `>`, `>=`, `<`, `<=`, `==`.
 - `os` (String) OS signal score from Crowdstrike. Value must be between 1 and 100.
 - `os_distro_name` (String) The operating system excluding version information.

--- a/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
@@ -177,10 +177,10 @@ func resourceCloudflareDevicePostureRuleSchema() map[string]*schema.Schema {
 						ValidateFunc: validation.StringInSlice([]string{">", ">=", "<", "<=", "=="}, true),
 						Description:  fmt.Sprintf("The count comparison operator for kolide. %s", renderAvailableDocumentationValuesStringSlice([]string{">", ">=", "<", "<=", "=="})),
 					},
-					"issue_config": {
+					"issue_count": {
 						Type:        schema.TypeString,
 						Optional:    true,
-						Description: "The Number of Issues for kolide.",
+						Description: "The number of issues for kolide.",
 					},
 				},
 			},


### PR DESCRIPTION
acceptance tests all passing

```
TF_ACC=1 go test ./internal/sdkv2provider -v -run "^TestAccCloudflareDevicePostureRule_" -count 1 -timeout 120m -parallel 1
=== RUN   TestAccCloudflareDevicePostureRule_SerialNumber
--- PASS: TestAccCloudflareDevicePostureRule_SerialNumber (22.65s)
=== RUN   TestAccCloudflareDevicePostureRule_OsVersion
--- PASS: TestAccCloudflareDevicePostureRule_OsVersion (20.76s)
=== RUN   TestAccCloudflareDevicePostureRule_LinuxOsDistro
--- PASS: TestAccCloudflareDevicePostureRule_LinuxOsDistro (23.66s)
=== RUN   TestAccCloudflareDevicePostureRule_DomainJoined
--- PASS: TestAccCloudflareDevicePostureRule_DomainJoined (21.50s)
=== RUN   TestAccCloudflareDevicePostureRule_Firewall
--- PASS: TestAccCloudflareDevicePostureRule_Firewall (14.74s)
=== RUN   TestAccCloudflareDevicePostureRule_DiskEncryption_RequireAll
--- PASS: TestAccCloudflareDevicePostureRule_DiskEncryption_RequireAll (16.26s)
=== RUN   TestAccCloudflareDevicePostureRule_DiskEncryption_CheckDisks
--- PASS: TestAccCloudflareDevicePostureRule_DiskEncryption_CheckDisks (15.11s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider	135.201s
```