### PR TITLE
resource/cloudflare_tunnel_config: fix duration handling

### DIFF
--- a/.changelog/2510.txt
+++ b/.changelog/2510.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_tunnel_config: fix sending incorrect values for various timeouts in the origin configuration block
+```


### PR DESCRIPTION
Due to [marshal/unmarshal support lacking for `time.Duration` in Go 1](https://github.com/golang/go/issues/10275), we were previously sending nanosecond values to the API instead of the required seconds. This would have resulted in higher than usual timeout durations (10 seconds would have been sent as 1000000000 seconds since it duration unmarshals to nanoseconds).

Updates all the instances of time duration handling in `cloudflare_tunnel_config` resource to use the newly introduced `TunnelDuration` to ensure we correctly setting the units.

Depends on cloudflare/cloudflare-go#1303
Closes #2495