### PR TITLE
Fix healthcheck port example values

### DIFF
--- a/docs/resources/healthcheck.md
+++ b/docs/resources/healthcheck.md
@@ -26,7 +26,7 @@ resource "cloudflare_healthcheck" "http_health_check" {
     "EEU"
   ]
   type = "HTTPS"
-  port = "443"
+  port = 443
   method = "GET"
   path = "/health"
   expected_body = "alive"
@@ -59,7 +59,7 @@ resource "cloudflare_healthcheck" "tcp_health_check" {
     "EEU"
   ]
   type = "TCP"
-  port = "22"
+  port = 22
   method = "connection_established"
   timeout = 10
   retries = 2

--- a/examples/resources/cloudflare_healthcheck/resource.tf
+++ b/examples/resources/cloudflare_healthcheck/resource.tf
@@ -10,7 +10,7 @@ resource "cloudflare_healthcheck" "http_health_check" {
     "EEU"
   ]
   type = "HTTPS"
-  port = "443"
+  port = 443
   method = "GET"
   path = "/health"
   expected_body = "alive"
@@ -43,7 +43,7 @@ resource "cloudflare_healthcheck" "tcp_health_check" {
     "EEU"
   ]
   type = "TCP"
-  port = "22"
+  port = 22
   method = "connection_established"
   timeout = 10
   retries = 2


### PR DESCRIPTION
The type of `port` is a number but the example has it as strings