### PR TITLE
Fix `access_ca_certificate` import

### DIFF
--- a/.changelog/2539.txt
+++ b/.changelog/2539.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_access_ca_certificate: Fix issue with importing existing certificate as the application id was not being set.
+```

--- a/docs/resources/access_ca_certificate.md
+++ b/docs/resources/access_ca_certificate.md
@@ -59,8 +59,8 @@ Import is supported using the following syntax:
 
 ```shell
 # Account level CA certificate import.
-$ terraform import cloudflare_access_ca_certificate.example account/<account_id>/<certificate_id>
+$ terraform import cloudflare_access_ca_certificate.example account/<account_id>/<application_id>/<certificate_id>
 
 # Zone level CA certificate import.
-$ terraform import cloudflare_access_ca_certificate.example account/<zone_id>/<certificate_id>
+$ terraform import cloudflare_access_ca_certificate.example account/<zone_id>/<application_id>/<certificate_id>
 ```

--- a/examples/resources/cloudflare_access_ca_certificate/import.sh
+++ b/examples/resources/cloudflare_access_ca_certificate/import.sh
@@ -1,5 +1,5 @@
 # Account level CA certificate import.
-$ terraform import cloudflare_access_ca_certificate.example account/<account_id>/<certificate_id>
+$ terraform import cloudflare_access_ca_certificate.example account/<account_id>/<application_id>/<certificate_id>
 
 # Zone level CA certificate import.
-$ terraform import cloudflare_access_ca_certificate.example account/<zone_id>/<certificate_id>
+$ terraform import cloudflare_access_ca_certificate.example account/<zone_id>/<application_id>/<certificate_id>

--- a/internal/sdkv2provider/resource_cloudflare_access_ca_certificate.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_ca_certificate.go
@@ -116,13 +116,13 @@ func resourceCloudflareAccessCACertificateDelete(ctx context.Context, d *schema.
 }
 
 func resourceCloudflareAccessCACertificateImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	attributes := strings.SplitN(d.Id(), "/", 3)
+	attributes := strings.SplitN(d.Id(), "/", 4)
 
-	if len(attributes) != 3 {
-		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"account/accountID/accessCACertificateID\" or \"zone/zoneID/accessCACertificateID\"", d.Id())
+	if len(attributes) != 4 {
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"account/accountID/applicationID/accessCACertificateID\" or \"zone/zoneID/applicationID/accessCACertificateID\"", d.Id())
 	}
 
-	identifierType, identifierID, accessCACertificateID := attributes[0], attributes[1], attributes[2]
+	identifierType, identifierID, applicationID, accessCACertificateID := attributes[0], attributes[1], attributes[2], attributes[3]
 
 	if AccessIdentifierType(identifierType) != AccountType && AccessIdentifierType(identifierType) != ZoneType {
 		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"account/accountID/accessCACertificateID\" or \"zone/zoneID/accessCACertificateID\"", d.Id())
@@ -133,6 +133,7 @@ func resourceCloudflareAccessCACertificateImport(ctx context.Context, d *schema.
 	//lintignore:R001
 	d.Set(fmt.Sprintf("%s_id", identifierType), identifierID)
 	d.SetId(accessCACertificateID)
+	d.Set("application_id", applicationID)
 
 	readErr := resourceCloudflareAccessCACertificateRead(ctx, d, meta)
 	if readErr != nil {

--- a/internal/sdkv2provider/resource_cloudflare_access_ca_certificate.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_ca_certificate.go
@@ -125,7 +125,7 @@ func resourceCloudflareAccessCACertificateImport(ctx context.Context, d *schema.
 	identifierType, identifierID, applicationID, accessCACertificateID := attributes[0], attributes[1], attributes[2], attributes[3]
 
 	if AccessIdentifierType(identifierType) != AccountType && AccessIdentifierType(identifierType) != ZoneType {
-		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"account/accountID/accessCACertificateID\" or \"zone/zoneID/accessCACertificateID\"", d.Id())
+		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"account/accountID/applicationID/accessCACertificateID\" or \"zone/zoneID/applicationID/accessCACertificateID\"", d.Id())
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("Importing Cloudflare Access CA Certificate: id %s for %s %s", accessCACertificateID, identifierType, identifierID))

--- a/internal/sdkv2provider/resource_cloudflare_access_ca_certificate.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_ca_certificate.go
@@ -78,7 +78,7 @@ func resourceCloudflareAccessCACertificateRead(ctx context.Context, d *schema.Re
 		}
 		return diag.FromErr(fmt.Errorf("error finding Access CA Certificate %q: %w", d.Id(), err))
 	}
-
+	d.SetId(accessCACert.ID)
 	d.Set("aud", accessCACert.Aud)
 	d.Set("public_key", accessCACert.PublicKey)
 


### PR DESCRIPTION
Fixes importing access_ca_certifcates.

Reading an access application requires using the application ID
https://github.com/cloudflare/terraform-provider-cloudflare/blob/master/internal/sdkv2provider/resource_cloudflare_access_ca_certificate.go#L65-L70

This is not provided with the import as it only sets account ID and the access certificate ID
https://github.com/cloudflare/terraform-provider-cloudflare/blob/master/internal/sdkv2provider/resource_cloudflare_access_ca_certificate.go#L134-L135

It might be worth reconsidering how the IDs are handled with the `access_ca_certifcate` resource because the actual certificate ID is never used and only the application ID is.