### PR TITLE
Fix kind field in `http_request_dynamic_redirect` ruleset example

### DIFF
--- a/examples/resources/cloudflare_ruleset/resource.tf
+++ b/examples/resources/cloudflare_ruleset/resource.tf
@@ -324,7 +324,7 @@ resource "cloudflare_ruleset" "redirect_from_value_example" {
   zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
   name        = "redirects"
   description = "Redirect ruleset"
-  kind        = "root"
+  kind        = "zone"
   phase       = "http_request_dynamic_redirect"
 
   rules {


### PR DESCRIPTION
Using `root` as the kind of a `http_request_dynamic_redirect` rule gives the following error:
```
│ 'root' is not a valid value for kind because kind "root" cannot be used for
│ phase "http_request_dynamic_redirect" (20004)
```