### PR TITLE
fix test assertion for cloudflare_device_settings_policy

### DIFF
--- a/internal/sdkv2provider/resource_cloudflare_fallback_domain_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_fallback_domain_test.go
@@ -153,6 +153,7 @@ resource "cloudflare_device_settings_policy" "%[1]s" {
 	support_url               = "support_url"
 	switch_locked             = true
 	exclude_office_ips		  = false
+	description               = "%[1]s"
 }
 
 resource "cloudflare_fallback_domain" "%[1]s" {


### PR DESCRIPTION
fixes the following test failures

```
TF_ACC=1 go test ./internal/sdkv2provider -v -run "^TestAccCloudflareFallbackDomain_" -count 1 -timeout 120m -parallel 1
=== RUN   TestAccCloudflareFallbackDomain_Basic
--- PASS: TestAccCloudflareFallbackDomain_Basic (6.18s)
=== RUN   TestAccCloudflareFallbackDomain_DefaultPolicy
    resource_cloudflare_fallback_domain_test.go:60: Step 2/2 error: Error running pre-apply refresh: exit status 1
        
        Error: Missing required argument
        
          on terraform_plugin_test.tf line 2, in resource "cloudflare_device_settings_policy" "qzadlytelj":
           2: resource "cloudflare_device_settings_policy" "qzadlytelj" {
        
        The argument "description" is required, but no definition was found.
    testing_new.go:88: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: Missing required argument
        
          on terraform_plugin_test.tf line 2, in resource "cloudflare_device_settings_policy" "qzadlytelj":
           2: resource "cloudflare_device_settings_policy" "qzadlytelj" {
        
        The argument "description" is required, but no definition was found.
--- FAIL: TestAccCloudflareFallbackDomain_DefaultPolicy (7.32s)
=== RUN   TestAccCloudflareFallbackDomain_WithAttachedPolicy
    resource_cloudflare_fallback_domain_test.go:104: Step 1/1 error: Error running pre-apply refresh: exit status 1
        
        Error: Missing required argument
        
          on terraform_plugin_test.tf line 2, in resource "cloudflare_device_settings_policy" "rjthpmrkro":
           2: resource "cloudflare_device_settings_policy" "rjthpmrkro" {
        
        The argument "description" is required, but no definition was found.
--- FAIL: TestAccCloudflareFallbackDomain_WithAttachedPolicy (0.25s)
FAIL
FAIL	github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider	14.723s
FAIL
make: *** [testacc] Error 1
```

```
TF_ACC=1 go test ./internal/sdkv2provider -v -run "^TestAccCloudflareFallbackDomain_" -count 1 -timeout 120m -parallel 1
=== RUN   TestAccCloudflareFallbackDomain_Basic
--- PASS: TestAccCloudflareFallbackDomain_Basic (13.82s)
=== RUN   TestAccCloudflareFallbackDomain_DefaultPolicy
--- PASS: TestAccCloudflareFallbackDomain_DefaultPolicy (43.18s)
=== RUN   TestAccCloudflareFallbackDomain_WithAttachedPolicy
--- PASS: TestAccCloudflareFallbackDomain_WithAttachedPolicy (12.25s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider	70.246s
```