### PR TITLE
Fix detection of conflicting entrypoint rulesets

### DIFF
--- a/.changelog/2566.txt
+++ b/.changelog/2566.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: Fix detection of conflicting entrypoint rulesets
+```


### PR DESCRIPTION
There can only be a single entrypoint ruleset for each phase in an
account or zone. Therefore, we have a detection to perform some special
behavior when an entrypoint ruleset already exists.

This change fixes that detection to only apply to entrypoint rulesets,
as it was previously being performed for non-entrypoint rulesets too.
See the additional code comment in the commit for details on how this
detection is performed only on entrypoint rulesets.