### PR TITLE
Read load_balancer rules from API when importing

### DIFF
--- a/.changelog/2571.txt
+++ b/.changelog/2571.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_load_balancer: fix import of load_balancer when rules included overrides or fixed_response
+```

--- a/internal/sdkv2provider/resource_cloudflare_load_balancer.go
+++ b/internal/sdkv2provider/resource_cloudflare_load_balancer.go
@@ -301,6 +301,7 @@ func resourceCloudflareLoadBalancerRead(ctx context.Context, d *schema.ResourceD
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("failed to flatten rules: %w", err))
 		}
+
 		if err := d.Set("rules", fr); err != nil {
 			return diag.FromErr(fmt.Errorf("failed to set rules: %w\n %v", err, fr))
 		}
@@ -444,61 +445,49 @@ func flattenRules(rules []*cloudflare.LoadBalancerRule) ([]interface{}, error) {
 			m["fixed_response"] = []interface{}{m["fixed_response"]}
 		}
 		if m["overrides"] != nil {
-			if overrides, ok := m["overrides"].(map[string]interface{}); ok {
-				if overrides["pop_pools"] != nil {
-					overrides["pop_pools"] = flattenGeoPools(
-						r.Overrides.PoPPools,
-						"pop",
-						loadBalancerOverridesLocalPoolElems,
-					)
-				}
+			if overrides, ok := m["overrides"].(map[string]interface{}); ok && len(overrides) > 0 {
+				overrides["pop_pools"] = flattenGeoPools(
+					r.Overrides.PoPPools,
+					"pop",
+					loadBalancerOverridesLocalPoolElems,
+				)
 
-				if overrides["country_pools"] != nil {
-					overrides["country_pools"] = flattenGeoPools(
-						r.Overrides.CountryPools,
-						"country",
-						loadBalancerOverridesLocalPoolElems,
-					)
-				}
+				overrides["country_pools"] = flattenGeoPools(
+					r.Overrides.CountryPools,
+					"country",
+					loadBalancerOverridesLocalPoolElems,
+				)
 
-				if overrides["region_pools"] != nil {
-					overrides["region_pools"] = flattenGeoPools(
-						r.Overrides.RegionPools,
-						"region",
-						loadBalancerOverridesLocalPoolElems,
-					)
-				}
+				overrides["region_pools"] = flattenGeoPools(
+					r.Overrides.RegionPools,
+					"region",
+					loadBalancerOverridesLocalPoolElems,
+				)
 
-				if overrides["session_affinity_attributes"] != nil {
-					overrides["session_affinity_attributes"] = schema.NewSet(
-						schema.HashResource(loadBalancerOverridesSessionAffinityAttributesElem),
-						[]interface{}{overrides["session_affinity_attributes"]},
-					)
-				}
+				overrides["session_affinity_attributes"] = schema.NewSet(
+					schema.HashResource(loadBalancerOverridesSessionAffinityAttributesElem),
+					[]interface{}{overrides["session_affinity_attributes"]},
+				)
 
-				if overrides["adaptive_routing"] != nil {
-					overrides["adaptive_routing"] = schema.NewSet(
-						schema.HashResource(loadBalancerOverridesAdaptiveRoutingElem),
-						[]interface{}{overrides["adaptive_routing"]},
-					)
-				}
+				overrides["adaptive_routing"] = schema.NewSet(
+					schema.HashResource(loadBalancerOverridesAdaptiveRoutingElem),
+					[]interface{}{overrides["adaptive_routing"]},
+				)
 
-				if overrides["location_strategy"] != nil {
-					overrides["location_strategy"] = schema.NewSet(
-						schema.HashResource(loadBalancerOverridesLocationStrategyElem),
-						[]interface{}{overrides["location_strategy"]},
-					)
-				}
+				overrides["location_strategy"] = schema.NewSet(
+					schema.HashResource(loadBalancerOverridesLocationStrategyElem),
+					[]interface{}{overrides["location_strategy"]},
+				)
 
-				if overrides["random_steering"] != nil {
-					overrides["random_steering"] = schema.NewSet(
-						schema.HashResource(loadBalancerOverridesRandomSteeringElem),
-						[]interface{}{overrides["random_steering"]},
-					)
-				}
+				overrides["random_steering"] = schema.NewSet(
+					schema.HashResource(loadBalancerOverridesRandomSteeringElem),
+					[]interface{}{overrides["random_steering"]},
+				)
+
+				m["overrides"] = []interface{}{m["overrides"]}
+			} else {
+				m["overrides"] = []interface{}{}
 			}
-
-			m["overrides"] = []interface{}{m["overrides"]}
 		}
 
 		cfResources = append(cfResources, m)

--- a/internal/sdkv2provider/resource_cloudflare_load_balancer.go
+++ b/internal/sdkv2provider/resource_cloudflare_load_balancer.go
@@ -445,7 +445,7 @@ func flattenRules(rules []*cloudflare.LoadBalancerRule) ([]interface{}, error) {
 		}
 		if m["overrides"] != nil {
 			if overrides, ok := m["overrides"].(map[string]interface{}); ok {
-				if overrides["pool"] != nil {
+				if overrides["pop_pools"] != nil {
 					overrides["pop_pools"] = flattenGeoPools(
 						r.Overrides.PoPPools,
 						"pop",

--- a/internal/sdkv2provider/resource_cloudflare_load_balancer.go
+++ b/internal/sdkv2provider/resource_cloudflare_load_balancer.go
@@ -323,7 +323,7 @@ func resourceCloudflareLoadBalancerRead(ctx context.Context, d *schema.ResourceD
 		tflog.Warn(ctx, fmt.Sprintf("Error setting region_pools on load balancer %q: %s", d.Id(), err))
 	}
 
-	if loadBalancer.PersistenceTTL != 0 {
+	if _, sessionAffinityTTLOk := d.GetOk("session_affinity_ttl"); sessionAffinityTTLOk && loadBalancer.PersistenceTTL != 0 {
 		d.Set("session_affinity_ttl", loadBalancer.PersistenceTTL)
 	}
 

--- a/internal/sdkv2provider/resource_cloudflare_load_balancer_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_load_balancer_test.go
@@ -129,6 +129,15 @@ func TestAccCloudflareLoadBalancer_SessionAffinity(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccCloudflareLoadBalancer_SessionAffinityIPCookie(t *testing.T) {
+	t.Parallel()
+	var loadBalancer cloudflare.LoadBalancer
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := generateRandomResourceName()
+	name := "cloudflare_load_balancer." + rnd
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },


### PR DESCRIPTION
_Potential_ solution for: https://github.com/cloudflare/terraform-provider-cloudflare/issues/2561

I say _potential_ because its a complete overhaul of how _flattenRules_ works - perhaps an oversimplification in which I may have introduced regressions.

The solution reads the load balancer rules from the API response instead of the state. It shoves both: `overrides` and `fixed_response` into a slice (as the schema demands).

After a `terraform import `, printing the statefile includes the overrides:
```
{
  "version": 4,
  "terraform_version": "1.3.7",
  "serial": 108,
  "lineage": "904a1c69-8fe2-7aed-396d-3c1600de4b62",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "cloudflare_load_balancer",
      "name": "test",
      "provider": "provider[\"registry.terraform.io/cloudflare/cloudflare\"]",
      "instances": [
        {
          "schema_version": 1,
          "attributes": {
            "adaptive_routing": [],
            "country_pools": [],
            "created_on": "2023-06-30T14:27:21.847561Z",
            "default_pool_ids": [
              "93bf98cef7c19b43b6fee9c974ea1be7",
              "7a53d74dfc5369c6aee97ba2d0577316",
              "63b386189dc3806bbfab02ba8a42cc8c"
            ],
            "description": "",
            "enabled": true,
            "fallback_pool_id": "93bf98cef7c19b43b6fee9c974ea1be7",
            "id": "a6d1a90a10e74d80389a0a059a4577b1",
            "location_strategy": [],
            "modified_on": "2023-06-30T14:27:21.847561Z",
            "name": "testlb.apps.shopifystaging.com",
            "pop_pools": [],
            "proxied": true,
            "random_steering": [],
            "region_pools": [],
            "rules": [
              {
                "condition": "(http.request.uri.query contains \"east\")",
                "disabled": false,
                "fixed_response": [],
                "name": "east",
                "overrides": [
                  {
                    "adaptive_routing": [],
                    "country_pools": [],
                    "default_pools": [
                      "7a53d74dfc5369c6aee97ba2d0577316"
                    ],
                    "fallback_pool": "",
                    "location_strategy": [],
                    "pop_pools": [],
                    "random_steering": [],
                    "region_pools": [],
                    "session_affinity": "",
                    "session_affinity_attributes": [],
                    "session_affinity_ttl": 0,
                    "steering_policy": "",
                    "ttl": 0
                  }
                ],
                "priority": 0,
                "terminates": false
              },
              {
                "condition": "(http.request.uri.query contains \"central\")",
                "disabled": false,
                "fixed_response": [],
                "name": "central",
                "overrides": [
                  {
                    "adaptive_routing": [],
                    "country_pools": [],
                    "default_pools": [
                      "7a53d74dfc5369c6aee97ba2d0577316"
                    ],
                    "fallback_pool": "",
                    "location_strategy": [],
                    "pop_pools": [],
                    "random_steering": [],
                    "region_pools": [],
                    "session_affinity": "",
                    "session_affinity_attributes": [],
                    "session_affinity_ttl": 0,
                    "steering_policy": "",
                    "ttl": 0
                  }
                ],
                "priority": 10,
                "terminates": false
              }
            ],
            "session_affinity": "none",
            "session_affinity_attributes": [],
            "session_affinity_ttl": null,
            "steering_policy": "dynamic_latency",
            "ttl": 0,
            "zone_id": "1a1742e3ce58501dbca1be3d75d91a02"
          },
          "sensitive_attributes": [],
          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
        }
      ]
    }
  ],
  "check_results": null
}
```

I've tried modifying override rules via Cloudflare's dashboard and re-planning changes in terraform - terraform is able to detect the differences and propose a correct plan:
```
Terraform will perform the following actions:

  # cloudflare_load_balancer.test will be updated in-place
  ~ resource "cloudflare_load_balancer" "test" {
      ~ default_pool_ids = [
            "93bf98cef7c19b43b6fee9c974ea1be7",
          - "7a53d74dfc5369c6aee97ba2d0577316",
            "63b386189dc3806bbfab02ba8a42cc8c",
          + "7a53d74dfc5369c6aee97ba2d0577316",
        ]
        id               = "a6d1a90a10e74d80389a0a059a4577b1"
        name             = "testlb.apps.shopifystaging.com"
        # (9 unchanged attributes hidden)

      ~ rules {
            name       = "east"
            # (4 unchanged attributes hidden)

          ~ overrides {
              ~ default_pools        = [
                  - "7a53d74dfc5369c6aee97ba2d0577316",
                  + "63b386189dc3806bbfab02ba8a42cc8c",
                ]
                # (2 unchanged attributes hidden)
            }
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
``` 

Closes #2561