### PR TITLE
LB: Add Terraform import example for cloudflare_load_balancer_monitor

### DIFF
--- a/.changelog/2572.txt
+++ b/.changelog/2572.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_load_balancer_monitor: Add example import.
+```

--- a/docs/resources/load_balancer_monitor.md
+++ b/docs/resources/load_balancer_monitor.md
@@ -89,4 +89,10 @@ Required:
 - `header` (String) The header name.
 - `values` (Set of String) A list of values for the header.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+$ terraform import cloudflare_load_balancer_monitor.example <account_id>/<load_balancer_monitor_id>
+```

--- a/docs/resources/load_balancer_pool.md
+++ b/docs/resources/load_balancer_pool.md
@@ -126,5 +126,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-$ terraform import cloudflare_load_balancer_pool.example <account_id>/<load_balancer_poool_id>
+$ terraform import cloudflare_load_balancer_pool.example <account_id>/<load_balancer_pool_id>
 ```

--- a/examples/resources/cloudflare_load_balancer_monitor/import.sh
+++ b/examples/resources/cloudflare_load_balancer_monitor/import.sh
@@ -1,0 +1,1 @@
+$ terraform import cloudflare_load_balancer_monitor.example <account_id>/<load_balancer_monitor_id>

--- a/examples/resources/cloudflare_load_balancer_pool/import.sh
+++ b/examples/resources/cloudflare_load_balancer_pool/import.sh
@@ -1,1 +1,1 @@
-$ terraform import cloudflare_load_balancer_pool.example <account_id>/<load_balancer_poool_id>
+$ terraform import cloudflare_load_balancer_pool.example <account_id>/<load_balancer_pool_id>


### PR DESCRIPTION
`cloudflare_load_balancer_monitor` is missing a `terraform import` example: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/load_balancer_monitor

There are import examples for the other LB resources, such as [cloudflare_load_balancer ](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/load_balancer#import)and [cloudflare_load_balancer_pool](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/load_balancer_pool#import).

- also fix typo 'poool' to 'pool'

---

Note: I have not tested this change. Since I'm relatively new to Terraform, just want to double-check—are all of Cloudflare's terraform resources import-able? I noticed a few other examples were missing `import.sh`, such as`cloudflare_api*` and`cloudflare_email*` (and several others).