### PR TITLE
resource/cloudflare_api_token: remove `Import` handler

### DIFF
--- a/internal/sdkv2provider/resource_cloudflare_api_token.go
+++ b/internal/sdkv2provider/resource_cloudflare_api_token.go
@@ -21,9 +21,6 @@ func resourceCloudflareApiToken() *schema.Resource {
 		ReadContext:   resourceCloudflareApiTokenRead,
 		UpdateContext: resourceCloudflareApiTokenUpdate,
 		DeleteContext: resourceCloudflareApiTokenDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
 		Description: heredoc.Doc(`
 			Provides a resource which manages Cloudflare API tokens.
 


### PR DESCRIPTION
Once an API token is created, you only get the value once. After that point, it is not available so importing will not be usable for the majority of use cases. Instead, you should recreate the token.

Closes #2570