### PR TITLE
resource/cloudflare_tunnel_config: fix TunnelDuration order of magnitude

### DIFF
--- a/internal/sdkv2provider/resource_cloudflare_tunnel_config.go
+++ b/internal/sdkv2provider/resource_cloudflare_tunnel_config.go
@@ -36,15 +36,15 @@ func resourceCloudflareTunnelConfig() *schema.Resource {
 func buildTunnelOriginRequest(originRequest map[string]interface{}) (originConfig cloudflare.OriginRequestConfig) {
 	if v, ok := originRequest["connect_timeout"]; ok {
 		timeout, _ := time.ParseDuration(v.(string))
-		originConfig.ConnectTimeout = &cloudflare.TunnelDuration{Duration: timeout}
+		originConfig.ConnectTimeout = &cloudflare.TunnelDuration{Duration: timeout / time.Seconds}
 	}
 	if v, ok := originRequest["tls_timeout"]; ok {
 		timeout, _ := time.ParseDuration(v.(string))
-		originConfig.TLSTimeout = &cloudflare.TunnelDuration{Duration: timeout}
+		originConfig.TLSTimeout = &cloudflare.TunnelDuration{Duration: timeout / time.Seconds}
 	}
 	if v, ok := originRequest["tcp_keep_alive"]; ok {
 		timeout, _ := time.ParseDuration(v.(string))
-		originConfig.TCPKeepAlive = &cloudflare.TunnelDuration{Duration: timeout}
+		originConfig.TCPKeepAlive = &cloudflare.TunnelDuration{Duration: timeout / time.Seconds}
 	}
 	if v, ok := originRequest["no_happy_eyeballs"]; ok {
 		originConfig.NoHappyEyeballs = cloudflare.BoolPtr(v.(bool))
@@ -54,7 +54,7 @@ func buildTunnelOriginRequest(originRequest map[string]interface{}) (originConfi
 	}
 	if v, ok := originRequest["keep_alive_timeout"]; ok {
 		timeout, _ := time.ParseDuration(v.(string))
-		originConfig.KeepAliveTimeout = &cloudflare.TunnelDuration{Duration: timeout}
+		originConfig.KeepAliveTimeout = &cloudflare.TunnelDuration{Duration: timeout / time.Seconds}
 	}
 	if v, ok := originRequest["http_host_header"]; ok {
 		originConfig.HTTPHostHeader = cloudflare.StringPtr(v.(string))


### PR DESCRIPTION
> [_A TunnelDuration is a Duration that has custom serialization for JSON. JSON in Javascript assumes that int fields are 32 bits and Duration fields are deserialized assuming that numbers are in nanoseconds, which in 32bit integers limits to just 2 seconds. This type assumes that when serializing/deserializing from JSON, that the number is in seconds, while it maintains the YAML serde assumptions._](https://pkg.go.dev/github.com/cloudflare/cloudflare-go@v0.70.0#TunnelDuration)

### Workaround

```terraform
resource "cloudflare_tunnel_config" "example" {
  ...
  config {
    ...
    origin_request {
      # HACK: fix the default values
      connect_timeout = "30ns" # 30s
      keep_alive_timeout = "90ns" # 90s
      tcp_keep_alive = "30ns" # 30s
      tls_timeout = "10ns" # 10s
    }
  }
}
```