### PR TITLE
add sweepers to all framework resources

### DIFF
--- a/internal/framework/service/example/example_test.go
+++ b/internal/framework/service/example/example_test.go
@@ -1,5 +1,27 @@
 package example
 
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func init() {
+	resource.AddTestSweepers("cloudflare_turnstile_widget", &resource.Sweeper{
+		Name: "cloudflare_turnstile_widget",
+		F: func(region string) error {
+			// Clean up left over resources from either manually touching the UI
+			// or leaked test results.
+
+			return nil
+		},
+	})
+}
+
 // func TestAccExampleResource(t *testing.T) {
 // 	resource.Test(t, resource.TestCase{
 // 		PreCheck:                 func() { provider.TestAccPreCheck(t) },

--- a/internal/framework/service/r2_bucket/resource_test.go
+++ b/internal/framework/service/r2_bucket/resource_test.go
@@ -1,14 +1,49 @@
 package r2_bucket_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func init() {
+	resource.AddTestSweepers("cloudflare_r2_bucket", &resource.Sweeper{
+		Name: "cloudflare_r2_bucket",
+		F: func(region string) error {
+			client, err := acctest.SharedClient()
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+			if err != nil {
+				return fmt.Errorf("error establishing client: %w", err)
+			}
+
+			ctx := context.Background()
+			buckets, err := client.ListR2Buckets(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListR2BucketsParams{})
+			if err != nil {
+				return fmt.Errorf("failed to fetch R2 buckets: %w", err)
+			}
+
+			for _, bucket := range buckets {
+				err := client.DeleteR2Bucket(ctx, cloudflare.AccountIdentifier(accountID), bucket.Name)
+				if err != nil {
+					return fmt.Errorf("failed to delete R2 bucket %q: %w", bucket.Name, err)
+				}
+			}
+
+			return nil
+		},
+	})
+}
 
 func TestAccCloudflareR2Bucket_Basic(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()


### PR DESCRIPTION
Each resource needs a `TestMain` to handle the `sweep` flag.

Adds a sweeper for all `framework` resources.