### PR TITLE
Remove a old syntax for rules.action_parameters.overrides.categories

### DIFF
--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -73,13 +73,13 @@ resource "cloudflare_ruleset" "zone_level_managed_waf_with_category_based_overri
         categories {
           category = "wordpress"
           action   = "block"
-          status   = "enabled"
+          enabled  = true
         }
 
         categories {
           category = "joomla"
           action   = "block"
-          status   = "enabled"
+          enabled  = true
         }
       }
     }

--- a/examples/resources/cloudflare_ruleset/resource.tf
+++ b/examples/resources/cloudflare_ruleset/resource.tf
@@ -48,13 +48,13 @@ resource "cloudflare_ruleset" "zone_level_managed_waf_with_category_based_overri
         categories {
           category = "wordpress"
           action   = "block"
-          status   = "enabled"
+          enabled  = true
         }
 
         categories {
           category = "joomla"
           action   = "block"
-          status   = "enabled"
+          enabled  = true
         }
       }
     }


### PR DESCRIPTION
Currently rules.action_parameters.overrides.categories accepts `enabled` field to define enable or disable the override, but the document has a old syntax that express we should use `status` field 