### PR TITLE
resource/cloudflare_ruleset: update internal references and methods to match cloudflare-go bump

### DIFF
--- a/internal/framework/service/rulesets/resource_test.go
+++ b/internal/framework/service/rulesets/resource_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -30,24 +31,24 @@ func init() {
 			}
 
 			ctx := context.Background()
-			accountRulesets, err := client.ListAccountRulesets(ctx, accountID)
+			accountRulesets, err := client.ListRulesets(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListRulesetsParams{})
 			if err != nil {
 				return fmt.Errorf("failed to fetch rulesets: %w", err)
 			}
 
 			for _, ruleset := range accountRulesets {
 				if ruleset.Kind != "managed" {
-					err := client.DeleteAccountRuleset(ctx, accountID, ruleset.ID)
+					err := client.DeleteRuleset(ctx, cloudflare.AccountIdentifier(accountID), ruleset.ID)
 					if err != nil {
 						return fmt.Errorf("failed to delete ruleset %q: %w", ruleset.ID, err)
 					}
 				}
 			}
 
-			zoneRulesets, _ := client.ListZoneRulesets(ctx, zoneID)
+			zoneRulesets, _ := client.ListRulesets(ctx, cloudflare.AccountIdentifier(zoneID), cloudflare.ListRulesetsParams{})
 			for _, ruleset := range zoneRulesets {
 				if ruleset.Kind != "managed" {
-					err := client.DeleteZoneRuleset(ctx, zoneID, ruleset.ID)
+					err := client.DeleteRuleset(ctx, cloudflare.AccountIdentifier(zoneID), ruleset.ID)
 					if err != nil {
 						return fmt.Errorf("failed to delete ruleset %q: %w", ruleset.ID, err)
 					}

--- a/internal/sdkv2provider/data_source_rulesets.go
+++ b/internal/sdkv2provider/data_source_rulesets.go
@@ -1119,12 +1119,14 @@ func dataSourceCloudflareRulesetsRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	var rulesetsList []cloudflare.Ruleset
+	var identifier *cloudflare.ResourceContainer
 	if accountID != "" {
-		rulesetsList, err = client.ListAccountRulesets(ctx, accountID)
+		identifier = cloudflare.AccountIdentifier(accountID)
 	} else {
-		rulesetsList, err = client.ListZoneRulesets(ctx, zoneID)
+		identifier = cloudflare.ZoneIdentifier(zoneID)
 	}
+
+	rulesetsList, err := client.ListRulesets(ctx, identifier, cloudflare.ListRulesetsParams{})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -1159,12 +1161,7 @@ func dataSourceCloudflareRulesetsRead(ctx context.Context, d *schema.ResourceDat
 		}
 
 		if includeRules {
-			var fullRuleset cloudflare.Ruleset
-			if accountID != "" {
-				fullRuleset, err = client.GetAccountRuleset(ctx, accountID, ruleset.ID)
-			} else {
-				fullRuleset, err = client.GetZoneRuleset(ctx, zoneID, ruleset.ID)
-			}
+			fullRuleset, err := client.GetRuleset(ctx, identifier, ruleset.ID)
 			if err != nil {
 				return diag.FromErr(err)
 			}


### PR DESCRIPTION
acceptance tests all passing with `cloudflare-go@master` shimmed in 

```
TF_ACC=1 go test ./internal/framework/service/rulesets -v -count 1 -run ^TestAccCloudflareRuleset_ -timeout 120m -parallel 1
=== RUN   TestAccCloudflareRuleset_WAFBasic
--- PASS: TestAccCloudflareRuleset_WAFBasic (5.38s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRuleset
--- PASS: TestAccCloudflareRuleset_WAFManagedRuleset (4.19s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetWithoutDescription
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetWithoutDescription (4.19s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetOWASP
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetOWASP (4.11s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetOWASPBlockXSSWithAnomalyOver60
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetOWASPBlockXSSWithAnomalyOver60 (5.24s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetOWASPOnlyPL1
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetOWASPOnlyPL1 (4.45s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetDeployMultiple
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetDeployMultiple (5.86s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithSkip
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithSkip (6.83s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithTopSkipAndLastSkip
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithTopSkipAndLastSkip (6.68s)
=== RUN   TestAccCloudflareRuleset_SkipPhaseAndProducts
--- PASS: TestAccCloudflareRuleset_SkipPhaseAndProducts (11.57s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetWithCategoryAndRuleBasedOverrides
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetWithCategoryAndRuleBasedOverrides (4.36s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetWithIDBasedOverrides
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetWithIDBasedOverrides (10.61s)
=== RUN   TestAccCloudflareRuleset_MagicTransitUpdateWithHigherPriority
    acctest.go:76: Skipping acceptance test for default account (f037e56e89293a057740de681ac9abbe). Default account is not configured for Magic Transit.
--- SKIP: TestAccCloudflareRuleset_MagicTransitUpdateWithHigherPriority (0.00s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetWithPayloadLogging
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetWithPayloadLogging (4.10s)
=== RUN   TestAccCloudflareRuleset_RateLimit
--- PASS: TestAccCloudflareRuleset_RateLimit (4.94s)
=== RUN   TestAccCloudflareRuleset_RateLimitScorePerPeriod
--- PASS: TestAccCloudflareRuleset_RateLimitScorePerPeriod (4.51s)
=== RUN   TestAccCloudflareRuleset_PreserveRuleRefs
--- PASS: TestAccCloudflareRuleset_PreserveRuleRefs (38.04s)
=== RUN   TestAccCloudflareRuleset_CustomErrors
--- PASS: TestAccCloudflareRuleset_CustomErrors (3.91s)
=== RUN   TestAccCloudflareRuleset_RequestOrigin
--- PASS: TestAccCloudflareRuleset_RequestOrigin (3.88s)
=== RUN   TestAccCloudflareRuleset_TransformationRuleURIPath
--- PASS: TestAccCloudflareRuleset_TransformationRuleURIPath (4.20s)
=== RUN   TestAccCloudflareRuleset_TransformationRuleURIQuery
--- PASS: TestAccCloudflareRuleset_TransformationRuleURIQuery (4.02s)
=== RUN   TestAccCloudflareRuleset_TransformationRuleURIPathAndQueryCombination
--- PASS: TestAccCloudflareRuleset_TransformationRuleURIPathAndQueryCombination (4.13s)
=== RUN   TestAccCloudflareRuleset_TransformationRuleRequestHeaders
--- PASS: TestAccCloudflareRuleset_TransformationRuleRequestHeaders (4.30s)
=== RUN   TestAccCloudflareRuleset_TransformationRuleResponseHeaders
--- PASS: TestAccCloudflareRuleset_TransformationRuleResponseHeaders (4.46s)
=== RUN   TestAccCloudflareRuleset_ResponseCompression
--- PASS: TestAccCloudflareRuleset_ResponseCompression (3.94s)
=== RUN   TestAccCloudflareRuleset_ActionParametersMultipleSkips
--- PASS: TestAccCloudflareRuleset_ActionParametersMultipleSkips (5.64s)
=== RUN   TestAccCloudflareRuleset_ActionParametersOverridesAction
--- PASS: TestAccCloudflareRuleset_ActionParametersOverridesAction (4.26s)
=== RUN   TestAccCloudflareRuleset_ActionParametersHTTPDDoSOverride
--- PASS: TestAccCloudflareRuleset_ActionParametersHTTPDDoSOverride (4.26s)
=== RUN   TestAccCloudflareRuleset_ActionParametersOverrideAllRulesetRules
--- PASS: TestAccCloudflareRuleset_ActionParametersOverrideAllRulesetRules (4.10s)
=== RUN   TestAccCloudflareRuleset_AccountLevelCustomWAFRule
--- PASS: TestAccCloudflareRuleset_AccountLevelCustomWAFRule (5.86s)
=== RUN   TestAccCloudflareRuleset_ExposedCredentialCheck
--- PASS: TestAccCloudflareRuleset_ExposedCredentialCheck (3.22s)
=== RUN   TestAccCloudflareRuleset_Logging
--- PASS: TestAccCloudflareRuleset_Logging (3.82s)
=== RUN   TestAccCloudflareRuleset_ConditionallySetActionParameterVersion
--- PASS: TestAccCloudflareRuleset_ConditionallySetActionParameterVersion (7.99s)
=== RUN   TestAccCloudflareRuleset_WAFManagedRulesetWithActionManagedChallenge
--- PASS: TestAccCloudflareRuleset_WAFManagedRulesetWithActionManagedChallenge (9.20s)
=== RUN   TestAccCloudflareRuleset_LogCustomField
--- PASS: TestAccCloudflareRuleset_LogCustomField (3.91s)
=== RUN   TestAccCloudflareRuleset_ActionParametersOverridesThrashingStatus
--- PASS: TestAccCloudflareRuleset_ActionParametersOverridesThrashingStatus (24.13s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsAllEnabled
--- PASS: TestAccCloudflareRuleset_CacheSettingsAllEnabled (5.39s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsOptionalsEmpty
--- PASS: TestAccCloudflareRuleset_CacheSettingsOptionalsEmpty (6.60s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsEdgeTTLRespectOrigin
--- PASS: TestAccCloudflareRuleset_CacheSettingsEdgeTTLRespectOrigin (4.41s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsNoCacheForStatus
--- PASS: TestAccCloudflareRuleset_CacheSettingsNoCacheForStatus (4.21s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsStatusRangeGreaterThan
--- PASS: TestAccCloudflareRuleset_CacheSettingsStatusRangeGreaterThan (4.41s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsStatusRangeLessThan
--- PASS: TestAccCloudflareRuleset_CacheSettingsStatusRangeLessThan (4.53s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsFalse
--- PASS: TestAccCloudflareRuleset_CacheSettingsFalse (4.17s)
=== RUN   TestAccCloudflareRuleset_Config
--- PASS: TestAccCloudflareRuleset_Config (4.29s)
=== RUN   TestAccCloudflareRuleset_Redirect
--- PASS: TestAccCloudflareRuleset_Redirect (5.80s)
=== RUN   TestAccCloudflareRuleset_DynamicRedirect
--- PASS: TestAccCloudflareRuleset_DynamicRedirect (4.36s)
=== RUN   TestAccCloudflareRuleset_DynamicRedirectWithoutPreservingQueryString
--- PASS: TestAccCloudflareRuleset_DynamicRedirectWithoutPreservingQueryString (4.14s)
=== RUN   TestAccCloudflareRuleset_TransformationRuleURIStripOffQueryString
--- PASS: TestAccCloudflareRuleset_TransformationRuleURIStripOffQueryString (3.97s)
=== RUN   TestAccCloudflareRuleset_TransformationRuleURIStripOffPath
--- PASS: TestAccCloudflareRuleset_TransformationRuleURIStripOffPath (4.19s)
=== RUN   TestAccCloudflareRuleset_ConfigSingleFalseyValue
--- PASS: TestAccCloudflareRuleset_ConfigSingleFalseyValue (3.95s)
=== RUN   TestAccCloudflareRuleset_ConfigConflictingCacheByDevice
--- PASS: TestAccCloudflareRuleset_ConfigConflictingCacheByDevice (0.35s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsMissingEdgeTTLWithOverrideOrigin
--- PASS: TestAccCloudflareRuleset_CacheSettingsMissingEdgeTTLWithOverrideOrigin (0.32s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsMissingBrowserTTLWithOverrideOrigin
--- PASS: TestAccCloudflareRuleset_CacheSettingsMissingBrowserTTLWithOverrideOrigin (0.35s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsInvalidEdgeTTLWithOverrideOrigin
--- PASS: TestAccCloudflareRuleset_CacheSettingsInvalidEdgeTTLWithOverrideOrigin (0.34s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsInvalidBrowserTTLWithOverrideOrigin
--- PASS: TestAccCloudflareRuleset_CacheSettingsInvalidBrowserTTLWithOverrideOrigin (0.28s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsDefinedQueryStringExcludeKeys
--- PASS: TestAccCloudflareRuleset_CacheSettingsDefinedQueryStringExcludeKeys (4.40s)
=== RUN   TestAccCloudflareRuleset_CacheSettingsDefinedQueryStringIncludeKeys
--- PASS: TestAccCloudflareRuleset_CacheSettingsDefinedQueryStringIncludeKeys (4.31s)
=== RUN   TestAccCloudflareRuleset_ImportHandlesMissingValues
--- PASS: TestAccCloudflareRuleset_ImportHandlesMissingValues (0.45s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/framework/service/rulesets	310.123s
```

Depends on cloudflare/cloudflare-go#1333