### PR TITLE
Set the default value for the cache_key.exclude_origin setting to false

### DIFF
--- a/.changelog/2623.txt
+++ b/.changelog/2623.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resrouce/cloudflare_ruleset: Resolves bug with exclude_origin always being false by default
+```

--- a/internal/framework/service/rulesets/resource.go
+++ b/internal/framework/service/rulesets/resource.go
@@ -540,10 +540,17 @@ func toRulesetResourceModel(ctx context.Context, zoneID, accountID basetypes.Str
 						include, _ := basetypes.NewSetValueFrom(ctx, types.StringType, ruleResponse.ActionParameters.CacheKey.CustomKey.Header.Include)
 						checkPresence, _ := basetypes.NewSetValueFrom(ctx, types.StringType, ruleResponse.ActionParameters.CacheKey.CustomKey.Header.CheckPresence)
 						if len(include.Elements()) > 0 || len(checkPresence.Elements()) > 0 {
+							var excludeOrigin types.Bool
+							if !reflect.ValueOf(ruleResponse.ActionParameters.CacheKey.CustomKey.Header.ExcludeOrigin).IsNil() {
+								excludeOrigin = flatteners.Bool(ruleResponse.ActionParameters.CacheKey.CustomKey.Header.ExcludeOrigin)
+							} else {
+								excludeOrigin = types.BoolNull()
+							}
+
 							key.Header = []*ActionParameterCacheKeyCustomKeyHeaderModel{{
 								Include:       include,
 								CheckPresence: checkPresence,
-								ExcludeOrigin: flatteners.Bool(ruleResponse.ActionParameters.CacheKey.CustomKey.Header.ExcludeOrigin),
+								ExcludeOrigin: excludeOrigin,
 							}}
 						}
 					}

--- a/internal/framework/service/rulesets/resource_test.go
+++ b/internal/framework/service/rulesets/resource_test.go
@@ -2310,7 +2310,6 @@ func TestAccCloudflareRuleset_CacheSettingsDefinedQueryStringExcludeKeys(t *test
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.edge_ttl.0.default", "7200"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.query_string.0.exclude.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.query_string.0.exclude.0", "example"),
-					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "false"),
 				),
 			},
 		},
@@ -2341,7 +2340,76 @@ func TestAccCloudflareRuleset_CacheSettingsDefinedQueryStringIncludeKeys(t *test
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.edge_ttl.0.default", "7200"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.query_string.0.include.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.query_string.0.include.0", "another_example"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_CacheSettingsHandleDefaultHeaderExcludeOrigin(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareRulesetCacheSettingsHandleDefaultHeaderExcludeOrigin(rnd, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "set cache settings for the request"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_cache_settings"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "set_cache_settings"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "example"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.edge_ttl.0.mode", "override_origin"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.edge_ttl.0.default", "7200"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.check_presence.0", "x-forwarded-for"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.0", "x-test"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.1", "x-test2"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "false"),
+				),
+			},
+			{
+				Config: testAccCloudflareRulesetCacheSettingsHandleHeaderExcludeOriginFalse(rnd, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "set cache settings for the request"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_cache_settings"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "set_cache_settings"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "example"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.edge_ttl.0.mode", "override_origin"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.edge_ttl.0.default", "7200"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.check_presence.0", "x-forwarded-for"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.0", "x-test"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.1", "x-test2"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "false"),
+				),
+			},
+			{
+				Config: testAccCloudflareRulesetCacheSettingsHandleHeaderExcludeOriginSet(rnd, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "set cache settings for the request"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_cache_settings"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "set_cache_settings"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "example"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.edge_ttl.0.mode", "override_origin"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.edge_ttl.0.default", "7200"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.check_presence.0", "x-forwarded-for"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.0", "x-test"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.1", "x-test2"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "true"),
 				),
 			},
 		},
@@ -4324,7 +4392,7 @@ func testAccCloudflareRulesetConfigConflictingCacheByDeviceConfigs(rnd, zoneID s
 
 func testAccCloudflareRulesetCacheSettingsExplicitCustomKeyCacheKeysQueryStringsExclude(rnd, zoneID string) string {
 	return fmt.Sprintf(`
-	resource "cloudflare_ruleset" "cache_settings_example" {
+	resource "cloudflare_ruleset" "%[1]s" {
 		zone_id     = "%[2]s"
     	name        = "%[1]s"
 		description = "set cache settings for the request"
@@ -4357,7 +4425,7 @@ func testAccCloudflareRulesetCacheSettingsExplicitCustomKeyCacheKeysQueryStrings
 
 func testAccCloudflareRulesetCacheSettingsExplicitCustomKeyCacheKeysQueryStringsInclude(rnd, zoneID string) string {
 	return fmt.Sprintf(`
-	resource "cloudflare_ruleset" "cache_settings_example" {
+	resource "cloudflare_ruleset" "%[1]s" {
 		zone_id     = "%[2]s"
     	name        = "%[1]s"
 		description = "set cache settings for the request"
@@ -4381,6 +4449,107 @@ func testAccCloudflareRulesetCacheSettingsExplicitCustomKeyCacheKeysQueryStrings
 				  include = ["another_example"]
 				}
 			  }
+			}
+		  }
+		}
+	  }
+	`, rnd, zoneID)
+}
+
+func testAccCloudflareRulesetCacheSettingsHandleDefaultHeaderExcludeOrigin(rnd, zoneID string) string {
+	return fmt.Sprintf(`
+	resource "cloudflare_ruleset" "%[1]s" {
+		zone_id     = "%[2]s"
+    	name        = "%[1]s"
+		description = "set cache settings for the request"
+		kind        = "zone"
+		phase       = "http_request_cache_settings"
+		rules {
+		  action      = "set_cache_settings"
+		  description = "example"
+		  enabled     = true
+		  expression  = "(http.host eq \"example.com\" and starts_with(http.request.uri.path, \"/example\"))"
+		  action_parameters {
+			cache = true
+			edge_ttl {
+			  mode    = "override_origin"
+			  default = 7200
+			}
+			cache_key {
+			  custom_key {
+				  header {
+					check_presence = ["x-forwarded-for"]
+					include        = ["x-test", "x-test2"]
+				  }
+		      }
+			}
+		  }
+		}
+	  }
+	`, rnd, zoneID)
+}
+
+func testAccCloudflareRulesetCacheSettingsHandleHeaderExcludeOriginSet(rnd, zoneID string) string {
+	return fmt.Sprintf(`
+	resource "cloudflare_ruleset" "%[1]s" {
+		zone_id     = "%[2]s"
+    	name        = "%[1]s"
+		description = "set cache settings for the request"
+		kind        = "zone"
+		phase       = "http_request_cache_settings"
+		rules {
+		  action      = "set_cache_settings"
+		  description = "example"
+		  enabled     = true
+		  expression  = "(http.host eq \"example.com\" and starts_with(http.request.uri.path, \"/example\"))"
+		  action_parameters {
+			cache = true
+			edge_ttl {
+			  mode    = "override_origin"
+			  default = 7200
+			}
+			cache_key {
+			  custom_key {
+				  header {
+					check_presence = ["x-forwarded-for"]
+					include        = ["x-test", "x-test2"]
+					exclude_origin = true
+				  }
+		      }
+			}
+		  }
+		}
+	  }
+	`, rnd, zoneID)
+}
+
+func testAccCloudflareRulesetCacheSettingsHandleHeaderExcludeOriginFalse(rnd, zoneID string) string {
+	return fmt.Sprintf(`
+	resource "cloudflare_ruleset" "%[1]s" {
+		zone_id     = "%[2]s"
+    	name        = "%[1]s"
+		description = "set cache settings for the request"
+		kind        = "zone"
+		phase       = "http_request_cache_settings"
+		rules {
+		  action      = "set_cache_settings"
+		  description = "example"
+		  enabled     = true
+		  expression  = "(http.host eq \"example.com\" and starts_with(http.request.uri.path, \"/example\"))"
+		  action_parameters {
+			cache = true
+			edge_ttl {
+			  mode    = "override_origin"
+			  default = 7200
+			}
+			cache_key {
+			  custom_key {
+				  header {
+					check_presence = ["x-forwarded-for"]
+					include        = ["x-test", "x-test2"]
+					exclude_origin = false
+				  }
+		      }
 			}
 		  }
 		}

--- a/internal/framework/service/rulesets/resource_test.go
+++ b/internal/framework/service/rulesets/resource_test.go
@@ -2289,6 +2289,7 @@ func TestAccCloudflareRuleset_CacheSettingsInvalidBrowserTTLWithOverrideOrigin(t
 func TestAccCloudflareRuleset_CacheSettingsDefinedQueryStringExcludeKeys(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	resourceName := "cloudflare_ruleset." + rnd
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
@@ -2296,6 +2297,21 @@ func TestAccCloudflareRuleset_CacheSettingsDefinedQueryStringExcludeKeys(t *test
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudflareRulesetCacheSettingsExplicitCustomKeyCacheKeysQueryStringsExclude(rnd, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "set cache settings for the request"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_cache_settings"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "set_cache_settings"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "example"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.edge_ttl.0.mode", "override_origin"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.edge_ttl.0.default", "7200"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.query_string.0.exclude.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.query_string.0.exclude.0", "example"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "false"),
+				),
 			},
 		},
 	})
@@ -2304,6 +2320,7 @@ func TestAccCloudflareRuleset_CacheSettingsDefinedQueryStringExcludeKeys(t *test
 func TestAccCloudflareRuleset_CacheSettingsDefinedQueryStringIncludeKeys(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	resourceName := "cloudflare_ruleset." + rnd
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
@@ -2311,6 +2328,21 @@ func TestAccCloudflareRuleset_CacheSettingsDefinedQueryStringIncludeKeys(t *test
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudflareRulesetCacheSettingsExplicitCustomKeyCacheKeysQueryStringsInclude(rnd, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "set cache settings for the request"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_cache_settings"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "set_cache_settings"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "example"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.edge_ttl.0.mode", "override_origin"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.edge_ttl.0.default", "7200"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.query_string.0.include.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.query_string.0.include.0", "another_example"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "false"),
+				),
 			},
 		},
 	})
@@ -4294,7 +4326,7 @@ func testAccCloudflareRulesetCacheSettingsExplicitCustomKeyCacheKeysQueryStrings
 	return fmt.Sprintf(`
 	resource "cloudflare_ruleset" "cache_settings_example" {
 		zone_id     = "%[2]s"
-    name        = "%[1]s"
+    	name        = "%[1]s"
 		description = "set cache settings for the request"
 		kind        = "zone"
 		phase       = "http_request_cache_settings"
@@ -4327,7 +4359,7 @@ func testAccCloudflareRulesetCacheSettingsExplicitCustomKeyCacheKeysQueryStrings
 	return fmt.Sprintf(`
 	resource "cloudflare_ruleset" "cache_settings_example" {
 		zone_id     = "%[2]s"
-    name        = "%[1]s"
+    	name        = "%[1]s"
 		description = "set cache settings for the request"
 		kind        = "zone"
 		phase       = "http_request_cache_settings"

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -621,8 +621,12 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 																			MarkdownDescription: "List of headers to check for presence in the custom key.",
 																		},
 																		"exclude_origin": schema.BoolAttribute{
+																			Computed:            true,
 																			Optional:            true,
 																			MarkdownDescription: "Exclude the origin header from the custom key.",
+																			PlanModifiers: []planmodifier.Bool{
+																				defaults.DefaultBool(false),
+																			},
 																		},
 																	},
 																},


### PR DESCRIPTION
The API response by default will return a value for false for the exclude_origin value in the custom cache key setting. This adjusts the default value for the schema to be false to account for this behavior from the API. An extension to the tests was added to ensure backwards compatibility in cases where exclude_origin was not set for the cache key mechanisms.

Closes #2612