### PR TITLE
fixed LoadBalancing random_steering values not always being set correctly

### DIFF
--- a/.changelog/2635.txt
+++ b/.changelog/2635.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_load_balancer: handle inconsistent sorting bug in `schema.HashResource` resulting in resources incorrectly being updated when no changes have been made
+```

--- a/internal/sdkv2provider/resource_cloudflare_load_balancer.go
+++ b/internal/sdkv2provider/resource_cloudflare_load_balancer.go
@@ -746,22 +746,29 @@ func expandLocationStrategy(set interface{}) *cloudflare.LocationStrategy {
 }
 
 func expandRandomSteering(set interface{}) *cloudflare.RandomSteering {
-	var cfRandomSteering cloudflare.RandomSteering
 
-	if l := set.(*schema.Set).List(); len(l) > 0 {
-		for k, v := range l[len(l)-1].(map[string]interface{}) {
+	for _, l := range set.(*schema.Set).List() {
+		var cfRandomSteering cloudflare.RandomSteering
+		for k, v := range l.(map[string]interface{}) {
 			switch k {
 			case "pool_weights":
 				poolWeights := make(map[string]float64)
 				for poolID, poolWeight := range v.(map[string]interface{}) {
 					poolWeights[poolID] = poolWeight.(float64)
 				}
-				cfRandomSteering.PoolWeights = poolWeights
+				if len(poolWeights) > 0 {
+					cfRandomSteering.PoolWeights = poolWeights
+				}
 			case "default_weight":
 				cfRandomSteering.DefaultWeight = v.(float64)
 			}
 		}
+
+		// only return a non nil value if something was set
+		if cfRandomSteering.DefaultWeight != 0 || cfRandomSteering.PoolWeights != nil {
+			return &cfRandomSteering
+		}
 	}
 
-	return &cfRandomSteering
+	return nil
 }


### PR DESCRIPTION
adjusted expandRandomSteering to only return a value when a non default value has been set into the random_steering set. Empty sets should not be expanded and sent back up.