### PR TITLE
Stop customhostnames from waiting for SSL if it's already active

### DIFF
--- a/.changelog/2638.txt
+++ b/.changelog/2638.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_custom_hostname: Fix customhostnames from waiting for SSL with `wait_for_ssl_pending_validation` if SSL status is `active`
+```

--- a/.changelog/2638.txt
+++ b/.changelog/2638.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/cloudflare_custom_hostname: Fix customhostnames from waiting for SSL with `wait_for_ssl_pending_validation` if SSL status is `active`
+resource/cloudflare_custom_hostname: prevent infinite loop when `wait_for_ssl_pending_validation` is set if SSL status is already `active`
 ```

--- a/internal/sdkv2provider/resource_cloudflare_custom_hostname.go
+++ b/internal/sdkv2provider/resource_cloudflare_custom_hostname.go
@@ -165,7 +165,7 @@ func resourceCloudflareCustomHostnameCreate(ctx context.Context, d *schema.Resou
 			if err != nil {
 				return retry.NonRetryableError(errors.Wrap(err, "failed to fetch custom hostname"))
 			}
-			if customHostname.SSL != nil && customHostname.SSL.Status != "pending_validation" {
+			if customHostname.SSL != nil && customHostname.SSL.Status != "pending_validation" && customHostname.SSL.Status != "active" {
 				return retry.RetryableError(fmt.Errorf("hostname ssl sub-object is not yet in pending_validation status"))
 			}
 			return nil

--- a/internal/sdkv2provider/resource_cloudflare_custom_hostname.go
+++ b/internal/sdkv2provider/resource_cloudflare_custom_hostname.go
@@ -165,9 +165,15 @@ func resourceCloudflareCustomHostnameCreate(ctx context.Context, d *schema.Resou
 			if err != nil {
 				return retry.NonRetryableError(errors.Wrap(err, "failed to fetch custom hostname"))
 			}
-			if customHostname.SSL != nil && customHostname.SSL.Status != "pending_validation" && customHostname.SSL.Status != "active" {
+
+			if customHostname.SSL.Status == "active" {
+				return nil
+			}
+
+			if customHostname.SSL != nil && customHostname.SSL.Status != "pending_validation" {
 				return retry.RetryableError(fmt.Errorf("hostname ssl sub-object is not yet in pending_validation status"))
 			}
+
 			return nil
 		})
 		if err != nil {


### PR DESCRIPTION
This can happen if you are supplying a custom certificate.

The hostname will go active in SSL and never go pending. Resulting in the provider waiting forever.