### PR TITLE
Allow full deletion of pop_pools, country_pools, region_pools on load balancer updates

### DIFF
--- a/.changelog/2673.txt
+++ b/.changelog/2673.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_load_balancer: fix full deletion of pop_pools, region_pools, country_pools on update
+```

--- a/internal/sdkv2provider/resource_cloudflare_load_balancer_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_load_balancer_test.go
@@ -322,6 +322,53 @@ func TestAccCloudflareLoadBalancer_RandomSteering(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareLoadBalancer_GeoBalancedUpdate(t *testing.T) {
+	t.Parallel()
+	var loadBalancer cloudflare.LoadBalancer
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := generateRandomResourceName()
+	name := "cloudflare_load_balancer." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCloudflareLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareLoadBalancerConfigGeoBalancedPoPCountry(zoneID, zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudflareLoadBalancerIDIsValid(name, zoneID),
+					// checking our overrides of default values worked
+					resource.TestCheckResourceAttr(name, "description", "tf-acctest load balancer using pop/country geo-balancing"),
+					resource.TestCheckResourceAttr(name, "proxied", "true"),
+					resource.TestCheckResourceAttr(name, "ttl", "0"),
+					resource.TestCheckResourceAttr(name, "steering_policy", "geo"),
+					resource.TestCheckResourceAttr(name, "pop_pools.#", "1"),
+					resource.TestCheckResourceAttr(name, "country_pools.#", "1"),
+					resource.TestCheckResourceAttr(name, "region_pools.#", "0"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareLoadBalancerConfigGeoBalancedPoPCountryToRegionUpdate(zoneID, zone, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareLoadBalancerExists(name, &loadBalancer),
+					testAccCheckCloudflareLoadBalancerIDIsValid(name, zoneID),
+					// checking our updates to geo steering with only a region defined worked
+					resource.TestCheckResourceAttr(name, "description", "tf-acctest load balancer using pop/country geo-balancing updated to region geo-balancing"),
+					resource.TestCheckResourceAttr(name, "proxied", "true"),
+					resource.TestCheckResourceAttr(name, "ttl", "0"),
+					resource.TestCheckResourceAttr(name, "steering_policy", "geo"),
+					resource.TestCheckResourceAttr(name, "pop_pools.#", "0"),
+					resource.TestCheckResourceAttr(name, "country_pools.#", "0"),
+					resource.TestCheckResourceAttr(name, "region_pools.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudflareLoadBalancer_GeoBalanced(t *testing.T) {
 	t.Parallel()
 	var loadBalancer cloudflare.LoadBalancer
@@ -801,6 +848,44 @@ resource "cloudflare_load_balancer" "%[3]s" {
     country = "US"
     pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
   }
+  region_pools {
+    region = "WNAM"
+    pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
+  }
+}`, zoneID, zone, id)
+}
+
+func testAccCheckCloudflareLoadBalancerConfigGeoBalancedPoPCountry(zoneID, zone, id string) string {
+	return testAccCheckCloudflareLoadBalancerPoolConfigBasic(id, accountID) + fmt.Sprintf(`
+resource "cloudflare_load_balancer" "%[3]s" {
+  zone_id = "%[1]s"
+  name = "tf-testacc-lb-%[3]s.%[2]s"
+  fallback_pool_id = "${cloudflare_load_balancer_pool.%[3]s.id}"
+  default_pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
+  description = "tf-acctest load balancer using pop/country geo-balancing"
+  proxied = true
+  steering_policy = "geo"
+  pop_pools {
+    pop = "LAX"
+    pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
+  }
+  country_pools {
+    country = "US"
+    pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
+  }
+}`, zoneID, zone, id)
+}
+
+func testAccCheckCloudflareLoadBalancerConfigGeoBalancedPoPCountryToRegionUpdate(zoneID, zone, id string) string {
+	return testAccCheckCloudflareLoadBalancerPoolConfigBasic(id, accountID) + fmt.Sprintf(`
+resource "cloudflare_load_balancer" "%[3]s" {
+  zone_id = "%[1]s"
+  name = "tf-testacc-lb-%[3]s.%[2]s"
+  fallback_pool_id = "${cloudflare_load_balancer_pool.%[3]s.id}"
+  default_pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]
+  description = "tf-acctest load balancer using pop/country geo-balancing updated to region geo-balancing"
+  proxied = true
+  steering_policy = "geo"
   region_pools {
     region = "WNAM"
     pool_ids = ["${cloudflare_load_balancer_pool.%[3]s.id}"]

--- a/internal/sdkv2provider/schema_cloudflare_load_balancer.go
+++ b/internal/sdkv2provider/schema_cloudflare_load_balancer.go
@@ -653,7 +653,6 @@ func resourceCloudflareLoadBalancerSchema() map[string]*schema.Schema {
 		"pop_pools": {
 			Type:        schema.TypeSet,
 			Optional:    true,
-			Computed:    true,
 			Elem:        loadBalancerPopPoolElem,
 			Description: "A set containing mappings of Cloudflare Point-of-Presence (PoP) identifiers to a list of pool IDs (ordered by their failover priority) for the PoP (datacenter). This feature is only available to enterprise customers.",
 		},
@@ -661,7 +660,6 @@ func resourceCloudflareLoadBalancerSchema() map[string]*schema.Schema {
 		"country_pools": {
 			Type:        schema.TypeSet,
 			Optional:    true,
-			Computed:    true,
 			Elem:        loadBalancerCountryPoolElem,
 			Description: "A set containing mappings of country codes to a list of pool IDs (ordered by their failover priority) for the given country.",
 		},
@@ -669,7 +667,6 @@ func resourceCloudflareLoadBalancerSchema() map[string]*schema.Schema {
 		"region_pools": {
 			Type:        schema.TypeSet,
 			Optional:    true,
-			Computed:    true,
 			Elem:        loadBalancerRegionPoolElem,
 			Description: "A set containing mappings of region codes to a list of pool IDs (ordered by their failover priority) for the given region.",
 		},


### PR DESCRIPTION
Resolves #2659, supersedes #2660

Currently `pop_pools`, `country_pools`, and `region_pools` are defined as `Computed: true` in their respective schemas. As a result, the `d.GetOk()` for each in [resourceCloudflareLoadBalancerUpdate](https://github.com/thetwoj/terraform-provider-cloudflare/blob/master/internal/sdkv2provider/resource_cloudflare_load_balancer.go#L147) is returning the currently configured value when the corresponding definition is deleted from the Terraform config, effectively making it impossible to delete all entries from `pop_pools`, `country_pools`, or `region_pools` on a load balancer once they're initially defined. By removing `Computed: true` from the schemas full deletions in Terraform are respected, mirroring the behavior from calling the REST API directly with empty maps for any of the pool sets.

This MR also adds a test for this behavior - configuring a load balancer for geo steering via pop and country balancing before updating it to use region balancing instead. This test fails in the absence of the schema changes in this MR.

New test without schema changes:
```bash
$ TESTARGS='-run "^TestAccCloudflareLoadBalancer_GeoBalancedUpdate" -count 1 -parallel 1 -v' make testacc
...
=== RUN   TestAccCloudflareLoadBalancer_GeoBalancedUpdate
=== PAUSE TestAccCloudflareLoadBalancer_GeoBalancedUpdate
=== CONT  TestAccCloudflareLoadBalancer_GeoBalancedUpdate
    resource_cloudflare_load_balancer_test.go:333: Step 2/2 error: Check failed: Check 7/9 error: cloudflare_load_balancer.leessrdmop: Attribute 'pop_pools.#' expected "0", got "1"
--- FAIL: TestAccCloudflareLoadBalancer_GeoBalancedUpdate (6.49s)
...
```

New test with schema changes:
```bash
$ TESTARGS='-run "^TestAccCloudflareLoadBalancer_GeoBalancedUpdate" -count 1 -parallel 1 -v' make testacc
...
=== RUN   TestAccCloudflareLoadBalancer_GeoBalancedUpdate
=== PAUSE TestAccCloudflareLoadBalancer_GeoBalancedUpdate
=== CONT  TestAccCloudflareLoadBalancer_GeoBalancedUpdate
--- PASS: TestAccCloudflareLoadBalancer_GeoBalancedUpdate (7.02s)
...
```

When running all the load balancer tests with this MR's changes the only failure is on a pool count assertion because I'm running the tests on an account with existing infrastructure deployed in other zones
```bash
TESTARGS='-run "^TestAccCloudflareLoadBalancer.*" -count 1 -parallel 1 -v' make testacc
...
=== CONT  TestAccCloudflareLoadBalancerPools
    data_source_load_balancer_pools_test.go:18: Step 1/1 error: Check failed: Check 1/1 error: data.cloudflare_load_balancer_pools.qilephdkdz: Attribute 'pools.#' expected "2", got "304"
--- FAIL: TestAccCloudflareLoadBalancerPools (4.97s)
...
```

Example of referenced successful API call body to delete `pop_pools` from an existing load balancer:
```json
PUT https://api.cloudflare.com/client/v4/zones/xxxx/load_balancers/xxxx
{
    "proxied": true,
    "enabled": true,
    "name": "xxxx",
    "steering_policy": "geo",
    "fallback_pool": "f72a8b39ffce25663b06137cc4a774d2",
    "default_pools": [
        "f72a8b39ffce25663b06137cc4a774d2"
    ],
    "pop_pools": {},
    "region_pools": {
        "WNAM": [
            "4cf1f50d9fbc79ce98046893971faeac"
        ]
    }
}
``` 