### PR TITLE
Add possibility to configure Pages Alerts

### DIFF
--- a/.changelog/2694.txt
+++ b/.changelog/2694.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_notification_policy: Add possibility to configure Pages Alerts.
+```

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -105,6 +105,8 @@ Optional:
 
 - `alert_trigger_preferences` (Set of String) Alert trigger preferences. Example: `slo`.
 - `enabled` (Set of String) State of the pool to alert on.
+- `environment` (Set of String) Environment of pages. Available values: `ENVIRONMENT_PREVIEW`, `ENVIRONMENT_PRODUCTION`.
+- `event` (Set of String) Pages event to alert. Available values: `EVENT_DEPLOYMENT_STARTED`, `EVENT_DEPLOYMENT_FAILED`, `EVENT_DEPLOYMENT_SUCCESS`.
 - `event_source` (Set of String) Source configuration to alert on for pool or origin.
 - `event_type` (Set of String) Stream event type to alert on.
 - `health_check_id` (Set of String) Identifier health check. Required when using `filters.0.status`.
@@ -115,6 +117,7 @@ Optional:
 - `packets_per_second` (Set of String) Packets per second threshold for dos alert.
 - `pool_id` (Set of String) Load balancer pool identifier.
 - `product` (Set of String) Product name. Available values: `worker_requests`, `worker_durable_objects_requests`, `worker_durable_objects_duration`, `worker_durable_objects_data_transfer`, `worker_durable_objects_stored_data`, `worker_durable_objects_storage_deletes`, `worker_durable_objects_storage_writes`, `worker_durable_objects_storage_reads`.
+- `project_id` (Set of String) Identifier of pages project.
 - `protocol` (Set of String) Protocol to alert on for dos.
 - `requests_per_second` (Set of String) Requests per second threshold for dos alert.
 - `services` (Set of String)

--- a/internal/sdkv2provider/schema_cloudflare_notification_policy.go
+++ b/internal/sdkv2provider/schema_cloudflare_notification_policy.go
@@ -300,6 +300,30 @@ func notificationPolicyFilterSchema() *schema.Schema {
 					Optional:    true,
 					Description: "Protocol to alert on for dos.",
 				},
+				"project_id": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+					Optional:    true,
+					Description: "Identifier of pages project.",
+				},
+				"environment": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+					Optional:    true,
+					Description: "Environment of pages.",
+				},
+				"event": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+					Optional:    true,
+					Description: "Pages event to alert.",
+				},
 				"event_source": {
 					Type: schema.TypeSet,
 					Elem: &schema.Schema{


### PR DESCRIPTION
Added `project_id`, `environment` and `event` filter options.

Fix for https://github.com/cloudflare/terraform-provider-cloudflare/issues/2693