### PR TITLE
Mark source owner and repo as force replacement for pages projects

### DIFF
--- a/.changelog/2750.txt
+++ b/.changelog/2750.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/pages_project: force replace when changing pages source
+```

--- a/docs/resources/pages_project.md
+++ b/docs/resources/pages_project.md
@@ -344,13 +344,13 @@ Required:
 Optional:
 
 - `deployments_enabled` (Boolean) Toggle deployments on this repo. Defaults to `true`.
-- `owner` (String) Project owner username.
+- `owner` (String) Project owner username. **Modifying this attribute will force creation of a new resource.**
 - `pr_comments_enabled` (Boolean) Enable Pages to comment on Pull Requests. Defaults to `true`.
 - `preview_branch_excludes` (List of String) Branches will be excluded from automatic deployment.
 - `preview_branch_includes` (List of String) Branches will be included for automatic deployment.
 - `preview_deployment_setting` (String) Preview Deployment Setting. Defaults to `all`.
 - `production_deployment_enabled` (Boolean) Enable production deployments. Defaults to `true`.
-- `repo_name` (String) Project repository name.
+- `repo_name` (String) Project repository name. **Modifying this attribute will force creation of a new resource.**
 
 ## Import
 

--- a/internal/sdkv2provider/schema_cloudflare_pages_project.go
+++ b/internal/sdkv2provider/schema_cloudflare_pages_project.go
@@ -55,11 +55,13 @@ func resourceCloudflarePagesProjectSchema() map[string]*schema.Schema {
 							Description: "Project owner username.",
 							Type:        schema.TypeString,
 							Optional:    true,
+							ForceNew:    true,
 						},
 						"repo_name": {
 							Description: "Project repository name.",
 							Type:        schema.TypeString,
 							Optional:    true,
+							ForceNew:    true,
 						},
 						"production_branch": {
 							Description: "Project production branch name.",


### PR DESCRIPTION
Fixes #2737 

Pages doesn't support changing the git source of a pages project, and you need to delete and recreate. PR marks project owner or repo name as ForceNew.