### PR TITLE
Add suppoort for Bypass By Default mode for the Edge TTL block in Rulesets

### DIFF
--- a/.changelog/2764.txt
+++ b/.changelog/2764.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/cloudflare_ruleset: Add support for bypass by default in Edge TTL modes
+resource/cloudflare_ruleset: Add support for cache bypass by default in Edge TTL modes
 ```

--- a/.changelog/2764.txt
+++ b/.changelog/2764.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_ruleset: Add support for bypass by default in Edge TTL modes
+```

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -641,7 +641,7 @@ Required:
 
 Optional:
 
-- `default` (Number) Default edge TTL
+- `default` (Number) Default edge TTL.
 - `status_code_ttl` (Block List) Edge TTL for the status codes. (see [below for nested schema](#nestedblock--rules--action_parameters--edge_ttl--status_code_ttl))
 
 <a id="nestedblock--rules--action_parameters--edge_ttl--status_code_ttl"></a>

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -637,7 +637,7 @@ Optional:
 
 Required:
 
-- `mode` (String) Mode of the edge TTL.
+- `mode` (String) Mode of the edge TTL. Available values: `override_origin`, `respect_origin`, `bypass_by_default`
 
 Optional:
 

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -466,12 +466,12 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 												"mode": schema.StringAttribute{
 													Required:            true,
 													Validators:          []validator.String{stringvalidator.OneOf("override_origin", "respect_origin", "bypass_by_default")},
-													MarkdownDescription: "Mode of the edge TTL.",
+													MarkdownDescription: fmt.Sprintf("Mode of the edge TTL. %s", utils.RenderAvailableDocumentationValuesStringSlice([]string{"override_origin", "respect_origin", "bypass_by_default"})),
 												},
 												"default": schema.Int64Attribute{
 													Optional:            true,
 													Validators:          []validator.Int64{int64validator.AtLeast(1)},
-													MarkdownDescription: "Default edge TTL",
+													MarkdownDescription: "Default edge TTL.",
 												},
 											},
 											Validators: []validator.Object{EdgeTTLValidator{}},

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -465,7 +465,7 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 											Attributes: map[string]schema.Attribute{
 												"mode": schema.StringAttribute{
 													Required:            true,
-													Validators:          []validator.String{stringvalidator.OneOf("override_origin", "respect_origin")},
+													Validators:          []validator.String{stringvalidator.OneOf("override_origin", "respect_origin", "bypass_by_default")},
 													MarkdownDescription: "Mode of the edge TTL.",
 												},
 												"default": schema.Int64Attribute{

--- a/internal/framework/service/rulesets/validators.go
+++ b/internal/framework/service/rulesets/validators.go
@@ -71,6 +71,14 @@ func (v EdgeTTLValidator) ValidateObject(ctx context.Context, req validator.Obje
 				fmt.Sprintf("using mode '%s' requires setting a default for ttl", parameter.Mode.ValueString()),
 			)
 		}
+	} else if parameter.Mode.ValueString() == "bypass_by_default" {
+		if !parameter.Default.IsNull() {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				errInvalidConfiguration,
+				fmt.Sprintf("cannot set default ttl when using mode '%s'", parameter.Mode.ValueString()),
+			)
+		}
 	}
 }
 

--- a/internal/framework/service/rulesets/validators_test.go
+++ b/internal/framework/service/rulesets/validators_test.go
@@ -95,6 +95,42 @@ func TestEdgeTTLValidation(t *testing.T) {
 				}
 			})
 		})
+
+		t.Run("bypass by default mode is specified", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("errors when ttl is passed", func(t *testing.T) {
+				t.Parallel()
+
+				resp := &validator.ObjectResponse{}
+				req := constructEdgeTTLObjectRequest("bypass_by_default", big.NewFloat(1))
+				edgeValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: diag.Diagnostics{
+						diag.NewAttributeErrorDiagnostic(path.Root("edge_ttl"), "invalid configuration", "cannot set default ttl when using mode 'bypass_by_default'"),
+					},
+				}
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+
+			t.Run("passes without ttl", func(t *testing.T) {
+				t.Parallel()
+
+				resp := &validator.ObjectResponse{}
+				req := constructEdgeTTLObjectRequest("bypass_by_default", nil)
+				edgeValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: nil,
+				}
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+		})
 	})
 }
 


### PR DESCRIPTION
Pretty much the exact same as https://github.com/cloudflare/terraform-provider-cloudflare/pull/2756

Just with a different mode for Edge TTL