### PR TITLE
make user agent string configurable

### DIFF
--- a/.changelog/2816.txt
+++ b/.changelog/2816.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Allow user agent string to be configurable via an environment variable
+```

--- a/internal/consts/provider.go
+++ b/internal/consts/provider.go
@@ -89,6 +89,9 @@ const (
 
 	UserAgentDefault = "terraform/%s terraform-plugin-sdk/%s terraform-provider-cloudflare/%s"
 
+	// Configurable user agent string
+	UserAgentEnvVarKey = "CLOUDFLARE_PROVIDER_USER_AGENT"
+
 	// Schema key for the account ID configuration.
 	AccountIDSchemaKey = "account_id"
 

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -234,7 +235,14 @@ func (p *CloudflareProvider) Configure(ctx context.Context, req provider.Configu
 
 	options = append(options, cloudflare.Debug(logging.IsDebugOrHigher()))
 
-	ua := fmt.Sprintf(consts.UserAgentDefault, req.TerraformVersion, meta.SDKVersionString(), p.version)
+	var ua string
+	userAgentString, ok := os.LookupEnv(consts.UserAgentEnvVarKey)
+	if !ok {
+		ua = fmt.Sprintf(consts.UserAgentDefault, req.TerraformVersion, meta.SDKVersionString(), p.version)
+	} else {
+		ua = userAgentString
+	}
+
 	options = append(options, cloudflare.UserAgent(ua))
 
 	config := Config{Options: options}

--- a/internal/sdkv2provider/provider.go
+++ b/internal/sdkv2provider/provider.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -377,7 +378,14 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 
 		options = append(options, cloudflare.Debug(logging.IsDebugOrHigher()))
 
-		ua := fmt.Sprintf(consts.UserAgentDefault, p.TerraformVersion, meta.SDKVersionString(), version)
+		var ua string
+		userAgentString, ok := os.LookupEnv(consts.UserAgentEnvVarKey)
+		if !ok {
+			ua = fmt.Sprintf(consts.UserAgentDefault, p.TerraformVersion, meta.SDKVersionString(), version)
+		} else {
+			ua = userAgentString
+		}
+
 		options = append(options, cloudflare.UserAgent(ua))
 
 		config := Config{Options: options}


### PR DESCRIPTION
This allows the user agent string to be configurable, meaning providers that "bridge" this provider don't report Terraform as their origin