### PR TITLE
Make a note about logging only being supported with skip action

### DIFF
--- a/.changelog/2851.txt
+++ b/.changelog/2851.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/ruleset: Add note that logging is only supported with the skip action
+resource/cloudflare_ruleset: Add note that logging is only supported with the skip action
 ```

--- a/.changelog/2851.txt
+++ b/.changelog/2851.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/ruleset: Add note that logging is only supported with the skip action
+```

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -467,7 +467,7 @@ Optional:
 - `description` (String) Brief summary of the ruleset rule and its intended use.
 - `enabled` (Boolean) Whether the rule is active.
 - `exposed_credential_check` (Block List) List of parameters that configure exposed credential checks. (see [below for nested schema](#nestedblock--rules--exposed_credential_check))
-- `logging` (Block List) List parameters to configure how the rule generates logs. (see [below for nested schema](#nestedblock--rules--logging))
+- `logging` (Block List) List parameters to configure how the rule generates logs. Only valid for skip action. (see [below for nested schema](#nestedblock--rules--logging))
 - `ratelimit` (Block List) List of parameters that configure HTTP rate limiting behaviour. (see [below for nested schema](#nestedblock--rules--ratelimit))
 - `ref` (String) Rule reference.
 

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -945,7 +945,7 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 							},
 						},
 						"logging": schema.ListNestedBlock{
-							MarkdownDescription: "List parameters to configure how the rule generates logs.",
+							MarkdownDescription: "List parameters to configure how the rule generates logs. Only valid for skip action.",
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									"enabled": schema.BoolAttribute{


### PR DESCRIPTION
A small docs update clarifying that logging options are only valid for the skip action. There is an API error of logging options only allowed in the skip action (20018) that is returned if you try with other rules. 