### PR TITLE
add `casb_findings` to allowed list of logpush datasets

### DIFF
--- a/.changelog/2859.txt
+++ b/.changelog/2859.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_logpush_job: add support for `casb_findings` dataset
+```

--- a/docs/resources/logpush_job.md
+++ b/docs/resources/logpush_job.md
@@ -110,7 +110,7 @@ resource "cloudflare_logpush_job" "example_job" {
 
 ### Required
 
-- `dataset` (String) The kind of the dataset to use with the logpush job. Available values: `access_requests`, `firewall_events`, `http_requests`, `spectrum_events`, `nel_reports`, `audit_logs`, `gateway_dns`, `gateway_http`, `gateway_network`, `dns_logs`, `network_analytics_logs`, `workers_trace_events`, `device_posture_results`, `zero_trust_network_sessions`.
+- `dataset` (String) The kind of the dataset to use with the logpush job. Available values: `access_requests`, `casb_findings`, `firewall_events`, `http_requests`, `spectrum_events`, `nel_reports`, `audit_logs`, `gateway_dns`, `gateway_http`, `gateway_network`, `dns_logs`, `network_analytics_logs`, `workers_trace_events`, `device_posture_results`, `zero_trust_network_sessions`.
 - `destination_conf` (String) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included. See [Logpush destination documentation](https://developers.cloudflare.com/logs/reference/logpush-api-configuration#destination).
 
 ### Optional

--- a/internal/sdkv2provider/schema_cloudflare_logpush_job.go
+++ b/internal/sdkv2provider/schema_cloudflare_logpush_job.go
@@ -45,6 +45,7 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 			Required: true,
 			ValidateFunc: validation.StringInSlice([]string{
 				"access_requests",
+				"casb_findings",
 				"firewall_events",
 				"http_requests",
 				"spectrum_events",
@@ -63,6 +64,7 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 				"The kind of the dataset to use with the logpush job. %s",
 				renderAvailableDocumentationValuesStringSlice([]string{
 					"access_requests",
+					"casb_findings",
 					"firewall_events",
 					"http_requests",
 					"spectrum_events",


### PR DESCRIPTION
The `casb_findings` logpush dataset is not currently supported by the `cloudflare_logpush_job` resource. This PR adds support for this dataset type.

The console support this, and I have also tested with the `/client/v4/accounts/{account_identifier}/logpush/jobs` endpoint to double check the API supports this

Docs about this logpush dataset can be found here: [https://developers.cloudflare.com/logs/reference/log-fields/account/casb_findings/](https://developers.cloudflare.com/logs/reference/log-fields/account/casb_findings/)

I have not raised an issue for this, as it seems fairly minor - happy to do so if requested.