### PR TITLE
Remove default session_duration for cloudflare_access_organization

### DIFF
--- a/.changelog/2872.txt
+++ b/.changelog/2872.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_access_organization: Remove default value for 'session_duration'
+```

--- a/docs/resources/access_organization.md
+++ b/docs/resources/access_organization.md
@@ -44,7 +44,7 @@ resource "cloudflare_access_organization" "example" {
 - `is_ui_read_only` (Boolean) When set to true, this will disable all editing of Access resources via the Zero Trust Dashboard.
 - `login_design` (Block List) (see [below for nested schema](#nestedblock--login_design))
 - `name` (String) The name of your Zero Trust organization.
-- `session_duration` (String) How often a user will be forced to re-authorise. Must be in the format `48h` or `2h45m`. Defaults to `24h`.
+- `session_duration` (String) How often a user will be forced to re-authorise. Must be in the format `48h` or `2h45m`.
 - `ui_read_only_toggle_reason` (String) A description of the reason why the UI read only field is being toggled.
 - `user_seat_expiration_inactive_time` (String) The amount of time a user seat is inactive before it expires. When the user seat exceeds the set time of inactivity, the user is removed as an active seat and no longer counts against your Teams seat count. Must be in the format `300ms` or `2h45m`.
 - `zone_id` (String) The zone identifier to target for the resource. Conflicts with `account_id`.

--- a/internal/sdkv2provider/schema_cloudflare_access_organization.go
+++ b/internal/sdkv2provider/schema_cloudflare_access_organization.go
@@ -59,7 +59,6 @@ func resourceCloudflareAccessOrganizationSchema() map[string]*schema.Schema {
 		"session_duration": {
 			Type:     schema.TypeString,
 			Optional: true,
-			Default:  "24h",
 			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 				v := val.(string)
 				_, err := time.ParseDuration(v)


### PR DESCRIPTION
Removes erroneous default to align with [Cloudflare API Documentation](https://developers.cloudflare.com/api/operations/zero-trust-organization-update-your-zero-trust-organization)
https://github.com/cloudflare/terraform-provider-cloudflare/blob/e79d6d45aadb2b2ebd9f684a80dbd0778dffde2c/internal/sdkv2provider/schema_cloudflare_access_organization.go#L62 

Fixes #2865