### PR TITLE
Allow zero to not default to null for mitigation_timeout

### DIFF
--- a/.changelog/2874.txt
+++ b/.changelog/2874.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_rulesets: Allow zero to not default to null for mitigation_timeout
+```

--- a/internal/framework/service/rulesets/resource.go
+++ b/internal/framework/service/rulesets/resource.go
@@ -730,7 +730,7 @@ func toRulesetResourceModel(ctx context.Context, zoneID, accountID basetypes.Str
 				Period:                  flatteners.Int64(int64(ruleResponse.RateLimit.Period)),
 				RequestsPerPeriod:       flatteners.Int64(int64(ruleResponse.RateLimit.RequestsPerPeriod)),
 				RequestsToOrigin:        flatteners.Bool(cloudflare.BoolPtr(ruleResponse.RateLimit.RequestsToOrigin)),
-				MitigationTimeout:       flatteners.Int64(int64(ruleResponse.RateLimit.MitigationTimeout)),
+				MitigationTimeout:       types.Int64Value(int64(ruleResponse.RateLimit.MitigationTimeout)),
 				ScorePerPeriod:          flatteners.Int64(int64(ruleResponse.RateLimit.ScorePerPeriod)),
 				ScoreResponseHeaderName: flatteners.String(ruleResponse.RateLimit.ScoreResponseHeaderName),
 				CountingExpression:      flatteners.String(ruleResponse.RateLimit.CountingExpression),

--- a/internal/framework/service/rulesets/resource_test.go
+++ b/internal/framework/service/rulesets/resource_test.go
@@ -829,6 +829,52 @@ func TestAccCloudflareRuleset_RateLimitScorePerPeriod(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareRuleset_RateLimitMitigationTimeoutOfZero(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := utils.GenerateRandomResourceName()
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRulesetRateLimitWithMitigationTimeoutOfZero(rnd, "example HTTP rate limit", zoneID, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "example HTTP rate limit"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_ratelimit"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "block"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.response.0.status_code", "418"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.response.0.content_type", "text/plain"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.response.0.content", "test content"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.expression", "(http.request.uri.path matches \"^/api/\")"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", "example http rate limit"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.ratelimit.#", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.ratelimit.0.characteristics.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.ratelimit.0.period", "60"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.ratelimit.0.requests_per_period", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.ratelimit.0.mitigation_timeout", "0"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.ratelimit.0.requests_to_origin", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudflareRuleset_PreserveRuleRefs(t *testing.T) {
 	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
 	// service does not yet support the API tokens and it results in
@@ -3481,6 +3527,41 @@ func testAccCheckCloudflareRulesetRateLimitScorePerPeriod(rnd, name, zoneID, zon
 		score_response_header_name = "my-score"
         mitigation_timeout = 60
         requests_to_origin = true
+      }
+      expression = "(http.request.uri.path matches \"^/api/\")"
+      description = "example http rate limit"
+      enabled = true
+    }
+  }`, rnd, name, zoneID, zoneName)
+}
+
+func testAccCheckCloudflareRulesetRateLimitWithMitigationTimeoutOfZero(rnd, name, zoneID, zoneName string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+    zone_id  = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_ratelimit"
+
+    rules {
+      action = "block"
+      action_parameters {
+        response {
+          status_code = 418
+          content_type = "text/plain"
+          content = "test content"
+        }
+      }
+      ratelimit {
+        characteristics = [
+          "cf.colo.id",
+          "ip.src"
+        ]
+        period              = 60
+        requests_per_period = 1000
+        requests_to_origin  = false
+        mitigation_timeout  = 0
       }
       expression = "(http.request.uri.path matches \"^/api/\")"
       description = "example http rate limit"

--- a/internal/sdkv2provider/data_source_rulesets_test.go
+++ b/internal/sdkv2provider/data_source_rulesets_test.go
@@ -24,55 +24,6 @@ func TestAccCloudflareRulesetsProviderDataSource_PreventZoneIdAndAccountIdConfli
 	})
 }
 
-func testCloudflareRulesetsProviderDataSourceConfigRatelimit(rnd, name string) string {
-	return fmt.Sprintf(`
-data "cloudflare_rulesets" "%[1]s" {
-  account_id = "123abc"
-  zone_id = "456def"
-  kind        = "zone"
-  name        = "%[2]s"
-  description = "a_description"
-  phase       = "http_ratelimit"
-
-
-  rules {
-      action = "managed_challenge"
-      ratelimit {
-        characteristics = [
-          "cf.colo.id",
-          "ip.src",
-        ]
-        period              = 60
-        requests_per_period = 1000
-        requests_to_origin  = false
-        mitigation_timeout  = 0
-      }
-      expression = "http.host eq \"example.com\""
-      description = "a_rule_description"
-      enabled     = true
-  }
-}
-`, rnd, name)
-}
-
-func TestAccCloudflareRulesetsProviderDataSource_ConfigRatelimit(t *testing.T) {
-	rnd := generateRandomResourceName()
-	name := fmt.Sprintf("data.cloudflare_rulesets.%s", rnd)
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testCloudflareRulesetsProviderDataSourceConfigRatelimit(rnd, name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "rulesets.0.rules.0.mitigation_timeout", "0"),
-					resource.TestCheckResourceAttr(name, "rulesets.0.rules.0.action", "managed_challenge"),
-				),
-			},
-		},
-	})
-}
-
 func testCloudflareRulesetsProviderDataSourceConfigConflictingFields(rnd string) string {
 	return fmt.Sprintf(`
 data "cloudflare_rulesets" "%[1]s" {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/2445

Terraform state displays the mitigation timeout as null `MitigationTimeout:<null>` because the flattener translates zeros to null. https://github.com/cloudflare/terraform-provider-cloudflare/blob/master/internal/framework/flatteners/int64.go#L24