### PR TITLE
test: fix failing tests for observatory test

### DIFF
--- a/internal/sdkv2provider/resource_cloudflare_observatory_scheduled.go
+++ b/internal/sdkv2provider/resource_cloudflare_observatory_scheduled.go
@@ -45,7 +45,7 @@ func resourceCloudflareObservatoryScheduledTestCreate(ctx context.Context, d *sc
 	test, err := client.CreateObservatoryScheduledPageTest(ctx, cloudflare.ZoneIdentifier(zoneID), params)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating observatory scheduled test %q: %w", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error creating observatory scheduled test %q: %w", params.URL, err))
 	}
 
 	d.SetId(stringChecksum(fmt.Sprintf("%s:%s", test.Schedule.URL, test.Schedule.Region)))

--- a/internal/sdkv2provider/resource_cloudflare_observatory_scheduled_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_observatory_scheduled_test.go
@@ -28,7 +28,7 @@ func TestAccCloudflareObservatoryScheduledTest_Create(t *testing.T) {
 				Config: testAccCloudflareObservatoryScheduledTest(rnd, zoneID, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, consts.ZoneIDSchemaKey, zoneID),
-					resource.TestCheckResourceAttr(name, "url", domain+"/"),
+					resource.TestCheckResourceAttr(name, "url", domain+"/"+rnd),
 					resource.TestCheckResourceAttr(name, "region", "us-central1"),
 					resource.TestCheckResourceAttr(name, "frequency", "DAILY"),
 				),
@@ -61,7 +61,7 @@ func testAccCloudflareObservatoryScheduledTest(resourceName, zoneID, domain stri
 	return fmt.Sprintf(`
 resource "cloudflare_observatory_scheduled_test" "%[1]s" {
   zone_id   = "%[2]s"
-  url       = "%[3]s"
+  url       = "%[3]s/%[1]s"
   region    = "us-central1"
   frequency = "DAILY"
 }


### PR DESCRIPTION
There is a limit on how many URLs you can create in one day, so randomise the URLs