### PR TITLE
Add support for `body_scanning` to `cloudflare_teams_account`

### DIFF
--- a/.changelog/2887.txt
+++ b/.changelog/2887.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_teams_account: add support for `body_scanning` config
+```

--- a/docs/resources/teams_account.md
+++ b/docs/resources/teams_account.md
@@ -26,6 +26,10 @@ resource "cloudflare_teams_account" "example" {
     background_color = "#000000"
   }
 
+  body_scanning {
+    inspection_mode = "deep"
+  }
+
   antivirus {
     enabled_download_phase = true
     enabled_upload_phase   = false
@@ -75,6 +79,7 @@ resource "cloudflare_teams_account" "example" {
 - `activity_log_enabled` (Boolean) Whether to enable the activity log.
 - `antivirus` (Block List, Max: 1) Configuration block for antivirus traffic scanning. (see [below for nested schema](#nestedblock--antivirus))
 - `block_page` (Block List, Max: 1) Configuration for a custom block page. (see [below for nested schema](#nestedblock--block_page))
+- `body_scanning` (Block List, Max: 1) Configuration for body scanning. (see [below for nested schema](#nestedblock--body_scanning))
 - `fips` (Block List, Max: 1) Configure compliance with Federal Information Processing Standards. (see [below for nested schema](#nestedblock--fips))
 - `logging` (Block List, Max: 1) (see [below for nested schema](#nestedblock--logging))
 - `non_identity_browser_isolation_enabled` (Boolean) Enable non-identity onramp for Browser Isolation. Defaults to `false`.
@@ -112,6 +117,14 @@ Optional:
 - `mailto_address` (String) Admin email for users to contact.
 - `mailto_subject` (String) Subject line for emails created from block page.
 - `name` (String) Name of block page configuration.
+
+
+<a id="nestedblock--body_scanning"></a>
+### Nested Schema for `body_scanning`
+
+Required:
+
+- `inspection_mode` (String) Body scanning inspection mode. Available values: `deep`, `shallow`.
 
 
 <a id="nestedblock--fips"></a>

--- a/examples/resources/cloudflare_teams_account/resource.tf
+++ b/examples/resources/cloudflare_teams_account/resource.tf
@@ -10,6 +10,10 @@ resource "cloudflare_teams_account" "example" {
     background_color = "#000000"
   }
 
+  body_scanning {
+    inspection_mode = "deep"
+  }
+
   antivirus {
     enabled_download_phase = true
     enabled_upload_phase   = false

--- a/internal/sdkv2provider/resource_cloudflare_access_policy_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_policy_test.go
@@ -993,6 +993,9 @@ func testAccessPolicyIsolationRequiredConfig(resourceID, zone, accountID string)
 		  mailto_subject = "hello"
 		  mailto_address = "test@cloudflare.com"
 		}
+		body_scanning {
+		  inspection_mode = "deep"
+		}
 		fips {
 		  tls = true
 		}

--- a/internal/sdkv2provider/resource_cloudflare_teams_accounts_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_accounts_test.go
@@ -42,6 +42,7 @@ func TestAccCloudflareTeamsAccounts_ConfigurationBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "block_page.0.mailto_address", "test@cloudflare.com"),
 					resource.TestCheckResourceAttr(name, "block_page.0.background_color", "#000000"),
 					resource.TestCheckResourceAttr(name, "block_page.0.logo_path", "https://example.com"),
+					resource.TestCheckResourceAttr(name, "body_scanning.0.inspection_mode", "deep"),
 					resource.TestCheckResourceAttr(name, "logging.0.redact_pii", "true"),
 					resource.TestCheckResourceAttr(name, "logging.0.settings_by_rule_type.0.dns.0.log_all", "false"),
 					resource.TestCheckResourceAttr(name, "logging.0.settings_by_rule_type.0.dns.0.log_blocks", "true"),
@@ -79,6 +80,9 @@ resource "cloudflare_teams_account" "%[1]s" {
     background_color = "#000000"
 	mailto_subject = "hello"
 	mailto_address = "test@cloudflare.com"
+  }
+  body_scanning {
+    inspection_mode = "deep"
   }
   fips {
     tls = true

--- a/internal/sdkv2provider/schema_cloudflare_teams_accounts.go
+++ b/internal/sdkv2provider/schema_cloudflare_teams_accounts.go
@@ -1,8 +1,11 @@
 package sdkv2provider
 
 import (
+	"fmt"
+
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceCloudflareTeamsAccountSchema() map[string]*schema.Schema {
@@ -19,6 +22,15 @@ func resourceCloudflareTeamsAccountSchema() map[string]*schema.Schema {
 			Description: "Configuration for a custom block page.",
 			Elem: &schema.Resource{
 				Schema: blockPageSchema,
+			},
+		},
+		"body_scanning": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Configuration for body scanning.",
+			Elem: &schema.Resource{
+				Schema: bodyScanningSchema,
 			},
 		},
 		"fips": {
@@ -152,6 +164,19 @@ var blockPageSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "Subject line for emails created from block page.",
+	},
+}
+
+var inspectionModeOptions = []string{"deep", "shallow"}
+var bodyScanningSchema = map[string]*schema.Schema{
+	"inspection_mode": {
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringInSlice(inspectionModeOptions, false),
+		Description: fmt.Sprintf(
+			"Body scanning inspection mode. %s",
+			renderAvailableDocumentationValuesStringSlice(inspectionModeOptions),
+		),
 	},
 }
 


### PR DESCRIPTION
Resolves #2374

The teams account configuration APIs and the Go SDK now support Enhanced File Detection (`body_scanning`), see links below. This PR adds support for this parameter to this provider.

Enhanced file detection: https://developers.cloudflare.com/cloudflare-one/insights/logs/gateway-logs/#enhanced-file-detection
API docs: [https://developers.cloudflare.com/api/operations/zero-trust-accounts-get-zero-trust-account-configuration](https://developers.cloudflare.com/api/operations/zero-trust-accounts-get-zero-trust-account-configuration)
SDK: [https://github.com/cloudflare/cloudflare-go/blob/master/teams_accounts.go#L47](https://github.com/cloudflare/cloudflare-go/blob/master/teams_accounts.go#L47) (released in `v0.80.0`)

In addition to the tests in the this repository, I have tested this change using `dev_overrides` on a local project with several scenarios, and it behaves as expected.
