### PR TITLE
Document default for `proxied` on `cloudflare_record`

### DIFF
--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -53,7 +53,7 @@ resource "cloudflare_record" "_sip_tls" {
 - `comment` (String) Comments or notes about the DNS record. This field has no effect on DNS responses.
 - `data` (Block List, Max: 1) Map of attributes that constitute the record value. Conflicts with `value`. (see [below for nested schema](#nestedblock--data))
 - `priority` (Number) The priority of the record.
-- `proxied` (Boolean) Whether the record gets Cloudflare's origin protection.
+- `proxied` (Boolean) Whether the record gets Cloudflare's origin protection; defaults to `false`.
 - `tags` (Set of String) Custom tags for the DNS record.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `ttl` (Number) The TTL of the record.

--- a/internal/sdkv2provider/schema_cloudflare_record.go
+++ b/internal/sdkv2provider/schema_cloudflare_record.go
@@ -255,7 +255,7 @@ func resourceCloudflareRecordSchema() map[string]*schema.Schema {
 		"proxied": {
 			Optional:    true,
 			Type:        schema.TypeBool,
-			Description: "Whether the record gets Cloudflare's origin protection.",
+			Description: "Whether the record gets Cloudflare's origin protection; defaults to `false`.",
 		},
 
 		"created_on": {


### PR DESCRIPTION
This was originally requested in #4/fixed in b09befa, but was lost in the move to autogen docs (0813d55).