### PR TITLE
Add deprecation message to tiered_caching in Argo resource

### DIFF
--- a/.changelog/2906.txt
+++ b/.changelog/2906.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-add deprecation message to Argo resource tiered_caching attribute
+resource/cloudflare_argo: `tiered_caching` attribute is deprecated in favour of the dedicated `cloudflare_tiered_cache` resource.
 ```

--- a/.changelog/2906.txt
+++ b/.changelog/2906.txt
@@ -1,0 +1,3 @@
+```release-note:note
+add deprecation message to Argo resource tiered_caching attribute
+```

--- a/docs/resources/argo.md
+++ b/docs/resources/argo.md
@@ -30,7 +30,7 @@ resource "cloudflare_argo" "example" {
 ### Optional
 
 - `smart_routing` (String) Whether smart routing is enabled. Available values: `on`, `off`.
-- `tiered_caching` (String) Whether tiered caching is enabled. Available values: `on`, `off`.
+- `tiered_caching` (String, Deprecated) Whether tiered caching is enabled. Available values: `on`, `off`.
 
 ### Read-Only
 

--- a/internal/sdkv2provider/schema_cloudflare_argo.go
+++ b/internal/sdkv2provider/schema_cloudflare_argo.go
@@ -20,6 +20,7 @@ func resourceCloudflareArgoSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 			Optional:     true,
 			Description:  fmt.Sprintf("Whether tiered caching is enabled. %s", renderAvailableDocumentationValuesStringSlice([]string{"on", "off"})),
+			Deprecated:   "tiered_caching has been deprecated in favour of using `cloudflare_tiered_cache` resource instead.",
 		},
 		"smart_routing": {
 			Type:         schema.TypeString,


### PR DESCRIPTION
Deprecating tiered_caching attribute in [Argo resource](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/argo ) and in favor of [cloudflare_tiered_cache](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/tiered_cache) resource to manage tiered cache.