### PR TITLE
add notification policy tunnel health filters

### DIFF
--- a/.changelog/2911.txt
+++ b/.changelog/2911.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_notification_policy: Add support for `new_status` and `tunnel_id` filters
+```

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -117,6 +117,7 @@ Optional:
 - `limit` (Set of String) A numerical limit. Example: `100`.
 - `megabits_per_second` (Set of String) Megabits per second threshold for dos alert.
 - `new_health` (Set of String) Health status to alert on for pool or origin.
+- `new_status` (Set of String) The new tunnel status that will trigger the dispatch of a notification. Available values: `TUNNEL_STATUS_TYPE_HEALTHY`, `TUNNEL_STATUS_TYPE_DEGRADED`, `TUNNEL_STATUS_TYPE_DOWN`.
 - `packets_per_second` (Set of String) Packets per second threshold for dos alert.
 - `pool_id` (Set of String) Load balancer pool identifier.
 - `product` (Set of String) Product name. Available values: `worker_requests`, `worker_durable_objects_requests`, `worker_durable_objects_duration`, `worker_durable_objects_data_transfer`, `worker_durable_objects_stored_data`, `worker_durable_objects_storage_deletes`, `worker_durable_objects_storage_writes`, `worker_durable_objects_storage_reads`.
@@ -128,6 +129,7 @@ Optional:
 - `status` (Set of String) Status to alert on.
 - `target_hostname` (Set of String) Target host to alert on for dos.
 - `target_zone_name` (Set of String) Target domain to alert on.
+- `tunnel_id` (Set of String) Tunnel identifier.
 - `where` (Set of String) Filter for alert.
 - `zones` (Set of String) A list of zone identifiers.
 

--- a/internal/sdkv2provider/schema_cloudflare_notification_policy.go
+++ b/internal/sdkv2provider/schema_cloudflare_notification_policy.go
@@ -68,6 +68,12 @@ var notificationPolicyIncidentImpactLevels = []string{
 	"INCIDENT_IMPACT_CRITICAL",
 }
 
+var notificationPolicyTunnelStatus = []string{
+	"TUNNEL_STATUS_TYPE_HEALTHY",
+	"TUNNEL_STATUS_TYPE_DEGRADED",
+	"TUNNEL_STATUS_TYPE_DOWN",
+}
+
 func resourceCloudflareNotificationPolicySchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		consts.AccountIDSchemaKey: {
@@ -366,6 +372,21 @@ func notificationPolicyFilterSchema() *schema.Schema {
 					},
 					Optional:    true,
 					Description: fmt.Sprintf("The incident impact level that will trigger the dispatch of a notification. %s", renderAvailableDocumentationValuesStringSlice(notificationPolicyIncidentImpactLevels)),
+				},
+				"tunnel_id": {
+					Type:        schema.TypeSet,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+					Optional:    true,
+					Description: "Tunnel identifier.",
+				},
+				"new_status": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringInSlice(notificationPolicyTunnelStatus, false),
+					},
+					Optional:    true,
+					Description: fmt.Sprintf("The new tunnel status that will trigger the dispatch of a notification. %s", renderAvailableDocumentationValuesStringSlice(notificationPolicyTunnelStatus)),
 				},
 			},
 		},


### PR DESCRIPTION
resolves #2276 
Unfortunately it looks like the actual API values of `new_status` are not explicitly defined anywhere.
https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/monitor-tunnels/notifications/

I was able to find them by inspecting the dash payload when creating a new notification policy.

![2023-11-04-131600_324x180_scrot](https://github.com/cloudflare/terraform-provider-cloudflare/assets/2215967/850506e5-8891-416e-bc74-051498077b11)
