### PR TITLE
docs(cloudflare_certificate_pack): Fix import doc

### DIFF
--- a/docs/resources/certificate_pack.md
+++ b/docs/resources/certificate_pack.md
@@ -96,7 +96,7 @@ Read-Only:
 Import is supported using the following syntax:
 
 ```shell
-$ terraform import cloudflare_certificate_pack.example 1d5fdc9e88c8a8c4518b068cd94331fe/8fda82e2-6af9-4eb2-992a-5ab65b792ef1
+$ terraform import cloudflare_certificate_pack.example <zone_id>/<certificate_pack_id>
 ```
 
 While supported, importing isn't recommended and it is advised to replace the

--- a/examples/resources/cloudflare_certificate_pack/import.sh
+++ b/examples/resources/cloudflare_certificate_pack/import.sh
@@ -1,1 +1,1 @@
-$ terraform import cloudflare_certificate_pack.example 1d5fdc9e88c8a8c4518b068cd94331fe/8fda82e2-6af9-4eb2-992a-5ab65b792ef1
+$ terraform import cloudflare_certificate_pack.example <zone_id>/<certificate_pack_id>


### PR DESCRIPTION
Specify params to pass to import command, like all [other docs](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_mutual_tls_certificate#import)
