### PR TITLE
ruleset expression correction

### DIFF
--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -250,7 +250,7 @@ resource "cloudflare_ruleset" "custom_fields_logging_example" {
       ]
     }
 
-    expression  = "(http.host eq \"example.host.com\")"
+    expression  = "true"
     description = "log custom fields rule"
     enabled     = true
   }


### PR DESCRIPTION
Correction in docs for Custom fields logging. The expression filled value is misleading and should be "true". During my deployment of custom log filters there is not other match condition in expression.