### PR TITLE
Adds support for magic_ids_detections Logpush dataset

### DIFF
--- a/.changelog/2983.txt
+++ b/.changelog/2983.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
- resource/cloudflare_logpush_job: add support for `magic_ids_detections`.
- ```
+resource/cloudflare_logpush_job: add support for `magic_ids_detections`.
+```

--- a/.changelog/2983.txt
+++ b/.changelog/2983.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+ resource/cloudflare_logpush_job: add support for `magic_ids_detections`.
+ ```

--- a/docs/resources/logpush_job.md
+++ b/docs/resources/logpush_job.md
@@ -110,7 +110,7 @@ resource "cloudflare_logpush_job" "example_job" {
 
 ### Required
 
-- `dataset` (String) The kind of the dataset to use with the logpush job. Available values: `access_requests`, `casb_findings`, `firewall_events`, `http_requests`, `spectrum_events`, `nel_reports`, `audit_logs`, `gateway_dns`, `gateway_http`, `gateway_network`, `dns_logs`, `network_analytics_logs`, `workers_trace_events`, `device_posture_results`, `zero_trust_network_sessions`.
+- `dataset` (String) The kind of the dataset to use with the logpush job. Available values: `access_requests`, `casb_findings`, `firewall_events`, `http_requests`, `spectrum_events`, `nel_reports`, `audit_logs`, `gateway_dns`, `gateway_http`, `gateway_network`, `dns_logs`, `network_analytics_logs`, `workers_trace_events`, `device_posture_results`, `zero_trust_network_sessions`, `magic_ids_detections`.
 - `destination_conf` (String) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included. See [Logpush destination documentation](https://developers.cloudflare.com/logs/reference/logpush-api-configuration#destination).
 
 ### Optional

--- a/internal/sdkv2provider/schema_cloudflare_logpush_job.go
+++ b/internal/sdkv2provider/schema_cloudflare_logpush_job.go
@@ -59,6 +59,7 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 				"workers_trace_events",
 				"device_posture_results",
 				"zero_trust_network_sessions",
+				"magic_ids_detections",
 			}, false),
 			Description: fmt.Sprintf(
 				"The kind of the dataset to use with the logpush job. %s",
@@ -78,6 +79,7 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 					"workers_trace_events",
 					"device_posture_results",
 					"zero_trust_network_sessions",
+					"magic_ids_detections",
 				}),
 			),
 		},


### PR DESCRIPTION
This PR
- Adds `magic_ids_detections` to the available Logpush Job datasets
- Updates docs

Dev-Docs:
https://developers.cloudflare.com/logs/reference/log-fields/account/magic_ids_detections/

