### PR TITLE
bug fix: fixed type on teams rule notification settings url

### DIFF
--- a/.changelog/3030.txt
+++ b/.changelog/3030.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_teams_rule: changed type & validation on the notification settings url
+```

--- a/docs/resources/teams_rule.md
+++ b/docs/resources/teams_rule.md
@@ -132,7 +132,7 @@ Optional:
 
 - `enabled` (Boolean) Enable notification settings.
 - `message` (String) Notification content.
-- `support_url` (Boolean) Support URL to show in the notification.
+- `support_url` (String) Support URL to show in the notification.
 
 
 <a id="nestedblock--rule_settings--payload_log"></a>

--- a/internal/sdkv2provider/schema_cloudflare_teams_rules.go
+++ b/internal/sdkv2provider/schema_cloudflare_teams_rules.go
@@ -232,9 +232,9 @@ var notificationSettings = map[string]*schema.Schema{
 		Description: "Notification content",
 	},
 	"support_url": {
-		Type:         schema.TypeString,
-		Optional:     true,
-		Description:  "Support URL to show in the notification",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Support URL to show in the notification",
 	},
 }
 

--- a/internal/sdkv2provider/schema_cloudflare_teams_rules.go
+++ b/internal/sdkv2provider/schema_cloudflare_teams_rules.go
@@ -232,8 +232,7 @@ var notificationSettings = map[string]*schema.Schema{
 		Description: "Notification content",
 	},
 	"support_url": {
-		Type:         schema.TypeBool,
-		ValidateFunc: validation.StringInSlice(cloudflare.TeamsRulesUntrustedCertActionValues(), false),
+		Type:         schema.TypeString,
 		Optional:     true,
 		Description:  "Support URL to show in the notification",
 	},


### PR DESCRIPTION
@jacobbednarz I just noticed a parameter in the last change was wrong. This feature is not used by any customers yet. So it is safe to change the type. Sorry I didn't catch this in the step before and didn't run `make docs` either, so it slipped through the cracks until I manually tested the changes today.