### PR TITLE
Add tunnel_id filter to cloudflare_notification_policy

### DIFF
--- a/.changelog/3038.txt
+++ b/.changelog/3038.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_notification_policy: Add tunnel_id filter for tunnel_health_event policies
+```

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -130,6 +130,7 @@ Optional:
 - `status` (Set of String) Status to alert on.
 - `target_hostname` (Set of String) Target host to alert on for dos.
 - `target_zone_name` (Set of String) Target domain to alert on.
+- `tunnel_id` (Set of String) Tunnel IDs to alert on.
 - `where` (Set of String) Filter for alert.
 - `zones` (Set of String) A list of zone identifiers.
 

--- a/internal/sdkv2provider/schema_cloudflare_notification_policy.go
+++ b/internal/sdkv2provider/schema_cloudflare_notification_policy.go
@@ -391,6 +391,14 @@ func notificationPolicyFilterSchema() *schema.Schema {
 					Optional:    true,
 					Description: "Selectors for alert. Valid options depend on the alert type.",
 				},
+				"tunnel_id": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+					Optional:    true,
+					Description: "Tunnel IDs to alert on.",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #3037 by adding the `tunnel_id` attribute to the schema.
Real-world tested on a tunnel+notification policy.