### PR TITLE
Prevent misidentified changes in dlp resources

### DIFF
--- a/.changelog/3044.txt
+++ b/.changelog/3044.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_dlp_profile: Prevent misidentified changes in dlp resources
+```

--- a/internal/sdkv2provider/resource_cloudflare_dlp_profile.go
+++ b/internal/sdkv2provider/resource_cloudflare_dlp_profile.go
@@ -62,7 +62,9 @@ func dlpEntryToSchema(entry cloudflare.DLPEntry) map[string]interface{} {
 	if entry.Name != "" {
 		entrySchema["name"] = entry.Name
 	}
-	entrySchema["enabled"] = entry.Enabled != nil && *entry.Enabled == true
+	if entry.Enabled != nil {
+		entrySchema["enabled"] = *entry.Enabled
+	}
 	if entry.Pattern != nil {
 		entrySchema["pattern"] = []interface{}{dlpPatternToSchema(*entry.Pattern)}
 	}


### PR DESCRIPTION
By ensuring schemas are consistent