### PR TITLE
WIP: Add `cloudflare_access_group` data source

### DIFF
--- a/internal/sdkv2provider/data_source_access_group.go
+++ b/internal/sdkv2provider/data_source_access_group.go
@@ -1,0 +1,75 @@
+package sdkv2provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceCloudflareAccessGroup() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCloudflareAccessGroupRead,
+		Schema: map[string]*schema.Schema{
+			consts.AccountIDSchemaKey: {
+				Description:   consts.AccountIDSchemaDescription,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{consts.ZoneIDSchemaKey},
+			},
+			consts.ZoneIDSchemaKey: {
+				Description:   consts.ZoneIDSchemaDescription,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{consts.AccountIDSchemaKey},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceCloudflareAccessGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*cloudflare.API)
+	accountID := d.Get(consts.AccountIDSchemaKey).(string)
+	d.SetId(accountID)
+	searchAccessGroupName := d.Get("name").(string)
+
+	tflog.Debug(ctx, "reading accounts")
+	identifier, err := initIdentifier(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Call the Cloudflare API to retrieve the access group by name
+	accessGroups, _, err := client.ListAccessGroups(ctx, identifier, cloudflare.ListAccessGroupsParams{})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error listing Access Groups: %w", err))
+	}
+	if len(accessGroups) == 0 {
+		return diag.Errorf("no Access groups found")
+	}
+	var accessGroup cloudflare.AccessGroup
+	for _, group := range accessGroups {
+		if group.Name == searchAccessGroupName {
+			accessGroup = group
+			break
+		}
+	}
+	if accessGroup.ID == "" {
+		return diag.Errorf("No Access groups matching name %q", searchAccessGroupName)
+	}
+	d.SetId(accessGroup.ID)
+	d.Set("name", accessGroup.Name)
+
+	return nil
+}

--- a/internal/sdkv2provider/provider.go
+++ b/internal/sdkv2provider/provider.go
@@ -22,7 +22,7 @@ const (
 	MAXIMUM_NUMBER_OF_ENTITIES_REACHED_SUMMARY = "You've attempted to add a new %[1]s to the `terraform-plugin-sdkv2` which is no longer considered suitable for use."
 	MAXIMUM_NUMBER_OF_ENTITIES_REACHED_DETAIL  = "Due the number of known internal issues with `terraform-plugin-sdkv2` (most notably handling of zero values), we are no longer recommending using it and instead, advise using `terraform-plugin-framework` exclusively. If you must use terraform-plugin-sdkv2 for this new %[1]s you should first discuss it with a maintainer to fully understand the impact and potential ramifications. Only then should you bump %[2]s to include your %[1]s."
 	MAXIMUM_ALLOWED_SDKV2_RESOURCES            = 108
-	MAXIMUM_ALLOWED_SDKV2_DATASOURCES          = 19
+	MAXIMUM_ALLOWED_SDKV2_DATASOURCES          = 20
 )
 
 func init() {
@@ -185,6 +185,7 @@ func New(version string) func() *schema.Provider {
 				"cloudflare_zone_dnssec":                dataSourceCloudflareZoneDNSSEC(),
 				"cloudflare_zone":                       dataSourceCloudflareZone(),
 				"cloudflare_zones":                      dataSourceCloudflareZones(),
+				"cloudflare_access_group":               dataSourceCloudflareAccessGroup(),
 			},
 
 			ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
I am using the Terraform provider and have to retrieve the `cloudflare_access_group` by name.

I did a quick test and this worked, but it's only exposing the ID and the Name.

I got a deprecation warning for `MAXIMUM_ALLOWED_SDKV2_DATASOURCES = 20` and I haven't added any tests yet.
I haven't written Go or a Terraform provider before and only tried to get this working.

With valid access groups:

```
data.cloudflare_access_group.group1: Reading...
data.cloudflare_access_group.group2: Reading...
data.cloudflare_access_group.group1: Read complete after 0s [id=18238aca-9195-4f1d-b083-83f2b6e866b9]
data.cloudflare_access_group.group2: Read complete after 0s [id=eb21cc8e-da27-4453-bb23-f678f32db63f]

Changes to Outputs:
  + group1_id = {
      + account_id = "123425d31ae24a27770d5fe81341fdd9"
      + id         = "18238aca-9195-4f1d-b083-83f2b6e866b9"
      + name       = "abc"
      + zone_id    = null
    }
  + group2_id = {
      + account_id = "123425d31ae24a27770d5fe81341fdd9"
      + id         = "eb21cc8e-da27-4453-bb23-f678f32db63f"
      + name       = "def"
      + zone_id    = null
    }
```


With invalid access group:
```
data.cloudflare_access_group.group2: Reading...
data.cloudflare_access_group.group1: Reading...
data.cloudflare_access_group.group1: Read complete after 0s [id=18238aca-9195-4f1d-b083-83f2b6e866b9]

Changes to Outputs:
  + group1_id = {
      + account_id = "123425d31ae24a27770d5fe81341fdd9"
      + id         = "18238aca-9195-4f1d-b083-83f2b6e866b9"
      + name       = "abc"
      + zone_id    = null
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
╷
│ Error: no Access Groups matching name "def1"
│
│   with data.cloudflare_access_group.group2,
│   on data.tf line 7, in data "cloudflare_access_group" "group2":
│    7: data "cloudflare_access_group" "group2" {
│
```

There are also other data sources missing as for `device_settings_policy_id`. Is this currently on the roadmap of being added?

