### PR TITLE
Resolve ignored errors in `import cloudflare_access_application`

### DIFF
--- a/.changelog/3075.txt
+++ b/.changelog/3075.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_access_application: Fix error handling in `import cloudflare_access_application`
+```

--- a/.changelog/3075.txt
+++ b/.changelog/3075.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/cloudflare_access_application: Fix error handling in `import cloudflare_access_application`
+resource/cloudflare_access_application: leave existence error handling checks to the `Read` operation when performing imports.
 ```

--- a/internal/sdkv2provider/resource_cloudflare_access_application.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_application.go
@@ -322,10 +322,7 @@ func resourceCloudflareAccessApplicationImport(ctx context.Context, d *schema.Re
 	d.Set(consts.AccountIDSchemaKey, accountID)
 	d.SetId(accessApplicationID)
 
-	readErr := resourceCloudflareAccessApplicationRead(ctx, d, meta)
-	if readErr != nil {
-		return nil, errors.New("failed to read Access Application state")
-	}
+	resourceCloudflareAccessApplicationRead(ctx, d, meta)
 
 	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
Firstly, thanks for the great work on the provider.

While working with the `import cloudflare_access_application` command, I encountered an issue where it returns a generic error message `failed to read Access Application state`. This error message is not very informative and obscures the underlying issue.

I propose a modification inspired by the approach already used. (e.g. https://github.com/cloudflare/terraform-provider-cloudflare/blob/1ba09393e82e9db65fb6ca78215747a1980f6df4/internal/sdkv2provider/resource_cloudflare_workers_script.go#L440)

This PR is related to #2855(already closed).

Looking forward to feedback and suggestions for further improvements.