### PR TITLE
cloudflare_device_settings_policy.auto_connect is in seconds

### DIFF
--- a/.changelog/3080.txt
+++ b/.changelog/3080.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_device_settings_policy: updated docs that `auto_connect` is in seconds, not in minutes
+```

--- a/docs/resources/device_settings_policy.md
+++ b/docs/resources/device_settings_policy.md
@@ -47,7 +47,7 @@ resource "cloudflare_device_settings_policy" "developer_warp_policy" {
 - `allow_mode_switch` (Boolean) Whether to allow mode switch for this policy.
 - `allow_updates` (Boolean) Whether to allow updates under this policy.
 - `allowed_to_leave` (Boolean) Whether to allow devices to leave the organization. Defaults to `true`.
-- `auto_connect` (Number) The amount of time in minutes to reconnect after having been disabled.
+- `auto_connect` (Number) The amount of time in seconds to reconnect after having been disabled.
 - `captive_portal` (Number) The captive portal value for this policy. Defaults to `180`.
 - `default` (Boolean) Whether the policy refers to the default account policy.
 - `disable_auto_fallback` (Boolean) Whether to disable auto fallback for this policy.

--- a/internal/sdkv2provider/schema_cloudflare_device_settings_policy.go
+++ b/internal/sdkv2provider/schema_cloudflare_device_settings_policy.go
@@ -73,7 +73,7 @@ func resourceCloudflareDeviceSettingsPolicySchema() map[string]*schema.Schema {
 			Optional:    true,
 		},
 		"auto_connect": {
-			Description: "The amount of time in minutes to reconnect after having been disabled.",
+			Description: "The amount of time in seconds to reconnect after having been disabled.",
 			Type:        schema.TypeInt,
 			Optional:    true,
 		},


### PR DESCRIPTION
This fixes a bug in documentation. Specifically, the documentation states that cloudflare_device_settings_policy.auto_connect is in minutes. In reality though, that field is in seconds. This commit adjusts the documentation accordingly.