### PR TITLE
Remove unneeded parameters from cloudflare_ruleset

### DIFF
--- a/.changelog/3082.txt
+++ b/.changelog/3082.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_ruleset: reduce noise when ruleset changed, by remowing unneeded options `version` and `last_updated`.
+```

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -469,13 +469,11 @@ Optional:
 - `exposed_credential_check` (Block List) List of parameters that configure exposed credential checks. (see [below for nested schema](#nestedblock--rules--exposed_credential_check))
 - `logging` (Block List) List parameters to configure how the rule generates logs. Only valid for skip action. (see [below for nested schema](#nestedblock--rules--logging))
 - `ratelimit` (Block List) List of parameters that configure HTTP rate limiting behaviour. (see [below for nested schema](#nestedblock--rules--ratelimit))
-- `ref` (String) Rule reference.
+- `ref` (String) The reference of the rule (the rule ID by default). Example: `my_ref`
 
 Read-Only:
 
 - `id` (String) Unique rule identifier.
-- `last_updated` (String) The most recent update to this rule.
-- `version` (String) Version of the ruleset to deploy.
 
 <a id="nestedblock--rules--action_parameters"></a>
 ### Nested Schema for `rules.action_parameters`
@@ -532,7 +530,6 @@ Optional:
 - `status_code` (Number) HTTP status code of the custom error response.
 - `sxg` (Boolean) Turn on or off the SXG feature.
 - `uri` (Block List) List of URI properties to configure for the ruleset rule when performing URL rewrite transformations. (see [below for nested schema](#nestedblock--rules--action_parameters--uri))
-- `version` (String) Version of the ruleset to deploy.
 
 <a id="nestedblock--rules--action_parameters--algorithms"></a>
 ### Nested Schema for `rules.action_parameters.algorithms`

--- a/internal/framework/service/rulesets/model.go
+++ b/internal/framework/service/rulesets/model.go
@@ -14,7 +14,6 @@ type RulesetResourceModel struct {
 }
 
 type RulesModel struct {
-	Version                types.String                   `tfsdk:"version"`
 	Action                 types.String                   `tfsdk:"action"`
 	ActionParameters       []*ActionParametersModel       `tfsdk:"action_parameters"`
 	Description            types.String                   `tfsdk:"description"`
@@ -22,14 +21,12 @@ type RulesModel struct {
 	ExposedCredentialCheck []*ExposedCredentialCheckModel `tfsdk:"exposed_credential_check"`
 	Expression             types.String                   `tfsdk:"expression"`
 	ID                     types.String                   `tfsdk:"id"`
-	LastUpdated            types.String                   `tfsdk:"last_updated"`
 	Logging                []*LoggingModel                `tfsdk:"logging"`
 	Ratelimit              []*RatelimitModel              `tfsdk:"ratelimit"`
 	Ref                    types.String                   `tfsdk:"ref"`
 }
 
 type ActionParametersModel struct {
-	Version                  types.String                                 `tfsdk:"version"`
 	AdditionalCacheablePorts types.Set                                    `tfsdk:"additional_cacheable_ports"`
 	AutomaticHTTPSRewrites   types.Bool                                   `tfsdk:"automatic_https_rewrites"`
 	AutoMinify               []*ActionParameterAutoMinifyModel            `tfsdk:"autominify"`

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -3,6 +3,7 @@ package rulesets
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -108,15 +109,14 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 						consts.IDSchemaKey: schema.StringAttribute{
 							Computed:            true,
 							MarkdownDescription: "Unique rule identifier.",
-						},
-						"version": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Version of the ruleset to deploy.",
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"ref": schema.StringAttribute{
 							Optional:            true,
 							Computed:            true,
-							MarkdownDescription: "Rule reference.",
+							MarkdownDescription: "The reference of the rule (the rule ID by default). Example: `my_ref`",
 						},
 						"enabled": schema.BoolAttribute{
 							Optional:            true,
@@ -144,10 +144,6 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 								stringvalidator.OneOfCaseInsensitive(cloudflare.RulesetRuleActionValues()...),
 							},
 							Optional: true,
-						},
-						"last_updated": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "The most recent update to this rule.",
 						},
 					},
 					Blocks: map[string]schema.Block{
@@ -302,11 +298,6 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 									"origin_error_page_passthru": schema.BoolAttribute{
 										Optional:            true,
 										MarkdownDescription: "Pass-through error page for origin.",
-									},
-									"version": schema.StringAttribute{
-										Computed:            true,
-										Optional:            true,
-										MarkdownDescription: "Version of the ruleset to deploy.",
 									},
 								},
 								Blocks: map[string]schema.Block{


### PR DESCRIPTION
We start migration to the cloudflare_ruleset and faced the same issue as described here: https://github.com/cloudflare/terraform-provider-cloudflare/issues/2690

I checked `(known after apply)` parameters and realise that `version` and `last_updated` can't be set via [API](https://developers.cloudflare.com/api/operations/createZoneRuleset) and looks like no make sense to have them in the TF state.
 
 Also I added `PlanModifiers` for ID, because if I right understand rule ID shouldn't be changed from outside of terraform - only explicitly.
 