### PR TITLE
Add the ability to filter records on the content field

### DIFF
--- a/.changelog/3084.txt
+++ b/.changelog/3084.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+datasource/cloudflare_record: Add the option to filter by "content"
+```

--- a/docs/data-sources/record.md
+++ b/docs/data-sources/record.md
@@ -27,6 +27,7 @@ data "cloudflare_record" "example" {
 
 ### Optional
 
+- `content` (String) Content to filter record results on.
 - `priority` (Number) DNS priority to filter record results on.
 - `type` (String) DNS record type to filter record results on. Defaults to `A`.
 

--- a/internal/sdkv2provider/data_source_record.go
+++ b/internal/sdkv2provider/data_source_record.go
@@ -102,7 +102,6 @@ func dataSourceCloudflareRecordRead(ctx context.Context, d *schema.ResourceData,
 
 	if len(records) != 1 && !contains([]string{"MX", "URI"}, searchRecord.Type) {
 		return diag.Errorf("only wanted 1 DNS record. Got %d records", len(records))
-
 	} else {
 		var p uint16
 		if priority, ok := d.GetOkExists("priority"); ok {

--- a/internal/sdkv2provider/data_source_record.go
+++ b/internal/sdkv2provider/data_source_record.go
@@ -36,6 +36,11 @@ func dataSourceCloudflareRecord() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"A", "AAAA", "CAA", "CNAME", "TXT", "SRV", "LOC", "MX", "NS", "SPF", "CERT", "DNSKEY", "DS", "NAPTR", "SMIMEA", "SSHFP", "TLSA", "URI", "PTR", "HTTPS", "SVCB"}, false),
 				Description:  "DNS record type to filter record results on.",
 			},
+			"content": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Content to filter record results on.",
+			},
 			"priority": {
 				Type:             schema.TypeInt,
 				Optional:         true,
@@ -81,8 +86,9 @@ func dataSourceCloudflareRecordRead(ctx context.Context, d *schema.ResourceData,
 	zoneID := d.Get(consts.ZoneIDSchemaKey).(string)
 
 	searchRecord := cloudflare.ListDNSRecordsParams{
-		Name: d.Get("hostname").(string),
-		Type: d.Get("type").(string),
+		Name:    d.Get("hostname").(string),
+		Type:    d.Get("type").(string),
+		Content: d.Get("content").(string),
 	}
 
 	records, _, err := client.ListDNSRecords(ctx, cloudflare.ZoneIdentifier(zoneID), searchRecord)
@@ -96,6 +102,7 @@ func dataSourceCloudflareRecordRead(ctx context.Context, d *schema.ResourceData,
 
 	if len(records) != 1 && !contains([]string{"MX", "URI"}, searchRecord.Type) {
 		return diag.Errorf("only wanted 1 DNS record. Got %d records", len(records))
+
 	} else {
 		var p uint16
 		if priority, ok := d.GetOkExists("priority"); ok {


### PR DESCRIPTION
This PR solves [my problem](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1981#issuecomment-1910473742) described in #1981. 

With that change, I can now filter on the content of my NS records, so I only get one result back and can retrieve the id of the record to use it in my import statement. 

I ran `make tests` and `make docs` but did not execute the acceptance test. However I tested the behavior successfully by building the provider and using it for my use case. 

Please let me know if I missed anything for the PR process. 