### PR TITLE
BUGS-351: Use DLP entry names as the set key

### DIFF
--- a/.changelog/3090.txt
+++ b/.changelog/3090.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_dlp_profile: fixed plan flapping with DLP custom entries
+```

--- a/internal/sdkv2provider/resource_cloudflare_dlp_profile.go
+++ b/internal/sdkv2provider/resource_cloudflare_dlp_profile.go
@@ -113,9 +113,7 @@ func resourceCloudflareDLPProfileRead(ctx context.Context, d *schema.ResourceDat
 	for _, entry := range dlpProfile.Entries {
 		entries = append(entries, dlpEntryToSchema(entry))
 	}
-	d.Set("entry", schema.NewSet(schema.HashResource(&schema.Resource{
-		Schema: resourceCloudflareDLPEntrySchema(),
-	}), entries))
+	d.Set("entry", schema.NewSet(hashResourceCloudflareDLPEntry, entries))
 
 	return nil
 }

--- a/internal/sdkv2provider/resource_cloudflare_dlp_profile_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_dlp_profile_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccCloudflareDLPProfile_Custom(t *testing.T) {
@@ -48,6 +49,9 @@ func TestAccCloudflareDLPProfile_Custom_MultipleEntries(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudflareDLPProfileConfigCustomMultipleEntries(accountID, rnd, "custom profile 2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
@@ -63,10 +67,9 @@ func TestAccCloudflareDLPProfile_Custom_MultipleEntries(t *testing.T) {
 					}),
 
 					resource.TestCheckTypeSetElemNestedAttrs(name, "entry.*", map[string]string{
-						"name":                 fmt.Sprintf("%s_entry1", rnd),
-						"enabled":              "true",
-						"pattern.0.regex":      "^4[0-9]",
-						"pattern.0.validation": "luhn",
+						"name":            fmt.Sprintf("%s_entry1", rnd),
+						"enabled":         "true",
+						"pattern.0.regex": "^4[0-9]",
 					}),
 				),
 			},
@@ -135,7 +138,6 @@ resource "cloudflare_dlp_profile" "%[1]s" {
 	enabled = true
 	pattern {
 		regex = "^4[0-9]"
-		validation = "luhn"
 	}
   }
 

--- a/internal/sdkv2provider/schema_cloudflare_dlp_profile.go
+++ b/internal/sdkv2provider/schema_cloudflare_dlp_profile.go
@@ -58,6 +58,14 @@ func resourceCloudflareDLPEntrySchema() map[string]*schema.Schema {
 	}
 }
 
+// Custom hash function used on DLP entries. Extracts the "name" property
+// to provide a stable hash for profile entries and prevent spurious differences
+// between the state/infra.
+func hashResourceCloudflareDLPEntry(i interface{}) int {
+	v := i.(map[string]interface{})
+	return schema.HashString(v["name"])
+}
+
 func resourceCloudflareDLPProfileSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		consts.AccountIDSchemaKey: {
@@ -91,6 +99,7 @@ func resourceCloudflareDLPProfileSchema() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: resourceCloudflareDLPEntrySchema(),
 			},
+			Set: hashResourceCloudflareDLPEntry,
 		},
 		"allowed_match_count": {
 			Type:         schema.TypeInt,


### PR DESCRIPTION
Added a custom hash function to the `entries` set on the `cloudflare_dlp_profile` resource, which should give entries stable identifiers and prevent spurious plans. Updated acceptance test to check for spurious plans.