### PR TITLE
Add schema migrator to fix upgrade problem

### DIFF
--- a/.changelog/3102.txt
+++ b/.changelog/3102.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/email_routing_rule: Fix issue with upgrading resource from 4.22.0 to 4.23.0
+```

--- a/.changelog/3102.txt
+++ b/.changelog/3102.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/email_routing_rule: Fix issue with upgrading resource from 4.22.0 to 4.23.0
+resource/email_routing_rule: add schema migration for upgrading 4.22.0 to 4.23.0
 ```

--- a/internal/framework/service/email_routing_rule/schema.go
+++ b/internal/framework/service/email_routing_rule/schema.go
@@ -3,7 +3,6 @@ package email_routing_rule
 import (
 	"context"
 	"fmt"
-
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -23,7 +22,8 @@ func (r *EmailRoutingRuleResource) Schema(ctx context.Context, req resource.Sche
 	resp.Schema = schema.Schema{
 		MarkdownDescription: heredoc.Doc(`
 			The [Email Routing Rule](https://developers.cloudflare.com/email-routing/setup/email-routing-addresses/#email-rule-actions) resource allows you to create and manage email routing rules for a zone.
-	`),
+		`),
+		Version: 1,
 
 		Attributes: map[string]schema.Attribute{
 			consts.ZoneIDSchemaKey: schema.StringAttribute{
@@ -113,6 +113,128 @@ func (r *EmailRoutingRuleResource) Schema(ctx context.Context, req resource.Sche
 						},
 					},
 				},
+			},
+		},
+	}
+}
+
+func (r *EmailRoutingRuleResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
+		0: {
+			PriorSchema: &schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					consts.ZoneIDSchemaKey: schema.StringAttribute{
+						MarkdownDescription: consts.ZoneIDSchemaDescription,
+						Required:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
+					},
+					"id": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The ID of the email routing rule.",
+					},
+					"tag": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The tag of the email routing rule.",
+					},
+					"name": schema.StringAttribute{
+						Required:            true,
+						MarkdownDescription: "Routing rule name.",
+					},
+					"priority": schema.Int64Attribute{
+						MarkdownDescription: "The priority of the email routing rule.",
+						Optional:            true,
+						Computed:            true,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
+					},
+					"enabled": schema.BoolAttribute{
+						MarkdownDescription: "Whether the email routing rule is enabled.",
+						Optional:            true,
+					},
+				},
+				Blocks: map[string]schema.Block{
+					"matcher": schema.SetNestedBlock{
+						MarkdownDescription: "Matching patterns to forward to your actions.",
+						Validators: []validator.Set{
+							setvalidator.SizeAtLeast(1),
+							setvalidator.IsRequired(),
+						},
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"type": schema.StringAttribute{
+									Required:            true,
+									MarkdownDescription: fmt.Sprintf("Type of matcher. %s", utils.RenderAvailableDocumentationValuesStringSlice([]string{"literal", "all"})),
+									Validators: []validator.String{
+										stringvalidator.OneOf("literal", "all"),
+									},
+								},
+								"field": schema.StringAttribute{
+									Optional:            true,
+									MarkdownDescription: "Field to match on. Required for `type` of `literal`.",
+								},
+								"value": schema.StringAttribute{
+									Optional:            true,
+									MarkdownDescription: "Value to match on. Required for `type` of `literal`.",
+									Validators: []validator.String{
+										stringvalidator.LengthBetween(0, 90),
+									},
+								},
+							},
+						},
+					},
+					"action": schema.SetNestedBlock{
+						MarkdownDescription: "Actions to take when a match is found.",
+						Validators: []validator.Set{
+							setvalidator.SizeAtLeast(1),
+							setvalidator.IsRequired(),
+						},
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"type": schema.StringAttribute{
+									Required:            true,
+									MarkdownDescription: fmt.Sprintf("Type of action. %s", utils.RenderAvailableDocumentationValuesStringSlice([]string{"forward", "worker", "drop"})),
+									Validators: []validator.String{
+										stringvalidator.OneOf("forward", "worker", "drop"),
+									},
+								},
+								"value": schema.SetAttribute{
+									Optional:            true,
+									ElementType:         types.StringType,
+									MarkdownDescription: "Value to match on. Required for `type` of `literal`.",
+									Validators: []validator.Set{
+										setvalidator.ValueStringsAre(stringvalidator.LengthBetween(0, 90)),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var priorStateData EmailRoutingRuleModel
+
+				resp.Diagnostics.Append(req.State.Get(ctx, &priorStateData)...)
+
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				upgradedStateData := EmailRoutingRuleModel{
+					ZoneID:   priorStateData.ZoneID,
+					ID:       priorStateData.ID,
+					Tag:      priorStateData.ID,
+					Name:     priorStateData.Name,
+					Priority: priorStateData.Priority,
+					Enabled:  priorStateData.Enabled,
+					Action:   priorStateData.Action,
+					Matcher:  priorStateData.Matcher,
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateData)...)
 			},
 		},
 	}


### PR DESCRIPTION
Adds a schema migrator to fix upgrading email routing rule from 4.22.0 to 4.23.0. Fixes #3083 

In 4.22.0, the tag attribute was incorrectly not set. When applying now, it will copy of the ID attribute to tag attribute. 

Another solution could be to use the `ID` attribute, but ID doesn't exist on the cloudflare-go struct.