### PR TITLE
Add schema migrator for email_routing_address upgrading from 4.22

### DIFF
--- a/.changelog/3119.txt
+++ b/.changelog/3119.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_email_routing_address: add schema migrator
+```

--- a/internal/framework/service/email_routing_address/schema.go
+++ b/internal/framework/service/email_routing_address/schema.go
@@ -2,7 +2,6 @@ package email_routing_address
 
 import (
 	"context"
-
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -51,6 +50,73 @@ func (r *EmailRoutingAddressResource) Schema(ctx context.Context, req resource.S
 			"modified": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The date and time the destination address has been modified.",
+			},
+		},
+	}
+}
+
+func (r *EmailRoutingAddressResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
+		0: {
+			PriorSchema: &schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					consts.AccountIDSchemaKey: schema.StringAttribute{
+						MarkdownDescription: consts.AccountIDSchemaDescription,
+						Required:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
+					},
+					consts.IDSchemaKey: schema.StringAttribute{
+						MarkdownDescription: consts.IDSchemaDescription,
+						Computed:            true,
+					},
+					"tag": schema.StringAttribute{
+						MarkdownDescription: "Destination address identifier.",
+						Computed:            true,
+					},
+					"email": schema.StringAttribute{
+						Required:            true,
+						MarkdownDescription: "The contact email address of the user.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
+					},
+					"verified": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The date and time the destination address has been verified. Null means not verified yet.",
+					},
+					"created": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The date and time the destination address has been created.",
+					},
+					"modified": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The date and time the destination address has been modified.",
+					},
+				},
+			},
+
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var priorStateData EmailRoutingAddressModel
+
+				resp.Diagnostics.Append(req.State.Get(ctx, &priorStateData)...)
+
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				upgradedStateData := EmailRoutingAddressModel{
+					AccountID: priorStateData.AccountID,
+					ID:        priorStateData.ID,
+					Tag:       priorStateData.ID,
+					Email:     priorStateData.Email,
+					Verified:  priorStateData.Verified,
+					Created:   priorStateData.Created,
+					Modified:  priorStateData.Modified,
+				}
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateData)...)
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #3116. Same underlying issue as #3083 where the new method use `Tag` instead of ID as the resource ID.