### PR TITLE
Allow uploading Workers to dispatch namespaces + tags

### DIFF
--- a/.changelog/3154.txt
+++ b/.changelog/3154.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/cloudflare_worker_script: Add `dispatch_namespace` to support uploading to a Workers for Platforms namespace
+```
+
+```release-note:enhancement
+resource/cloudflare_worker_script: Add `tags` to support tagging Workers for Platforms Workers
+```

--- a/docs/resources/worker_script.md
+++ b/docs/resources/worker_script.md
@@ -75,6 +75,7 @@ resource "cloudflare_worker_script" "my_script" {
 - `compatibility_date` (String) The date to use for the compatibility flag.
 - `compatibility_flags` (Set of String) Compatibility flags used for Worker Scripts.
 - `d1_database_binding` (Block Set) (see [below for nested schema](#nestedblock--d1_database_binding))
+- `dispatch_namespace` (String) Name of the Workers for Platforms dispatch namespace.
 - `kv_namespace_binding` (Block Set) (see [below for nested schema](#nestedblock--kv_namespace_binding))
 - `logpush` (Boolean) Enabling allows Worker events to be sent to a defined Logpush destination.
 - `module` (Boolean) Whether to upload Worker as a module.
@@ -84,6 +85,7 @@ resource "cloudflare_worker_script" "my_script" {
 - `r2_bucket_binding` (Block Set) (see [below for nested schema](#nestedblock--r2_bucket_binding))
 - `secret_text_binding` (Block Set) (see [below for nested schema](#nestedblock--secret_text_binding))
 - `service_binding` (Block Set) (see [below for nested schema](#nestedblock--service_binding))
+- `tags` (Set of String)
 - `webassembly_binding` (Block Set) (see [below for nested schema](#nestedblock--webassembly_binding))
 
 ### Read-Only

--- a/examples/resources/cloudflare_worker_script/resource.tf
+++ b/examples/resources/cloudflare_worker_script/resource.tf
@@ -45,3 +45,11 @@ resource "cloudflare_worker_script" "my_script" {
     dataset = "dataset1"
   }
 }
+
+resource "cloudflare_worker_script" "wfp_user_worker" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  name       = "customer-worker-1"
+  content    = file("script.js")
+  dispatch_namespace = "my-namespace"
+  tags = ["free"]
+}

--- a/internal/sdkv2provider/resource_cloudflare_workers_script_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_workers_script_test.go
@@ -308,7 +308,7 @@ func testAccCheckCloudflareWorkerScriptExists(n string, script *cloudflare.Worke
 		}
 
 		name := strings.Replace(n, "cloudflare_worker_script.", "", -1)
-		foundBindings, err := getWorkerScriptBindings(context.Background(), accountID, name, client)
+		foundBindings, err := getWorkerScriptBindings(context.Background(), accountID, name, nil, client)
 		if err != nil {
 			return fmt.Errorf("cannot list script bindings: %w", err)
 		}

--- a/internal/sdkv2provider/schema_cloudflare_workers_script.go
+++ b/internal/sdkv2provider/schema_cloudflare_workers_script.go
@@ -207,6 +207,18 @@ func resourceCloudflareWorkerScriptSchema() map[string]*schema.Schema {
 			Optional: true,
 			Elem:     placementResource,
 		},
+		"dispatch_namespace": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Name of the Workers for Platforms dispatch namespace.",
+		},
+		"tags": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Computed: true,
+		},
+		// TODO: dispatch_namespace binding
 		"plain_text_binding": {
 			Type:     schema.TypeSet,
 			Optional: true,


### PR DESCRIPTION
Allows uploading to a Workers for Platforms namespace and with tags.

Example Terraform file:
```
resource "cloudflare_workers_for_platforms_dispatch_namespace" "namespace" {
  account_id = var.account_id
  name = "test-tf"
}

resource "cloudflare_worker_script" "dispatch_worker" {
  account_id = var.account_id
  name       = "test-dispatch-worker"
  module = true

  content    = <<EOF
  export default {
    fetch(req, env) {
      try {
        const whatWorker = req.headers.get('x-worker');
        if (whatWorker === null) {
          return new Response('404');
        }

        const worker = env.NAMESPACE.get(whatWorker);

        return worker.fetch(req)
          .catch(e => {
            if (e.message === 'Worker not found') {
              return new Response('Worker not found');
            } else {
              return new Response(e.message + '\n' + e.stack);
            }
          });
      } catch(e) {
        return new Response(e.message + '\n' + e.stack);
      }
    }
  }
  EOF
}

resource "cloudflare_worker_script" "user_worker" {
  account_id = var.account_id
  name       = "user-worker"
  dispatch_namespace = "test-tf"
  module = true
  tags = ["free"]

  content    = <<EOF
  export default {
    fetch(req, env) {
      return Response.json(env);
      // return new Response('Hello, World');
    }
  }
  EOF
}
```