### PR TITLE
digicert deprication

### DIFF
--- a/docs/resources/certificate_pack.md
+++ b/docs/resources/certificate_pack.md
@@ -23,14 +23,14 @@ you've confirmed the certificate is available.
 ## Example Usage
 
 ```terraform
-# Advanced certificate manager for DigiCert
+# Advanced certificate manager for Google
 resource "cloudflare_certificate_pack" "example" {
   zone_id               = "0da42c8d2132a9ddaf714f9e7c920711"
   type                  = "advanced"
   hosts                 = ["example.com", "sub.example.com"]
   validation_method     = "txt"
   validity_days         = 30
-  certificate_authority = "digicert"
+  certificate_authority = "Google"
   cloudflare_branding   = false
 }
 
@@ -51,7 +51,7 @@ resource "cloudflare_certificate_pack" "example" {
 
 ### Required
 
-- `certificate_authority` (String) Which certificate authority to issue the certificate pack. Available values: `digicert`, `lets_encrypt`, `google`. **Modifying this attribute will force creation of a new resource.**
+- `certificate_authority` (String) Which certificate authority to issue the certificate pack. Available values: `lets_encrypt`, `google`. **Modifying this attribute will force creation of a new resource.**
 - `hosts` (Set of String) List of hostnames to provision the certificate pack for. The zone name must be included as a host. Note: If using Let's Encrypt, you cannot use individual subdomains and only a wildcard for subdomain is available. **Modifying this attribute will force creation of a new resource.**
 - `type` (String) Certificate pack configuration type. Available values: `advanced`. **Modifying this attribute will force creation of a new resource.**
 - `validation_method` (String) Which validation method to use in order to prove domain ownership. Available values: `txt`, `http`, `email`. **Modifying this attribute will force creation of a new resource.**

--- a/examples/resources/cloudflare_certificate_pack/resource.tf
+++ b/examples/resources/cloudflare_certificate_pack/resource.tf
@@ -1,11 +1,11 @@
-# Advanced certificate manager for DigiCert
+# Advanced certificate manager for Google
 resource "cloudflare_certificate_pack" "example" {
   zone_id               = "0da42c8d2132a9ddaf714f9e7c920711"
   type                  = "advanced"
   hosts                 = ["example.com", "sub.example.com"]
   validation_method     = "txt"
   validity_days         = 30
-  certificate_authority = "digicert"
+  certificate_authority = "google"
   cloudflare_branding   = false
 }
 

--- a/internal/sdkv2provider/schema_cloudflare_certificate_pack.go
+++ b/internal/sdkv2provider/schema_cloudflare_certificate_pack.go
@@ -50,9 +50,9 @@ func resourceCloudflareCertificatePackSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validation.StringInSlice([]string{"digicert", "lets_encrypt", "google"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"lets_encrypt", "google"}, false),
 			Default:      nil,
-			Description:  fmt.Sprintf("Which certificate authority to issue the certificate pack. %s", renderAvailableDocumentationValuesStringSlice([]string{"digicert", "lets_encrypt", "google"})),
+			Description:  fmt.Sprintf("Which certificate authority to issue the certificate pack. %s", renderAvailableDocumentationValuesStringSlice([]string{"lets_encrypt", "google"})),
 		},
 		"validation_records": {
 			Type:     schema.TypeList,

--- a/internal/sdkv2provider/schema_cloudflare_custom_hostname.go
+++ b/internal/sdkv2provider/schema_cloudflare_custom_hostname.go
@@ -67,7 +67,7 @@ func resourceCloudflareCustomHostnameSchema() map[string]*schema.Schema {
 						Type:         schema.TypeString,
 						Optional:     true,
 						Computed:     true,
-						ValidateFunc: validation.StringInSlice([]string{"lets_encrypt", "digicert", "google"}, false),
+						ValidateFunc: validation.StringInSlice([]string{"lets_encrypt", "google"}, false),
 						Default:      nil,
 					},
 					"validation_records": {


### PR DESCRIPTION
According to the documentation, digicert will be deprecated. https://developers.cloudflare.com/ssl/reference/migration-guides/digicert-update/

> The advanced certificate renewals offboarding has been postponed and started gradually rolling out on October 26, 2023. This process is expected to be complete by the end of March 2024.
> 
> The SSL for SaaS renewals offboarding has been postponed and started gradually rolling out on November 1, 2023.