### PR TITLE
resource/cloudflare_logpush_job: only set the value in state when it is defined

### DIFF
--- a/.changelog/3188.txt
+++ b/.changelog/3188.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_logpush_job: only set the value in state when it is defined
+```


### PR DESCRIPTION
Updates the state management to only set the `output_options` when it is defined and avoid a permadiff showing it always being removed.

@dloebl as the implementor here, can you confirm this works on your side? preferably with real cases?