### PR TITLE
Fix import for cloudflare_list_item

### DIFF
--- a/.changelog/3191.txt
+++ b/.changelog/3191.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_list_item: fix id parsing for imports
+```

--- a/internal/framework/service/list_item/resource.go
+++ b/internal/framework/service/list_item/resource.go
@@ -135,7 +135,7 @@ func (r *ListItemResource) Delete(ctx context.Context, req resource.DeleteReques
 
 func (r *ListItemResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idparts := strings.Split(req.ID, "/")
-	if len(idparts) != 2 {
+	if len(idparts) != 3 {
 		resp.Diagnostics.AddError("error importing list item ", "invalid ID specified. Please specify the ID as \"accountID/listID/itemID\"")
 		return
 	}


### PR DESCRIPTION
There was a small typo introduced in the migration of cloudflare_list_item to the plugin framework in #3026, that breaks imports. The expected id format is a 3 part string separated by slashes, but the import code performs a check at the beginning that checks that it is only 2 parts long (even though the code right after expects 3 parts). This 1-character change fixes this issue.

The current workaround is to pin to a provider version at 4.22 or below.