### PR TITLE
Add is_deleted filter option to tunnel data source

### DIFF
--- a/.changelog/3201.txt
+++ b/.changelog/3201.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+datasource/cloudflare_tunnel: Add the option to filter deleted tunnels
+```

--- a/docs/data-sources/tunnel.md
+++ b/docs/data-sources/tunnel.md
@@ -25,6 +25,10 @@ data "cloudflare_tunnel" "example" {
 - `account_id` (String) The account identifier to target for the resource. **Modifying this attribute will force creation of a new resource.**
 - `name` (String) Name of the tunnel. **Modifying this attribute will force creation of a new resource.**
 
+### Optional
+
+- `is_deleted` (Boolean) If true, only include deleted tunnels. If false, exclude deleted tunnels. If empty, all tunnels will be included. **Modifying this attribute will force creation of a new resource.**
+
 ### Read-Only
 
 - `id` (String) ID of the tunnel.

--- a/internal/sdkv2provider/data_source_tunnel_test.go
+++ b/internal/sdkv2provider/data_source_tunnel_test.go
@@ -3,6 +3,7 @@ package sdkv2provider
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -38,6 +39,97 @@ data "cloudflare_tunnel" "%[2]s" {
 	account_id = cloudflare_tunnel.%[2]s.account_id
 	name       = cloudflare_tunnel.%[2]s.name
 	depends_on = [cloudflare_tunnel.%[2]s]
+}
+`, accountID, name)
+}
+
+func TestAccCloudflareTunnel_MatchIsDeleted(t *testing.T) {
+	rnd := generateRandomResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testCloudflareTunnelMatchIsDeletedStep1(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.cloudflare_tunnel."+rnd+"_default", "status", "inactive"),
+					resource.TestCheckResourceAttr("data.cloudflare_tunnel."+rnd+"_default", "is_deleted", "false"),
+					resource.TestCheckResourceAttr("data.cloudflare_tunnel."+rnd+"_not_deleted", "status", "inactive"),
+					resource.TestCheckResourceAttr("data.cloudflare_tunnel."+rnd+"_not_deleted", "is_deleted", "false"),
+				),
+			},
+			{
+				Config:  testCloudflareTunnelMatchIsDeletedStep1(rnd),
+				Destroy: true,
+			},
+			{
+				Config: testCloudflareTunnelMatchIsDeletedStep2(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.cloudflare_tunnel."+rnd+"_default", "status", "inactive"),
+					resource.TestCheckResourceAttr("data.cloudflare_tunnel."+rnd+"_default", "is_deleted", "true"),
+					resource.TestCheckResourceAttr("data.cloudflare_tunnel."+rnd+"_deleted", "status", "inactive"),
+					resource.TestCheckResourceAttr("data.cloudflare_tunnel."+rnd+"_deleted", "is_deleted", "true"),
+				),
+			},
+			{
+				Config: testCloudflareTunnelMatchIsDeletedStep3(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.cloudflare_tunnel."+rnd+"_not_deleted", "status", "inactive"),
+				),
+				ExpectError: regexp.MustCompile(`Error: No tunnels with name: ` + rnd),
+			},
+		},
+	})
+}
+
+func testCloudflareTunnelMatchIsDeletedStep1(name string) string {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	return fmt.Sprintf(`
+resource "cloudflare_tunnel" "%[2]s" {
+	account_id = "%[1]s"
+	name       = "%[2]s"
+	secret     = "AQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIAQIDBAUGBwg="
+}
+
+data "cloudflare_tunnel" "%[2]s_default" {
+	account_id = cloudflare_tunnel.%[2]s.account_id
+	name       = cloudflare_tunnel.%[2]s.name
+	depends_on = [cloudflare_tunnel.%[2]s]
+}
+
+data "cloudflare_tunnel" "%[2]s_not_deleted" {
+	account_id = "%[1]s"
+	name       = "%[2]s"
+	is_deleted = false
+	depends_on = [cloudflare_tunnel.%[2]s]
+}
+`, accountID, name)
+}
+
+func testCloudflareTunnelMatchIsDeletedStep2(name string) string {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	return fmt.Sprintf(`
+data "cloudflare_tunnel" "%[2]s_default" {
+	account_id = "%[1]s"
+	name       = "%[2]s"
+}
+
+data "cloudflare_tunnel" "%[2]s_deleted" {
+	account_id = "%[1]s"
+	name       = "%[2]s"
+	is_deleted = true
+}
+`, accountID, name)
+}
+
+func testCloudflareTunnelMatchIsDeletedStep3(name string) string {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	return fmt.Sprintf(`
+data "cloudflare_tunnel" "%[2]s_not_deleted" {
+	account_id = "%[1]s"
+	name       = "%[2]s"
+	is_deleted = false
 }
 `, accountID, name)
 }


### PR DESCRIPTION
This PR solves a problem we're having onboarding our services to Cloudflare. The problematic behaviour is already described in #3069.

With the addition of a `is_deleted` filter we can now ignore soft-deleted entities and get the correct tunnel back from the API.
The filter is utilising the already available [IsDeleted](https://github.com/cloudflare/cloudflare-go/blob/6f98ca9e9077ea6943b9cdc66f2dd7389cc58ade/tunnel.go#L222) parameter of the ListTunnel API.

`make test` and `TESTARGS='-run ^TestAccCloudflareTunnel_Match' make testacc` have been running successfully.

I have left the original functionality intact to not force anyone to adopt setting the parameter.

Closes #3069.