### PR TITLE
Add support for email_list in Access Group resources

### DIFF
--- a/.changelog/3247.txt
+++ b/.changelog/3247.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_access_group: Add the option for email_list to be used in require, include and exclude fields
+```

--- a/internal/sdkv2provider/resource_cloudflare_access_group.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_group.go
@@ -41,7 +41,6 @@ func resourceCloudflareAccessGroupRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	accessGroup, err := client.GetAccessGroup(ctx, identifier, d.Id())
-
 	if err != nil {
 		var notFoundError *cloudflare.NotFoundError
 		if errors.As(err, &notFoundError) {
@@ -344,6 +343,10 @@ func BuildAccessGroupCondition(options map[string]interface{}) []interface{} {
 					group = append(group, cloudflare.AccessGroupEmailDomain{EmailDomain: struct {
 						Domain string `json:"domain"`
 					}{Domain: value.(string)}})
+				case "email_list":
+					group = append(group, cloudflare.AccessGroupEmailList{EmailList: struct {
+						ID string `json:"id"`
+					}{ID: value.(string)}})
 				case "ip":
 					group = append(group, cloudflare.AccessGroupIP{IP: struct {
 						IP string `json:"ip"`
@@ -399,6 +402,7 @@ func TransformAccessGroupForSchema(ctx context.Context, accessGroup []interface{
 	certificate := false
 	emails := []string{}
 	emailDomains := []string{}
+	emailLists := []string{}
 	ips := []string{}
 	ipList := []string{}
 	serviceTokens := []string{}
@@ -440,6 +444,10 @@ func TransformAccessGroupForSchema(ctx context.Context, accessGroup []interface{
 			case "email_domain":
 				for _, domain := range groupValue.(map[string]interface{}) {
 					emailDomains = append(emailDomains, domain.(string))
+				}
+			case "email_list":
+				for _, list := range groupValue.(map[string]interface{}) {
+					emailLists = append(emailLists, list.(string))
 				}
 			case "ip":
 				for _, ip := range groupValue.(map[string]interface{}) {
@@ -563,6 +571,10 @@ func TransformAccessGroupForSchema(ctx context.Context, accessGroup []interface{
 
 	if len(emailDomains) > 0 {
 		groupMap["email_domain"] = emailDomains
+	}
+
+	if len(emailLists) > 0 {
+		groupMap["email_list"] = emailLists
 	}
 
 	if len(ips) > 0 {

--- a/internal/sdkv2provider/resource_cloudflare_access_group_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_group_test.go
@@ -181,6 +181,31 @@ func TestAccCloudflareAccessGroup_ConfigBasicAccount(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareAccessGroup_ConfigEmailList(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_access_group.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCloudflareAccessGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareAccessGroupConfigEmailList(rnd, cloudflare.ZoneIdentifier(zoneID)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareAccessGroupExists(name, cloudflare.ZoneIdentifier(zoneID), &accessGroup),
+					resource.TestCheckResourceAttr(name, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "require.0.email_list.0", "e3a0f205-c525-4e48-a293-ba5d1f00e638"),
+					resource.TestCheckResourceAttr(name, "require.0.email_list.1", "5d54cd30-ce52-46e4-9a46-a47887e1a167"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudflareAccessGroup_Exclude(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_group.%s", rnd)
@@ -609,6 +634,18 @@ resource "cloudflare_access_group" "%[1]s" {
 
   include {
     common_names = ["common", "name"]
+  }
+}`, resourceName, identifier.Type, identifier.Identifier)
+}
+
+func testAccCloudflareAccessGroupConfigEmailList(resourceName string, identifier *cloudflare.ResourceContainer) string {
+	return fmt.Sprintf(`
+resource "cloudflare_access_group" "%[1]s" {
+  %[2]s_id = "%[3]s"
+  name     = "%[1]s"
+
+  require {
+		email_list = ["e3a0f205-c525-4e48-a293-ba5d1f00e638", "5d54cd30-ce52-46e4-9a46-a47887e1a167"]
   }
 }`, resourceName, identifier.Type, identifier.Identifier)
 }

--- a/internal/sdkv2provider/schema_cloudflare_access_group.go
+++ b/internal/sdkv2provider/schema_cloudflare_access_group.go
@@ -61,6 +61,13 @@ var AccessGroupOptionSchemaElement = &schema.Resource{
 				Type: schema.TypeString,
 			},
 		},
+		"email_list": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"ip": {
 			Type:        schema.TypeList,
 			Description: "An IPv4 or IPv6 CIDR block.",


### PR DESCRIPTION
Adds support for using email_lists inside the access groups. The parameter is documented here in [the API](https://developers.cloudflare.com/api/operations/access-groups-update-an-access-group).

There was a discussion about [this here](https://github.com/cloudflare/terraform-provider-cloudflare/issues/2203). Issue was closed as it was pending the cloudflare-go support which has been released [quite some time ago](https://github.com/cloudflare/cloudflare-go/pull/1445) already.