### PR TITLE
Depend explicitly on the challenge to prevent some errors

### DIFF
--- a/docs/resources/logpush_job.md
+++ b/docs/resources/logpush_job.md
@@ -74,6 +74,9 @@ data "aws_s3_bucket_object" "challenge_file" {
 }
 
 resource "cloudflare_logpush_job" "example_job" {
+  depends_on = [
+    cloudflare_logpush_ownership_challenge.ownership_challenge, data.aws_s3_bucket_object.challenge_file
+  ]
   enabled             = true
   zone_id             = "0da42c8d2132a9ddaf714f9e7c920711"
   name                = "My-logpush-job"

--- a/docs/resources/logpush_job.md
+++ b/docs/resources/logpush_job.md
@@ -74,9 +74,7 @@ data "aws_s3_bucket_object" "challenge_file" {
 }
 
 resource "cloudflare_logpush_job" "example_job" {
-  depends_on = [
-    cloudflare_logpush_ownership_challenge.ownership_challenge, data.aws_s3_bucket_object.challenge_file
-  ]
+  depends_on          = [cloudflare_logpush_ownership_challenge.ownership_challenge]
   enabled             = true
   zone_id             = "0da42c8d2132a9ddaf714f9e7c920711"
   name                = "My-logpush-job"

--- a/examples/resources/cloudflare_logpush_job/resource.tf
+++ b/examples/resources/cloudflare_logpush_job/resource.tf
@@ -45,6 +45,9 @@ data "aws_s3_bucket_object" "challenge_file" {
 }
 
 resource "cloudflare_logpush_job" "example_job" {
+  depends_on = [
+    cloudflare_logpush_ownership_challenge.ownership_challenge, data.aws_s3_bucket_object.challenge_file
+  ]
   enabled             = true
   zone_id             = "0da42c8d2132a9ddaf714f9e7c920711"
   name                = "My-logpush-job"

--- a/examples/resources/cloudflare_logpush_job/resource.tf
+++ b/examples/resources/cloudflare_logpush_job/resource.tf
@@ -45,9 +45,7 @@ data "aws_s3_bucket_object" "challenge_file" {
 }
 
 resource "cloudflare_logpush_job" "example_job" {
-  depends_on = [
-    cloudflare_logpush_ownership_challenge.ownership_challenge, data.aws_s3_bucket_object.challenge_file
-  ]
+  depends_on          = [cloudflare_logpush_ownership_challenge.ownership_challenge]
   enabled             = true
   zone_id             = "0da42c8d2132a9ddaf714f9e7c920711"
   name                = "My-logpush-job"


### PR DESCRIPTION
like
```
"registry.terraform.io/cloudflare/cloudflare" produced an invalid new value
for .ownership_challenge: was null, but now cty.StringVal("[redacted]..[redacted]")
```

As recommended by @jacobbednarz in
https://github.com/cloudflare/terraform-provider-cloudflare/issues/2752#issuecomment-1712190497

Workaround for issues like
https://github.com/cloudflare/terraform-provider-cloudflare/issues/2794 https://github.com/cloudflare/terraform-provider-cloudflare/issues/2752 https://github.com/cloudflare/terraform-provider-cloudflare/issues/3001