### PR TITLE
provider: introduce a muxed client

### DIFF
--- a/.changelog/3262.txt
+++ b/.changelog/3262.txt
@@ -1,0 +1,3 @@
+```release-note:internal
+provider: introduce a muxed client to support using cloudflare-go/v0 and cloudflare-go/v2 together
+```

--- a/docs/data-sources/account_roles.md
+++ b/docs/data-sources/account_roles.md
@@ -13,18 +13,19 @@ Use this data source to lookup [Account Roles](https://api.cloudflare.com/#accou
 
 ```terraform
 data "cloudflare_account_roles" "account_roles" {
-    account_id = "f037e56e89293a057740de681ac9abbe"
+  account_id = "f037e56e89293a057740de681ac9abbe"
 }
 
 locals {
   roles_by_name = {
     for role in data.cloudflare_account_roles.account_roles.roles :
-      role.name => role
+    role.name => role
   }
 }
 
 resource "cloudflare_account_member" "member" {
-  ...
+  account_id    = "f037e56e89293a057740de681ac9abbe"
+  email_address = "user@example.com"
   role_ids = [
     local.roles_by_name["Administrator"].id
   ]

--- a/docs/resources/dlp_profile.md
+++ b/docs/resources/dlp_profile.md
@@ -18,7 +18,7 @@ They are referenced in Zero Trust Gateway rules.
 ```terraform
 # Predefined profile must be imported, cannot be created
 resource "cloudflare_dlp_profile" "creds" {
-  account_id          = "0da42c8d2132a9ddaf714f9e7c920711"
+  account_id          = "f037e56e89293a057740de681ac9abbe"
   name                = "Credentials and Secrets"
   type                = "predefined"
   allowed_match_count = 3
@@ -52,7 +52,7 @@ resource "cloudflare_dlp_profile" "creds" {
 
 # Custom profile
 resource "cloudflare_dlp_profile" "example_custom" {
-  account_id          = "0da42c8d2132a9ddaf714f9e7c920711"
+  account_id          = "f037e56e89293a057740de681ac9abbe"
   name                = "Example Custom Profile"
   description         = "A profile with example entries"
   type                = "custom"
@@ -62,7 +62,7 @@ resource "cloudflare_dlp_profile" "example_custom" {
     name    = "Matches visa credit cards"
     enabled = true
     pattern {
-      regex      = "4\d{3}([-\\. ])?\d{4}([-\\. ])?\d{4}([-\\. ])?\d{4}"
+      regex      = "4\\d{3}([-\\. ])?\\d{4}([-\\. ])?\\d{4}([-\\. ])?\\d{4}"
       validation = "luhn"
     }
   }
@@ -87,12 +87,12 @@ resource "cloudflare_dlp_profile" "example_custom" {
 - `entry` (Block Set, Min: 1) List of entries to apply to the profile. (see [below for nested schema](#nestedblock--entry))
 - `name` (String) Name of the profile. **Modifying this attribute will force creation of a new resource.**
 - `type` (String) The type of the profile. Available values: `custom`, `predefined`. **Modifying this attribute will force creation of a new resource.**
-- `ocr_enabled` (Boolean) If true, scan images via OCR to determine if any text present matches filters.
 
 ### Optional
 
 - `context_awareness` (Block List, Max: 1) Scan the context of predefined entries to only return matches surrounded by keywords. (see [below for nested schema](#nestedblock--context_awareness))
 - `description` (String) Brief summary of the profile and its intended use.
+- `ocr_enabled` (Boolean) If true, scan images via OCR to determine if any text present matches filters.
 
 ### Read-Only
 

--- a/docs/resources/workers_for_platforms_namespace.md
+++ b/docs/resources/workers_for_platforms_namespace.md
@@ -8,7 +8,7 @@ description: |-
 
 # cloudflare_workers_for_platforms_namespace (Resource)
 
-The [Workers for Platforms](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/) resource allows you 
+The [Workers for Platforms](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/) resource allows you
 to manage Cloudflare Workers for Platforms namespaces.
 
 ## Example Usage

--- a/examples/data-sources/cloudflare_account_roles/data-source.tf
+++ b/examples/data-sources/cloudflare_account_roles/data-source.tf
@@ -1,16 +1,17 @@
 data "cloudflare_account_roles" "account_roles" {
-    account_id = "f037e56e89293a057740de681ac9abbe"
+  account_id = "f037e56e89293a057740de681ac9abbe"
 }
 
 locals {
   roles_by_name = {
     for role in data.cloudflare_account_roles.account_roles.roles :
-      role.name => role
+    role.name => role
   }
 }
 
 resource "cloudflare_account_member" "member" {
-  ...
+  account_id    = "f037e56e89293a057740de681ac9abbe"
+  email_address = "user@example.com"
   role_ids = [
     local.roles_by_name["Administrator"].id
   ]

--- a/examples/resources/cloudflare_dlp_profile/resource.tf
+++ b/examples/resources/cloudflare_dlp_profile/resource.tf
@@ -1,6 +1,6 @@
 # Predefined profile must be imported, cannot be created
 resource "cloudflare_dlp_profile" "creds" {
-  account_id          = "0da42c8d2132a9ddaf714f9e7c920711"
+  account_id          = "f037e56e89293a057740de681ac9abbe"
   name                = "Credentials and Secrets"
   type                = "predefined"
   allowed_match_count = 3
@@ -34,7 +34,7 @@ resource "cloudflare_dlp_profile" "creds" {
 
 # Custom profile
 resource "cloudflare_dlp_profile" "example_custom" {
-  account_id          = "0da42c8d2132a9ddaf714f9e7c920711"
+  account_id          = "f037e56e89293a057740de681ac9abbe"
   name                = "Example Custom Profile"
   description         = "A profile with example entries"
   type                = "custom"
@@ -44,7 +44,7 @@ resource "cloudflare_dlp_profile" "example_custom" {
     name    = "Matches visa credit cards"
     enabled = true
     pattern {
-      regex      = "4\d{3}([-\\. ])?\d{4}([-\\. ])?\d{4}([-\\. ])?\d{4}"
+      regex      = "4\\d{3}([-\\. ])?\\d{4}([-\\. ])?\\d{4}([-\\. ])?\\d{4}"
       validation = "luhn"
     }
   }

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/cloudflare/cloudflare-go/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
@@ -84,6 +85,10 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vc
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cloudflare/cloudflare-go v0.93.0 h1:rV0eHb42NUewfK5qa2+LKAD4v4oFA0QGDABn/lMyF78=
 github.com/cloudflare/cloudflare-go v0.93.0/go.mod h1:N1u1cLZ4lG6NeezGOWi7P6aq1DK2iVYg9ze7GZbUmZE=
+github.com/cloudflare/cloudflare-go/v2 v2.0.0 h1:T73RHu9NbMIRGs1d4NbMHCnFB7semPVd3r8Fd2KuCjg=
+github.com/cloudflare/cloudflare-go/v2 v2.0.0/go.mod h1:AoIzb05z/rvdJLztPct4tSa+3IqXJJ6c+pbUFMOlTr8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
@@ -201,6 +203,16 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
+	cfv2 "github.com/cloudflare/cloudflare-go/v2"
+	"github.com/cloudflare/cloudflare-go/v2/option"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/provider"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -77,14 +79,23 @@ func TestAccSkipForDefaultAccount(t *testing.T, reason string) {
 	}
 }
 
-// sharedClient returns a common Cloudflare client setup needed for the
+// SharedV1Client returns a common Cloudflare V1 client setup needed for the
 // sweeper functions.
-func SharedClient() (*cloudflare.API, error) {
-	client, err := cloudflare.New(os.Getenv("CLOUDFLARE_API_KEY"), os.Getenv("CLOUDFLARE_EMAIL"))
+func SharedV1Client() (*cfv1.API, error) {
+	client, err := cfv1.New(os.Getenv("CLOUDFLARE_API_KEY"), os.Getenv("CLOUDFLARE_EMAIL"))
 
 	if err != nil {
 		return client, err
 	}
 
 	return client, nil
+}
+
+// SharedV2Client returns a common Cloudflare V2 client setup needed for the
+// sweeper functions.
+func SharedV2Client() *cfv2.Client {
+	return cfv2.NewClient(
+		option.WithAPIKey("CLOUDFLARE_API_KEY"),
+		option.WithAPIEmail("CLOUDFLARE_EMAIL"),
+	)
 }

--- a/internal/framework/muxclient/muxclient.go
+++ b/internal/framework/muxclient/muxclient.go
@@ -1,0 +1,15 @@
+package muxclient
+
+import (
+	cfv1 "github.com/cloudflare/cloudflare-go"
+	cfv2 "github.com/cloudflare/cloudflare-go/v2"
+)
+
+// Client is the intermediatry structure to allow us to run both versions of the
+// Go SDK alongside one another without collisions.
+//
+// The usage is resource dependent and no safe guards are included here.
+type Client struct {
+	V1 *cfv1.API
+	V2 *cfv2.Client
+}

--- a/internal/framework/muxclient/muxclient_test.go
+++ b/internal/framework/muxclient/muxclient_test.go
@@ -1,0 +1,35 @@
+package muxclient_test
+
+import (
+	"context"
+	"testing"
+
+	cfv1 "github.com/cloudflare/cloudflare-go"
+	cfv2 "github.com/cloudflare/cloudflare-go/v2"
+	"github.com/cloudflare/cloudflare-go/v2/option"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/muxclient"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/provider"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMuxClientInitialised(t *testing.T) {
+	c1 := muxclient.Client{}
+	assert.Empty(t, c1)
+
+	v1Config := provider.Config{}
+	v1Config.Email = "user@example.com"
+	cfv1Client, _ := v1Config.Client(context.TODO())
+
+	cfv2Client := cfv2.NewClient(
+		option.WithAPIEmail("user@example.com"),
+	)
+	c2 := &muxclient.Client{
+		V1: cfv1Client,
+		V2: cfv2Client,
+	}
+
+	assert.NotEmpty(t, c2)
+	assert.IsType(t, &cfv1.API{}, cfv1Client)
+	assert.IsType(t, &cfv2.Client{}, cfv2Client)
+	assert.IsType(t, &muxclient.Client{}, c2)
+}

--- a/internal/framework/service/access_mutual_tls_hostname_settings/resource_test.go
+++ b/internal/framework/service/access_mutual_tls_hostname_settings/resource_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
@@ -20,23 +20,23 @@ func init() {
 		F: func(region string) error {
 			ctx := context.Background()
 
-			client, clientErr := acctest.SharedClient()
+			client, clientErr := acctest.SharedV1Client()
 			if clientErr != nil {
 				return fmt.Errorf("Failed to create Cloudflare client: %w", clientErr)
 			}
 
-			deletedSettings := cloudflare.UpdateAccessMutualTLSHostnameSettingsParams{
-				Settings: []cloudflare.AccessMutualTLSHostnameSettings{},
+			deletedSettings := cfv1.UpdateAccessMutualTLSHostnameSettingsParams{
+				Settings: []cfv1.AccessMutualTLSHostnameSettings{},
 			}
 
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-			_, err := client.UpdateAccessMutualTLSHostnameSettings(ctx, cloudflare.AccountIdentifier(accountID), deletedSettings)
+			_, err := client.UpdateAccessMutualTLSHostnameSettings(ctx, cfv1.AccountIdentifier(accountID), deletedSettings)
 			if err != nil {
 				return fmt.Errorf("Failed to fetch Cloudflare Access Mutual TLS hostname settings: %w", err)
 			}
 
 			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
-			_, err = client.UpdateAccessMutualTLSHostnameSettings(ctx, cloudflare.ZoneIdentifier(zoneID), deletedSettings)
+			_, err = client.UpdateAccessMutualTLSHostnameSettings(ctx, cfv1.ZoneIdentifier(zoneID), deletedSettings)
 			if err != nil {
 				return fmt.Errorf("Failed to delete Cloudflare Access Mutual TLS hostname settings: %w", err)
 			}
@@ -68,7 +68,7 @@ func TestAccCloudflareAccessMutualTLSHostnameSettings_Simple(t *testing.T) {
 		CheckDestroy:             testAccCheckCloudflareAccessMutualTLSHostnameSettingsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccessMutualTLSHostnameSettingsConfig(rnd, cloudflare.AccountIdentifier(accountID), domain),
+				Config: testAccessMutualTLSHostnameSettingsConfig(rnd, cfv1.AccountIdentifier(accountID), domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
 					resource.TestCheckResourceAttr(name, "settings.0.hostname", domain),
@@ -81,7 +81,7 @@ func TestAccCloudflareAccessMutualTLSHostnameSettings_Simple(t *testing.T) {
 }
 
 func testAccCheckCloudflareAccessMutualTLSHostnameSettingsDestroy(s *terraform.State) error {
-	client, err := acctest.SharedClient()
+	client, err := acctest.SharedV1Client()
 	if err != nil {
 		return fmt.Errorf("Failed to create Cloudflare client: %w", err)
 	}
@@ -92,14 +92,14 @@ func testAccCheckCloudflareAccessMutualTLSHostnameSettingsDestroy(s *terraform.S
 		}
 
 		if rs.Primary.Attributes[consts.ZoneIDSchemaKey] != "" {
-			settings, _ := client.GetAccessMutualTLSHostnameSettings(context.Background(), cloudflare.ZoneIdentifier(rs.Primary.Attributes[consts.ZoneIDSchemaKey]))
+			settings, _ := client.GetAccessMutualTLSHostnameSettings(context.Background(), cfv1.ZoneIdentifier(rs.Primary.Attributes[consts.ZoneIDSchemaKey]))
 			if len(settings) != 0 {
 				return fmt.Errorf("AccessMutualTLSHostnameSettings still exists")
 			}
 		}
 
 		if rs.Primary.Attributes[consts.AccountIDSchemaKey] != "" {
-			settings, _ := client.GetAccessMutualTLSHostnameSettings(context.Background(), cloudflare.AccountIdentifier(rs.Primary.Attributes[consts.AccountIDSchemaKey]))
+			settings, _ := client.GetAccessMutualTLSHostnameSettings(context.Background(), cfv1.AccountIdentifier(rs.Primary.Attributes[consts.AccountIDSchemaKey]))
 			if len(settings) != 0 {
 				return fmt.Errorf("AccessMutualTLSHostnameSettings still exists")
 			}
@@ -109,7 +109,7 @@ func testAccCheckCloudflareAccessMutualTLSHostnameSettingsDestroy(s *terraform.S
 	return nil
 }
 
-func testAccessMutualTLSHostnameSettingsConfig(rnd string, identifier *cloudflare.ResourceContainer, domain string) string {
+func testAccessMutualTLSHostnameSettingsConfig(rnd string, identifier *cfv1.ResourceContainer, domain string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_access_mutual_tls_hostname_settings" "%[1]s" {
 	%[2]s_id             = "%[3]s"

--- a/internal/framework/service/api_token_permissions_groups/data_source.go
+++ b/internal/framework/service/api_token_permissions_groups/data_source.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
-	"github.com/cloudflare/cloudflare-go"
+	"sort"
+	"strings"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/muxclient"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"sort"
-	"strings"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -21,7 +22,7 @@ func NewDataSource() datasource.DataSource {
 
 // APITokenPermissionsGroupDataSource defines the data source implementation.
 type APITokenPermissionsGroupDataSource struct {
-	client *cloudflare.API
+	client *muxclient.Client
 }
 
 func (r *APITokenPermissionsGroupDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -33,12 +34,12 @@ func (r *APITokenPermissionsGroupDataSource) Configure(ctx context.Context, req 
 		return
 	}
 
-	client, ok := req.ProviderData.(*cloudflare.API)
+	client, ok := req.ProviderData.(*muxclient.Client)
 
 	if !ok {
 		resp.Diagnostics.AddError(
 			"unexpected resource configure type",
-			fmt.Sprintf("expected *cloudflare.API, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *muxclient.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
@@ -56,7 +57,7 @@ func (r *APITokenPermissionsGroupDataSource) Read(ctx context.Context, req datas
 		return
 	}
 
-	permissions, err := r.client.ListAPITokensPermissionGroups(ctx)
+	permissions, err := r.client.V1.ListAPITokensPermissionGroups(ctx)
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/framework/service/api_token_permissions_groups/schema.go
+++ b/internal/framework/service/api_token_permissions_groups/schema.go
@@ -2,6 +2,7 @@ package api_token_permissions_groups
 
 import (
 	"context"
+
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/internal/framework/service/d1/resource_test.go
+++ b/internal/framework/service/d1/resource_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -20,7 +20,7 @@ func init() {
 	resource.AddTestSweepers("cloudflare_d1_database", &resource.Sweeper{
 		Name: "cloudflare_d1_database",
 		F: func(region string) error {
-			client, err := acctest.SharedClient()
+			client, err := acctest.SharedV1Client()
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
 			if err != nil {
@@ -28,7 +28,7 @@ func init() {
 			}
 
 			ctx := context.Background()
-			databases, _, err := client.ListD1Databases(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListD1DatabasesParams{})
+			databases, _, err := client.ListD1Databases(ctx, cfv1.AccountIdentifier(accountID), cfv1.ListD1DatabasesParams{})
 			if err != nil {
 				return fmt.Errorf("failed to fetch R2 buckets: %w", err)
 			}
@@ -40,7 +40,7 @@ func init() {
 					continue
 				}
 
-				err := client.DeleteD1Database(ctx, cloudflare.AccountIdentifier(accountID), database.UUID)
+				err := client.DeleteD1Database(ctx, cfv1.AccountIdentifier(accountID), database.UUID)
 				if err != nil {
 					return fmt.Errorf("failed to delete D1 database %q: %w", database.Name, err)
 				}

--- a/internal/framework/service/d1/schema.go
+++ b/internal/framework/service/d1/schema.go
@@ -2,8 +2,9 @@ package d1
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"

--- a/internal/framework/service/dlp_datasets/data_source.go
+++ b/internal/framework/service/dlp_datasets/data_source.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/muxclient"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -16,7 +17,7 @@ func NewDataSource() datasource.DataSource {
 }
 
 type CloudflareDlpDatasetsDataSource struct {
-	client *cloudflare.API
+	client *muxclient.Client
 }
 
 func (d *CloudflareDlpDatasetsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -28,11 +29,11 @@ func (d *CloudflareDlpDatasetsDataSource) Configure(ctx context.Context, req dat
 		return
 	}
 
-	client, ok := req.ProviderData.(*cloudflare.API)
+	client, ok := req.ProviderData.(*muxclient.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected resource configure type",
-			fmt.Sprintf("Expected *cloudflare.API, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *muxclient.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
@@ -45,7 +46,7 @@ func (d *CloudflareDlpDatasetsDataSource) Read(ctx context.Context, req datasour
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
-	accountDatasets, err := d.client.ListDLPDatasets(ctx, cloudflare.AccountIdentifier(data.AccountID.ValueString()), cloudflare.ListDLPDatasetsParams{})
+	accountDatasets, err := d.client.V1.ListDLPDatasets(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()), cfv1.ListDLPDatasetsParams{})
 	if err != nil {
 		resp.Diagnostics.AddError("failed to fetch DLP Datasets: %w", err.Error())
 		return

--- a/internal/framework/service/email_routing_address/resource_test.go
+++ b/internal/framework/service/email_routing_address/resource_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -19,7 +19,7 @@ func init() {
 	resource.AddTestSweepers("cloudflare_email_routing_address", &resource.Sweeper{
 		Name: "cloudflare_email_routing_address",
 		F: func(region string) error {
-			client, err := acctest.SharedClient()
+			client, err := acctest.SharedV1Client()
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
 			if err != nil {
@@ -27,13 +27,13 @@ func init() {
 			}
 
 			ctx := context.Background()
-			emails, _, err := client.ListEmailRoutingDestinationAddresses(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListEmailRoutingAddressParameters{})
+			emails, _, err := client.ListEmailRoutingDestinationAddresses(ctx, cfv1.AccountIdentifier(accountID), cfv1.ListEmailRoutingAddressParameters{})
 			if err != nil {
 				return fmt.Errorf("failed to fetch email routing destination addresses: %w", err)
 			}
 
 			for _, email := range emails {
-				_, err := client.DeleteEmailRoutingDestinationAddress(ctx, cloudflare.AccountIdentifier(accountID), email.Tag)
+				_, err := client.DeleteEmailRoutingDestinationAddress(ctx, cfv1.AccountIdentifier(accountID), email.Tag)
 				if err != nil {
 					return fmt.Errorf("failed to delete email routing destination address %q: %w", email.Email, err)
 				}

--- a/internal/framework/service/email_routing_address/schema.go
+++ b/internal/framework/service/email_routing_address/schema.go
@@ -2,6 +2,7 @@ package email_routing_address
 
 import (
 	"context"
+
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/framework/service/email_routing_rule/resource_test.go
+++ b/internal/framework/service/email_routing_rule/resource_test.go
@@ -6,10 +6,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
-
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -22,7 +21,7 @@ func init() {
 	resource.AddTestSweepers("cloudflare_email_routing_rule", &resource.Sweeper{
 		Name: "cloudflare_email_routing_rule",
 		F: func(region string) error {
-			client, err := acctest.SharedClient()
+			client, err := acctest.SharedV1Client()
 			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 
 			if err != nil {
@@ -30,7 +29,7 @@ func init() {
 			}
 
 			ctx := context.Background()
-			rules, _, err := client.ListEmailRoutingRules(ctx, cloudflare.ZoneIdentifier(zoneID), cloudflare.ListEmailRoutingRulesParameters{})
+			rules, _, err := client.ListEmailRoutingRules(ctx, cfv1.ZoneIdentifier(zoneID), cfv1.ListEmailRoutingRulesParameters{})
 			if err != nil {
 				return fmt.Errorf("failed to fetch email routing rules: %w", err)
 			}
@@ -39,7 +38,7 @@ func init() {
 				for _, matchers := range rule.Matchers {
 					// you cannot delete a catch all rule
 					if matchers.Type != "all" {
-						_, err := client.DeleteEmailRoutingRule(ctx, cloudflare.ZoneIdentifier(zoneID), rule.Tag)
+						_, err := client.DeleteEmailRoutingRule(ctx, cfv1.ZoneIdentifier(zoneID), rule.Tag)
 						if err != nil {
 							return fmt.Errorf("failed to delete email routing rule %q: %w", rule.Name, err)
 						}

--- a/internal/framework/service/email_routing_rule/schema.go
+++ b/internal/framework/service/email_routing_rule/schema.go
@@ -3,6 +3,7 @@ package email_routing_rule
 import (
 	"context"
 	"fmt"
+
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"

--- a/internal/framework/service/example/example.go
+++ b/internal/framework/service/example/example.go
@@ -94,7 +94,7 @@ func (r *ExampleResource) Create(ctx context.Context, req resource.CreateRequest
 
 	// If applicable, this is a great opportunity to initialize any necessary
 	// provider client data and make a call using it.
-	// httpResp, err := r.client.Do(httpReq)
+	// httpResp, err := r.client.V1.Do(httpReq)
 	// if err != nil {
 	//     resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create example, got error: %s", err))
 	//     return
@@ -124,7 +124,7 @@ func (r *ExampleResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	// If applicable, this is a great opportunity to initialize any necessary
 	// provider client data and make a call using it.
-	// httpResp, err := r.client.Do(httpReq)
+	// httpResp, err := r.client.V1.Do(httpReq)
 	// if err != nil {
 	//     resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read example, got error: %s", err))
 	//     return
@@ -146,7 +146,7 @@ func (r *ExampleResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	// If applicable, this is a great opportunity to initialize any necessary
 	// provider client data and make a call using it.
-	// httpResp, err := r.client.Do(httpReq)
+	// httpResp, err := r.client.V1.Do(httpReq)
 	// if err != nil {
 	//     resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update example, got error: %s", err))
 	//     return
@@ -168,7 +168,7 @@ func (r *ExampleResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	// If applicable, this is a great opportunity to initialize any necessary
 	// provider client data and make a call using it.
-	// httpResp, err := r.client.Do(httpReq)
+	// httpResp, err := r.client.V1.Do(httpReq)
 	// if err != nil {
 	//     resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete example, got error: %s", err))
 	//     return

--- a/internal/framework/service/hyperdrive_config/resource.go
+++ b/internal/framework/service/hyperdrive_config/resource.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cloudflare/cloudflare-go"
-
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/flatteners"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/muxclient"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -25,7 +25,7 @@ func NewResource() resource.Resource {
 
 // HyperdriveConfigResource defines the resource implementation for hyperdrive configs.
 type HyperdriveConfigResource struct {
-	client *cloudflare.API
+	client *muxclient.Client
 }
 
 func (r *HyperdriveConfigResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -37,12 +37,12 @@ func (r *HyperdriveConfigResource) Configure(ctx context.Context, req resource.C
 		return
 	}
 
-	client, ok := req.ProviderData.(*cloudflare.API)
+	client, ok := req.ProviderData.(*muxclient.Client)
 
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *cloudflare.API, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *muxclient.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
@@ -64,10 +64,10 @@ func (r *HyperdriveConfigResource) Create(ctx context.Context, req resource.Crea
 
 	config := buildHyperdriveConfigFromModel(data, caching)
 
-	createHyperdriveConfig, err := r.client.CreateHyperdriveConfig(ctx, cloudflare.AccountIdentifier(data.AccountID.ValueString()),
-		cloudflare.CreateHyperdriveConfigParams{
+	createHyperdriveConfig, err := r.client.V1.CreateHyperdriveConfig(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()),
+		cfv1.CreateHyperdriveConfigParams{
 			Name: config.Name,
-			Origin: cloudflare.HyperdriveConfigOrigin{
+			Origin: cfv1.HyperdriveConfigOrigin{
 				Database: config.Origin.Database,
 				Password: config.Origin.Password,
 				Host:     config.Origin.Host,
@@ -75,7 +75,7 @@ func (r *HyperdriveConfigResource) Create(ctx context.Context, req resource.Crea
 				Scheme:   config.Origin.Scheme,
 				User:     config.Origin.User,
 			},
-			Caching: cloudflare.HyperdriveConfigCaching{
+			Caching: cfv1.HyperdriveConfigCaching{
 				Disabled: config.Caching.Disabled,
 			},
 		})
@@ -100,7 +100,7 @@ func (r *HyperdriveConfigResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	config, err := r.client.GetHyperdriveConfig(ctx, cloudflare.AccountIdentifier(data.AccountID.ValueString()), data.ID.ValueString())
+	config, err := r.client.V1.GetHyperdriveConfig(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()), data.ID.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading hyperdrive config", err.Error())
@@ -127,10 +127,10 @@ func (r *HyperdriveConfigResource) Update(ctx context.Context, req resource.Upda
 
 	config := buildHyperdriveConfigFromModel(data, caching)
 
-	updatedConfig, err := r.client.UpdateHyperdriveConfig(ctx, cloudflare.AccountIdentifier(data.AccountID.ValueString()), cloudflare.UpdateHyperdriveConfigParams{
+	updatedConfig, err := r.client.V1.UpdateHyperdriveConfig(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()), cfv1.UpdateHyperdriveConfigParams{
 		Name:         config.Name,
 		HyperdriveID: config.ID,
-		Origin: cloudflare.HyperdriveConfigOrigin{
+		Origin: cfv1.HyperdriveConfigOrigin{
 			Database: config.Origin.Database,
 			Password: config.Origin.Password,
 			Host:     config.Origin.Host,
@@ -138,7 +138,7 @@ func (r *HyperdriveConfigResource) Update(ctx context.Context, req resource.Upda
 			Scheme:   config.Origin.Scheme,
 			User:     config.Origin.User,
 		},
-		Caching: cloudflare.HyperdriveConfigCaching{
+		Caching: cfv1.HyperdriveConfigCaching{
 			Disabled: config.Caching.Disabled,
 		},
 	})
@@ -164,7 +164,7 @@ func (r *HyperdriveConfigResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	err := r.client.DeleteHyperdriveConfig(ctx, cloudflare.AccountIdentifier(data.AccountID.ValueString()), data.ID.ValueString())
+	err := r.client.V1.DeleteHyperdriveConfig(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()), data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting hyperdrive config", err.Error())
 	}
@@ -179,11 +179,11 @@ func (r *HyperdriveConfigResource) ImportState(ctx context.Context, req resource
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), idParts[1])...)
 }
 
-func buildHyperdriveConfigFromModel(config *HyperdriveConfigModel, caching *HyperdriveConfigCachingModel) cloudflare.HyperdriveConfig {
-	built := cloudflare.HyperdriveConfig{
+func buildHyperdriveConfigFromModel(config *HyperdriveConfigModel, caching *HyperdriveConfigCachingModel) cfv1.HyperdriveConfig {
+	built := cfv1.HyperdriveConfig{
 		ID:   config.ID.ValueString(),
 		Name: config.Name.ValueString(),
-		Origin: cloudflare.HyperdriveConfigOrigin{
+		Origin: cfv1.HyperdriveConfigOrigin{
 			Database: config.Origin.Database.ValueString(),
 			Password: config.Origin.Password.ValueString(),
 			Host:     config.Origin.Host.ValueString(),
@@ -199,16 +199,16 @@ func buildHyperdriveConfigFromModel(config *HyperdriveConfigModel, caching *Hype
 		built.Origin.User = config.Origin.User.ValueString()
 	}
 
-	built.Caching = cloudflare.HyperdriveConfigCaching{}
+	built.Caching = cfv1.HyperdriveConfigCaching{}
 
 	if caching != nil && !caching.Disabled.IsNull() {
-		built.Caching.Disabled = cloudflare.BoolPtr(caching.Disabled.ValueBool())
+		built.Caching.Disabled = cfv1.BoolPtr(caching.Disabled.ValueBool())
 	}
 
 	return built
 }
 
-func buildHyperdriveConfigModelFromHyperdriveConfig(ctx context.Context, data *HyperdriveConfigModel, config cloudflare.HyperdriveConfig) (*HyperdriveConfigModel, diag.Diagnostics) {
+func buildHyperdriveConfigModelFromHyperdriveConfig(ctx context.Context, data *HyperdriveConfigModel, config cfv1.HyperdriveConfig) (*HyperdriveConfigModel, diag.Diagnostics) {
 	var scheme = flatteners.String("postgres")
 	if data.Origin != nil {
 		scheme = data.Origin.Scheme

--- a/internal/framework/service/hyperdrive_config/resource_test.go
+++ b/internal/framework/service/hyperdrive_config/resource_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -21,7 +21,7 @@ func init() {
 	resource.AddTestSweepers("cloudflare_hyperdrive_config", &resource.Sweeper{
 		Name: "cloudflare_hyperdrive_config",
 		F: func(region string) error {
-			client, err := acctest.SharedClient()
+			client, err := acctest.SharedV1Client()
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
 			ctx := context.Background()
@@ -30,13 +30,13 @@ func init() {
 				tflog.Error(ctx, fmt.Sprintf("Failed to create Cloudflare client: %s", err))
 			}
 
-			resp, err := client.ListHyperdriveConfigs(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListHyperdriveConfigParams{})
+			resp, err := client.ListHyperdriveConfigs(ctx, cfv1.AccountIdentifier(accountID), cfv1.ListHyperdriveConfigParams{})
 			if err != nil {
 				return err
 			}
 
 			for _, q := range resp {
-				err := client.DeleteHyperdriveConfig(ctx, cloudflare.AccountIdentifier(accountID), q.ID)
+				err := client.DeleteHyperdriveConfig(ctx, cfv1.AccountIdentifier(accountID), q.ID)
 				if err != nil {
 					return err
 				}
@@ -54,7 +54,7 @@ func TestAccCloudflareHyperdriveConfig_Basic(t *testing.T) {
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	resourceName := "cloudflare_hyperdrive_config." + rnd
 
-	var origin = cloudflare.HyperdriveConfigOrigin{
+	var origin = cfv1.HyperdriveConfigOrigin{
 		Database: "database",
 		Host:     "host.example.com",
 		Port:     5432,
@@ -64,7 +64,7 @@ func TestAccCloudflareHyperdriveConfig_Basic(t *testing.T) {
 
 	var disabled = true
 
-	var caching = cloudflare.HyperdriveConfigCaching{
+	var caching = cfv1.HyperdriveConfigCaching{
 		Disabled: &disabled,
 	}
 
@@ -111,7 +111,7 @@ func TestAccCloudflareHyperdriveConfig_Minimum(t *testing.T) {
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	resourceName := "cloudflare_hyperdrive_config." + rnd
 
-	var origin = cloudflare.HyperdriveConfigOrigin{
+	var origin = cfv1.HyperdriveConfigOrigin{
 		Database: "database",
 		Host:     "host.example.com",
 		Port:     5432,
@@ -155,7 +155,7 @@ func TestAccCloudflareHyperdriveConfig_Minimum(t *testing.T) {
 }
 
 func testHyperdriveConfigConfig(
-	rnd, accountId, name string, password string, origin cloudflare.HyperdriveConfigOrigin, caching cloudflare.HyperdriveConfigCaching,
+	rnd, accountId, name string, password string, origin cfv1.HyperdriveConfigOrigin, caching cfv1.HyperdriveConfigCaching,
 ) string {
 	return fmt.Sprintf(`
 		resource "cloudflare_hyperdrive_config" "%[1]s" {
@@ -178,7 +178,7 @@ func testHyperdriveConfigConfig(
 }
 
 func testHyperdriveConfigConfigMinimum(
-	rnd, accountId, name string, password string, origin cloudflare.HyperdriveConfigOrigin,
+	rnd, accountId, name string, password string, origin cfv1.HyperdriveConfigOrigin,
 ) string {
 	return fmt.Sprintf(`
 		resource "cloudflare_hyperdrive_config" "%[1]s" {

--- a/internal/framework/service/list_item/resource_test.go
+++ b/internal/framework/service/list_item/resource_test.go
@@ -3,13 +3,14 @@ package list_item_test
 import (
 	"context"
 	"fmt"
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"os"
 	"regexp"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -19,7 +20,7 @@ func TestAccCloudflareListItem_Basic(t *testing.T) {
 	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
-	var ListItem cloudflare.ListItem
+	var ListItem cfv1.ListItem
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -44,7 +45,7 @@ func TestAccCloudflareListItem_MultipleItems(t *testing.T) {
 	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
-	var ListItem cloudflare.ListItem
+	var ListItem cfv1.ListItem
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -77,7 +78,7 @@ func TestAccCloudflareListItem_Update(t *testing.T) {
 	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
-	var listItem cloudflare.ListItem
+	var listItem cfv1.ListItem
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -127,7 +128,7 @@ func TestAccCloudflareListItem_ASN(t *testing.T) {
 	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
-	var ListItem cloudflare.ListItem
+	var ListItem cfv1.ListItem
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -152,7 +153,7 @@ func TestAccCloudflareListItem_Hostname(t *testing.T) {
 	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
-	var ListItem cloudflare.ListItem
+	var ListItem cfv1.ListItem
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -179,7 +180,7 @@ func TestAccCloudflareListItem_Redirect(t *testing.T) {
 	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
-	var ListItem cloudflare.ListItem
+	var ListItem cfv1.ListItem
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -225,7 +226,7 @@ func testAccCheckCloudflareIPListItem(ID, name, comment, accountID string) strin
     account_id = "%[4]s"
 	list_id    = cloudflare_list.%[2]s.id
 	ip         = "192.0.2.1"
-  } 
+  }
 `, ID, name, comment, accountID)
 }
 
@@ -267,7 +268,7 @@ func testAccCheckCloudflareIPListItemMultipleEntries(ID, name, comment, accountI
   } `, ID, name, comment, accountID)
 }
 
-func testAccCheckCloudflareListItemExists(n string, name string, listItem *cloudflare.ListItem) resource.TestCheckFunc {
+func testAccCheckCloudflareListItemExists(n string, name string, listItem *cfv1.ListItem) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 		listRS := s.RootModule().Resources["cloudflare_list."+name]
@@ -281,11 +282,11 @@ func testAccCheckCloudflareListItemExists(n string, name string, listItem *cloud
 			return fmt.Errorf("no List ID is set")
 		}
 
-		client, err := acctest.SharedClient()
+		client, err := acctest.SharedV1Client()
 		if err != nil {
 			return fmt.Errorf("error establishing client: %w", err)
 		}
-		foundList, err := client.GetListItem(context.Background(), cloudflare.AccountIdentifier(accountID), listRS.Primary.ID, rs.Primary.ID)
+		foundList, err := client.GetListItem(context.Background(), cfv1.AccountIdentifier(accountID), listRS.Primary.ID, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/framework/service/origin_ca_certificate/data_source.go
+++ b/internal/framework/service/origin_ca_certificate/data_source.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudflare/cloudflare-go"
-
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/muxclient"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -18,7 +17,7 @@ func NewDataSource() datasource.DataSource {
 }
 
 type CloudflareOriginCACertificateDataSource struct {
-	client *cloudflare.API
+	client *muxclient.Client
 }
 
 func (r *CloudflareOriginCACertificateDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -30,12 +29,12 @@ func (r *CloudflareOriginCACertificateDataSource) Configure(ctx context.Context,
 		return
 	}
 
-	client, ok := req.ProviderData.(*cloudflare.API)
+	client, ok := req.ProviderData.(*muxclient.Client)
 
 	if !ok {
 		resp.Diagnostics.AddError(
 			"unexpected resource configure type",
-			fmt.Sprintf("expected *cloudflare.API, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *muxclient.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
@@ -51,7 +50,7 @@ func (r *CloudflareOriginCACertificateDataSource) Read(ctx context.Context, req 
 		return
 	}
 
-	cert, err := r.client.GetOriginCACertificate(ctx, data.ID.ValueString())
+	cert, err := r.client.V1.GetOriginCACertificate(ctx, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("failed to fetch Origin CA: %w", err.Error())
 		return

--- a/internal/framework/service/r2_bucket/resource_test.go
+++ b/internal/framework/service/r2_bucket/resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -25,7 +25,7 @@ func init() {
 	resource.AddTestSweepers("cloudflare_r2_bucket", &resource.Sweeper{
 		Name: "cloudflare_r2_bucket",
 		F: func(region string) error {
-			client, err := acctest.SharedClient()
+			client, err := acctest.SharedV1Client()
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
 			accessKeyId := os.Getenv("CLOUDFLARE_R2_ACCESS_KEY_ID")
@@ -44,7 +44,7 @@ func init() {
 			}
 
 			ctx := context.Background()
-			buckets, err := client.ListR2Buckets(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListR2BucketsParams{})
+			buckets, err := client.ListR2Buckets(ctx, cfv1.AccountIdentifier(accountID), cfv1.ListR2BucketsParams{})
 			if err != nil {
 				return fmt.Errorf("failed to fetch R2 buckets: %w", err)
 			}
@@ -89,7 +89,7 @@ func init() {
 					}
 				}
 
-				err = client.DeleteR2Bucket(ctx, cloudflare.AccountIdentifier(accountID), bucket.Name)
+				err = client.DeleteR2Bucket(ctx, cfv1.AccountIdentifier(accountID), bucket.Name)
 				if err != nil {
 					return fmt.Errorf("failed to delete R2 bucket %q: %w", bucket.Name, err)
 				}

--- a/internal/framework/service/r2_bucket/schema.go
+++ b/internal/framework/service/r2_bucket/schema.go
@@ -2,6 +2,7 @@ package r2_bucket
 
 import (
 	"context"
+
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/framework/service/rulesets/resource_test.go
+++ b/internal/framework/service/rulesets/resource_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -22,7 +22,7 @@ func init() {
 	resource.AddTestSweepers("cloudflare_ruleset", &resource.Sweeper{
 		Name: "cloudflare_ruleset",
 		F: func(region string) error {
-			client, err := acctest.SharedClient()
+			client, err := acctest.SharedV1Client()
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 
@@ -31,24 +31,24 @@ func init() {
 			}
 
 			ctx := context.Background()
-			accountRulesets, err := client.ListRulesets(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListRulesetsParams{})
+			accountRulesets, err := client.ListRulesets(ctx, cfv1.AccountIdentifier(accountID), cfv1.ListRulesetsParams{})
 			if err != nil {
 				return fmt.Errorf("failed to fetch rulesets: %w", err)
 			}
 
 			for _, ruleset := range accountRulesets {
 				if ruleset.Kind != "managed" {
-					err := client.DeleteRuleset(ctx, cloudflare.AccountIdentifier(accountID), ruleset.ID)
+					err := client.DeleteRuleset(ctx, cfv1.AccountIdentifier(accountID), ruleset.ID)
 					if err != nil {
 						return fmt.Errorf("failed to delete ruleset %q: %w", ruleset.ID, err)
 					}
 				}
 			}
 
-			zoneRulesets, _ := client.ListRulesets(ctx, cloudflare.ZoneIdentifier(zoneID), cloudflare.ListRulesetsParams{})
+			zoneRulesets, _ := client.ListRulesets(ctx, cfv1.ZoneIdentifier(zoneID), cfv1.ListRulesetsParams{})
 			for _, ruleset := range zoneRulesets {
 				if ruleset.Kind != "managed" {
-					err := client.DeleteRuleset(ctx, cloudflare.ZoneIdentifier(zoneID), ruleset.ID)
+					err := client.DeleteRuleset(ctx, cfv1.ZoneIdentifier(zoneID), ruleset.ID)
 					if err != nil {
 						return fmt.Errorf("failed to delete ruleset %q: %w", ruleset.ID, err)
 					}

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -3,10 +3,9 @@ package rulesets
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/modifiers/defaults"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
@@ -18,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -80,24 +80,24 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 			"kind": schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{
-					stringvalidator.OneOfCaseInsensitive(cloudflare.RulesetKindValues()...),
+					stringvalidator.OneOfCaseInsensitive(cfv1.RulesetKindValues()...),
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
-				MarkdownDescription: fmt.Sprintf("Type of Ruleset to create. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cloudflare.RulesetKindValues())),
+				MarkdownDescription: fmt.Sprintf("Type of Ruleset to create. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cfv1.RulesetKindValues())),
 			},
 			"phase": schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{
-					stringvalidator.OneOfCaseInsensitive(cloudflare.RulesetPhaseValues()...),
+					stringvalidator.OneOfCaseInsensitive(cfv1.RulesetPhaseValues()...),
 					sbfmDeprecationWarningValidator{},
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
 				},
-				MarkdownDescription: fmt.Sprintf("Point in the request/response lifecycle where the ruleset will be created. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cloudflare.RulesetPhaseValues())),
+				MarkdownDescription: fmt.Sprintf("Point in the request/response lifecycle where the ruleset will be created. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cfv1.RulesetPhaseValues())),
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -139,9 +139,9 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 							MarkdownDescription: "Criteria for an HTTP request to trigger the ruleset rule action. Uses the Firewall Rules expression language based on Wireshark display filters. Refer to the [Firewall Rules language](https://developers.cloudflare.com/firewall/cf-firewall-language) documentation for all available fields, operators, and functions.",
 						},
 						"action": schema.StringAttribute{
-							MarkdownDescription: fmt.Sprintf("Action to perform in the ruleset rule. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cloudflare.RulesetRuleActionValues())),
+							MarkdownDescription: fmt.Sprintf("Action to perform in the ruleset rule. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cfv1.RulesetRuleActionValues())),
 							Validators: []validator.String{
-								stringvalidator.OneOfCaseInsensitive(cloudflare.RulesetRuleActionValues()...),
+								stringvalidator.OneOfCaseInsensitive(cfv1.RulesetRuleActionValues()...),
 							},
 							Optional: true,
 						},
@@ -232,7 +232,7 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 									"phases": schema.SetAttribute{
 										ElementType:         types.StringType,
 										Optional:            true,
-										MarkdownDescription: fmt.Sprintf("Point in the request/response lifecycle where the ruleset will be created. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cloudflare.RulesetPhaseValues())),
+										MarkdownDescription: fmt.Sprintf("Point in the request/response lifecycle where the ruleset will be created. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cfv1.RulesetPhaseValues())),
 									},
 									"polish": schema.StringAttribute{
 										Optional:            true,
@@ -241,7 +241,7 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 									"products": schema.SetAttribute{
 										ElementType:         types.StringType,
 										Optional:            true,
-										MarkdownDescription: fmt.Sprintf("Products to target with the actions. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cloudflare.RulesetActionParameterProductValues())),
+										MarkdownDescription: fmt.Sprintf("Products to target with the actions. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cfv1.RulesetActionParameterProductValues())),
 									},
 									"read_timeout": schema.Int64Attribute{
 										Optional:            true,
@@ -402,7 +402,7 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 												},
 												"operation": schema.StringAttribute{
 													Optional:            true,
-													MarkdownDescription: fmt.Sprintf("Action to perform on the HTTP request header. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cloudflare.RulesetRuleActionParametersHTTPHeaderOperationValues())),
+													MarkdownDescription: fmt.Sprintf("Action to perform on the HTTP request header. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cfv1.RulesetRuleActionParametersHTTPHeaderOperationValues())),
 												},
 											},
 										},
@@ -782,7 +782,7 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 												},
 												"action": schema.StringAttribute{
 													Optional:            true,
-													MarkdownDescription: fmt.Sprintf("Action to perform in the rule-level override. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cloudflare.RulesetRuleActionValues())),
+													MarkdownDescription: fmt.Sprintf("Action to perform in the rule-level override. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cfv1.RulesetRuleActionValues())),
 												},
 												"sensitivity_level": schema.StringAttribute{
 													Optional:            true,
@@ -803,9 +803,9 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 															},
 															"action": schema.StringAttribute{
 																Optional:            true,
-																MarkdownDescription: fmt.Sprintf("Action to perform in the tag-level override. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cloudflare.RulesetRuleActionValues())),
+																MarkdownDescription: fmt.Sprintf("Action to perform in the tag-level override. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cfv1.RulesetRuleActionValues())),
 																Validators: []validator.String{
-																	stringvalidator.OneOfCaseInsensitive(cloudflare.RulesetRuleActionValues()...),
+																	stringvalidator.OneOfCaseInsensitive(cfv1.RulesetRuleActionValues()...),
 																},
 															},
 															"enabled": schema.BoolAttribute{
@@ -825,9 +825,9 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 															},
 															"action": schema.StringAttribute{
 																Optional:            true,
-																MarkdownDescription: fmt.Sprintf("Action to perform in the rule-level override. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cloudflare.RulesetRuleActionValues())),
+																MarkdownDescription: fmt.Sprintf("Action to perform in the rule-level override. %s.", utils.RenderAvailableDocumentationValuesStringSlice(cfv1.RulesetRuleActionValues())),
 																Validators: []validator.String{
-																	stringvalidator.OneOfCaseInsensitive(cloudflare.RulesetRuleActionValues()...),
+																	stringvalidator.OneOfCaseInsensitive(cfv1.RulesetRuleActionValues()...),
 																},
 															},
 															"enabled": schema.BoolAttribute{

--- a/internal/framework/service/rulesets/validators.go
+++ b/internal/framework/service/rulesets/validators.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -27,10 +27,10 @@ func (v sbfmDeprecationWarningValidator) ValidateString(ctx context.Context, req
 		return
 	}
 
-	if req.ConfigValue.ValueString() == string(cloudflare.RulesetPhaseHTTPRequestSBFM) {
+	if req.ConfigValue.ValueString() == string(cfv1.RulesetPhaseHTTPRequestSBFM) {
 		resp.Diagnostics.AddAttributeWarning(
 			req.Path,
-			fmt.Sprintf(`%q phase will soon be deprecated in the "cloudflare_ruleset" resource`, string(cloudflare.RulesetPhaseHTTPRequestSBFM)),
+			fmt.Sprintf(`%q phase will soon be deprecated in the "cloudflare_ruleset" resource`, string(cfv1.RulesetPhaseHTTPRequestSBFM)),
 			v.Description(ctx),
 		)
 

--- a/internal/framework/service/turnstile/resource.go
+++ b/internal/framework/service/turnstile/resource.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/expanders"
-
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/flatteners"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/muxclient"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -25,7 +25,7 @@ func NewResource() resource.Resource {
 
 // TurnstileWidgetResource defines the resource implementation for challenge widgets.
 type TurnstileWidgetResource struct {
-	client *cloudflare.API
+	client *muxclient.Client
 }
 
 func (r *TurnstileWidgetResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -37,12 +37,12 @@ func (r *TurnstileWidgetResource) Configure(ctx context.Context, req resource.Co
 		return
 	}
 
-	client, ok := req.ProviderData.(*cloudflare.API)
+	client, ok := req.ProviderData.(*muxclient.Client)
 
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *cloudflare.API, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *muxclient.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
@@ -62,8 +62,8 @@ func (r *TurnstileWidgetResource) Create(ctx context.Context, req resource.Creat
 
 	widget := buildChallengeWidgetFromModel(ctx, data)
 
-	createWidget, err := r.client.CreateTurnstileWidget(ctx, cloudflare.AccountIdentifier(data.AccountID.ValueString()),
-		cloudflare.CreateTurnstileWidgetParams{
+	createWidget, err := r.client.V1.CreateTurnstileWidget(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()),
+		cfv1.CreateTurnstileWidgetParams{
 			OffLabel:     widget.OffLabel,
 			Name:         widget.Name,
 			Domains:      widget.Domains,
@@ -92,7 +92,7 @@ func (r *TurnstileWidgetResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	widget, err := r.client.GetTurnstileWidget(ctx, cloudflare.AccountIdentifier(data.AccountID.ValueString()), data.ID.ValueString())
+	widget, err := r.client.V1.GetTurnstileWidget(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()), data.ID.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading challenge widget", err.Error())
@@ -117,7 +117,7 @@ func (r *TurnstileWidgetResource) Update(ctx context.Context, req resource.Updat
 
 	widget := buildChallengeWidgetFromModel(ctx, data)
 
-	updatedWidget, err := r.client.UpdateTurnstileWidget(ctx, cloudflare.AccountIdentifier(data.AccountID.ValueString()), cloudflare.UpdateTurnstileWidgetParams{
+	updatedWidget, err := r.client.V1.UpdateTurnstileWidget(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()), cfv1.UpdateTurnstileWidgetParams{
 		SiteKey:      widget.SiteKey,
 		OffLabel:     widget.OffLabel,
 		Name:         widget.Name,
@@ -148,7 +148,7 @@ func (r *TurnstileWidgetResource) Delete(ctx context.Context, req resource.Delet
 		return
 	}
 
-	err := r.client.DeleteTurnstileWidget(ctx, cloudflare.AccountIdentifier(data.AccountID.ValueString()), data.ID.ValueString())
+	err := r.client.V1.DeleteTurnstileWidget(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()), data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting challenge widget", err.Error())
 	}
@@ -163,8 +163,8 @@ func (r *TurnstileWidgetResource) ImportState(ctx context.Context, req resource.
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), idParts[1])...)
 }
 
-func buildChallengeWidgetFromModel(ctx context.Context, widget *TurnstileWidgetModel) cloudflare.TurnstileWidget {
-	built := cloudflare.TurnstileWidget{
+func buildChallengeWidgetFromModel(ctx context.Context, widget *TurnstileWidgetModel) cfv1.TurnstileWidget {
+	built := cfv1.TurnstileWidget{
 		SiteKey:      widget.ID.ValueString(),
 		Name:         widget.Name.ValueString(),
 		BotFightMode: widget.BotFightMode.ValueBool(),
@@ -177,7 +177,7 @@ func buildChallengeWidgetFromModel(ctx context.Context, widget *TurnstileWidgetM
 	return built
 }
 
-func buildChallengeModelFromWidget(accountID types.String, widget cloudflare.TurnstileWidget) *TurnstileWidgetModel {
+func buildChallengeModelFromWidget(accountID types.String, widget cfv1.TurnstileWidget) *TurnstileWidgetModel {
 	built := TurnstileWidgetModel{
 		AccountID:    accountID,
 		ID:           flatteners.String(widget.SiteKey),

--- a/internal/framework/service/turnstile/resource_test.go
+++ b/internal/framework/service/turnstile/resource_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -20,7 +20,7 @@ func init() {
 	resource.AddTestSweepers("cloudflare_turnstile_widget", &resource.Sweeper{
 		Name: "cloudflare_turnstile_widget",
 		F: func(region string) error {
-			client, err := acctest.SharedClient()
+			client, err := acctest.SharedV1Client()
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
 			if err != nil {
@@ -28,13 +28,13 @@ func init() {
 			}
 
 			ctx := context.Background()
-			widgets, _, err := client.ListTurnstileWidgets(ctx, cloudflare.AccountIdentifier(accountID), cloudflare.ListTurnstileWidgetParams{})
+			widgets, _, err := client.ListTurnstileWidgets(ctx, cfv1.AccountIdentifier(accountID), cfv1.ListTurnstileWidgetParams{})
 			if err != nil {
 				return fmt.Errorf("failed to fetch turnstile widgets: %w", err)
 			}
 
 			for _, widget := range widgets {
-				err := client.DeleteTurnstileWidget(ctx, cloudflare.AccountIdentifier(accountID), widget.SiteKey)
+				err := client.DeleteTurnstileWidget(ctx, cfv1.AccountIdentifier(accountID), widget.SiteKey)
 				if err != nil {
 					return fmt.Errorf("failed to delete turnstile widget %q: %w", widget.SiteKey, err)
 				}

--- a/internal/framework/service/user/data_source.go
+++ b/internal/framework/service/user/data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudflare/cloudflare-go"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/muxclient"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -16,7 +16,7 @@ func NewDataSource() datasource.DataSource {
 }
 
 type CloudflareUserDataSource struct {
-	client *cloudflare.API
+	client *muxclient.Client
 }
 
 func (r *CloudflareUserDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -28,12 +28,12 @@ func (r *CloudflareUserDataSource) Configure(ctx context.Context, req datasource
 		return
 	}
 
-	client, ok := req.ProviderData.(*cloudflare.API)
+	client, ok := req.ProviderData.(*muxclient.Client)
 
 	if !ok {
 		resp.Diagnostics.AddError(
 			"unexpected resource configure type",
-			fmt.Sprintf("expected *cloudflare.API, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *muxclient.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
@@ -49,7 +49,7 @@ func (r *CloudflareUserDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	user, err := r.client.UserDetails(ctx)
+	user, err := r.client.V1.UserDetails(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("unable to retrieve user details", err.Error())
 		return

--- a/internal/framework/service/workers_for_platforms/resource.go
+++ b/internal/framework/service/workers_for_platforms/resource.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/muxclient"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -21,7 +22,7 @@ func NewResource() resource.Resource {
 
 // WorkersForPlatformsResource defines the resource implementation.
 type WorkersForPlatformsResource struct {
-	client *cloudflare.API
+	client *muxclient.Client
 }
 
 func (r *WorkersForPlatformsResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -33,12 +34,12 @@ func (r *WorkersForPlatformsResource) Configure(ctx context.Context, req resourc
 		return
 	}
 
-	client, ok := req.ProviderData.(*cloudflare.API)
+	client, ok := req.ProviderData.(*muxclient.Client)
 
 	if !ok {
 		resp.Diagnostics.AddError(
 			"unexpected resource configure type",
-			fmt.Sprintf("Expected *cloudflare.API, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *muxclient.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
@@ -56,8 +57,8 @@ func (r *WorkersForPlatformsResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
-	namespace, err := r.client.CreateWorkersForPlatformsDispatchNamespace(ctx, cloudflare.AccountIdentifier(data.AccountID.ValueString()),
-		cloudflare.CreateWorkersForPlatformsDispatchNamespaceParams{
+	namespace, err := r.client.V1.CreateWorkersForPlatformsDispatchNamespace(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()),
+		cfv1.CreateWorkersForPlatformsDispatchNamespaceParams{
 			Name: data.Name.ValueString(),
 		},
 	)
@@ -79,7 +80,7 @@ func (r *WorkersForPlatformsResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	namespace, err := r.client.GetWorkersForPlatformsDispatchNamespace(ctx, cloudflare.AccountIdentifier(data.AccountID.ValueString()), data.ID.ValueString())
+	namespace, err := r.client.V1.GetWorkersForPlatformsDispatchNamespace(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()), data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("failed reading Workers for Platforms namespace", err.Error())
 		return
@@ -110,7 +111,7 @@ func (r *WorkersForPlatformsResource) Delete(ctx context.Context, req resource.D
 		return
 	}
 
-	err := r.client.DeleteWorkersForPlatformsDispatchNamespace(ctx, cloudflare.AccountIdentifier(data.AccountID.ValueString()), data.Name.ValueString())
+	err := r.client.V1.DeleteWorkersForPlatformsDispatchNamespace(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()), data.Name.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError("failed to delete Workers for Platforms namespace", err.Error())

--- a/internal/framework/service/workers_for_platforms/resource_test.go
+++ b/internal/framework/service/workers_for_platforms/resource_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go"
+	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -20,7 +20,7 @@ func init() {
 	resource.AddTestSweepers("cloudflare_workers_for_platforms_namespace", &resource.Sweeper{
 		Name: "cloudflare_workers_for_platforms_namespace",
 		F: func(region string) error {
-			client, err := acctest.SharedClient()
+			client, err := acctest.SharedV1Client()
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
 			if err != nil {
@@ -28,13 +28,13 @@ func init() {
 			}
 
 			ctx := context.Background()
-			resp, err := client.ListWorkersForPlatformsDispatchNamespaces(ctx, cloudflare.AccountIdentifier(accountID))
+			resp, err := client.ListWorkersForPlatformsDispatchNamespaces(ctx, cfv1.AccountIdentifier(accountID))
 			if err != nil {
 				return err
 			}
 
 			for _, namespace := range resp.Result {
-				err := client.DeleteWorkersForPlatformsDispatchNamespace(ctx, cloudflare.AccountIdentifier(accountID), namespace.NamespaceName)
+				err := client.DeleteWorkersForPlatformsDispatchNamespace(ctx, cfv1.AccountIdentifier(accountID), namespace.NamespaceName)
 				if err != nil {
 					return err
 				}

--- a/internal/framework/service/workers_for_platforms/schema.go
+++ b/internal/framework/service/workers_for_platforms/schema.go
@@ -14,7 +14,7 @@ import (
 func (r *WorkersForPlatformsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: heredoc.Doc(`
-			The [Workers for Platforms](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/) resource allows you 
+			The [Workers for Platforms](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/) resource allows you
 			to manage Cloudflare Workers for Platforms namespaces.
 	`),
 


### PR DESCRIPTION
With the [announcement of the cloudflare-go/v2][1], we need to introduce a
way to use both versions of the SDK in the provider. This moves us to a
world where the v1 and v2 of the clients can coexist and still be
initialised in a consistent fashion.

At a high level, the guidance for modifying resources and datasources is:

- If you have an existing resource, use the cloudflare-go V1 SDK which
  whatever version of the Terraform SDK/framework version you have
  today.
- If you have a new resource, build it using cloudflare-go V2 SDK and
  the terraform-plugin-framework.

While this commit is rather large by LOC, it is the following changes
but made across the provider.

- Introduce a `muxclient` package. Allows Terraform internals to have a
  single client instead of trying to swap on the fly potentially causing
  concurrency issues.
- Split `acctest.SharedClient` into `SharedV1Client` and `SharedV2Client`
  for use in both versions of acceptance tests.
- Aliases and namespacing to handle the different package versions.

These changes should be internal and not end user facing.

[1]: https://blog.cloudflare.com/workers-production-safety