### PR TITLE
WAFFLE-640: Mark cloudflare_rate_limit as deprecated

### DIFF
--- a/.changelog/3279.txt
+++ b/.changelog/3279.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/cloudflare_rate_limit: This resource is being deprecated in favor of the cloudflare_rulesets resource
+```

--- a/docs/resources/filter.md
+++ b/docs/resources/filter.md
@@ -13,8 +13,8 @@ Filter expressions that can be referenced across multiple features,
 e.g. Firewall Rules. See [what is a filter](https://developers.cloudflare.com/firewall/api/cf-filters/what-is-a-filter/)
 for more details and available fields and operators.
 
-~> `cloudflare_filter` is in a deprecation phase that will last for one
-  year (May 1st, 2024). During this time period, this resource is still fully
+~> `cloudflare_filter` is in a deprecation phase that will last for 14 months
+  (July 1st, 2024). During this time period, this resource is still fully
   supported but you are strongly advised to move to the
   `cloudflare_ruleset` resource. Full details can be found in the
   [developer documentation](https://developers.cloudflare.com/waf/reference/migration-guides/firewall-rules-to-custom-rules/#relevant-changes-for-terraform-users).

--- a/docs/resources/firewall_rule.md
+++ b/docs/resources/firewall_rule.md
@@ -20,10 +20,10 @@ rule creation.
 Filter expressions needs to be created first before using Firewall
 Rule.
 
-~> `cloudflare_firewall_rule` is in a deprecation phase that will last for one
-  year (May 1st, 2024). During this time period, this resource is still fully
-  supported but you are strongly advised  to move to the `cloudflare_ruleset`
-  resource. Full details can be found in the
+~> `cloudflare_firewall_rule` is in a deprecation phase that will last for 14
+  months (July 1st, 2024). During this time period, this resource is still
+  fully supported but you are strongly advised  to move to the
+  `cloudflare_ruleset` resource. Full details can be found in the
   [developer documentation](https://developers.cloudflare.com/waf/reference/migration-guides/firewall-rules-to-custom-rules/#relevant-changes-for-terraform-users).
 
 ## Example Usage

--- a/docs/resources/rate_limit.md
+++ b/docs/resources/rate_limit.md
@@ -13,6 +13,13 @@ Provides a Cloudflare rate limit resource for a given zone. This can
 be used to limit the traffic you receive zone-wide, or matching more
 specific types of requests/responses.
 
+~> `cloudflare_rate_limit` is in a deprecation phase that will last for 14
+  months (July 1st, 2024). During this time period, this resource is still
+  fully supported but you are strongly advised to move to the
+  `cloudflare_ruleset` resource. Full details can be found in the
+  [developer documentation](https://developers.cloudflare.com/waf/reference/migration-guides/old-rate-limiting-deprecation/#relevant-changes-for-terraform-users).
+
+
 ## Example Usage
 
 ```terraform

--- a/docs/resources/teams_account.md
+++ b/docs/resources/teams_account.md
@@ -163,6 +163,10 @@ Optional:
 
 - `id` (String) ID of custom certificate.
 
+Read-Only:
+
+- `updated_at` (String)
+
 
 <a id="nestedblock--extended_email_matching"></a>
 ### Nested Schema for `extended_email_matching`

--- a/internal/sdkv2provider/resource_cloudflare_filter.go
+++ b/internal/sdkv2provider/resource_cloudflare_filter.go
@@ -31,7 +31,7 @@ func resourceCloudflareFilter() *schema.Resource {
 		`),
 		DeprecationMessage: heredoc.Doc(fmt.Sprintf(`
 			%s resource is in a deprecation phase that will
-			last for one year (May 1st, 2024). During this time period, this
+			last for 14 months (July 1st, 2024). During this time period, this
 			resource is still fully supported but you are strongly advised
 			to move to the %s resource. For more information, see
 			https://developers.cloudflare.com/waf/reference/migration-guides/firewall-rules-to-custom-rules/#relevant-changes-for-terraform-users.

--- a/internal/sdkv2provider/resource_cloudflare_firewall_rule.go
+++ b/internal/sdkv2provider/resource_cloudflare_firewall_rule.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 	"strings"
 
-	"github.com/MakeNowJust/heredoc/v2"
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -35,7 +35,7 @@ func resourceCloudflareFirewallRule() *schema.Resource {
 		`),
 		DeprecationMessage: heredoc.Doc(fmt.Sprintf(`
 			%s resource is in a deprecation phase that will
-			last for one year (May 1st, 2024). During this time period, this
+			last for 14 months (July 1st, 2024). During this time period, this
 			resource is still fully supported but you are strongly advised
 			to move to the %s resource. For more information, see
 			https://developers.cloudflare.com/waf/reference/migration-guides/firewall-rules-to-custom-rules/#relevant-changes-for-terraform-users.

--- a/internal/sdkv2provider/resource_cloudflare_rate_limit.go
+++ b/internal/sdkv2provider/resource_cloudflare_rate_limit.go
@@ -29,6 +29,13 @@ func resourceCloudflareRateLimit() *schema.Resource {
 			be used to limit the traffic you receive zone-wide, or matching more
 			specific types of requests/responses.
 		`),
+		DeprecationMessage: heredoc.Doc(fmt.Sprintf(`
+			%s resource is in a deprecation phase that will
+			last for 14 months (July 1st, 2024). During this time period, this
+			resource is still fully supported but you are strongly advised
+			to move to the %s resource. For more information, see
+			https://developers.cloudflare.com/waf/reference/migration-guides/old-rate-limiting-deprecation/#relevant-changes-for-terraform-users.
+		`, "`cloudflare_rate_limit`", "`cloudflare_ruleset`")),
 	}
 }
 

--- a/templates/resources/filter.md.tmpl
+++ b/templates/resources/filter.md.tmpl
@@ -9,8 +9,8 @@ description: |-
 
 {{ .Description | trimspace }}
 
-~> `cloudflare_filter` is in a deprecation phase that will last for one
-  year (May 1st, 2024). During this time period, this resource is still fully
+~> `cloudflare_filter` is in a deprecation phase that will last for 14 months
+  (July 1st, 2024). During this time period, this resource is still fully
   supported but you are strongly advised to move to the
   `cloudflare_ruleset` resource. Full details can be found in the
   [developer documentation](https://developers.cloudflare.com/waf/reference/migration-guides/firewall-rules-to-custom-rules/#relevant-changes-for-terraform-users).

--- a/templates/resources/rate_limit.md.tmpl
+++ b/templates/resources/rate_limit.md.tmpl
@@ -9,11 +9,12 @@ description: |-
 
 {{ .Description | trimspace }}
 
-~> `cloudflare_firewall_rule` is in a deprecation phase that will last for 14
+~> `cloudflare_rate_limit` is in a deprecation phase that will last for 14
   months (July 1st, 2024). During this time period, this resource is still
-  fully supported but you are strongly advised  to move to the
+  fully supported but you are strongly advised to move to the
   `cloudflare_ruleset` resource. Full details can be found in the
-  [developer documentation](https://developers.cloudflare.com/waf/reference/migration-guides/firewall-rules-to-custom-rules/#relevant-changes-for-terraform-users).
+  [developer documentation](https://developers.cloudflare.com/waf/reference/migration-guides/old-rate-limiting-deprecation/#relevant-changes-for-terraform-users).
+
 
 {{ if .HasExample -}}
 ## Example Usage


### PR DESCRIPTION
* Mark cloudflare_rate_limit as deprecated
* Update deprecation date to 1st July for `cloudflare_firewall_rule` and `cloudflare_filter`