### PR TITLE
Support the os_version_extra field in posture checks and devices schema

### DIFF
--- a/.changelog/3281.txt
+++ b/.changelog/3281.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_device_posture_rules: added support for os_version_extra
+```

--- a/docs/resources/device_posture_rule.md
+++ b/docs/resources/device_posture_rule.md
@@ -92,6 +92,7 @@ Optional:
 - `total_score` (Number) The total score from Tanium.
 - `version` (String) The operating system semantic version.
 - `version_operator` (String) The version comparison operator for crowdstrike. Available values: `>`, `>=`, `<`, `<=`, `==`.
+- `os_version_extra` (String) Extra operating system version details following the semantic version value.
 
 
 <a id="nestedblock--match"></a>

--- a/examples/resources/cloudflare_device_posture_rule/resource.tf
+++ b/examples/resources/cloudflare_device_posture_rule/resource.tf
@@ -16,5 +16,6 @@ resource "cloudflare_device_posture_rule" "eaxmple" {
     operator           = "<"
     os_distro_name     = "ubuntu"
     os_distro_revision = "1.0.0"
+    os_version_extra   = "(a)"
   }
 }

--- a/internal/sdkv2provider/data_source_devices.go
+++ b/internal/sdkv2provider/data_source_devices.go
@@ -47,6 +47,7 @@ func dataResourceCloudflareDevicesRead(ctx context.Context, d *schema.ResourceDa
 			"os_distro_name":     device.OSDistroName,
 			"os_distro_revision": device.OsDistroRevision,
 			"os_version":         device.OSVersion,
+			"os_version_extra":   device.OSVersionExtra,
 			"revoked_at":         device.RevokedAt,
 			"serial_number":      device.SerialNumber,
 			"updated":            device.Updated,

--- a/internal/sdkv2provider/resource_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/resource_cloudflare_device_posture_rule.go
@@ -210,6 +210,9 @@ func setDevicePostureRuleInput(rule *cloudflare.DevicePostureRule, d *schema.Res
 		if osDistroRevision, ok := d.GetOk("input.0.os_distro_revision"); ok {
 			input.OsDistroRevision = osDistroRevision.(string)
 		}
+		if osVersionExtra, ok := d.GetOk("input.0.os_version_extra"); ok {
+			input.OSVersionExtra = osVersionExtra.(string)
+		}
 		if os, ok := d.GetOk("input.0.os"); ok {
 			input.Os = os.(string)
 		}
@@ -310,6 +313,7 @@ func convertInputToSchema(input cloudflare.DevicePostureRuleInput) []map[string]
 		"version":            input.Version,
 		"os_distro_name":     input.OsDistroName,
 		"os_distro_revision": input.OsDistroRevision,
+		"os_version_extra":   input.OSVersionExtra,
 		"operator":           input.Operator,
 		"domain":             input.Domain,
 		"compliance_status":  input.ComplianceStatus,

--- a/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
@@ -122,6 +122,11 @@ func resourceCloudflareDevicePostureRuleSchema() map[string]*schema.Schema {
 						Optional:    true,
 						Description: "The operating system semantic version.",
 					},
+					"os_version_extra": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Extra version value following the operating system semantic version.",
+					},
 					"operator": {
 						Type:         schema.TypeString,
 						Optional:     true,

--- a/internal/sdkv2provider/schema_data_source_cloudflare_devices.go
+++ b/internal/sdkv2provider/schema_data_source_cloudflare_devices.go
@@ -87,6 +87,11 @@ func resoureceCloudflareDevicesSchema() map[string]*schema.Schema {
 						Optional:    true,
 						Description: "The operating system version.",
 					},
+					"os_version_extra": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Extra version value following the operating system version.",
+					},
 					"revoked_at": {
 						Type:        schema.TypeString,
 						Optional:    true,


### PR DESCRIPTION
Add support for the existing os_version_extra field that has been in production for a while:
- Supports the os_version_extra field in [the device response.](https://github.com/cloudflare/cloudflare-go/blob/master/teams_devices.go#L35)
- Supports the os_version_extra field in [device posture checks](https://github.com/cloudflare/cloudflare-go/blob/master/device_posture_rule.go#L184).