### PR TITLE
Fix error handling in cloudflare_turnstile

### DIFF
--- a/.changelog/3284.txt
+++ b/.changelog/3284.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_turnstile: Fix error handling corrupting state
+```

--- a/internal/framework/service/turnstile/resource.go
+++ b/internal/framework/service/turnstile/resource.go
@@ -73,6 +73,7 @@ func (r *TurnstileWidgetResource) Create(ctx context.Context, req resource.Creat
 		})
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating challenge widget", err.Error())
+		return
 	}
 
 	data = buildChallengeModelFromWidget(
@@ -96,6 +97,7 @@ func (r *TurnstileWidgetResource) Read(ctx context.Context, req resource.ReadReq
 
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading challenge widget", err.Error())
+		return
 	}
 
 	data = buildChallengeModelFromWidget(
@@ -129,6 +131,7 @@ func (r *TurnstileWidgetResource) Update(ctx context.Context, req resource.Updat
 
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading challenge widget", err.Error())
+		return
 	}
 
 	data = buildChallengeModelFromWidget(
@@ -151,6 +154,7 @@ func (r *TurnstileWidgetResource) Delete(ctx context.Context, req resource.Delet
 	err := r.client.V1.DeleteTurnstileWidget(ctx, cfv1.AccountIdentifier(data.AccountID.ValueString()), data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting challenge widget", err.Error())
+		return
 	}
 }
 
@@ -158,6 +162,7 @@ func (r *TurnstileWidgetResource) ImportState(ctx context.Context, req resource.
 	idParts := strings.Split(req.ID, "/")
 	if len(idParts) != 2 {
 		resp.Diagnostics.AddError("Error importing challenge widget", "Invalid ID specified. Please specify the ID as \"accounts_id/sitekey\"")
+		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("account_id"), idParts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), idParts[1])...)


### PR DESCRIPTION
When we receive an error from the API, we would record an error (not return) and write an invalid State. For some reason, Terraform accepts it... yet it seems to corrupt the tf state.

Add some returns to handle error more cleanly.

Related: #3093 (but unsure if that's the only fix required)