### PR TITLE
Add support for cloudchamber_logs Logpush dataset

### DIFF
--- a/.changelog/3300.txt
+++ b/.changelog/3300.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+Add support for logpush cloudchamber_logs
+```

--- a/docs/resources/logpush_job.md
+++ b/docs/resources/logpush_job.md
@@ -111,7 +111,7 @@ resource "cloudflare_logpush_job" "example_job" {
 
 ### Required
 
-- `dataset` (String) The kind of the dataset to use with the logpush job. Available values: `access_requests`, `casb_findings`, `firewall_events`, `http_requests`, `spectrum_events`, `nel_reports`, `audit_logs`, `gateway_dns`, `gateway_http`, `gateway_network`, `dns_logs`, `network_analytics_logs`, `workers_trace_events`, `device_posture_results`, `zero_trust_network_sessions`, `magic_ids_detections`, `page_shield_events`.
+- `dataset` (String) The kind of the dataset to use with the logpush job. Available values: `access_requests`, `casb_findings`, `firewall_events`, `http_requests`, `spectrum_events`, `nel_reports`, `audit_logs`, `gateway_dns`, `gateway_http`, `gateway_network`, `dns_logs`, `network_analytics_logs`, `workers_trace_events`, `device_posture_results`, `zero_trust_network_sessions`, `magic_ids_detections`, `page_shield_events`, `cloudchamber_logs`.
 - `destination_conf` (String) Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. Additional configuration parameters supported by the destination may be included. See [Logpush destination documentation](https://developers.cloudflare.com/logs/reference/logpush-api-configuration#destination).
 
 ### Optional

--- a/internal/sdkv2provider/schema_cloudflare_logpush_job.go
+++ b/internal/sdkv2provider/schema_cloudflare_logpush_job.go
@@ -29,6 +29,7 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 		"zero_trust_network_sessions",
 		"magic_ids_detections",
 		"page_shield_events",
+		"cloudchamber_logs",
 	}
 	frequencyAllowedValues := []string{"high", "low"}
 	outputTypeAllowedValues := []string{"ndjson", "csv"}


### PR DESCRIPTION
This adds the `cloudchamber_logs` dataset to Logpush as a valid option, as well as updating the docs to list the dataset.