### PR TITLE
resource/cloudflare_zone_settings_override: add support for `nel`

### DIFF
--- a/.changelog/3305.txt
+++ b/.changelog/3305.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_zone_settings_override: add support for NEL
+```

--- a/internal/sdkv2provider/resource_cloudflare_zone_settings_override.go
+++ b/internal/sdkv2provider/resource_cloudflare_zone_settings_override.go
@@ -35,6 +35,7 @@ var fetchAsSingleSetting = []string{
 	"early_hints",
 	"origin_max_http_version",
 	"fonts",
+	"nel",
 }
 
 func resourceCloudflareZoneSettingsOverrideCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -186,7 +187,7 @@ func flattenZoneSettings(ctx context.Context, d *schema.ResourceData, settings [
 			continue
 		}
 
-		if s.ID == "minify" || s.ID == "mobile_redirect" {
+		if s.ID == "minify" || s.ID == "mobile_redirect" || s.ID == "nel" {
 			cfg[s.ID] = []interface{}{s.Value.(map[string]interface{})}
 		} else if s.ID == "security_header" {
 			cfg[s.ID] = []interface{}{s.Value.(map[string]interface{})["strict_transport_security"]}
@@ -354,7 +355,7 @@ func expandZoneSetting(d *schema.ResourceData, keyFormatString, k string, settin
 				zoneSettingValue = settingValue
 			}
 		}
-	case "minify", "mobile_redirect":
+	case "minify", "mobile_redirect", "nel":
 		{
 			listValue := settingValue.([]interface{})
 			if len(listValue) > 0 && listValue != nil {

--- a/internal/sdkv2provider/resource_cloudflare_zone_settings_override_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_zone_settings_override_test.go
@@ -218,3 +218,35 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
 	}
 }`, rnd, zoneID)
 }
+
+func TestAccCloudflareZoneSettingsOverride_NEL(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := generateRandomResourceName()
+	name := "cloudflare_zone_settings_override." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareZoneSettingsOverrideNEL(rnd, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareZoneSettings(name),
+					resource.TestCheckResourceAttr(name, "settings.0.nel.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareZoneSettingsOverrideNEL(rnd, zoneID string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_zone_settings_override" "%[1]s" {
+  zone_id = "%[2]s"
+  settings {
+    nel {
+      enabled = true
+	}
+  }
+}`, rnd, zoneID)
+}

--- a/internal/sdkv2provider/schema_cloudflare_zone_settings_override.go
+++ b/internal/sdkv2provider/schema_cloudflare_zone_settings_override.go
@@ -536,4 +536,20 @@ var resourceCloudflareZoneSettingsSchema = map[string]*schema.Schema{
 		Optional:     true,
 		Computed:     true,
 	},
+
+	"nel": {
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MinItems: 1,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"enabled": {
+					Type:     schema.TypeBool,
+					Required: true,
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
Adds support for managing network error logging.