### PR TITLE
test: prefer using API tokens

### DIFF
--- a/internal/framework/service/access_mutual_tls_hostname_settings/resource_test.go
+++ b/internal/framework/service/access_mutual_tls_hostname_settings/resource_test.go
@@ -47,13 +47,6 @@ func init() {
 }
 
 func TestAccCloudflareAccessMutualTLSHostnameSettings_Simple(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_mutual_tls_hostname_settings.%s", rnd)
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")

--- a/internal/framework/service/api_token_permissions_groups/data_source_test.go
+++ b/internal/framework/service/api_token_permissions_groups/data_source_test.go
@@ -2,7 +2,6 @@ package api_token_permissions_groups_test
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 
@@ -12,13 +11,6 @@ import (
 )
 
 func TestAccCloudflareApiTokenPermissionGroups_Basic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// permission groups endpoint does not yet support the API tokens, and it
-	// results in misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,

--- a/internal/framework/service/rulesets/resource_test.go
+++ b/internal/framework/service/rulesets/resource_test.go
@@ -61,13 +61,6 @@ func init() {
 }
 
 func TestAccCloudflareRuleset_WAFBasic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	resourceName := "cloudflare_ruleset." + rnd
@@ -101,13 +94,6 @@ func TestAccCloudflareRuleset_WAFBasic(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_WAFManagedRuleset(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -138,13 +124,6 @@ func TestAccCloudflareRuleset_WAFManagedRuleset(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_WAFManagedRulesetWithoutDescription(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -174,13 +153,6 @@ func TestAccCloudflareRuleset_WAFManagedRulesetWithoutDescription(t *testing.T) 
 }
 
 func TestAccCloudflareRuleset_WAFManagedRulesetOWASP(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -211,13 +183,6 @@ func TestAccCloudflareRuleset_WAFManagedRulesetOWASP(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_WAFManagedRulesetOWASPBlockXSSWithAnomalyOver60(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -259,13 +224,6 @@ func TestAccCloudflareRuleset_WAFManagedRulesetOWASPBlockXSSWithAnomalyOver60(t 
 }
 
 func TestAccCloudflareRuleset_WAFManagedRulesetOWASPOnlyPL1(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -309,13 +267,6 @@ func TestAccCloudflareRuleset_WAFManagedRulesetOWASPOnlyPL1(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_WAFManagedRulesetDeployMultiple(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -359,13 +310,6 @@ func TestAccCloudflareRuleset_WAFManagedRulesetDeployMultiple(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithSkip(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -415,13 +359,6 @@ func TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithSkip(t *testing
 }
 
 func TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithTopSkipAndLastSkip(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -477,13 +414,6 @@ func TestAccCloudflareRuleset_WAFManagedRulesetDeployMultipleWithTopSkipAndLastS
 }
 
 func TestAccCloudflareRuleset_SkipPhaseAndProducts(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -527,13 +457,6 @@ func TestAccCloudflareRuleset_SkipPhaseAndProducts(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_WAFManagedRulesetWithCategoryAndRuleBasedOverrides(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -575,13 +498,6 @@ func TestAccCloudflareRuleset_WAFManagedRulesetWithCategoryAndRuleBasedOverrides
 }
 
 func TestAccCloudflareRuleset_WAFManagedRulesetWithIDBasedOverrides(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -619,13 +535,6 @@ func TestAccCloudflareRuleset_WAFManagedRulesetWithIDBasedOverrides(t *testing.T
 }
 
 func TestAccCloudflareRuleset_MagicTransitUpdateWithHigherPriority(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	acctest.TestAccSkipForDefaultAccount(t, "Default account is not configured for Magic Transit.")
 
 	rnd := utils.GenerateRandomResourceName()
@@ -668,13 +577,6 @@ func TestAccCloudflareRuleset_MagicTransitUpdateWithHigherPriority(t *testing.T)
 }
 
 func TestAccCloudflareRuleset_WAFManagedRulesetWithPayloadLogging(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -707,13 +609,6 @@ func TestAccCloudflareRuleset_WAFManagedRulesetWithPayloadLogging(t *testing.T) 
 }
 
 func TestAccCloudflareRuleset_RateLimit(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -759,13 +654,6 @@ func TestAccCloudflareRuleset_RateLimit(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_RateLimitScorePerPeriod(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
@@ -806,13 +694,6 @@ func TestAccCloudflareRuleset_RateLimitScorePerPeriod(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_RateLimitMitigationTimeoutOfZero(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
@@ -852,13 +733,6 @@ func TestAccCloudflareRuleset_RateLimitMitigationTimeoutOfZero(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_PreserveRuleRefs(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	resourceName := "cloudflare_ruleset." + rnd
@@ -1013,13 +887,6 @@ func notEqualsValue(expected *string) func(string) error {
 }
 
 func TestAccCloudflareRuleset_CustomErrors(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1051,13 +918,6 @@ func TestAccCloudflareRuleset_CustomErrors(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_RequestOrigin(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1091,13 +951,6 @@ func TestAccCloudflareRuleset_RequestOrigin(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_RequestOriginPortWithoutHost(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1129,13 +982,6 @@ func TestAccCloudflareRuleset_RequestOriginPortWithoutHost(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_TransformationRuleURIPath(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1164,13 +1010,6 @@ func TestAccCloudflareRuleset_TransformationRuleURIPath(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_TransformationRuleURIQuery(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1199,13 +1038,6 @@ func TestAccCloudflareRuleset_TransformationRuleURIQuery(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_TransformationRuleURIPathAndQueryCombination(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1238,13 +1070,6 @@ func TestAccCloudflareRuleset_TransformationRuleURIPathAndQueryCombination(t *te
 }
 
 func TestAccCloudflareRuleset_TransformationRuleRequestHeaders(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1284,13 +1109,6 @@ func TestAccCloudflareRuleset_TransformationRuleRequestHeaders(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_TransformationRuleResponseHeaders(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1360,13 +1178,6 @@ func TestAccCloudflareRuleset_ResponseCompression(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_ActionParametersMultipleSkips(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1406,13 +1217,6 @@ func TestAccCloudflareRuleset_ActionParametersMultipleSkips(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_ActionParametersOverridesAction(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1449,13 +1253,6 @@ func TestAccCloudflareRuleset_ActionParametersOverridesAction(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_ActionParametersHTTPDDoSOverride(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1489,13 +1286,6 @@ func TestAccCloudflareRuleset_ActionParametersHTTPDDoSOverride(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_ActionParametersOverrideAllRulesetRules(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1529,13 +1319,6 @@ func TestAccCloudflareRuleset_ActionParametersOverrideAllRulesetRules(t *testing
 }
 
 func TestAccCloudflareRuleset_AccountLevelCustomWAFRule(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1564,13 +1347,6 @@ func TestAccCloudflareRuleset_AccountLevelCustomWAFRule(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_ExposedCredentialCheck(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	resourceName := "cloudflare_ruleset." + rnd
@@ -1602,13 +1378,6 @@ func TestAccCloudflareRuleset_ExposedCredentialCheck(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_Logging(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	resourceName := "cloudflare_ruleset." + rnd
@@ -1639,13 +1408,6 @@ func TestAccCloudflareRuleset_Logging(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_ConditionallySetActionParameterVersion(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1665,13 +1427,6 @@ func TestAccCloudflareRuleset_ConditionallySetActionParameterVersion(t *testing.
 }
 
 func TestAccCloudflareRuleset_WAFManagedRulesetWithActionManagedChallenge(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -1768,13 +1523,6 @@ func TestAccCloudflareRuleset_LogCustomField(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_ActionParametersOverridesThrashingStatus(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the WAF
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")

--- a/internal/framework/service/user/data_source_test.go
+++ b/internal/framework/service/user/data_source_test.go
@@ -1,20 +1,13 @@
 package user_test
 
 import (
+	"testing"
+
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"os"
-	"testing"
 )
 
 func TestAccCloudflareUserDataSource(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// permission groups endpoint does not yet support the API tokens, and it
-	// results in misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,

--- a/internal/sdkv2provider/import_cloudflare_worker_route_test.go
+++ b/internal/sdkv2provider/import_cloudflare_worker_route_test.go
@@ -10,13 +10,6 @@ import (
 )
 
 func TestAccCloudflareWorkerRoute_Import(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Workers
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	var route cloudflare.WorkerRoute
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")

--- a/internal/sdkv2provider/import_cloudflare_worker_script_test.go
+++ b/internal/sdkv2provider/import_cloudflare_worker_script_test.go
@@ -10,12 +10,6 @@ import (
 )
 
 func TestAccCloudflareWorkerScript_Import(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Workers
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	var script cloudflare.WorkerScript
 	rnd := generateRandomResourceName()

--- a/internal/sdkv2provider/resource_cloudflare_access_custom_page_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_custom_page_test.go
@@ -9,10 +9,6 @@ import (
 )
 
 func TestAccCloudflareAccessCustomPage_IdentityDenied(t *testing.T) {
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	resourceName := fmt.Sprintf("cloudflare_access_custom_page.%s", rnd)
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
@@ -36,10 +32,6 @@ func TestAccCloudflareAccessCustomPage_IdentityDenied(t *testing.T) {
 }
 
 func TestAccCloudflareAccessCustomPage_Forbidden(t *testing.T) {
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	resourceName := fmt.Sprintf("cloudflare_access_custom_page.%s", rnd)
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")

--- a/internal/sdkv2provider/resource_cloudflare_access_identity_provider_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_identity_provider_test.go
@@ -53,13 +53,6 @@ func testSweepCloudflareAccessIdentityProviders(r string) error {
 }
 
 func TestAccCloudflareAccessIdentityProvider_OneTimePin(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the OTP Access
-	// endpoint does not yet support the API tokens for updates and it results in
-	// state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	resourceName := "cloudflare_access_identity_provider." + rnd
 	resource.Test(t, resource.TestCase{

--- a/internal/sdkv2provider/resource_cloudflare_access_keys_configuration_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_keys_configuration_test.go
@@ -9,13 +9,6 @@ import (
 )
 
 func TestAccCloudflareAccessKeysConfiguration_WithKeyRotationIntervalDaysSet(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_keys_configuration.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -45,13 +38,6 @@ resource "cloudflare_access_keys_configuration" "%[1]s" {
 }
 
 func TestAccCloudflareAccessKeysConfiguration_WithoutKeyRotationIntervalDaysSet(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_keys_configuration.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")

--- a/internal/sdkv2provider/resource_cloudflare_access_mutual_tls_certificate_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_mutual_tls_certificate_test.go
@@ -60,13 +60,6 @@ func testSweepCloudflareAccessMutualTLSCertificate(r string) error {
 }
 
 func TestAccCloudflareAccessMutualTLSBasic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_mutual_tls_certificate.%s", rnd)
 	cert := os.Getenv("CLOUDFLARE_MUTUAL_TLS_CERTIFICATE")
@@ -103,13 +96,6 @@ func TestAccCloudflareAccessMutualTLSBasic(t *testing.T) {
 }
 
 func TestAccCloudflareAccessMutualTLSBasicWithZoneID(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_mutual_tls_certificate.%s", rnd)
 	cert := os.Getenv("CLOUDFLARE_MUTUAL_TLS_CERTIFICATE")

--- a/internal/sdkv2provider/resource_cloudflare_access_policy_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_policy_test.go
@@ -14,13 +14,6 @@ import (
 )
 
 func TestAccCloudflareAccessPolicy_ServiceToken(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := "cloudflare_access_policy." + rnd
 	zone := os.Getenv("CLOUDFLARE_DOMAIN")

--- a/internal/sdkv2provider/resource_cloudflare_access_service_tokens_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_service_tokens_test.go
@@ -3,7 +3,6 @@ package sdkv2provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -14,13 +13,6 @@ import (
 )
 
 func TestAccCloudflareAccessServiceToken_Basic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// Service Tokens endpoint does not yet support the API tokens and it
-	// results in misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_service_token.%s", rnd)
 	resourceName := strings.Split(name, ".")[1]
@@ -166,13 +158,6 @@ func testAccCheckCloudflareAccessServiceTokenRenewed(n string, oldResourceState 
 }
 
 func TestAccCloudflareAccessServiceToken_Delete(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// Service Tokens endpoint does not yet support the API tokens and it
-	// results in misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_service_token.%s", rnd)
 	resourceName := strings.Split(name, ".")[1]
@@ -220,13 +205,6 @@ func TestAccCloudflareAccessServiceToken_Delete(t *testing.T) {
 }
 
 func TestAccCloudflareAccessServiceToken_WithDuration(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// Service Tokens endpoint does not yet support the API tokens and it
-	// results in misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_access_service_token.%s", rnd)
 	resourceName := strings.Split(name, ".")[1]

--- a/internal/sdkv2provider/resource_cloudflare_access_tag_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_tag_test.go
@@ -9,10 +9,6 @@ import (
 )
 
 func TestAccCloudflareAccessTag_Basic(t *testing.T) {
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	resourceName := fmt.Sprintf("cloudflare_access_tag.%s", rnd)
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")

--- a/internal/sdkv2provider/resource_cloudflare_account_member_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_account_member_test.go
@@ -12,12 +12,6 @@ import (
 func TestAccCloudflareAccountMember_Basic(t *testing.T) {
 	skipForDefaultAccount(t, "Account is using domain scoped roles and cannot be used for legacy permissions.")
 
-	// Temporarily unset CLOUDFLARE_API_TOKEN as the API token won't have
-	// permission to manage account members.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := "cloudflare_account_member." + rnd
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -44,12 +38,6 @@ func TestAccCloudflareAccountMember_Basic(t *testing.T) {
 
 func TestAccCloudflareAccountMember_DirectAdd(t *testing.T) {
 	skipForDefaultAccount(t, "Account is using domain scoped roles and cannot be used for legacy permissions.")
-
-	// Temporarily unset CLOUDFLARE_API_TOKEN as the API token won't have
-	// permission to manage account members.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	name := "cloudflare_account_member." + rnd

--- a/internal/sdkv2provider/resource_cloudflare_api_shield_operation_schema_validation_settings_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_api_shield_operation_schema_validation_settings_test.go
@@ -10,12 +10,6 @@ import (
 )
 
 func TestAccCloudflareAPIShieldOperationSchemaValidationSettings_Create(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	resourceID := "cloudflare_api_shield_operation_schema_validation_settings." + rnd
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")

--- a/internal/sdkv2provider/resource_cloudflare_api_shield_operation_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_api_shield_operation_test.go
@@ -14,11 +14,6 @@ import (
 )
 
 func TestAccCloudflareAPIShieldOperation_Create(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	resourceID := "cloudflare_api_shield_operation." + rnd
@@ -44,11 +39,6 @@ func TestAccCloudflareAPIShieldOperation_Create(t *testing.T) {
 }
 
 func TestAccCloudflareAPIShieldOperation_ForceNew(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	resourceID := "cloudflare_api_shield_operation." + rnd

--- a/internal/sdkv2provider/resource_cloudflare_api_shield_schema_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_api_shield_schema_test.go
@@ -15,11 +15,6 @@ import (
 )
 
 func TestAccCloudflareAPIShieldSchema_Create(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd, rnd2 := generateRandomResourceName(), generateRandomResourceName()
 	resourceID := "cloudflare_api_shield_schema." + rnd
@@ -72,11 +67,6 @@ func TestAccCloudflareAPIShieldSchema_Create(t *testing.T) {
 }
 
 func TestAccCloudflareAPIShieldSchema_CreateForceNew(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	resourceID := "cloudflare_api_shield_schema." + rnd
@@ -137,11 +127,6 @@ func TestAccCloudflareAPIShieldSchema_CreateForceNew(t *testing.T) {
 }
 
 func TestAccCloudflareAPIShieldSchema_Update(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	resourceID := "cloudflare_api_shield_schema." + rnd

--- a/internal/sdkv2provider/resource_cloudflare_api_shield_schema_validation_settings_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_api_shield_schema_validation_settings_test.go
@@ -13,11 +13,6 @@ import (
 )
 
 func TestAccCloudflareAPIShieldSchemaValidationSettings_Create(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	resourceID := "cloudflare_api_shield_schema_validation_settings." + rnd

--- a/internal/sdkv2provider/resource_cloudflare_api_shield_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_api_shield_test.go
@@ -11,11 +11,6 @@ import (
 )
 
 func TestAccAPIShield_Basic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	resourceID := "cloudflare_api_shield." + rnd
@@ -39,11 +34,6 @@ func TestAccAPIShield_Basic(t *testing.T) {
 }
 
 func TestAccAPIShield_EmptyAuthIdCharacteristics(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	resourceID := "cloudflare_api_shield." + rnd

--- a/internal/sdkv2provider/resource_cloudflare_api_token_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_api_token_test.go
@@ -9,11 +9,6 @@ import (
 )
 
 func TestAccAPIToken_Basic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	resourceID := "cloudflare_api_token." + rnd
@@ -40,11 +35,6 @@ func TestAccAPIToken_Basic(t *testing.T) {
 }
 
 func TestAccAPIToken_AllowDeny(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
@@ -68,11 +58,6 @@ func TestAccAPIToken_AllowDeny(t *testing.T) {
 }
 
 func TestAccAPIToken_DoesNotSetConditions(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	name := "cloudflare_api_token." + rnd
@@ -109,11 +94,6 @@ func testAccCloudflareAPITokenWithoutCondition(resourceName, rnd, permissionID s
 }
 
 func TestAccAPIToken_SetIndividualCondition(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	name := "cloudflare_api_token." + rnd
@@ -156,11 +136,6 @@ func testAccCloudflareAPITokenWithIndividualCondition(rnd string, permissionID s
 }
 
 func TestAccAPIToken_SetAllCondition(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	name := "cloudflare_api_token." + rnd
@@ -238,11 +213,6 @@ func testAPITokenConfigAllowDeny(resourceID, permissionID, zoneID string, allowA
 }
 
 func TestAccAPIToken_TokenTTL(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the API token
-	// endpoint does not yet support the API tokens without an explicit scope.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	name := "cloudflare_api_token." + rnd

--- a/internal/sdkv2provider/resource_cloudflare_custom_hostname_fallback_origin_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_custom_hostname_fallback_origin_test.go
@@ -13,13 +13,6 @@ import (
 )
 
 func TestAccCloudflareCustomHostnameFallbackOrigin(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the custom hostname
-	// fallback endpoint does not yet support the API tokens for updates and it
-	// results in state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := generateRandomResourceName()
@@ -59,13 +52,6 @@ resource "cloudflare_record" "%[2]s" {
 }
 
 func TestAccCloudflareCustomHostnameFallbackOriginUpdate(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the custom hostname
-	// fallback endpoint does not yet support the API tokens for updates and it
-	// results in state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := generateRandomResourceName()

--- a/internal/sdkv2provider/resource_cloudflare_device_policy_certificates_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_device_policy_certificates_test.go
@@ -2,7 +2,6 @@ package sdkv2provider
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
@@ -10,13 +9,6 @@ import (
 )
 
 func TestAccCloudflareDevicePolicyCertificatesCreate(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_device_policy_certificates.%s", rnd)
 

--- a/internal/sdkv2provider/resource_cloudflare_device_posture_integration_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_device_posture_integration_test.go
@@ -13,13 +13,6 @@ import (
 )
 
 func TestAccCloudflareDevicePostureIntegrationCreate(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_device_posture_integration.%s", rnd)
 

--- a/internal/sdkv2provider/resource_cloudflare_device_posture_rule_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_device_posture_rule_test.go
@@ -3,7 +3,6 @@ package sdkv2provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/cloudflare/cloudflare-go"
@@ -13,13 +12,6 @@ import (
 )
 
 func TestAccCloudflareDevicePostureRule_SerialNumber(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_device_posture_rule.%s", rnd)
 
@@ -46,13 +38,6 @@ func TestAccCloudflareDevicePostureRule_SerialNumber(t *testing.T) {
 }
 
 func TestAccCloudflareDevicePostureRule_OsVersion(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_device_posture_rule.%s", rnd)
 
@@ -80,13 +65,6 @@ func TestAccCloudflareDevicePostureRule_OsVersion(t *testing.T) {
 }
 
 func TestAccCloudflareDevicePostureRule_OsVersionExtra(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_device_posture_rule.%s", rnd)
 
@@ -115,13 +93,6 @@ func TestAccCloudflareDevicePostureRule_OsVersionExtra(t *testing.T) {
 }
 
 func TestAccCloudflareDevicePostureRule_LinuxOsDistro(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_device_posture_rule.%s", rnd)
 
@@ -150,13 +121,6 @@ func TestAccCloudflareDevicePostureRule_LinuxOsDistro(t *testing.T) {
 }
 
 func TestAccCloudflareDevicePostureRule_DomainJoined(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_device_posture_rule.%s", rnd)
 
@@ -183,13 +147,6 @@ func TestAccCloudflareDevicePostureRule_DomainJoined(t *testing.T) {
 }
 
 func TestAccCloudflareDevicePostureRule_Firewall(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_device_posture_rule.%s", rnd)
 
@@ -218,13 +175,6 @@ func TestAccCloudflareDevicePostureRule_Firewall(t *testing.T) {
 }
 
 func TestAccCloudflareDevicePostureRule_DiskEncryption_RequireAll(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_device_posture_rule.%s", rnd)
 
@@ -253,13 +203,6 @@ func TestAccCloudflareDevicePostureRule_DiskEncryption_RequireAll(t *testing.T) 
 }
 
 func TestAccCloudflareDevicePostureRule_DiskEncryption_CheckDisks(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_device_posture_rule.%s", rnd)
 

--- a/internal/sdkv2provider/resource_cloudflare_device_settings_policy_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_device_settings_policy_test.go
@@ -3,7 +3,6 @@ package sdkv2provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -14,16 +13,6 @@ import (
 )
 
 func TestAccCloudflareDeviceSettingsPolicy_Create(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		defer func(apiToken string) {
-			os.Setenv("CLOUDFLARE_API_TOKEN", apiToken)
-		}(os.Getenv("CLOUDFLARE_API_TOKEN"))
-		os.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd, defaultRnd := generateRandomResourceName(), generateRandomResourceName()
 	name, defaultName := fmt.Sprintf("cloudflare_device_settings_policy.%s", rnd), fmt.Sprintf("cloudflare_device_settings_policy.%s", defaultRnd)
 	precedence := uint64(10)

--- a/internal/sdkv2provider/resource_cloudflare_fallback_domain_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_fallback_domain_test.go
@@ -3,7 +3,6 @@ package sdkv2provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
@@ -14,13 +13,6 @@ import (
 )
 
 func TestAccCloudflareFallbackDomain_Basic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_fallback_domain.%s", rnd)
 
@@ -47,13 +39,6 @@ func TestAccCloudflareFallbackDomain_Basic(t *testing.T) {
 }
 
 func TestAccCloudflareFallbackDomain_DefaultPolicy(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_fallback_domain.%s", rnd)
 
@@ -91,13 +76,6 @@ func TestAccCloudflareFallbackDomain_DefaultPolicy(t *testing.T) {
 }
 
 func TestAccCloudflareFallbackDomain_WithAttachedPolicy(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_fallback_domain.%s", rnd)
 

--- a/internal/sdkv2provider/resource_cloudflare_healthcheck_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_healthcheck_test.go
@@ -14,12 +14,6 @@ import (
 )
 
 func TestAccCloudflareHealthcheckTCPExists(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Healthcheck
-	// service does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 
 	rnd := generateRandomResourceName()
@@ -44,12 +38,6 @@ func TestAccCloudflareHealthcheckTCPExists(t *testing.T) {
 }
 
 func TestAccCloudflareHealthcheckTCPUpdate(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Healthcheck
-	// service does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 
 	rnd := generateRandomResourceName()
@@ -89,12 +77,6 @@ func TestAccCloudflareHealthcheckTCPUpdate(t *testing.T) {
 }
 
 func TestAccCloudflareHealthcheckHTTPExists(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Healthcheck
-	// service does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 
 	rnd := generateRandomResourceName()

--- a/internal/sdkv2provider/resource_cloudflare_list_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_list_test.go
@@ -53,12 +53,6 @@ func testSweepCloudflareList(r string) error {
 }
 
 func TestAccCloudflareList_Exists(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the IP List
-	// endpoint does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_list.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -85,12 +79,6 @@ func TestAccCloudflareList_Exists(t *testing.T) {
 }
 
 func TestAccCloudflareList_UpdateDescription(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the IP List
-	// endpoint does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_list.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -134,12 +122,6 @@ func TestAccCloudflareList_UpdateDescription(t *testing.T) {
 }
 
 func TestAccCloudflareList_Update(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the IP List
-	// endpoint does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rndIP := generateRandomResourceName()
 	rndRedirect := generateRandomResourceName()
 	rndASN := generateRandomResourceName()
@@ -279,12 +261,6 @@ func TestAccCloudflareList_Update(t *testing.T) {
 }
 
 func TestAccCloudflareList_UpdateIgnoreIPOrdering(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the IP List
-	// endpoint does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
@@ -306,12 +282,6 @@ func TestAccCloudflareList_UpdateIgnoreIPOrdering(t *testing.T) {
 }
 
 func TestAccCloudflareList_RemoveInlineConfig(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the IP List
-	// endpoint does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_list.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -352,12 +322,6 @@ func TestAccCloudflareList_RemoveInlineConfig(t *testing.T) {
 
 func TestAccCloudflareList_Import(t *testing.T) {
 	t.Skip("Pending investigation into item.0.value.0.asn being imported incorrectly")
-
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the IP List
-	// endpoint does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_list.%s", rnd)

--- a/internal/sdkv2provider/resource_cloudflare_logpull_retention_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_logpull_retention_test.go
@@ -10,13 +10,6 @@ import (
 )
 
 func TestAccLogpullRetentionSetStatus(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Logpull
-	// service is throwing authentication errors despite it being marked as
-	// available.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := "cloudflare_logpull_retention." + rnd
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")

--- a/internal/sdkv2provider/resource_cloudflare_notification_policy_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_notification_policy_test.go
@@ -13,12 +13,6 @@ import (
 )
 
 func TestAccCloudflareNotificationPolicy_Basic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the IP List
-	// endpoint does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	resourceName := "cloudflare_notification_policy." + rnd
 	updatedPolicyName := "updated test SSL policy from terraform provider"
@@ -96,12 +90,6 @@ func testCheckCloudflareNotificationPolicyUpdated(resName, policyName, policyDes
 }
 
 func TestAccCloudflareNotificationPolicy_WithFiltersAttribute(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the IP List
-	// endpoint does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	resourceName := "cloudflare_notification_policy." + rnd
 	updatedPolicyName := "updated workers usage notification"

--- a/internal/sdkv2provider/resource_cloudflare_notification_policy_webhooks_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_notification_policy_webhooks_test.go
@@ -9,13 +9,6 @@ import (
 )
 
 func TestAccCloudflareNotificationPolicyWebhooks(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the notification
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	resourceName := "cloudflare_notification_policy_webhooks." + rnd
 	webhooksDestination := "https://example.com"

--- a/internal/sdkv2provider/resource_cloudflare_split_tunnel_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_split_tunnel_test.go
@@ -2,7 +2,6 @@ package sdkv2provider
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -11,13 +10,6 @@ import (
 )
 
 func TestAccCloudflareSplitTunnel_Include(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_split_tunnel.%s", rnd)
 
@@ -52,13 +44,6 @@ func TestAccCloudflareSplitTunnel_Include(t *testing.T) {
 }
 
 func TestAccCloudflareSplitTunnel_ConflictingTunnelProperties(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 
 	resource.Test(t, resource.TestCase{
@@ -133,13 +118,6 @@ resource "cloudflare_split_tunnel" "%[1]s" {
 }
 
 func TestAccCloudflareSplitTunnel_Exclude(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_split_tunnel.%s", rnd)
 
@@ -163,13 +141,6 @@ func TestAccCloudflareSplitTunnel_Exclude(t *testing.T) {
 }
 
 func TestAccCloudflareSplitTunnel_IncludeTunnelOrdering(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 
 	resource.Test(t, resource.TestCase{

--- a/internal/sdkv2provider/resource_cloudflare_teams_accounts_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_accounts_test.go
@@ -2,7 +2,6 @@ package sdkv2provider
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
@@ -10,13 +9,6 @@ import (
 )
 
 func TestAccCloudflareTeamsAccounts_ConfigurationBasic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_teams_account.%s", rnd)
 
@@ -101,7 +93,7 @@ resource "cloudflare_teams_account" "%[1]s" {
     fail_closed = true
 	notification_settings {
 		enabled = true
-		message = "msg" 
+		message = "msg"
 		support_url = "https://hello.com/"
 	}
   }

--- a/internal/sdkv2provider/resource_cloudflare_teams_list_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_list_test.go
@@ -3,7 +3,6 @@ package sdkv2provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -15,13 +14,6 @@ import (
 )
 
 func TestAccCloudflareTeamsList_Basic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_teams_list.%s", rnd)
 
@@ -48,13 +40,6 @@ func TestAccCloudflareTeamsList_Basic(t *testing.T) {
 }
 
 func TestAccCloudflareTeamsList_LottaListItems(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_teams_list.%s", rnd)
 
@@ -80,13 +65,6 @@ func TestAccCloudflareTeamsList_LottaListItems(t *testing.T) {
 }
 
 func TestAccCloudflareTeamsList_Reordered(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 
 	resource.Test(t, resource.TestCase{

--- a/internal/sdkv2provider/resource_cloudflare_teams_location_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_location_test.go
@@ -3,7 +3,6 @@ package sdkv2provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/cloudflare/cloudflare-go"
@@ -13,13 +12,6 @@ import (
 )
 
 func TestAccCloudflareTeamsLocationBasic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_teams_location.%s", rnd)
 

--- a/internal/sdkv2provider/resource_cloudflare_teams_proxy_endpoints_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_proxy_endpoints_test.go
@@ -3,7 +3,6 @@ package sdkv2provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -14,13 +13,6 @@ import (
 )
 
 func TestAccCloudflareTeamsProxyEndpoint_Basic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_teams_proxy_endpoint.%s", rnd)
 

--- a/internal/sdkv2provider/resource_cloudflare_teams_rules_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_rules_test.go
@@ -3,7 +3,6 @@ package sdkv2provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/cloudflare/cloudflare-go"
@@ -13,13 +12,6 @@ import (
 )
 
 func TestAccCloudflareTeamsRule_Basic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_teams_rule.%s", rnd)
 
@@ -85,13 +77,6 @@ resource "cloudflare_teams_rule" "%[1]s" {
 }
 
 func TestAccCloudflareTeamsRule_NoSettings(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_teams_rule.%s", rnd)
 

--- a/internal/sdkv2provider/resource_cloudflare_tunnel_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_tunnel_test.go
@@ -14,12 +14,6 @@ import (
 )
 
 func TestAccCloudflareTunnelCreate_Basic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Argo Tunnel
-	// endpoint does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	accID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_tunnel.%s", rnd)
@@ -53,12 +47,6 @@ func testAccCheckCloudflareTunnelBasic(accID, name string) string {
 }
 
 func TestAccCloudflareTunnelCreate_Managed(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Argo Tunnel
-	// endpoint does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	accID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_tunnel.%s", rnd)
@@ -94,12 +82,6 @@ func testAccCheckCloudflareTunnelManaged(accID, name string) string {
 }
 
 func TestAccCloudflareTunnelCreate_Unmanaged(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Argo Tunnel
-	// endpoint does not yet support the API tokens.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	accID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_tunnel.%s", rnd)

--- a/internal/sdkv2provider/resource_cloudflare_user_agent_blocking_rule_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_user_agent_blocking_rule_test.go
@@ -13,13 +13,6 @@ import (
 )
 
 func TestAccCloudflareUserAgentBlockingRule_Basic(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the UA
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
-
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_user_agent_blocking_rule.%s", rnd)

--- a/internal/sdkv2provider/resource_cloudflare_workers_route_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_workers_route_test.go
@@ -17,12 +17,6 @@ const (
 )
 
 func TestAccCloudflareWorkerRoute_MultiScript(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Workers
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	var route cloudflare.WorkerRoute
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -97,12 +91,6 @@ resource "cloudflare_worker_script" "%[4]s" {
 }
 
 func TestAccCloudflareWorkerRoute_MultiScriptDisabledRoute(t *testing.T) {
-	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Workers
-	// service does not yet support the API tokens and it results in
-	// misleading state error messages.
-	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-	}
 
 	var route cloudflare.WorkerRoute
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")


### PR DESCRIPTION
Cleans up the test assertions to use API tokens where possible.