### PR TITLE
docs: update ingress_rule description of cloudflare_tunnel_config

### DIFF
--- a/docs/resources/tunnel_config.md
+++ b/docs/resources/tunnel_config.md
@@ -85,7 +85,7 @@ resource "cloudflare_tunnel_config" "example_config" {
 
 Required:
 
-- `ingress_rule` (Block List, Min: 1) Each incoming request received by cloudflared causes cloudflared to send a request to a local service. This section configures the rules that determine which requests are sent to which local services. [Read more](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/ingress/). (see [below for nested schema](#nestedblock--config--ingress_rule))
+- `ingress_rule` (Block List, Min: 1) Each incoming request received by cloudflared causes cloudflared to send a request to a local service. This section configures the rules that determine which requests are sent to which local services. Last rule must match all requests, e.g `service = "http_status:503"`. [Read more](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/ingress/). (see [below for nested schema](#nestedblock--config--ingress_rule))
 
 Optional:
 

--- a/internal/sdkv2provider/schema_cloudflare_tunnel_config.go
+++ b/internal/sdkv2provider/schema_cloudflare_tunnel_config.go
@@ -205,7 +205,7 @@ func resourceCloudflareTunnelConfigSchema() map[string]*schema.Schema {
 					},
 					"ingress_rule": {
 						Type:        schema.TypeList,
-						Description: "Each incoming request received by cloudflared causes cloudflared to send a request to a local service. This section configures the rules that determine which requests are sent to which local services. [Read more](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/ingress/)",
+						Description: "Each incoming request received by cloudflared causes cloudflared to send a request to a local service. This section configures the rules that determine which requests are sent to which local services. Last rule must match all requests, e.g `service = \"http_status:503\"`. [Read more](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/ingress/)",
 						Required:    true,
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Update `ingress_rule` description of `cloudflare_tunnel_config` in schema to highlight that last rule must be all matching (unsure whether this well render well the provider docs but it should be mentioned). We came across this as well in our module: https://github.com/avaloqcloud/terraform-cloudflare-service-publishing/blob/main/variables.tf#L278. 

`workflow/skip-changelog-entry` label should be added.

fixes #2920