### PR TITLE
docs: add additional info on the usage of standalone/reusable policies

### DIFF
--- a/.changelog/3329.txt
+++ b/.changelog/3329.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_access_policy: add additional info on the usage of standalone/reusable policies doc
+```

--- a/docs/resources/access_policy.md
+++ b/docs/resources/access_policy.md
@@ -20,6 +20,8 @@ a particular resource.
    Any cloudflare_access_application resource can reference reusable policies through its `policies` argument.
    To destroy a reusable policy and remove it from all applications' policies lists on the same apply, preemptively set the
    lifecycle option `create_before_destroy` to true on the 'cloudflare_access_policy' resource.
+   Keep in mind that standalone/reusable policies are only supported with `account_id`, not `zone_id`.
+
 
 ## Example Usage
 


### PR DESCRIPTION
Hi, this PR contains a description update on `cloudflare_access_policy` documentation page.

Related discussion: https://github.com/cloudflare/terraform-provider-cloudflare/issues/3319#issuecomment-2127169105