### PR TITLE
Force Cloudflare Access Application to be recreated if SaaS app auth_type is changed

### DIFF
--- a/.changelog/3332.txt
+++ b/.changelog/3332.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Force Cloudflare Access Application to be recreated if SaaS app auth_type is changed
+resource/cloudflare_access_application: force recreation if SaaS app `auth_type` is changed
 ```

--- a/.changelog/3332.txt
+++ b/.changelog/3332.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Force Cloudflare Access Application to be recreated if SaaS app auth_type is changed
+```

--- a/docs/resources/access_application.md
+++ b/docs/resources/access_application.md
@@ -130,16 +130,19 @@ Optional:
 
 Optional:
 
+- `allow_pkce_without_client_secret` (Boolean) Allow PKCE flow without a client secret.
 - `app_launcher_url` (String) The URL where this applications tile redirects users.
-- `auth_type` (String)
+- `auth_type` (String) **Modifying this attribute will force creation of a new resource.**
 - `consumer_service_url` (String) The service provider's endpoint that is responsible for receiving and parsing a SAML assertion.
 - `custom_attribute` (Block List) Custom attribute mapped from IDPs. (see [below for nested schema](#nestedblock--saas_app--custom_attribute))
+- `custom_claim` (Block List) Custom claim mapped from IDPs. (see [below for nested schema](#nestedblock--saas_app--custom_claim))
 - `default_relay_state` (String) The relay state used if not provided by the identity provider.
 - `grant_types` (Set of String) The OIDC flows supported by this application.
 - `group_filter_regex` (String) A regex to filter Cloudflare groups returned in ID token and userinfo endpoint.
 - `name_id_format` (String) The format of the name identifier sent to the SaaS application.
 - `name_id_transform_jsonata` (String) A [JSONata](https://jsonata.org/) expression that transforms an application's user identities into a NameID value for its SAML assertion. This expression should evaluate to a singular string. The output of this expression can override the `name_id_format` setting.
 - `redirect_uris` (Set of String) The permitted URL's for Cloudflare to return Authorization codes and Access/ID tokens.
+- `refresh_token_options` (Block List) Refresh token grant options. (see [below for nested schema](#nestedblock--saas_app--refresh_token_options))
 - `saml_attribute_transform_jsonata` (String) A [JSONata](https://jsonata.org/) expression that transforms an application's user identities into attribute assertions in the SAML response. The expression can transform id, email, name, and groups values. It can also transform fields listed in the saml_attributes or oidc_fields of the identity provider used to authenticate. The output of this expression must be a JSON object.
 - `scopes` (Set of String) Define the user information shared with access.
 - `sp_entity_id` (String) A globally unique name for an identity or service provider.
@@ -173,6 +176,44 @@ Required:
 
 - `name` (String) The name of the attribute as provided by the IDP.
 
+Optional:
+
+- `name_by_idp` (Map of String) A mapping from IdP ID to claim name.
+
+
+
+<a id="nestedblock--saas_app--custom_claim"></a>
+### Nested Schema for `saas_app.custom_claim`
+
+Required:
+
+- `source` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--saas_app--custom_claim--source))
+
+Optional:
+
+- `name` (String) The name of the attribute as provided to the SaaS app.
+- `required` (Boolean) True if the attribute must be always present.
+- `scope` (String) The scope of the claim.
+
+<a id="nestedblock--saas_app--custom_claim--source"></a>
+### Nested Schema for `saas_app.custom_claim.source`
+
+Required:
+
+- `name` (String) The name of the attribute as provided by the IDP.
+
+Optional:
+
+- `name_by_idp` (Map of String) A mapping from IdP ID to claim name.
+
+
+
+<a id="nestedblock--saas_app--refresh_token_options"></a>
+### Nested Schema for `saas_app.refresh_token_options`
+
+Optional:
+
+- `lifetime` (String) How long a refresh token will be valid for after creation. Valid units are m,h,d. Must be longer than 1m.
 
 
 

--- a/internal/sdkv2provider/resource_cloudflare_access_application_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_application_test.go
@@ -1027,6 +1027,32 @@ func TestAccCloudflareAccessApplication_WithAppLauncherCustomization(t *testing.
 	})
 }
 
+func TestAccCloudflareAccessApplication_AuthTypeForcesNewResource(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_access_application.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
+		Steps: []resource.TestStep{
+			{Config: testAccCloudflareAccessApplicationConfigWithSAMLSaas(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "saas_app.auth_type", "saml"),
+				),
+			},
+			{Config: testAccCloudflareAccessApplicationConfigWithOIDCSaas(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "saas_app.auth_type", "oidc"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCloudflareAccessApplicationConfigBasic(rnd string, domain string, identifier *cloudflare.ResourceContainer) string {
 	return fmt.Sprintf(`
 resource "cloudflare_access_application" "%[1]s" {

--- a/internal/sdkv2provider/resource_cloudflare_access_application_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_application_test.go
@@ -1039,12 +1039,14 @@ func TestAccCloudflareAccessApplication_AuthTypeForcesNewResource(t *testing.T) 
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
 		Steps: []resource.TestStep{
-			{Config: testAccCloudflareAccessApplicationConfigWithSAMLSaas(rnd, accountID),
+			{
+				Config: testAccCloudflareAccessApplicationConfigWithSAMLSaas(rnd, accountID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "saas_app.auth_type", "saml"),
 				),
 			},
-			{Config: testAccCloudflareAccessApplicationConfigWithOIDCSaas(rnd, accountID),
+			{
+				Config: testAccCloudflareAccessApplicationConfigWithOIDCSaas(rnd, accountID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "saas_app.auth_type", "oidc"),
 				),
@@ -1670,7 +1672,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 		user_deprovision         = true
 	}
 }
-	
+
 resource "cloudflare_access_application" "%[1]s" {
   account_id       = "%[2]s"
   name             = "%[1]s"
@@ -1722,7 +1724,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 		user_deprovision         = true
 	}
 }
-	
+
 resource "cloudflare_access_application" "%[1]s" {
   account_id       = "%[2]s"
   name             = "%[1]s"
@@ -1762,7 +1764,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 		user_deprovision         = true
 	}
 }
-	
+
 resource "cloudflare_access_application" "%[1]s" {
   account_id       = "%[2]s"
   name             = "%[1]s"
@@ -1813,7 +1815,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 		user_deprovision         = true
 	}
 }
-	
+
 resource "cloudflare_access_application" "%[1]s" {
   account_id       = "%[2]s"
   name             = "%[1]s"
@@ -1868,7 +1870,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 		user_deprovision         = true
 	}
 }
-	
+
 resource "cloudflare_access_application" "%[1]s" {
   account_id       = "%[2]s"
   name             = "%[1]s"
@@ -1922,7 +1924,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 		user_deprovision         = true
 	}
 }
-	
+
 resource "cloudflare_access_application" "%[1]s" {
   account_id       = "%[2]s"
   name             = "%[1]s"
@@ -1980,7 +1982,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 		user_deprovision         = true
 	}
 }
-	
+
 resource "cloudflare_access_application" "%[1]s" {
   account_id       = "%[2]s"
   name             = "%[1]s"
@@ -2030,7 +2032,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 		user_deprovision         = true
 	}
 }
-	
+
 resource "cloudflare_access_application" "%[1]s" {
   account_id       = "%[2]s"
   name             = "%[1]s"
@@ -2068,7 +2070,7 @@ func testAccCloudflareAccessApplicationConfigWithReusablePolicies(rnd, domain st
 resource "cloudflare_access_policy" "%[1]s_p1" {
   account_id     			= "%[3]s"
   name                      = "%[1]s"
-  decision			  		= "allow"	
+  decision			  		= "allow"
   include {
     email = ["a@example.com"]
   }
@@ -2077,7 +2079,7 @@ resource "cloudflare_access_policy" "%[1]s_p1" {
 resource "cloudflare_access_policy" "%[1]s_p2" {
   account_id     			= "%[3]s"
   name                      = "%[1]s"
-  decision			  		= "non_identity"	
+  decision			  		= "non_identity"
   include {
     ip = ["127.0.0.1/32"]
   }

--- a/internal/sdkv2provider/resource_cloudflare_access_application_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_application_test.go
@@ -1042,13 +1042,13 @@ func TestAccCloudflareAccessApplication_AuthTypeForcesNewResource(t *testing.T) 
 			{
 				Config: testAccCloudflareAccessApplicationConfigWithSAMLSaas(rnd, accountID),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "saas_app.auth_type", "saml"),
+					resource.TestCheckResourceAttr(name, "saas_app.0.auth_type", ""),
 				),
 			},
 			{
 				Config: testAccCloudflareAccessApplicationConfigWithOIDCSaas(rnd, accountID),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "saas_app.auth_type", "oidc"),
+					resource.TestCheckResourceAttr(name, "saas_app.0.auth_type", "oidc"),
 				),
 			},
 		},

--- a/internal/sdkv2provider/schema_cloudflare_access_application.go
+++ b/internal/sdkv2provider/schema_cloudflare_access_application.go
@@ -167,6 +167,7 @@ func resourceCloudflareAccessApplicationSchema() map[string]*schema.Schema {
 						Optional:     true,
 						ValidateFunc: validation.StringInSlice([]string{"oidc", "saml"}, false),
 						Description:  "",
+						ForceNew:     true,
 					},
 					"public_key": {
 						Type:        schema.TypeString,


### PR DESCRIPTION
The auth_type of an application cannot be changed. The only way is to delete the app and create it again as the API will return a 500 when changing an app from oidc to saml or vice-versa.

In the UI, this is stated very clearly:
> To change the authentication protocols for this application, delete the application and add the application again with your preferred authentication protocol.

This change adds the `ForceNew` behaviour to `auth_type`, so that when it is changed, the resource will be recreated, rather than updated.

Close #3314 