### PR TITLE
load_balancing pool: support virtual_network_id

### DIFF
--- a/.changelog/3333.txt
+++ b/.changelog/3333.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_load_balancer_pool: Add support for virtual_network_id
+```

--- a/docs/data-sources/load_balancer_pools.md
+++ b/docs/data-sources/load_balancer_pools.md
@@ -83,6 +83,7 @@ Read-Only:
 - `enabled` (Boolean)
 - `header` (Set of Object) (see [below for nested schema](#nestedobjatt--pools--origins--header))
 - `name` (String)
+- `virtual_network_id` (String)
 - `weight` (Number)
 
 <a id="nestedobjatt--pools--origins--header"></a>

--- a/docs/resources/load_balancer_pool.md
+++ b/docs/resources/load_balancer_pool.md
@@ -91,6 +91,7 @@ Optional:
 
 - `enabled` (Boolean) Whether this origin is enabled. Disabled origins will not receive traffic and are excluded from health checks. Defaults to `true`.
 - `header` (Block Set) HTTP request headers. (see [below for nested schema](#nestedblock--origins--header))
+- `virtual_network_id` (String) The virtual network subnet ID the origin belongs in. Virtual network must also belong to the account.
 - `weight` (Number) The weight (0.01 - 1.00) of this origin, relative to other origins in the pool. Equal values mean equal weighting. A weight of 0 means traffic will not be sent to this origin, but health is still checked. When [`origin_steering.policy="least_outstanding_requests"`](#policy), weight is used to scale the origin's outstanding requests. When [`origin_steering.policy="least_connections"`](#policy), weight is used to scale the origin's open connections. Defaults to `1`.
 
 <a id="nestedblock--origins--header"></a>

--- a/internal/sdkv2provider/resource_cloudflare_load_balancer_pool.go
+++ b/internal/sdkv2provider/resource_cloudflare_load_balancer_pool.go
@@ -207,10 +207,11 @@ func expandLoadBalancerOrigins(originSet *schema.Set) (origins []cloudflare.Load
 	for _, iface := range originSet.List() {
 		o := iface.(map[string]interface{})
 		origin := cloudflare.LoadBalancerOrigin{
-			Name:    o["name"].(string),
-			Address: o["address"].(string),
-			Enabled: o["enabled"].(bool),
-			Weight:  o["weight"].(float64),
+			Name:             o["name"].(string),
+			Address:          o["address"].(string),
+			VirtualNetworkID: o["virtual_network_id"].(string),
+			Enabled:          o["enabled"].(bool),
+			Weight:           o["weight"].(float64),
 		}
 
 		if header, ok := o["header"]; ok {
@@ -303,11 +304,12 @@ func flattenLoadBalancerOrigins(d *schema.ResourceData, origins []cloudflare.Loa
 	flattened := make([]interface{}, 0)
 	for _, o := range origins {
 		cfg := map[string]interface{}{
-			"name":    o.Name,
-			"address": o.Address,
-			"enabled": o.Enabled,
-			"weight":  o.Weight,
-			"header":  flattenLoadBalancerPoolHeader(o.Header),
+			"name":               o.Name,
+			"address":            o.Address,
+			"virtual_network_id": o.VirtualNetworkID,
+			"enabled":            o.Enabled,
+			"weight":             o.Weight,
+			"header":             flattenLoadBalancerPoolHeader(o.Header),
 		}
 
 		flattened = append(flattened, cfg)

--- a/internal/sdkv2provider/schema_cloudflare_load_balancer_pool.go
+++ b/internal/sdkv2provider/schema_cloudflare_load_balancer_pool.go
@@ -135,6 +135,15 @@ var originsElem = &schema.Resource{
 			Description: "The IP address (IPv4 or IPv6) of the origin, or the publicly addressable hostname.",
 		},
 
+		"virtual_network_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Description: "The virtual network subnet ID the origin belongs in. Virtual network must also belong to the account.",
+		},
+
 		"weight": {
 			Type:         schema.TypeFloat,
 			Optional:     true,


### PR DESCRIPTION
### Description

Support `virtual_network_id` on Load Balancing Pool origins.

Closes #3087 
Closes #3297 

Public API documentation [here](https://developers.cloudflare.com/api/operations/load-balancer-pools-create-pool).

### Testing

Verified the new test passes:
```
$ TESTARGS='-run "^TestAccCloudflareLoadBalancerPool_VirtualNetworkID" -count 1 -parallel 1' make testacc
```

### Manual Tests

For these manual tests I hard-coded in the vnet and did not generate it on-the-fly.

**Try with invalid UUID:**
```
    resource_cloudflare_load_balancer_pool_test.go:270: Step 1/1 error: Error running apply: exit status 1
        
        Error: error creating load balancer pool: virtual_network_id must be valid UUID: validation failed (1002)
        
          with cloudflare_load_balancer_pool.omnjdokumi,
          on terraform_plugin_test.tf line 12, in resource "cloudflare_load_balancer_pool" "omnjdokumi":
          12: resource "cloudflare_load_balancer_pool" "omnjdokumi" {
        
--- FAIL: TestAccCloudflareLoadBalancerPool_VirtualNetworkID (1.49s)
```

**Try with UUID of vnet that does not include 192.0.2.1/32:**
```
    resource_cloudflare_load_balancer_pool_test.go:270: Step 1/1 error: Error running apply: exit status 1
        
        Error: error creating load balancer pool: virtual_network_id does not belong to tunnel route that covers origin IP: validation failed (1002)
        
          with cloudflare_load_balancer_pool.hfsxlmambe,
          on terraform_plugin_test.tf line 12, in resource "cloudflare_load_balancer_pool" "hfsxlmambe":
          12: resource "cloudflare_load_balancer_pool" "hfsxlmambe" {
        
--- FAIL: TestAccCloudflareLoadBalancerPool_VirtualNetworkID (0.97s)
```

**Try with UUID that does include 192.0.2.1/32:**
```
--- PASS: TestAccCloudflareLoadBalancerPool_VirtualNetworkID (4.30s)
PASS
```
