### PR TITLE
Mirror API record_delimiter defaults

### DIFF
--- a/.changelog/3334.txt
+++ b/.changelog/3334.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_logpush_job: Mirror API defaults for record_delimiter to include newline
+```

--- a/docs/resources/logpush_job.md
+++ b/docs/resources/logpush_job.md
@@ -147,7 +147,8 @@ Optional:
 - `output_type` (String) Specifies the output type. Available values: `ndjson`, `csv`. Defaults to `ndjson`.
 - `record_delimiter` (String) String to be inserted in-between the records as separator.
 - `record_prefix` (String) String to be prepended before each record. Defaults to `{`.
-- `record_suffix` (String) String to be appended after each record. Defaults to `}`.
+- `record_suffix` (String) String to be appended after each record. Defaults to `}
+`.
 - `record_template` (String) String to use as template for each record instead of the default comma-separated list.
 - `sample_rate` (Number) Specifies the sampling rate. Defaults to `1`.
 - `timestamp_format` (String) Specifies the format for timestamps. Available values: `unixnano`, `unix`, `rfc3339`. Defaults to `unixnano`.

--- a/internal/sdkv2provider/schema_cloudflare_logpush_job.go
+++ b/internal/sdkv2provider/schema_cloudflare_logpush_job.go
@@ -175,7 +175,7 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 					"record_suffix": {
 						Type:        schema.TypeString,
 						Optional:    true,
-						Default:     "}",
+						Default:     "}\n",
 						Description: "String to be appended after each record",
 					},
 					"record_template": {


### PR DESCRIPTION
According to https://developers.cloudflare.com/logs/reference/log-output-options/ the default options for record_suffix are "}\n" and not "}" The defaults cause malformed JSON when there is more than a single record in a time interval.

Perhaps a better default would be to set record_delimiter to "\n" and keep field_delimiter "}" but this change is intended to mirror the published documentation