### PR TITLE
resource/cloudflare_list_item: handle overlapping redirect `source_url`

### DIFF
--- a/.changelog/3335.txt
+++ b/.changelog/3335.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_list_item: handle overlapping redirect `source_url`
+```

--- a/internal/framework/service/list_item/resource.go
+++ b/internal/framework/service/list_item/resource.go
@@ -312,6 +312,13 @@ func createListItem(ctx context.Context, client *muxclient.Client, data *ListIte
 			break
 		}
 
+		for _, item := range items {
+			if item.Redirect.SourceUrl == searchTerm {
+				items = []cfv1.ListItem{item}
+				break
+			}
+		}
+
 		//lintignore:R018
 		time.Sleep(time.Duration(attempts) * time.Second)
 	}


### PR DESCRIPTION
To determine the individual list item identifier, we perform an additional HTTP search against the endpoint filtering for the value. In the case of IPs, we use a "starts with" match whereas for redirects, it is a contains. This creates an edge whereby if you have a multiple redirects whereby they share a substring, you cannot differentiate them.

This introduces an additional loop performing an exact match against what the user has provided with all found search results.

NB: For a small dataset, this is manageable however, for 10+ similar items, you are very likely to exhaust your API quota due to additional requests. In the future, the service will improve the search to provide different search match types which we can lean on here instead.