### PR TITLE
Fix updating access apps self_hosted_domains returning errors

### DIFF
--- a/.changelog/3340.txt
+++ b/.changelog/3340.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare-access-application: fixes bug when updating self_hosted_domains
+```

--- a/internal/sdkv2provider/resource_cloudflare_access_application.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_application.go
@@ -171,7 +171,13 @@ func resourceCloudflareAccessApplicationRead(ctx context.Context, d *schema.Reso
 	d.Set("name", accessApplication.Name)
 	d.Set("aud", accessApplication.AUD)
 	d.Set("session_duration", accessApplication.SessionDuration)
-	d.Set("domain", accessApplication.Domain)
+	if _, domainWasSet := d.GetOk("domain"); domainWasSet {
+		// Only set the domain if it was set in the configuration, as apps can be created without a domain
+		// if they define a non-empty self_hosted_domains array
+		d.Set("domain", accessApplication.Domain)
+	} else {
+		d.Set("domain", nil)
+	}
 	d.Set("type", accessApplication.Type)
 	d.Set("auto_redirect_to_identity", accessApplication.AutoRedirectToIdentity)
 	d.Set("enable_binding_cookie", accessApplication.EnableBindingCookie)


### PR DESCRIPTION
Internal ticket AUTH-5818

Fixes the following bug:


initial config:
```
 
resource "cloudflare_access_application" "app1" {
  account_id = var.account_id
  name         = "tf app 1"
  self_hosted_domains = ["tfapp1_1.eduardogomes.art", "tfapp1_2.eduardogomes.art"]
}
```
 
That succeeds /\
 But if you now  change to 

```
resource "cloudflare_access_application" "app1" {
 account_id = var.account_id
 name         = "tf app 1"
 self_hosted_domains = ["tfapp1_3.eduardogomes.art", "tfapp1_4.eduardogomes.art"]
}
```

Then you get
`Error: error updating Access Application for accounts "5fe2038d8318e008cfa4474735b6fbd6": error from makeRequest: access.api.error.invalid_request: domain not included in self_hosted_domains (1213`





