### PR TITLE
Fix importing waiting room events

### DIFF
--- a/.changelog/3351.txt
+++ b/.changelog/3351.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_waiting_room_event: fix panic when trying to import a resource
+```

--- a/internal/sdkv2provider/resource_cloudflare_waiting_room_event.go
+++ b/internal/sdkv2provider/resource_cloudflare_waiting_room_event.go
@@ -193,7 +193,7 @@ func resourceCloudflareWaitingRoomEventImport(ctx context.Context, d *schema.Res
 	if len(idAttr) == 3 {
 		zoneID = idAttr[0]
 		waitingRoomID = idAttr[1]
-		waitingRoomEventID = idAttr[3]
+		waitingRoomEventID = idAttr[2]
 	} else {
 		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"zoneID/waitingRoomID/eventID\" for import", d.Id())
 	}


### PR DESCRIPTION
There is currently a bug when importing a waiting room event because the
value is out of range. The 3rd element of an array is indexed with value
2, not value 3