### PR TITLE
resource/cloudflare_list_item: implement exact match for IP values

### DIFF
--- a/.changelog/3368.txt
+++ b/.changelog/3368.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/cloudflare_list_item: implement exact match for IP values to prevent overlapping IP prefixes from not being found
 ```
+
+```release-note:bug
+resource/cloudflare_list_item: fix crash when not using `type = "redirect"` due to attempting to compare `nil`
+```

--- a/.changelog/3368.txt
+++ b/.changelog/3368.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_list_item: implement exact match for IP values to prevent overlapping IP prefixes from not being found
+```

--- a/internal/framework/service/list_item/resource.go
+++ b/internal/framework/service/list_item/resource.go
@@ -312,6 +312,11 @@ func createListItem(ctx context.Context, client *muxclient.Client, data *ListIte
 				items = []cfv1.ListItem{item}
 				break
 			}
+
+			if item.IP != nil && cfv1.String(item.IP) == searchTerm {
+				items = []cfv1.ListItem{item}
+				break
+			}
 		}
 		if len(items) == 1 {
 			break

--- a/internal/framework/service/list_item/resource.go
+++ b/internal/framework/service/list_item/resource.go
@@ -308,7 +308,7 @@ func createListItem(ctx context.Context, client *muxclient.Client, data *ListIte
 		}
 
 		for _, item := range items {
-			if item.Redirect.SourceUrl == searchTerm {
+			if item.Redirect != nil && item.Redirect.SourceUrl == searchTerm {
 				items = []cfv1.ListItem{item}
 				break
 			}


### PR DESCRIPTION
Similar to the fix for redirects that was made in https://github.com/cloudflare/terraform-provider-cloudflare/pull/3335, we are now
extending that expression to handle IP matches to prevent overlapping IP
prefixes from giving us the incorrect values.

This PR also includes a fix for when you were not using a redirect and it 
would still attempt to validate the search term against the `nil` value
resulting in a crash.

Closes #3359
