### PR TITLE
docs: add a skip rule on managed ruleset example

### DIFF
--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -38,13 +38,29 @@ resource "cloudflare_ruleset" "magic_transit_example" {
   }
 }
 
-# Zone-level WAF Managed Ruleset
+# Zone-level WAF Managed Ruleset with exceptions
 resource "cloudflare_ruleset" "zone_level_managed_waf" {
   zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
   name        = "managed WAF"
-  description = "managed WAF ruleset description"
+  description = "managed WAF ruleset with exceptions description"
   kind        = "zone"
   phase       = "http_request_firewall_managed"
+
+  rules {
+    action = "skip"
+    action_parameters {
+      rules = {
+        # Format: "<RULESET_ID>" = "<RULE_ID_1>,<RULE_ID_2>,..."
+        "efb7b8c949ac4650a09736fc376e9aee" = "5de7edfa648c4d6891dc3e7f84534ffa,e3a567afc347477d9702d9047e97d760"
+      }
+    }
+    expression = "(cf.zone.name eq \"example.com\" and http.request.uri.query contains \"skip=rules\")"
+    description = "Skip WordPress and SQLi rules"
+    enabled     = true
+    logging {
+      enabled = true
+    }
+  }
 
   rules {
     action = "execute"


### PR DESCRIPTION
### Explicitly Highlight Logging Parameter

#### Summary
This PR addresses the need to explicitly highlight the logging parameter in our configuration.

#### Context
Even though the logging parameter is optional, omitting it currently leads to the following error:

```
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to cloudflare_ruleset.dummy_org, provider "provider[\"[registry.terraform.io/cloudflare/cloudflare\](http://registry.terraform.io/cloudflare/cloudflare%5C)"]" produced an unexpected
│ new value: .rules[0].logging: block count changed from 0 to 1.
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```
#### Details
To improve clarity and prevent potential configuration issues, this PR:
1. **Documents the logging parameter**: Clearly indicates the presence and role of the logging parameter in the configuration.
2. **Prevents common errors**: By highlighting this parameter, users are less likely to encounter the aforementioned error due to its omission.

#### Testing
- Verified that specifying the logging parameter works as expected.

#### Impact
This change should enhance user experience by reducing the likelihood of configuration errors related to the logging parameter.

