### PR TITLE
docs: fix typo on split_tunnel resource

### DIFF
--- a/docs/resources/split_tunnel.md
+++ b/docs/resources/split_tunnel.md
@@ -38,6 +38,7 @@ resource "cloudflare_split_tunnel" "example_split_tunnel_include" {
 resource "cloudflare_device_settings_policy" "developer_warp_policy" {
   account_id    = "f037e56e89293a057740de681ac9abbe"
   name          = "Developers"
+  description   = "Developers WARP settings policy description"
   precedence    = 10
   match         = "any(identity.groups.name[*] in {\"Developers\"})"
   switch_locked = true
@@ -57,7 +58,7 @@ resource "cloudflare_split_tunnel" "example_device_settings_policy_split_tunnel_
 # Including *.example.com in WARP routes for a particular device policy
 resource "cloudflare_split_tunnel" "example_split_tunnel_include" {
   account_id = "f037e56e89293a057740de681ac9abbe"
-  policy_id  = cloudflare_device_policy.developer_warp_policy.id
+  policy_id  = cloudflare_device_settings_policy.developer_warp_policy.id
   mode       = "include"
   tunnels {
     host        = "*.example.com"

--- a/examples/resources/cloudflare_split_tunnel/resource.tf
+++ b/examples/resources/cloudflare_split_tunnel/resource.tf
@@ -22,6 +22,7 @@ resource "cloudflare_split_tunnel" "example_split_tunnel_include" {
 resource "cloudflare_device_settings_policy" "developer_warp_policy" {
   account_id    = "f037e56e89293a057740de681ac9abbe"
   name          = "Developers"
+  description   = "Developers WARP settings policy description"
   precedence    = 10
   match         = "any(identity.groups.name[*] in {\"Developers\"})"
   switch_locked = true
@@ -41,7 +42,7 @@ resource "cloudflare_split_tunnel" "example_device_settings_policy_split_tunnel_
 # Including *.example.com in WARP routes for a particular device policy
 resource "cloudflare_split_tunnel" "example_split_tunnel_include" {
   account_id = "f037e56e89293a057740de681ac9abbe"
-  policy_id  = cloudflare_device_policy.developer_warp_policy.id
+  policy_id  = cloudflare_device_settings_policy.developer_warp_policy.id
   mode       = "include"
   tunnels {
     host        = "*.example.com"


### PR DESCRIPTION
# Overview

Recently, I've been working on the Cloudflare provider, specifically focusing on Cloudflare Tunnel. I just noticed a typo in the documentation for the split_tunnel resource. The example is missing a required variable and refers to an incorrect resource name.
