### PR TITLE
resource/cloudflare_notification_policy: Add tunnel_name filter

### DIFF
--- a/.changelog/3417.txt
+++ b/.changelog/3417.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_notification_policy: Add tunnel_name filter for Magic Health Checks
+```

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -134,6 +134,7 @@ Optional:
 - `target_ip` (Set of String) Target ip to alert on for dos in CIDR notation.
 - `target_zone_name` (Set of String) Target domain to alert on.
 - `tunnel_id` (Set of String) Tunnel IDs to alert on.
+- `tunnel_name` (Set of String) Tunnel Names to alert on.
 - `where` (Set of String) Filter for alert.
 - `zones` (Set of String) A list of zone identifiers.
 

--- a/internal/sdkv2provider/schema_cloudflare_notification_policy.go
+++ b/internal/sdkv2provider/schema_cloudflare_notification_policy.go
@@ -514,6 +514,14 @@ func notificationPolicyFilterSchema() *schema.Schema {
 					Optional:    true,
 					Description: "Tunnel IDs to alert on.",
 				},
+				"tunnel_name": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+					Optional:    true,
+					Description: "Tunnel Names to alert on.",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds a missing tunnel_name filter to the notification policy resource, which allows to filter on specific Magic WAN/Transit tunnels.

Ref: https://developers.cloudflare.com/api/operations/notification-policies-create-a-notification-policy