### PR TITLE
test: introduce test helper for loading test cases

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1,7 +1,9 @@
 package acctest
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	cfv1 "github.com/cloudflare/cloudflare-go"
@@ -184,4 +186,31 @@ func SharedV2Client() *cfv2.Client {
 		option.WithAPIKey("CLOUDFLARE_API_KEY"),
 		option.WithAPIEmail("CLOUDFLARE_EMAIL"),
 	)
+}
+
+// LoadTestCase takes a filename and variadic parameters to build test case output.
+//
+// Example: If you have a "basic" test case that for `r2_bucket` resource, inside
+// of the `testdata` directory, you need to have a `basic.tf` file.
+//
+//	  $ tree internal/services/r2_bucket/
+//	  ├── ...
+//	  ├── schema.go
+//	  └── testdata
+//		  └── basic.tf
+//
+// The invocation would be `LoadTestCase("basic.tf", rnd, acountID)`.
+func LoadTestCase(filename string, parameters ...interface{}) string {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+
+	fullPath := filepath.Join(pwd, "testdata", filename)
+	f, err := os.ReadFile(fullPath)
+	if err != nil {
+		return ""
+	}
+
+	return fmt.Sprintf(string(f), parameters...)
 }

--- a/internal/services/r2_bucket/resource_test.go
+++ b/internal/services/r2_bucket/resource_test.go
@@ -154,18 +154,9 @@ func TestAccCloudflareR2Bucket_Minimum(t *testing.T) {
 }
 
 func testAccCheckCloudflareR2BucketMinimum(rnd, accountID string) string {
-	return fmt.Sprintf(`
-  resource "cloudflare_r2_bucket" "%[1]s" {
-    account_id = "%[2]s"
-    name       = "%[1]s"
-  }`, rnd, accountID)
+	return acctest.LoadTestCase("minimum.tf", rnd, accountID)
 }
 
 func testAccCheckCloudflareR2BucketBasic(rnd, accountID string) string {
-	return fmt.Sprintf(`
-  resource "cloudflare_r2_bucket" "%[1]s" {
-    account_id = "%[2]s"
-    name       = "%[1]s"
-	location_hint   = "ENAM"
-  }`, rnd, accountID)
+	return acctest.LoadTestCase("basic.tf", rnd, accountID)
 }

--- a/internal/services/r2_bucket/testdata/basic.tf
+++ b/internal/services/r2_bucket/testdata/basic.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_r2_bucket" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+	location_hint   = "ENAM"
+}

--- a/internal/services/r2_bucket/testdata/minimum.tf
+++ b/internal/services/r2_bucket/testdata/minimum.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_r2_bucket" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+}


### PR DESCRIPTION
`LoadTestCase` takes a filename and variadic parameters to build test case output.

Example: If you have a "basic" test case that for `r2_bucket` resource, inside of the `testdata` directory, you need to have a `basic.tf` file.

  $ tree internal/services/r2_bucket/
  ├── ...
  ├── schema.go
  └── testdata
	  └── basic.tf

The invocation would be `LoadTestCase("basic.tf", rnd, acountID)`.