### PR TITLE
refactor(logger): curlify log output

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go/v2/option"
@@ -26,13 +27,16 @@ func Middleware(ctx context.Context) option.Middleware {
 }
 
 func LogRequest(ctx context.Context, req *http.Request) error {
-	lines := []string{"\n== Request ==", fmt.Sprintf("url: %s %s", req.Method, req.URL.Path)}
+	sensitiveHeaderNames := []string{"x-auth-email", "x-auth-key", "x-auth-user-service-key", "authorization"}
+	lines := []string{fmt.Sprintf("\n%s %s %s", req.Method, req.URL.Path, req.Proto)}
 
 	// Log headers
-	lines = append(lines, "== Headers ==")
 	for name, values := range req.Header {
 		for _, value := range values {
-			lines = append(lines, fmt.Sprintf("- %s: %s", name, value))
+			if slices.Contains(sensitiveHeaderNames, strings.ToLower(name)) {
+				value = "[redacted]"
+			}
+			lines = append(lines, fmt.Sprintf("> %s: %s", strings.ToLower(name), value))
 		}
 	}
 
@@ -47,23 +51,22 @@ func LogRequest(ctx context.Context, req *http.Request) error {
 		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 		// Log the body
-		lines = append(lines, fmt.Sprintf("\n== Body ==\n%s\n", string(bodyBytes)))
+		lines = append(lines, ">\n", string(bodyBytes), "\n")
 	}
 
-	tflog.Warn(ctx, strings.Join(lines, "\n"))
+	tflog.Debug(ctx, strings.Join(lines, "\n"))
 
 	return nil
 }
 
 func LogResponse(ctx context.Context, resp *http.Response) error {
 	// Log the status code
-	lines := []string{"\n== Response ==", fmt.Sprintf("status: %s", resp.Status)}
+	lines := []string{fmt.Sprintf("\n< %s %s", resp.Proto, resp.Status)}
 
 	// Log headers
-	lines = append(lines, "== Headers ==")
 	for name, values := range resp.Header {
 		for _, value := range values {
-			lines = append(lines, fmt.Sprintf("- %s: %s", name, value))
+			lines = append(lines, fmt.Sprintf("< %s: %s", strings.ToLower(name), value))
 		}
 	}
 
@@ -76,10 +79,10 @@ func LogResponse(ctx context.Context, resp *http.Response) error {
 	// Restore the original body to the response so it can be read again
 	resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
-	lines = append(lines, fmt.Sprintf("\n== Body ==\n%s\n", string(bodyBytes)))
+	lines = append(lines, "<\n", string(bodyBytes), "\n")
 
 	// Log the body
-	tflog.Warn(ctx, strings.Join(lines, "\n"))
+	tflog.Debug(ctx, strings.Join(lines, "\n"))
 
 	return nil
 }


### PR DESCRIPTION
Updates the logger to resemble more curl-esque requests and responses (direction denoted with `>` for request and `<` for responses) when logging the HTTP transactions.

```
2024-07-04T15:54:31.427+1000 [DEBUG]  cloudflare: 
POST /client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/acm/total_tls HTTP/1.1
> user-agent: terraform-provider-cloudflare/dev terraform-plugin-framework terraform/1.9.0
> x-stainless-runtime: terraform-plugin-framework
> x-auth-key: [redacted]
> x-auth-email: [redacted]
> content-type: application/json
> x-stainless-arch: arm64
> x-stainless-runtime-version: go1.22.4
> accept: application/json
> x-stainless-lang: Terraform
> x-stainless-os: MacOS
> x-stainless-package-version: dev
>

{"certificate_authority":"google","enabled":false}

: tf_resource_type=cloudflare_total_tls tf_req_id=ccf09721-1191-769e-894c-09ebfe9d6e0e tf_provider_addr=registry.terraform.io/hashicorp/cloudflare tf_rpc=ApplyResourceChange
2024-07-04T15:54:31.911+1000 [DEBUG]  cloudflare: 
< HTTP/1.1 400 Bad Request
< date: Thu, 04 Jul 2024 05:54:31 GMT
< connection: keep-alive
< cf-ray: 89dcdc731bb75738-SYD
< set-cookie: __cflb=0H28vgHxwvgAQtjUGUFqYFDiSDreGJnUuADd4Z3wnxm; SameSite=Lax; path=/; expires=Thu, 04-Jul-24 08:24:32 GMT; HttpOnly
< set-cookie: __cf_bm=pwjbshn_eTddH.otP6V00cBtBOUktKBHs3ifGnfnKEo-1720072471-1.0.1.1-Xmo88evxdqS7myZcWABwsMDUBt0._Xghb8hGmWb24mqbTGW81EjKu3zesWRqth87Ln.SZX9GBE.X_VLrc.ySUA; path=/; expires=Thu, 04-Jul-24 06:24:31 GMT; domain=.api.cloudflare.com; HttpOnly; Secure; SameSite=None
< set-cookie: __cfruid=b923535aa097da89b4ac1f676a9e6294e1e5c4b5-1720072471; path=/; domain=.api.cloudflare.com; HttpOnly; Secure; SameSite=None
< vary: Accept-Encoding
< content-type: application/json
< cf-cache-status: DYNAMIC
< server: cloudflare
<

{"success":false,"errors":[{"code":1467,"message":"No state between current settings and new settings has changed."}],"messages":[]}
```

In the future, I'd love to provide a compressed format as well but that's for another day.

As part of this refactor, I've also introduced a redaction for any sensitive HTTP headers where we don't need the value and providing it in debug logs has the potential to leak credentials.