### PR TITLE
Fix partial risk behavior configuration bug

### DIFF
--- a/.changelog/3463.txt
+++ b/.changelog/3463.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-fix resource/cloudflare_risk_behavior bug where partial definition of risk behaviors resulted in a provider error
+resource/cloudflare_risk_behavior: fix bug where partial definition of risk behaviors resulted in a provider error
 ```

--- a/.changelog/3463.txt
+++ b/.changelog/3463.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fix resource/cloudflare_risk_behavior bug where partial definition of risk behaviors resulted in a provider error
+```

--- a/internal/framework/service/risk_behavior/resource.go
+++ b/internal/framework/service/risk_behavior/resource.go
@@ -70,7 +70,14 @@ func (r *RiskBehaviorResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	behaviorsSet := ConvertBehaviorsCtoT(behaviors.Behaviors)
+	retained := map[string]cloudflare.Behavior{}
+	for k, b := range behaviors.Behaviors {
+		_, ok := behaviorsMap[k]
+		if ok {
+			retained[k] = b
+		}
+	}
+	behaviorsSet := ConvertBehaviorsCtoT(retained)
 
 	data.AccountID = types.StringValue(accountId)
 	data.Behaviors = behaviorsSet
@@ -94,11 +101,26 @@ func (r *RiskBehaviorResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	behaviorsSet := ConvertBehaviorsCtoT(behaviors.Behaviors)
+	retained := map[string]cloudflare.Behavior{}
+	for k, b := range behaviors.Behaviors {
+		if containsBehavior(data.Behaviors, k) {
+			retained[k] = b
+		}
+	}
+	behaviorsSet := ConvertBehaviorsCtoT(retained)
 
 	data.AccountID = types.StringValue(accountId)
 	data.Behaviors = behaviorsSet
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func containsBehavior(s []RiskBehaviorBehaviorModel, n string) bool {
+	for _, a := range s {
+		if a.Name.ValueString() == n {
+			return true
+		}
+	}
+	return false
 }
 
 func ConvertBehaviorsTtoC(b []RiskBehaviorBehaviorModel) (map[string]cloudflare.Behavior, error) {
@@ -163,7 +185,15 @@ func (r *RiskBehaviorResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	behaviorsSet := ConvertBehaviorsCtoT(behaviors.Behaviors)
+	retained := map[string]cloudflare.Behavior{}
+	for k, b := range behaviors.Behaviors {
+		_, ok := behaviorsMap[k]
+		if ok {
+			retained[k] = b
+		}
+	}
+
+	behaviorsSet := ConvertBehaviorsCtoT(retained)
 
 	data.AccountID = types.StringValue(accountId)
 	data.Behaviors = behaviorsSet

--- a/internal/framework/service/risk_behavior/resource_test.go
+++ b/internal/framework/service/risk_behavior/resource_test.go
@@ -51,6 +51,38 @@ func init() {
 	})
 }
 
+func TestAccCloudflareRiskBehavior_Partial(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_risk_behavior." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareRiskBehaviorsPartial(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(name, "behavior.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareRiskBehaviorsPartial(name, accountId string) string {
+	return fmt.Sprintf(`
+	resource cloudflare_risk_behavior %s {
+		account_id = "%s"
+		behavior {
+			name = "imp_travel"
+			enabled = true
+			risk_level = "high"
+		}
+	}`, name, accountId)
+}
+
 func TestAccCloudflareRiskBehavior_Basic(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_risk_behavior." + rnd


### PR DESCRIPTION
Previously, if a user's account supported risk behaviors A, B and C but only behaviors A and B were configured, a 'provider produced inconsistent results after apply' error occurred.

This is because the cloudflare API call for user risk behaviors returns the status of all behaviors.

This PR changes the user risk behavior terraform provider to - on read, create and update calls - prune the API call results to only include the behaviors the terraform config includes

A test confirming that the fix works has been included