### PR TITLE
chore(access_service_token): remove `min_days_for_renewal`

### DIFF
--- a/.grit/patterns/terraform_cloudflare_v5_attribute_renames.grit
+++ b/.grit/patterns/terraform_cloudflare_v5_attribute_renames.grit
@@ -9,6 +9,9 @@ pattern terraform_cloudflare_v5_attribute_renames() {
     `application_id = $id` as $app_id => . where { $app_id <: within `resource "cloudflare_access_policy" $_ { $_ }` },
     `precedence = $p` as $precedence => . where { $precedence <: within `resource "cloudflare_access_policy" $_ { $_ }` },
 
+    // cloudflare_access_service_token
+    `min_days_for_renewal = $days` as $renewal => . where { $renewal <: within `resource "cloudflare_access_service_token" $_ { $_ }` },
+
     // cloudflare_zone
     `account_id = $id` => `account = {
       id = $id

--- a/templates/guides/version-5-upgrade.md
+++ b/templates/guides/version-5-upgrade.md
@@ -94,6 +94,27 @@ terraform_cloudflare_v5()
   }
   ```
 
+## cloudflare_access_service_token
+
+- `min_days_for_renewal` is no longer used. If you would like similar functionality, you can use `duration = "forever"` instead.
+
+  Before
+  ```hcl
+  resource "cloudflare_access_service_token" "example" {
+    account_id           = "f037e56e89293a057740de681ac9abbe"
+    name                 = "CI/CD app renewed"
+    min_days_for_renewal = 30
+  }
+  ```
+
+  After
+  ```hcl
+  resource "cloudflare_access_service_token" "example" {
+    account_id = "f037e56e89293a057740de681ac9abbe"
+    name       = "CI/CD app renewed"
+  }
+  ```
+
 ## cloudflare_access_rule
 ## cloudflare_address_map
 ## cloudflare_api_shield
@@ -135,7 +156,6 @@ terraform_cloudflare_v5()
 ## cloudflare_waiting_room_rules
 ## cloudflare_worker_script
 ## cloudflare_zone_lockdown
-
 ## cloudflare_zone
 
 - `account_id` is now an `account` object with the `id` attribute inside.


### PR DESCRIPTION
This was custom functionality that can now be achieved by setting the `duration = "forever"`.