### PR TITLE
Add support for the Intune compliance status values for device posture checks

### DIFF
--- a/.changelog/3492.txt
+++ b/.changelog/3492.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_device_posture_rules: added support for intune compliance_status values
+```

--- a/docs/resources/device_posture_rule.md
+++ b/docs/resources/device_posture_rule.md
@@ -64,8 +64,8 @@ Optional:
 - `certificate_id` (String) The UUID of a Cloudflare managed certificate.
 - `check_disks` (Set of String) Specific volume(s) to check for encryption.
 - `cn` (String) The common name for a certificate.
-- `compliance_status` (String) The workspace one or intune device compliance status. Available values: (supported by workspace one and intune) `compliant`, `noncompliant`, (supported only by intune) "unknown", "conflict", "error", "ingraceperiod".
-- `connection_id` (String) The workspace one connection id.
+- `compliance_status` (String) The workspace one or intune device compliance status. `compliant` and `noncompliant` are values supported by both providers. `unknown`, `conflict`, `error`, `ingraceperiod` values are only supported by intune. Available values: `compliant`, `noncompliant`, `unknown`, `conflict`, `error`, `ingraceperiod`.
+- `connection_id` (String) The workspace one or intune connection id.
 - `count_operator` (String) The count comparison operator for kolide. Available values: `>`, `>=`, `<`, `<=`, `==`.
 - `domain` (String) The domain that the client must join.
 - `eid_last_seen` (String) The datetime a device last seen in RFC 3339 format from Tanium.

--- a/docs/resources/device_posture_rule.md
+++ b/docs/resources/device_posture_rule.md
@@ -64,7 +64,7 @@ Optional:
 - `certificate_id` (String) The UUID of a Cloudflare managed certificate.
 - `check_disks` (Set of String) Specific volume(s) to check for encryption.
 - `cn` (String) The common name for a certificate.
-- `compliance_status` (String) The workspace one device compliance status. Available values: `compliant`, `noncompliant`.
+- `compliance_status` (String) The workspace one or intune device compliance status. Available values: (supported by workspace one and intune) `compliant`, `noncompliant`, (supported only by intune) "unknown", "conflict", "error", "ingraceperiod".
 - `connection_id` (String) The workspace one connection id.
 - `count_operator` (String) The count comparison operator for kolide. Available values: `>`, `>=`, `<`, `<=`, `==`.
 - `domain` (String) The domain that the client must join.

--- a/internal/sdkv2provider/resource_cloudflare_device_posture_rule_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_device_posture_rule_test.go
@@ -290,6 +290,8 @@ func TestAccCloudflareDevicePostureRule_DiskEncryption_CheckDisks(t *testing.T) 
 }
 
 func TestAccCloudflareDevicePostureRule_Intune(t *testing.T) {
+	skipForDefaultAccount(t, "Assertion requires active Intune license.")
+
 	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
 	// service does not yet support the API tokens and it results in
 	// misleading state error messages.
@@ -297,9 +299,13 @@ func TestAccCloudflareDevicePostureRule_Intune(t *testing.T) {
 		t.Setenv("CLOUDFLARE_API_TOKEN", "")
 	}
 
+	if v := os.Getenv("CLOUDFLARE_DEVICE_POSTURE_INTUNE_CONNECTION_ID"); v == "" {
+		t.Fatal("CLOUDFLARE_DEVICE_POSTURE_INTUNE_CONNECTION_ID must be set for this acceptance test")
+	}
+
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_device_posture_rule.%s", rnd)
-	connectionID := "54bd2a16-ab0f-46a7-8d8b-31776c21fcb9"
+	connectionID := os.Getenv("CLOUDFLARE_DEVICE_POSTURE_INTUNE_CONNECTION_ID")
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
@@ -147,7 +147,7 @@ func resourceCloudflareDevicePostureRuleSchema() map[string]*schema.Schema {
 						Type:         schema.TypeString,
 						Optional:     true,
 						ValidateFunc: validation.StringInSlice([]string{"compliant", "noncompliant", "unknown", "conflict", "error", "ingraceperiod"}, true),
-						Description:  fmt.Sprintf("The workspace one or intune device compliance status. 'compliant' and 'noncompliant' are values supported by both providers. 'unknown', 'conflict', 'error', 'ingraceperiod' values are only supported by intune. %s", renderAvailableDocumentationValuesStringSlice([]string{"compliant", "noncompliant", "unknown", "conflict", "error", "ingraceperiod"})),
+						Description:  fmt.Sprintf("The workspace one or intune device compliance status. `compliant` and `noncompliant` are values supported by both providers. `unknown`, `conflict`, `error`, `ingraceperiod` values are only supported by intune. %s", renderAvailableDocumentationValuesStringSlice([]string{"compliant", "noncompliant", "unknown", "conflict", "error", "ingraceperiod"})),
 					},
 					"os_distro_name": {
 						Type:        schema.TypeString,

--- a/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
@@ -141,13 +141,13 @@ func resourceCloudflareDevicePostureRuleSchema() map[string]*schema.Schema {
 					"connection_id": {
 						Type:        schema.TypeString,
 						Optional:    true,
-						Description: "The workspace one connection id.",
+						Description: "The workspace one or intune connection id.",
 					},
 					"compliance_status": {
 						Type:         schema.TypeString,
 						Optional:     true,
-						ValidateFunc: validation.StringInSlice([]string{"compliant", "noncompliant"}, true),
-						Description:  fmt.Sprintf("The workspace one device compliance status. %s", renderAvailableDocumentationValuesStringSlice([]string{"compliant", "noncompliant"})),
+						ValidateFunc: validation.StringInSlice([]string{"compliant", "noncompliant", "unknown", "conflict", "error", "ingraceperiod"}, true),
+						Description:  fmt.Sprintf("The workspace one or intune device compliance status. 'compliant' and 'noncompliant' are values supported by both providers. 'unknown', 'conflict', 'error', 'ingraceperiod' values are only supported by intune. %s", renderAvailableDocumentationValuesStringSlice([]string{"compliant", "noncompliant", "unknown", "conflict", "error", "ingraceperiod"})),
 					},
 					"os_distro_name": {
 						Type:        schema.TypeString,


### PR DESCRIPTION
Currently, device posture rules support the `compliance_status` `input` field in Terraform for the Workspace One posture provider. 

Intune, a different posture provider, also uses the `compliance_status` `input` key to configure a posture rule, but we do not support the majority of configuration values for it. 

Technically, the `compliance_status` key can be used for an `intune` device posture rule `type` if the value is `compliant` or `noncompliant`. However, this is not documented for the `compliance_status` field, which states it is for workspace one only ([source](https://github.com/cloudflare/terraform-provider-cloudflare/blob/master/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go#L150)).

Workspace One AND Intune both use the `compliant` and `noncompliant` values for the `compliance_status` `input` key, but Intune has additional fields that need to be supported: "unknown", "conflict", "error", "ingraceperiod".

To solve this, we will update the documentation to state that the `compliance_status` key is utilized by both the Workspace One and Intune posture providers, and add support for the additional values that Intune provides.

`connection_id` is a different `input` field that is also shared by both workspace one and intune. We will update the documentation to reflect this as well.
