### PR TITLE
resource/cloudflare_record: deprecate value for content

### DIFF
--- a/.changelog/3509.txt
+++ b/.changelog/3509.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/cloudflare_record: `value` is now deprecated in favour of `content`
+```

--- a/.grit/.gitignore
+++ b/.grit/.gitignore
@@ -1,0 +1,2 @@
+.gritmodules*
+*.log

--- a/.grit/patterns/cloudflare_record_deprecate_value_for_content.grit
+++ b/.grit/patterns/cloudflare_record_deprecate_value_for_content.grit
@@ -1,0 +1,9 @@
+engine marzano(0.1)
+language hcl
+
+pattern cloudflare_record_deprecate_value_for_content() {
+  `value = $v` as $record => `content = $v` where $record <: and {
+    within `resource "cloudflare_record" $_ { $_ }`,
+    not within `data { $_ }`,
+  }
+}

--- a/docs/data-sources/zone.md
+++ b/docs/data-sources/zone.md
@@ -26,7 +26,7 @@ data "cloudflare_zone" "example" {
 resource "cloudflare_record" "example" {
   zone_id = data.cloudflare_zone.example.id
   name    = "www"
-  value   = "203.0.113.1"
+  content = "203.0.113.1"
   type    = "A"
   proxied = true
 }

--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -16,7 +16,7 @@ Provides a Cloudflare record resource.
 resource "cloudflare_record" "example" {
   zone_id = var.cloudflare_zone_id
   name    = "terraform"
-  value   = "192.0.2.1"
+  content = "192.0.2.1"
   type    = "A"
   ttl     = 3600
 }
@@ -51,13 +51,14 @@ resource "cloudflare_record" "_sip_tls" {
 
 - `allow_overwrite` (Boolean) Allow creation of this record in Terraform to overwrite an existing record, if any. This does not affect the ability to update the record in Terraform and does not prevent other resources within Terraform or manual changes outside Terraform from overwriting this record. **This configuration is not recommended for most environments**. Defaults to `false`.
 - `comment` (String) Comments or notes about the DNS record. This field has no effect on DNS responses.
+- `content` (String) The content of the record. Conflicts with `data`.
 - `data` (Block List, Max: 1) Map of attributes that constitute the record value. Conflicts with `value`. (see [below for nested schema](#nestedblock--data))
 - `priority` (Number) The priority of the record.
 - `proxied` (Boolean) Whether the record gets Cloudflare's origin protection.
 - `tags` (Set of String) Custom tags for the DNS record.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `ttl` (Number) The TTL of the record.
-- `value` (String) The value of the record. Conflicts with `data`.
+- `value` (String, Deprecated) The value of the record. Conflicts with `data`.
 
 ### Read-Only
 

--- a/docs/resources/regional_hostname.md
+++ b/docs/resources/regional_hostname.md
@@ -17,7 +17,7 @@ Provides a Data Localization Suite Regional Hostname.
 resource "cloudflare_record" "example" {
   zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
   name    = "example.com"
-  value   = "192.0.2.1"
+  content = "192.0.2.1"
   type    = "A"
   ttl     = 3600
 }

--- a/examples/data-sources/cloudflare_zone/data-source.tf
+++ b/examples/data-sources/cloudflare_zone/data-source.tf
@@ -5,7 +5,7 @@ data "cloudflare_zone" "example" {
 resource "cloudflare_record" "example" {
   zone_id = data.cloudflare_zone.example.id
   name    = "www"
-  value   = "203.0.113.1"
+  content = "203.0.113.1"
   type    = "A"
   proxied = true
 }

--- a/examples/resources/cloudflare_record/resource.tf
+++ b/examples/resources/cloudflare_record/resource.tf
@@ -2,7 +2,7 @@
 resource "cloudflare_record" "example" {
   zone_id = var.cloudflare_zone_id
   name    = "terraform"
-  value   = "192.0.2.1"
+  content = "192.0.2.1"
   type    = "A"
   ttl     = 3600
 }

--- a/examples/resources/cloudflare_regional_hostname/resource.tf
+++ b/examples/resources/cloudflare_regional_hostname/resource.tf
@@ -3,7 +3,7 @@
 resource "cloudflare_record" "example" {
   zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
   name    = "example.com"
-  value   = "192.0.2.1"
+  content = "192.0.2.1"
   type    = "A"
   ttl     = 3600
 }

--- a/internal/sdkv2provider/resource_cloudflare_record.go
+++ b/internal/sdkv2provider/resource_cloudflare_record.go
@@ -61,6 +61,11 @@ func resourceCloudflareRecordCreate(ctx context.Context, d *schema.ResourceData,
 		newRecord.Content = value.(string)
 	}
 
+	content, contentOk := d.GetOk("content")
+	if contentOk {
+		newRecord.Content = content.(string)
+	}
+
 	data, dataOk := d.GetOk("data")
 	tflog.Debug(ctx, fmt.Sprintf("Data found in config: %#v", data))
 
@@ -81,9 +86,9 @@ func resourceCloudflareRecordCreate(ctx context.Context, d *schema.ResourceData,
 		newRecord.Data = newDataMap
 	}
 
-	if valueOk == dataOk {
+	if contentOk == dataOk {
 		return diag.FromErr(fmt.Errorf(
-			"either 'value' (present: %t) or 'data' (present: %t) must be provided",
+			"either 'content' (present: %t) or 'data' (present: %t) must be provided",
 			valueOk, dataOk))
 	}
 
@@ -235,6 +240,7 @@ func resourceCloudflareRecordRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("hostname", record.Name)
 	d.Set("type", record.Type)
 	d.Set("value", record.Content)
+	d.Set("content", record.Content)
 	d.Set("ttl", record.TTL)
 	d.Set("proxied", record.Proxied)
 	d.Set("created_on", record.CreatedOn.Format(time.RFC3339Nano))
@@ -259,12 +265,23 @@ func resourceCloudflareRecordRead(ctx context.Context, d *schema.ResourceData, m
 func resourceCloudflareRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudflare.API)
 	zoneID := d.Get(consts.ZoneIDSchemaKey).(string)
+	var contentValue string
+
+	value, valueOk := d.GetOk("value")
+	if valueOk {
+		contentValue = value.(string)
+	}
+
+	content, contentOk := d.GetOk("content")
+	if contentOk {
+		contentValue = content.(string)
+	}
 
 	updateRecord := cloudflare.UpdateDNSRecordParams{
 		ID:      d.Id(),
 		Type:    d.Get("type").(string),
 		Name:    d.Get("name").(string),
-		Content: d.Get("value").(string),
+		Content: contentValue,
 	}
 
 	data, dataOk := d.GetOk("data")

--- a/internal/sdkv2provider/resource_cloudflare_record.go
+++ b/internal/sdkv2provider/resource_cloudflare_record.go
@@ -26,7 +26,7 @@ func resourceCloudflareRecord() *schema.Resource {
 			StateContext: resourceCloudflareRecordImport,
 		},
 		Description:   heredoc.Doc(`Provides a Cloudflare record resource.`),
-		SchemaVersion: 2,
+		SchemaVersion: 3,
 		Schema:        resourceCloudflareRecordSchema(),
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Second),
@@ -37,6 +37,11 @@ func resourceCloudflareRecord() *schema.Resource {
 				Type:    resourceCloudflareRecordV1().CoreConfigSchema().ImpliedType(),
 				Upgrade: resourceCloudflareRecordStateUpgradeV2,
 				Version: 1,
+			},
+			{
+				Type:    resourceCloudflareRecordV2().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceCloudflareRecordStateUpgradeV3,
+				Version: 2,
 			},
 		},
 	}

--- a/internal/sdkv2provider/resource_cloudflare_record_migrate.go
+++ b/internal/sdkv2provider/resource_cloudflare_record_migrate.go
@@ -2,8 +2,12 @@ package sdkv2provider
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceCloudflareRecordV1() *schema.Resource {
@@ -180,5 +184,317 @@ func resourceCloudflareRecordV1() *schema.Resource {
 
 func resourceCloudflareRecordStateUpgradeV2(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	rawState["data"] = []interface{}{rawState["data"]}
+	return rawState, nil
+}
+
+func resourceCloudflareRecordV2() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			consts.ZoneIDSchemaKey: {
+				Description: consts.ZoneIDSchemaDescription,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				StateFunc: func(i interface{}) string {
+					return strings.ToLower(i.(string))
+				},
+
+				Description: "The name of the record.",
+			},
+
+			"hostname": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The FQDN of the record.",
+			},
+
+			"type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"A", "AAAA", "CAA", "CNAME", "TXT", "SRV", "LOC", "MX", "NS", "SPF", "CERT", "DNSKEY", "DS", "NAPTR", "SMIMEA", "SSHFP", "TLSA", "URI", "PTR", "HTTPS", "SVCB"}, false),
+				Description:  fmt.Sprintf("The type of the record. %s", renderAvailableDocumentationValuesStringSlice([]string{"A", "AAAA", "CAA", "CNAME", "TXT", "SRV", "LOC", "MX", "NS", "SPF", "CERT", "DNSKEY", "DS", "NAPTR", "SMIMEA", "SSHFP", "TLSA", "URI", "PTR", "HTTPS", "SVCB"})),
+			},
+
+			"value": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ConflictsWith:    []string{"data"},
+				DiffSuppressFunc: suppressTrailingDots,
+				Description:      "The value of the record.",
+				Deprecated:       "`value` is deprecated in favour of `content` and will be removed in the next major release.",
+			},
+
+			"content": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ConflictsWith:    []string{"data"},
+				DiffSuppressFunc: suppressTrailingDots,
+				Description:      "The content of the record.",
+			},
+
+			"data": {
+				Type:          schema.TypeList,
+				MaxItems:      1,
+				Optional:      true,
+				ConflictsWith: []string{"value"},
+				Description:   "Map of attributes that constitute the record value.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Properties present in several record types
+						"algorithm": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"key_tag": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"flags": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"service": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"certificate": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"type": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"usage": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"selector": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"matching_type": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"weight": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+
+						// SRV record properties
+						"proto": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"priority": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"target": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						// LOC record properties
+						"size": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"altitude": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"long_degrees": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"lat_degrees": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"precision_horz": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"precision_vert": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"long_direction": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"long_minutes": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"long_seconds": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"lat_direction": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"lat_minutes": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"lat_seconds": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+
+						// DNSKEY record properties
+						"protocol": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"public_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						// DS record properties
+						"digest_type": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"digest": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						// NAPTR record properties
+						"order": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"preference": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"regex": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"replacement": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						// SSHFP record properties
+						"fingerprint": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						// URI record properties
+						"content": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						// CAA record properties
+						"tag": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"ttl": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "The TTL of the record.",
+			},
+
+			"priority": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				DiffSuppressFunc: suppressPriority,
+				Description:      "The priority of the record.",
+			},
+
+			"proxied": {
+				Optional:    true,
+				Type:        schema.TypeBool,
+				Description: "Whether the record gets Cloudflare's origin protection.",
+			},
+
+			"created_on": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The RFC3339 timestamp of when the record was created.",
+			},
+
+			"metadata": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "A key-value map of string metadata Cloudflare associates with the record.",
+			},
+
+			"modified_on": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The RFC3339 timestamp of when the record was last modified.",
+			},
+
+			"proxiable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Shows whether this record can be proxied.",
+			},
+
+			"allow_overwrite": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Allow creation of this record in Terraform to overwrite an existing record, if any. This does not affect the ability to update the record in Terraform and does not prevent other resources within Terraform or manual changes outside Terraform from overwriting this record. **This configuration is not recommended for most environments**",
+			},
+
+			"comment": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Comments or notes about the DNS record. This field has no effect on DNS responses.",
+			},
+
+			"tags": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Custom tags for the DNS record.",
+			},
+		},
+	}
+}
+
+func resourceCloudflareRecordStateUpgradeV3(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	rawState["value"] = rawState["content"]
 	return rawState, nil
 }

--- a/internal/sdkv2provider/resource_cloudflare_record_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_record_test.go
@@ -79,7 +79,7 @@ func TestAccCloudflareRecord_Basic(t *testing.T) {
 					testAccCheckCloudflareRecordDates(resourceName, &record, testStartTime),
 					resource.TestCheckResourceAttr(resourceName, "name", "tf-acctest-basic"),
 					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
-					resource.TestCheckResourceAttr(resourceName, "value", "192.168.0.10"),
+					resource.TestCheckResourceAttr(resourceName, "content", "192.168.0.10"),
 					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("tf-acctest-basic.%s", zoneName)),
 					resource.TestMatchResourceAttr(resourceName, consts.ZoneIDSchemaKey, regexp.MustCompile("^[a-z0-9]{32}$")),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "3600"),
@@ -147,7 +147,7 @@ func TestAccCloudflareRecord_Apex(t *testing.T) {
 					testAccCheckCloudflareRecordAttributes(&record),
 					resource.TestCheckResourceAttr(resourceName, "name", "@"),
 					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
-					resource.TestCheckResourceAttr(resourceName, "value", "192.168.0.10"),
+					resource.TestCheckResourceAttr(resourceName, "content", "192.168.0.10"),
 				),
 			},
 		},
@@ -170,7 +170,7 @@ func TestAccCloudflareRecord_LOC(t *testing.T) {
 				Config: testAccCheckCloudflareRecordConfigLOC(zoneID, "tf-acctest-loc", rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareRecordExists(resourceName, &record),
-					resource.TestCheckResourceAttr(resourceName, "value", "37 46 46.000 N 122 23 35.000 W 0.00 100.00 0.00 0.00"),
+					resource.TestCheckResourceAttr(resourceName, "content", "37 46 46.000 N 122 23 35.000 W 0.00 100.00 0.00 0.00"),
 					resource.TestCheckResourceAttr(resourceName, "proxiable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "data.0.lat_degrees", "37"),
 					resource.TestCheckResourceAttr(resourceName, "data.0.lat_degrees", "37"),
@@ -210,15 +210,12 @@ func TestAccCloudflareRecord_SRV(t *testing.T) {
 					testAccCheckCloudflareRecordExists(resourceName, &record),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("_xmpp-client._tcp.%s", rnd)),
 					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("_xmpp-client._tcp.%s.%s", rnd, domain)),
-					resource.TestCheckResourceAttr(resourceName, "value", "0 5222 talk.l.google.com"),
+					resource.TestCheckResourceAttr(resourceName, "content", "0 5222 talk.l.google.com"),
 					resource.TestCheckResourceAttr(resourceName, "proxiable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "data.0.priority", "5"),
 					resource.TestCheckResourceAttr(resourceName, "data.0.weight", "0"),
 					resource.TestCheckResourceAttr(resourceName, "data.0.port", "5222"),
 					resource.TestCheckResourceAttr(resourceName, "data.0.target", "talk.l.google.com"),
-					resource.TestCheckResourceAttr(resourceName, "data.0.service", "_xmpp-client"),
-					resource.TestCheckResourceAttr(resourceName, "data.0.proto", "_tcp"),
-					resource.TestCheckResourceAttr(resourceName, "data.0.name", rnd+"."+domain),
 				),
 			},
 		},
@@ -280,7 +277,7 @@ func TestAccCloudflareRecord_Proxied(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "proxiable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "proxied", "true"),
 					resource.TestCheckResourceAttr(resourceName, "type", "CNAME"),
-					resource.TestCheckResourceAttr(resourceName, "value", domain),
+					resource.TestCheckResourceAttr(resourceName, "content", domain),
 				),
 			},
 		},
@@ -483,7 +480,7 @@ func TestAccCloudflareRecord_MXWithPriorityZero(t *testing.T) {
 				Config: testAccCheckCloudflareRecordConfigMXWithPriorityZero(zoneID, rnd, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "priority", "0"),
-					resource.TestCheckResourceAttr(resourceName, "value", "mail.terraform.cfapi.net"),
+					resource.TestCheckResourceAttr(resourceName, "content", "mail.terraform.cfapi.net"),
 				),
 			},
 		},
@@ -578,7 +575,7 @@ func TestAccCloudflareRecord_MXNull(t *testing.T) {
 				Config: testAccCheckCloudflareRecordNullMX(zoneID, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", rnd),
-					resource.TestCheckResourceAttr(name, "value", "."),
+					resource.TestCheckResourceAttr(name, "content", "."),
 					resource.TestCheckResourceAttr(name, "priority", "0"),
 				),
 			},
@@ -787,7 +784,7 @@ func testAccCheckCloudflareRecordConfigBasic(zoneID, name, rnd string) string {
 resource "cloudflare_record" "%[3]s" {
 	zone_id = "%[1]s"
 	name = "%[2]s"
-	value = "192.168.0.10"
+	content = "192.168.0.10"
 	type = "A"
 	ttl = 3600
 	tags = ["tag1", "tag2"]
@@ -800,7 +797,7 @@ func testAccCheckCloudflareRecordConfigApex(zoneID, rnd string) string {
 resource "cloudflare_record" "%[2]s" {
 	zone_id = "%[1]s"
 	name = "@"
-	value = "192.168.0.10"
+	content = "192.168.0.10"
 	type = "A"
 	ttl = 3600
 }`, zoneID, rnd)
@@ -840,9 +837,6 @@ resource "cloudflare_record" "%[2]s" {
     weight = 0
     port = 5222
     target = "talk.l.google.com"
-    service = "_xmpp-client"
-    proto = "_tcp"
-    name = "%[2]s.%[3]s"
   }
   type = "SRV"
   ttl = 3600
@@ -869,7 +863,7 @@ func testAccCheckCloudflareRecordConfigProxied(zoneID, domain, name, rnd string)
 resource "cloudflare_record" "%[4]s" {
 	zone_id = "%[1]s"
 	name = "%[3]s"
-	value = "%[2]s"
+	content = "%[2]s"
 	type = "CNAME"
 	proxied = true
 }`, zoneID, domain, name, rnd)
@@ -880,7 +874,7 @@ func testAccCheckCloudflareRecordConfigNewValue(zoneID, name, rnd string) string
 resource "cloudflare_record" "%[3]s" {
 	zone_id = "%[1]s"
 	name = "%[2]s"
-	value = "192.168.0.11"
+	content = "192.168.0.11"
 	type = "A"
 	ttl = 3600
 	tags = ["updated_tag1", "updated_tag2"]
@@ -893,7 +887,7 @@ func testAccCheckCloudflareRecordConfigChangeType(zoneID, name, zoneName, rnd st
 resource "cloudflare_record" "%[4]s" {
 	zone_id = "%[1]s"
 	name = "%[2]s"
-	value = "%[3]s"
+	content = "%[3]s"
 	type = "CNAME"
 	ttl = 3600
 }`, zoneID, name, zoneName, rnd)
@@ -904,7 +898,7 @@ func testAccCheckCloudflareRecordConfigChangeHostname(zoneID, name, rnd string) 
 resource "cloudflare_record" "%[3]s" {
 	zone_id = "%[1]s"
 	name = "%[2]s-changed"
-	value = "192.168.0.10"
+	content = "192.168.0.10"
 	type = "A"
 	ttl = 3600
 }`, zoneID, name, rnd)
@@ -915,7 +909,7 @@ func testAccCheckCloudflareRecordConfigTtlValidation(zoneID, name, zoneName, rnd
 resource "cloudflare_record" "%[4]s" {
 	zone_id = "%[1]s"
 	name = "%[2]s"
-	value = "%[3]s"
+	content = "%[3]s"
 	type = "CNAME"
 	proxied = true
 	ttl = 3600
@@ -927,7 +921,7 @@ func testAccCheckCloudflareRecordConfigExplicitProxied(zoneID, name, zoneName, p
 resource "cloudflare_record" "%[2]s" {
 	zone_id = "%[1]s"
 	name = "%[2]s"
-	value = "%[3]s"
+	content = "%[3]s"
 	type = "CNAME"
 	proxied = %[4]s
 	ttl = %[5]s
@@ -939,7 +933,7 @@ func testAccCheckCloudflareRecordConfigMXWithPriorityZero(zoneID, name, zoneName
 resource "cloudflare_record" "%[2]s" {
 	zone_id = "%[1]s"
 	name = "%[2]s"
-	value = "mail.terraform.cfapi.net"
+	content = "mail.terraform.cfapi.net"
 	type = "MX"
 	priority = 0
 	proxied = false
@@ -983,7 +977,7 @@ func testAccCheckCloudflareRecordNullMX(zoneID, rnd string) string {
 		zone_id  = "%[2]s"
 		type     = "MX"
 		name     = "%[1]s"
-		value    = "."
+		content    = "."
 		priority = 0
 	  }
 	`, rnd, zoneID)
@@ -994,7 +988,7 @@ func testAccCheckCloudflareRecordConfigMultipleTags(zoneID, name, rnd string) st
 resource "cloudflare_record" "%[3]s" {
 	zone_id = "%[1]s"
 	name = "%[2]s"
-	value = "192.168.0.10"
+	content = "192.168.0.10"
 	type = "A"
 	ttl = 3600
 	tags = ["tag1", "tag2"]
@@ -1007,7 +1001,7 @@ func testAccCheckCloudflareRecordConfigNoTags(zoneID, name, rnd string) string {
 resource "cloudflare_record" "%[3]s" {
 	zone_id = "%[1]s"
 	name = "%[2]s"
-	value = "192.168.0.10"
+	content = "192.168.0.10"
 	type = "A"
 	ttl = 3600
 }`, zoneID, name, rnd)

--- a/internal/sdkv2provider/schema_cloudflare_record.go
+++ b/internal/sdkv2provider/schema_cloudflare_record.go
@@ -50,6 +50,16 @@ func resourceCloudflareRecordSchema() map[string]*schema.Schema {
 			ConflictsWith:    []string{"data"},
 			DiffSuppressFunc: suppressTrailingDots,
 			Description:      "The value of the record.",
+			Deprecated:       "`value` is deprecated in favour of `content` and will be removed in the next major release.",
+		},
+
+		"content": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Computed:         true,
+			ConflictsWith:    []string{"data"},
+			DiffSuppressFunc: suppressTrailingDots,
+			Description:      "The content of the record.",
 		},
 
 		"data": {


### PR DESCRIPTION
Under the covers, we've always used `content`. To allow a smoother
transition to v5 where the attributes are based on the schemas, we're
deprecating `value` now in order to give folks plenty of migration time.

Automatic migration can be handled with [Grit](https://docs.grit.io/cli/quickstart):

```
grit apply github.com/cloudflare/terraform-provider-cloudflare#cloudflare_record_deprecate_value_for_content
```