### PR TITLE
resource/cloudflare_teams_rule: add disable_clipboard_redirection

### DIFF
--- a/.changelog/3511.txt
+++ b/.changelog/3511.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_teams_rule: Add `disable_clipboard_redirection` attribute to `BISOAdminControls`
+```

--- a/docs/resources/teams_rule.md
+++ b/docs/resources/teams_rule.md
@@ -90,6 +90,7 @@ Required:
 
 Optional:
 
+- `disable_clipboard_redirection` (Boolean) Disable clipboard redirection.
 - `disable_copy_paste` (Boolean) Disable copy-paste.
 - `disable_download` (Boolean) Disable download.
 - `disable_keyboard` (Boolean) Disable keyboard usage.

--- a/internal/sdkv2provider/resource_cloudflare_teams_rules.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_rules.go
@@ -340,11 +340,12 @@ func flattenTeamsRuleBisoAdminControls(settings *cloudflare.TeamsBISOAdminContro
 		return nil
 	}
 	return []interface{}{map[string]interface{}{
-		"disable_printing":   settings.DisablePrinting,
-		"disable_copy_paste": settings.DisableCopyPaste,
-		"disable_download":   settings.DisableDownload,
-		"disable_upload":     settings.DisableUpload,
-		"disable_keyboard":   settings.DisableKeyboard,
+		"disable_printing":              settings.DisablePrinting,
+		"disable_copy_paste":            settings.DisableCopyPaste,
+		"disable_download":              settings.DisableDownload,
+		"disable_upload":                settings.DisableUpload,
+		"disable_keyboard":              settings.DisableKeyboard,
+		"disable_clipboard_redirection": settings.DisableClipboardRedirection,
 	}}
 }
 
@@ -370,12 +371,14 @@ func inflateTeamsRuleBisoAdminControls(settings interface{}) *cloudflare.TeamsBI
 	disableDownload := settingsMap["disable_download"].(bool)
 	disableUpload := settingsMap["disable_upload"].(bool)
 	disableKeyboard := settingsMap["disable_keyboard"].(bool)
+	disableClipboardRedirection := settingsMap["disable_clipboard_redirection"].(bool)
 	return &cloudflare.TeamsBISOAdminControlSettings{
-		DisablePrinting:  disablePrinting,
-		DisableCopyPaste: disableCopyPaste,
-		DisableDownload:  disableDownload,
-		DisableUpload:    disableUpload,
-		DisableKeyboard:  disableKeyboard,
+		DisablePrinting:             disablePrinting,
+		DisableCopyPaste:            disableCopyPaste,
+		DisableDownload:             disableDownload,
+		DisableUpload:               disableUpload,
+		DisableKeyboard:             disableKeyboard,
+		DisableClipboardRedirection: disableClipboardRedirection,
 	}
 }
 

--- a/internal/sdkv2provider/resource_cloudflare_teams_rules_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_rules_test.go
@@ -266,3 +266,83 @@ resource "cloudflare_teams_rule" "%[1]s" {
 }
 `, rnd, accountID)
 }
+
+func TestAccCloudflareTeamsRule_WithClipboardRedirection(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_teams_rule.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCloudflareTeamsRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareTeamsRuleConfigWithClipboardRedirection(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "description", "desc"),
+					resource.TestCheckResourceAttr(name, "precedence", "12302"),
+					resource.TestCheckResourceAttr(name, "action", "block"),
+					resource.TestCheckResourceAttr(name, "filters.0", "dns"),
+					resource.TestCheckResourceAttr(name, "traffic", "any(dns.domains[*] == \"example.com\")"),
+					resource.TestCheckResourceAttr(name, "rule_settings.#", "1"),
+					resource.TestCheckResourceAttr(name, "rule_settings.0.block_page_enabled", "true"),
+					resource.TestCheckResourceAttr(name, "rule_settings.0.block_page_reason", "cuz"),
+					resource.TestCheckResourceAttr(name, "rule_settings.0.insecure_disable_dnssec_validation", "false"),
+					resource.TestCheckResourceAttr(name, "rule_settings.0.egress.0.ipv4", "203.0.113.1"),
+					resource.TestCheckResourceAttr(name, "rule_settings.0.egress.0.ipv6", "2001:db8::/32"),
+					resource.TestCheckResourceAttr(name, "rule_settings.0.untrusted_cert.0.action", "error"),
+					resource.TestCheckResourceAttr(name, "rule_settings.0.payload_log.0.enabled", "true"),
+					resource.TestCheckResourceAttr(name, "rule_settings.0.biso_admin_controls.0.disable_clipboard_redirection", "true"), // Check new parameter
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareTeamsRuleConfigWithClipboardRedirection(rnd, accountID string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_teams_rule" "%[1]s" {
+  name = "%[1]s"
+  account_id = "%[2]s"
+  description = "desc"
+  precedence = 12302
+  action = "block"
+  filters = ["dns"]
+  traffic = "any(dns.domains[*] == \"example.com\")"
+  rule_settings {
+    block_page_enabled = true
+    block_page_reason = "cuz"
+    insecure_disable_dnssec_validation = false
+    egress {
+      ipv4 = "203.0.113.1"
+      ipv6 = "2001:db8::/32"
+    }
+    untrusted_cert {
+      action = "error"
+    }
+    payload_log {
+      enabled = true
+    }
+    biso_admin_controls {
+      disable_printing = false
+      disable_copy_paste = false
+      disable_download = false
+      disable_upload = false
+      disable_keyboard = false
+      disable_clipboard_redirection = true // Set new parameter
+    }
+  }
+}
+`, rnd, accountID)
+}

--- a/internal/sdkv2provider/schema_cloudflare_teams_rules.go
+++ b/internal/sdkv2provider/schema_cloudflare_teams_rules.go
@@ -322,6 +322,11 @@ var teamsBisoAdminControls = map[string]*schema.Schema{
 		Optional:    true,
 		Description: "Disable upload.",
 	},
+	"disable_clipboard_redirection": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Disable clipboard redirection.",
+	},
 }
 
 var teamsCheckSessionSettings = map[string]*schema.Schema{


### PR DESCRIPTION
This PR is adding `disable_clipboard_redirection` browser-isolation attribute to  `cloudflare_teams_rule`

Acceptance tests passed:
```
=== RUN   TestAccCloudflareTeamsRule_Basic
--- PASS: TestAccCloudflareTeamsRule_Basic (8.74s)
=== RUN   TestAccCloudflareTeamsRule_NoSettings
--- PASS: TestAccCloudflareTeamsRule_NoSettings (9.36s)
=== RUN   TestAccCloudflareTeamsRule_CustomResolver
--- PASS: TestAccCloudflareTeamsRule_CustomResolver (5.62s)
=== RUN   TestAccCloudflareTeamsRule_WithClipboardRedirection
--- PASS: TestAccCloudflareTeamsRule_WithClipboardRedirection (5.32s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider	29.325s
```