### PR TITLE
feat: add flag to skip the app launcher landing pg

### DIFF
--- a/.changelog/3519.txt
+++ b/.changelog/3519.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/access_application: add `skip_app_launcher_login_page` flag to skip the App Launcher landing page
+```

--- a/docs/resources/access_application.md
+++ b/docs/resources/access_application.md
@@ -87,6 +87,7 @@ resource "cloudflare_access_application" "staging_app" {
 - `self_hosted_domains` (Set of String) List of domains that access will secure. Only present for self_hosted, vnc, and ssh applications. Always includes the value set as `domain`.
 - `service_auth_401_redirect` (Boolean) Option to return a 401 status code in service authentication rules on failed requests. Defaults to `false`.
 - `session_duration` (String) How often a user will be forced to re-authorise. Must be in the format `48h` or `2h45m`. Defaults to `24h`.
+- `skip_app_launcher_login_page` (Boolean) Option to skip the App Launcher landing page. Defaults to `false`.
 - `skip_interstitial` (Boolean) Option to skip the authorization interstitial when using the CLI. Defaults to `false`.
 - `tags` (Set of String) The itags associated with the application.
 - `type` (String) The application type. Available values: `app_launcher`, `bookmark`, `biso`, `dash_sso`, `saas`, `self_hosted`, `ssh`, `vnc`, `warp`. Defaults to `self_hosted`.

--- a/docs/resources/teams_list.md
+++ b/docs/resources/teams_list.md
@@ -37,10 +37,19 @@ resource "cloudflare_teams_list" "example" {
 
 - `description` (String) The description of the teams list.
 - `items` (Set of String) The items of the teams list.
+- `items_with_description` (Set of Object) The items of the teams list that has explicit description. (see [below for nested schema](#nestedatt--items_with_description))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedatt--items_with_description"></a>
+### Nested Schema for `items_with_description`
+
+Optional:
+
+- `description` (String)
+- `value` (String)
 
 ## Import
 

--- a/docs/resources/zone_settings_override.md
+++ b/docs/resources/zone_settings_override.md
@@ -104,7 +104,7 @@ Optional:
 - `log_to_cloudflare` (String)
 - `max_upload` (Number)
 - `min_tls_version` (String)
-- `minify` (Block List, Max: 1, Deprecated) (see [below for nested schema](#nestedblock--settings--minify))
+- `minify` (Block List, Max: 1) (see [below for nested schema](#nestedblock--settings--minify))
 - `mirage` (String)
 - `mobile_redirect` (Block List, Max: 1, Deprecated) (see [below for nested schema](#nestedblock--settings--mobile_redirect))
 - `nel` (Block List, Max: 1) (see [below for nested schema](#nestedblock--settings--nel))

--- a/internal/sdkv2provider/resource_cloudflare_access_application.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_application.go
@@ -94,9 +94,10 @@ func resourceCloudflareAccessApplicationCreate(ctx context.Context, d *schema.Re
 
 	if appType == "app_launcher" {
 		newAccessApplication.AccessAppLauncherCustomization = cloudflare.AccessAppLauncherCustomization{
-			LogoURL:               d.Get("app_launcher_logo_url").(string),
-			BackgroundColor:       d.Get("bg_color").(string),
-			HeaderBackgroundColor: d.Get("header_bg_color").(string),
+			LogoURL:                  d.Get("app_launcher_logo_url").(string),
+			BackgroundColor:          d.Get("bg_color").(string),
+			HeaderBackgroundColor:    d.Get("header_bg_color").(string),
+			SkipAppLauncherLoginPage: cloudflare.BoolPtr(d.Get("skip_app_launcher_login_page").(bool)),
 		}
 
 		if _, ok := d.GetOk("landing_page_design"); ok {
@@ -196,6 +197,7 @@ func resourceCloudflareAccessApplicationRead(ctx context.Context, d *schema.Reso
 	d.Set("bg_color", accessApplication.AccessAppLauncherCustomization.BackgroundColor)
 	d.Set("header_bg_color", accessApplication.AccessAppLauncherCustomization.HeaderBackgroundColor)
 	d.Set("app_launcher_logo_url", accessApplication.AccessAppLauncherCustomization.LogoURL)
+	d.Set("skip_app_launcher_login_page", accessApplication.AccessAppLauncherCustomization.SkipAppLauncherLoginPage)
 	d.Set("allow_authenticate_via_warp", accessApplication.AllowAuthenticateViaWarp)
 	d.Set("options_preflight_bypass", accessApplication.OptionsPreflightBypass)
 

--- a/internal/sdkv2provider/resource_cloudflare_access_application_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_application_test.go
@@ -1048,6 +1048,7 @@ func TestAccCloudflareAccessApplication_WithAppLauncherCustomization(t *testing.
 					resource.TestCheckResourceAttr(name, "footer_links.#", "1"),
 					resource.TestCheckResourceAttr(name, "footer_links.0.name", "footer link"),
 					resource.TestCheckResourceAttr(name, "footer_links.0.url", "https://www.cloudflare.com"),
+					resource.TestCheckResourceAttr(name, "skip_app_launcher_login_page", "false"),
 				),
 			},
 		},

--- a/internal/sdkv2provider/schema_cloudflare_access_application.go
+++ b/internal/sdkv2provider/schema_cloudflare_access_application.go
@@ -559,6 +559,12 @@ func resourceCloudflareAccessApplicationSchema() map[string]*schema.Schema {
 				},
 			},
 		},
+		"skip_app_launcher_login_page": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Option to skip the App Launcher landing page.",
+		},
 		"allow_authenticate_via_warp": {
 			Type:        schema.TypeBool,
 			Optional:    true,


### PR DESCRIPTION
This repo doesn't have a PR template, so I've used the same one available in the `cloudflare-go` repo.

<!-- 
Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points. 
-->

## Description

A new flag, `skip_app_launcher_login_page`, is now available which can be toggled to skip the App Launcher landing page a.k.a. the page that is shown to users when they visit their auth. domain i.e. `<team>.cloudflareaccess.com`.

This flag is a part of Access and is an App Launcher customization property.

~**WARNING**: this PR should not be merged until https://github.com/cloudflare/cloudflare-go/pull/2793 is merged; this is because this PR  is dependent on `AccessAppLauncherCustomization.SkipAppLauncherLoginPage`.~

<!--
Describe your changes in detail through motivation and context. Why is
this change required? What problem does it solve? If it fixes an open
issue, link to the issue using GitHub's closing issues keywords[1].
-->
## Has your change been tested?

The test to test the creation of an App Launcher application with App Launcher customizations has been updated to include the `skip_app_launcher_login_page flag`.

<!--
Explain how the change has been tested and what you ran to confirm your
change affects other parts of the code. Automated tests are generally
expected and changes without tests should explain why they aren't
required.
-->

## Screenshots (if appropriate):

Screenshots N/A. 

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
