### PR TITLE
Remove deprecation warnings from policy changes

### DIFF
--- a/.changelog/3556.txt
+++ b/.changelog/3556.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/cloudflare_access_policy: remove deprecation notice related to precedence
+```

--- a/docs/resources/access_policy.md
+++ b/docs/resources/access_policy.md
@@ -67,12 +67,12 @@ resource "cloudflare_access_policy" "test_policy" {
 ### Optional
 
 - `account_id` (String) The account identifier to target for the resource. Conflicts with `zone_id`. **Modifying this attribute will force creation of a new resource.**
-- `application_id` (String, Deprecated) The ID of the application the policy is associated with. Required when using `precedence`. **Modifying this attribute will force creation of a new resource.**
+- `application_id` (String) The ID of the application the policy is associated with. Required when using `precedence`. **Modifying this attribute will force creation of a new resource.**
 - `approval_group` (Block List) (see [below for nested schema](#nestedblock--approval_group))
 - `approval_required` (Boolean)
 - `exclude` (Block List) A series of access conditions, see [Access Groups](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_group#conditions). (see [below for nested schema](#nestedblock--exclude))
 - `isolation_required` (Boolean) Require this application to be served in an isolated browser for users matching this policy.
-- `precedence` (Number, Deprecated) The unique precedence for policies on a single application. Required when using `application_id`.
+- `precedence` (Number) The unique precedence for policies on a single application. Required when using `application_id`.
 - `purpose_justification_prompt` (String) The prompt to display to the user for a justification for accessing the resource. Required when using `purpose_justification_required`.
 - `purpose_justification_required` (Boolean) Whether to prompt the user for a justification for accessing the resource.
 - `require` (Block List) A series of access conditions, see [Access Groups](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_group#conditions). (see [below for nested schema](#nestedblock--require))

--- a/internal/sdkv2provider/schema_cloudflare_access_policy.go
+++ b/internal/sdkv2provider/schema_cloudflare_access_policy.go
@@ -16,10 +16,7 @@ func resourceCloudflareAccessPolicySchema() map[string]*schema.Schema {
 			Optional:     true,
 			ForceNew:     true,
 			RequiredWith: []string{"precedence"},
-			Deprecated: "This field is deprecated. Policies can now be standalone and reusable by multiple applications." +
-				"Please use `cloudflare_access_application.policies` to associate reusable access policies with access" +
-				" applications.",
-			Description: "The ID of the application the policy is associated with.",
+			Description:  "The ID of the application the policy is associated with.",
 		},
 		consts.AccountIDSchemaKey: {
 			Description:   consts.AccountIDSchemaDescription,
@@ -44,10 +41,7 @@ func resourceCloudflareAccessPolicySchema() map[string]*schema.Schema {
 			Type:         schema.TypeInt,
 			Optional:     true,
 			RequiredWith: []string{"application_id"},
-			Deprecated: "This field is deprecated. Access policies can now be reusable by multiple applications." +
-				" Please use `cloudflare_access_application.policies` to link policies to an application with" +
-				" ascending order of precedence.",
-			Description: "The unique precedence for policies on a single application.",
+			Description:  "The unique precedence for policies on a single application.",
 		},
 		"decision": {
 			Type:         schema.TypeString,


### PR DESCRIPTION
We want to remove the warnings until the UI has been updated to support standalone policies. Once it does we can add them back.