### PR TITLE
update workflow images to pin to ubuntu-24.04 to fix out of storage errors

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   acceptance-tests:
     name: Acceptance Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       CLOUDFLARE_ACCOUNT_ID: f037e56e89293a057740de681ac9abbe

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/community-comment.yml
+++ b/.github/workflows/community-comment.yml
@@ -6,7 +6,7 @@ name: Add Community Note to Issues
 
 jobs:
   community-comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Add community note to new Issues
         if: github.event_name == 'issues'

--- a/.github/workflows/dependabot-changelog.yml
+++ b/.github/workflows/dependabot-changelog.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   generate-changelog:
     if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -9,7 +9,7 @@ on:
         required: true
 jobs:
   internal-issue-sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   golangci:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,7 +25,7 @@ jobs:
           only-new-issues: true
 
   tfproviderlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lock-released-issues.yml
+++ b/.github/workflows/lock-released-issues.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   lock-closed-issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps: 
       - uses: actions/checkout@v4
       - run: |

--- a/.github/workflows/maintainer-only-files.yml
+++ b/.github/workflows/maintainer-only-files.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   maintainer-only-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -9,7 +9,7 @@ on:
       - completed
 jobs:
   make-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: make docs

--- a/.github/workflows/milestone-closed.yml
+++ b/.github/workflows/milestone-closed.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   comment-on-closed-milestone:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       ids: ${{ steps.milestone-comment.outputs.ids }}
     steps:
@@ -25,7 +25,7 @@ jobs:
             For further feature requests or bug reports with this functionality, please create a [new GitHub issue](https://github.com/${{ github.repository }}/issues/new/choose) following the template. Thank you!
             
   lock-closed-issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: comment-on-closed-milestone
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -5,7 +5,7 @@ name: Add merged PR and linked issues to current milestone of target branch
 jobs:
   add-merged-to-current-milestone:
     if: github.event.pull_request.merged
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/next-acceptance-tests.yml
+++ b/.github/workflows/next-acceptance-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   acceptance-tests:
     name: Acceptance Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       CLOUDFLARE_ACCOUNT_ID: f037e56e89293a057740de681ac9abbe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - "v*"
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Cleanup unused directories and tools
         run: |

--- a/.github/workflows/reproduction-contains-dynamics.yml
+++ b/.github/workflows/reproduction-contains-dynamics.yml
@@ -8,7 +8,7 @@ on:
         
 jobs:
   reproduction-contains-dynamics:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Add comment to issue about not using dynamic expressions

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   semgrep:
     name: Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: returntocorp/semgrep
     if: (github.actor != 'dependabot[bot]')

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/terraform-log-check.yml
+++ b/.github/workflows/terraform-log-check.yml
@@ -9,7 +9,7 @@ on:
         required: true
 jobs:
   tf-log-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       CLOUDFLARE_ACCOUNT_ID: f037e56e89293a057740de681ac9abbe
       CLOUDFLARE_ALT_DOMAIN: terraform2.cfapi.net


### PR DESCRIPTION
there is currently a bug with ubuntu-latest workflow image that is causing our workflows to run out of storage
![image](https://github.com/user-attachments/assets/ccb83d0e-a74a-4dd3-a2d5-24fe3bbca82c)
https://github.com/actions/runner-images/issues/10386#issuecomment-2271433971

I've verified that the same go binaries are available in 24.04 as 22.04 (which latests is pointed at currently).
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#go
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#go

Looks like @jacobbednarz was looking into this yesterday as well but the cleanups didn't help:
https://github.com/cloudflare/terraform-provider-cloudflare/commit/2dade830a00b4629d07b33ce65c87d146e8110c4