### PR TITLE
Allow empty api_token for ENV authentication

### DIFF
--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -112,7 +112,7 @@ func (p *CloudflareProvider) Schema(ctx context.Context, req provider.SchemaRequ
 				MarkdownDescription: fmt.Sprintf("The API Token for operations. Alternatively, can be configured using the `%s` environment variable. Must provide only one of `api_key`, `api_token`, `api_user_service_key`.", consts.APITokenEnvVarKey),
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
-						regexp.MustCompile(`[A-Za-z0-9-_]{40}`),
+						regexp.MustCompile(`[A-Za-z0-9-_]{40}|^$`),
 						"API tokens must be 40 characters long and only contain characters a-z, A-Z, 0-9, hyphens and underscores",
 					),
 				},

--- a/internal/sdkv2provider/provider.go
+++ b/internal/sdkv2provider/provider.go
@@ -107,7 +107,7 @@ func New(version string) func() *schema.Provider {
 					Type:         schema.TypeString,
 					Optional:     true,
 					Description:  fmt.Sprintf("The API Token for operations. Alternatively, can be configured using the `%s` environment variable. Must provide only one of `api_key`, `api_token`, `api_user_service_key`.", consts.APITokenEnvVarKey),
-					ValidateFunc: validation.StringMatch(regexp.MustCompile("[A-Za-z0-9-_]{40}"), "API tokens must be 40 characters long and only contain characters a-z, A-Z, 0-9, hyphens and underscores"),
+					ValidateFunc: validation.StringMatch(regexp.MustCompile("[A-Za-z0-9-_]{40}|^$"), "API tokens must be 40 characters long and only contain characters a-z, A-Z, 0-9, hyphens and underscores"),
 				},
 
 				consts.APIUserServiceKeySchemaKey: {


### PR DESCRIPTION
A PR to implement the fix described here:
https://github.com/cloudflare/terraform-provider-cloudflare/issues/1919#issuecomment-2132204631


This would allow us to specify BOTH `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_API_USER_SERVICE_KEY` and then force "remove" the token from the aliased provider that we choose like this:

```tf
provider "cloudflare" {
  alias                = "user_service_key"
  api_token = "" #explicitly set to ""
}

provider "cloudflare" {
  api_user_service_key = "" #explicitly set to ""
}
```

When using variables for our Cloudflare api_token the values are stored in the state file. Using environment variables like this means the api token never leaves the build environment.