### PR TITLE
Safely deprecate value

### DIFF
--- a/.changelog/3674.txt
+++ b/.changelog/3674.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/cloudflare_record: fix a bug that prematurely removed the ability to set the deprecated `value` field.
+```

--- a/internal/sdkv2provider/resource_cloudflare_record.go
+++ b/internal/sdkv2provider/resource_cloudflare_record.go
@@ -71,6 +71,15 @@ func resourceCloudflareRecordCreate(ctx context.Context, d *schema.ResourceData,
 		newRecord.Content = content.(string)
 	}
 
+	if contentOk == valueOk {
+		return diag.FromErr(fmt.Errorf(
+			"'content' (present: %t) must not be set with 'value' (present: %t)",
+			contentOk, valueOk))
+	}
+	if valueOk {
+		contentOk = true
+	}
+
 	data, dataOk := d.GetOk("data")
 	tflog.Debug(ctx, fmt.Sprintf("Data found in config: %#v", data))
 


### PR DESCRIPTION
This patch follows up #3590 by allowing `value` to continue be set while still preserving it's deprecated status.

`value` and `content` are mutually exclusive. Setting both will return an error.

    │ Error: 'content' (present: true) must not be set with 'value' (present: true)

No state changes will take place when replacing `value` with `content` provided the value is identical.