### PR TITLE
Fix resource mapping of cloudflare_zero_trust_access_group

### DIFF
--- a/.changelog/3740.txt
+++ b/.changelog/3740.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_zero_trust_access_group: Fix false deprecation warnings
+```

--- a/internal/sdkv2provider/provider.go
+++ b/internal/sdkv2provider/provider.go
@@ -197,7 +197,7 @@ func New(version string) func() *schema.Provider {
 				"cloudflare_access_ca_certificate":                           resourceCloudflareAccessCACertificate(),
 				"cloudflare_zero_trust_access_short_lived_certificate":       resourceCloudflareZeroTrustAccessCACertificate(),
 				"cloudflare_access_group":                                    resourceCloudflareAccessGroup(),
-				"cloudflare_zero_trust_access_group":                         resourceCloudflareAccessGroup(),
+				"cloudflare_zero_trust_access_group":                         resourceCloudflareZeroTrustAccessGroup(),
 				"cloudflare_access_identity_provider":                        resourceCloudflareAccessIdentityProvider(),
 				"cloudflare_zero_trust_access_identity_provider":             resourceCloudflareZeroTrustAccessIdentityProvider(),
 				"cloudflare_access_custom_page":                              resourceCloudflareAccessCustomPage(),


### PR DESCRIPTION
**Fixes:** https://github.com/cloudflare/terraform-provider-cloudflare/issues/3733
**Description:** New resource `cloudflare_zero_trust_access_group` was mapped to the old resource function, which causes it to show deprecation warnings.