### PR TITLE
Deprecate frequency in cloudflare_logpush_job resource

### DIFF
--- a/.changelog/3745.txt
+++ b/.changelog/3745.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-resource/cloudflare_logpush_job: Deprecate Remove frequency in cloudflare_logpush_job
+resource/cloudflare_logpush_job: Deprecate `frequency` in favour of `max_upload_interval_seconds`
 ```

--- a/.changelog/3745.txt
+++ b/.changelog/3745.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/cloudflare_logpush_job: Deprecate Remove frequency in cloudflare_logpush_job
+```

--- a/docs/resources/logpush_job.md
+++ b/docs/resources/logpush_job.md
@@ -119,7 +119,7 @@ resource "cloudflare_logpush_job" "example_job" {
 - `account_id` (String) The account identifier to target for the resource. Must provide only one of `account_id`, `zone_id`.
 - `enabled` (Boolean) Whether to enable the job.
 - `filter` (String) Use filters to select the events to include and/or remove from your logs. For more information, refer to [Filters](https://developers.cloudflare.com/logs/reference/logpush-api-configuration/filters/).
-- `frequency` (String) A higher frequency will result in logs being pushed on faster with smaller files. `low` frequency will push logs less often with larger files. Available values: `high`, `low`. Defaults to `high`.
+- `frequency` (String, Deprecated) A higher frequency will result in logs being pushed on faster with smaller files. `low` frequency will push logs less often with larger files. Available values: `high`, `low`. Defaults to `high`.
 - `kind` (String) The kind of logpush job to create. Available values: `edge`, `instant-logs`, `""`.
 - `logpull_options` (String) Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpush options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options).
 - `max_upload_bytes` (Number) The maximum uncompressed file size of a batch of logs. Value must be between 5MB and 1GB.

--- a/internal/sdkv2provider/schema_cloudflare_logpush_job.go
+++ b/internal/sdkv2provider/schema_cloudflare_logpush_job.go
@@ -97,6 +97,7 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 			Optional:     true,
 			Default:      "high",
 			ValidateFunc: validation.StringInSlice(frequencyAllowedValues, false),
+			Deprecated:   "`frequency` has been deprecated in favour of using `max_upload_interval_seconds` instead.",
 			Description:  fmt.Sprintf("A higher frequency will result in logs being pushed on faster with smaller files. `low` frequency will push logs less often with larger files. %s", renderAvailableDocumentationValuesStringSlice(frequencyAllowedValues)),
 		},
 		"max_upload_bytes": {


### PR DESCRIPTION
This deprecate `frequency` in `cloudflare_logpush_job` resource.