### PR TITLE
Update schema Tanium's eid_last_seen field to be relative instead of a timestamp

### DIFF
--- a/.changelog/3764.txt
+++ b/.changelog/3764.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_device_posture_rule: Modify Tanium's eid_last_seen field to be relative instead of a timestamp value
+```

--- a/docs/resources/device_posture_rule.md
+++ b/docs/resources/device_posture_rule.md
@@ -69,7 +69,7 @@ Optional:
 - `connection_id` (String) The workspace one or intune connection id.
 - `count_operator` (String) The count comparison operator for kolide. Available values: `>`, `>=`, `<`, `<=`, `==`.
 - `domain` (String) The domain that the client must join.
-- `eid_last_seen` (String) The datetime a device last seen in RFC 3339 format from Tanium.
+- `eid_last_seen` (String) The time a device last seen in Tanium. Must be in the format `1h` or `30m`. Valid units are `d`, `h` and `m`.
 - `enabled` (Boolean) True if the firewall must be enabled.
 - `exists` (Boolean) Checks if the file should exist.
 - `extended_key_usage` (Set of String) List of values indicating purposes for which the certificate public key can be used. Available values: `clientAuth`, `emailProtection`.

--- a/docs/resources/zero_trust_device_posture_rule.md
+++ b/docs/resources/zero_trust_device_posture_rule.md
@@ -68,7 +68,7 @@ Optional:
 - `connection_id` (String) The workspace one or intune connection id.
 - `count_operator` (String) The count comparison operator for kolide. Available values: `>`, `>=`, `<`, `<=`, `==`.
 - `domain` (String) The domain that the client must join.
-- `eid_last_seen` (String) The datetime a device last seen in RFC 3339 format from Tanium.
+- `eid_last_seen` (String) The time a device last seen in Tanium. Must be in the format `1h` or `30m`. Valid units are `d`, `h` and `m`
 - `enabled` (Boolean) True if the firewall must be enabled.
 - `exists` (Boolean) Checks if the file should exist.
 - `id` (String) The Teams List id. Required for `serial_number` and `unique_client_id` rule types.

--- a/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
@@ -238,7 +238,7 @@ func resourceCloudflareDevicePostureRuleSchema() map[string]*schema.Schema {
 					"eid_last_seen": {
 						Type:        schema.TypeString,
 						Optional:    true,
-						Description: "The datetime a device last seen in RFC 3339 format from Tanium.",
+						Description: "The time a device last seen in Tanium. Must be in the format `1h` or `30m`. Valid units are `d`, `h` and `m`",
 					},
 					"risk_level": {
 						Type:         schema.TypeString,


### PR DESCRIPTION
The Tanium posture integration eid_last_seen selector value has been changed from an RFC3339 timestamp to a relative time value.

 To reflect this change, we are updating the documentation accordingly. The underlying types have not changed, so there is no need to update cloudflare-go or any underlying types.