### PR TITLE
fix(record): only use `content` value if `value` is not set

### DIFF
--- a/.changelog/3776.txt
+++ b/.changelog/3776.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_record: handle scenarios where `content` and `value` are both being set in state and erroneously always thinking the `content` field is the source of truth
+```

--- a/internal/sdkv2provider/import_resource_cloudflare_record_test.go
+++ b/internal/sdkv2provider/import_resource_cloudflare_record_test.go
@@ -24,7 +24,7 @@ func TestAccCloudflareRecord_ImportBasic(t *testing.T) {
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", zoneID),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "content"},
 			},
 		},
 	})
@@ -48,7 +48,7 @@ func TestAccCloudflareRecord_ImportSRV(t *testing.T) {
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", zoneID),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "content"},
 			},
 		},
 	})

--- a/internal/sdkv2provider/resource_cloudflare_record.go
+++ b/internal/sdkv2provider/resource_cloudflare_record.go
@@ -238,8 +238,18 @@ func resourceCloudflareRecordRead(ctx context.Context, d *schema.ResourceData, m
 	d.SetId(record.ID)
 	d.Set("hostname", record.Name)
 	d.Set("type", record.Type)
-	d.Set("value", record.Content)
-	d.Set("content", record.Content)
+
+	_, valueOk := d.GetOk("value")
+	if valueOk {
+		d.Set("value", record.Content)
+	}
+
+	_, contentOk := d.GetOk("content")
+	_, datatOk := d.GetOk("data")
+	if contentOk || datatOk {
+		d.Set("content", record.Content)
+	}
+
 	d.Set("ttl", record.TTL)
 	d.Set("proxied", record.Proxied)
 	d.Set("created_on", record.CreatedOn.Format(time.RFC3339Nano))

--- a/internal/sdkv2provider/resource_cloudflare_record_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_record_test.go
@@ -95,6 +95,33 @@ func TestAccCloudflareRecord_Basic(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareRecord_BasicValue(t *testing.T) {
+	t.Parallel()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := generateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_record.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCloudflareRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareRecordConfigBasicUsingValue(zoneID, "tf-acctest-basic", rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "value", "192.168.0.8"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareRecordConfigBasicUsingValueUpdated(zoneID, "tf-acctest-basic", rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "value", "192.168.0.9"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudflareRecord_CaseInsensitive(t *testing.T) {
 	t.Parallel()
 	var record cloudflare.DNSRecord
@@ -785,6 +812,32 @@ resource "cloudflare_record" "%[3]s" {
 	zone_id = "%[1]s"
 	name = "%[2]s"
 	content = "192.168.0.10"
+	type = "A"
+	ttl = 3600
+	tags = ["tag1", "tag2"]
+    comment = "this is a comment"
+}`, zoneID, name, rnd)
+}
+
+func testAccCheckCloudflareRecordConfigBasicUsingValue(zoneID, name, rnd string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_record" "%[3]s" {
+	zone_id = "%[1]s"
+	name = "%[2]s"
+	value = "192.168.0.8"
+	type = "A"
+	ttl = 3600
+	tags = ["tag1", "tag2"]
+    comment = "this is a comment"
+}`, zoneID, name, rnd)
+}
+
+func testAccCheckCloudflareRecordConfigBasicUsingValueUpdated(zoneID, name, rnd string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_record" "%[3]s" {
+	zone_id = "%[1]s"
+	name = "%[2]s"
+	value = "192.168.0.9"
 	type = "A"
 	ttl = 3600
 	tags = ["tag1", "tag2"]


### PR DESCRIPTION
Adds handling to prevent a scenario where the `d.GetOk("content")` call
will return true without the `content` value by the operator. Instead,
rely on the fact that if `value` is being used, `content` should not be
and vice versa.