### PR TITLE
resource/rulesets: add "contains" support to custom cache key headers

### DIFF
--- a/.changelog/3820.txt
+++ b/.changelog/3820.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/rulesets: add "contains" support to custom cache key headers
+```

--- a/docs/data-sources/rulesets.md
+++ b/docs/data-sources/rulesets.md
@@ -189,9 +189,9 @@ Read-Only:
 Read-Only:
 
 - `check_presence` (List of String)
+- `contains` (Map of Set of String)
 - `exclude_origin` (Boolean)
 - `include` (List of String)
-- `contains` (Map of String to List)
 
 
 <a id="nestedobjatt--rulesets--rules--action_parameters--version--custom_key--host"></a>

--- a/docs/data-sources/rulesets.md
+++ b/docs/data-sources/rulesets.md
@@ -191,6 +191,7 @@ Read-Only:
 - `check_presence` (List of String)
 - `exclude_origin` (Boolean)
 - `include` (List of String)
+- `contains` (Map of String to List)
 
 
 <a id="nestedobjatt--rulesets--rules--action_parameters--version--custom_key--host"></a>

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -301,9 +301,9 @@ resource "cloudflare_ruleset" "cache_settings_example" {
             check_presence = ["habc_t", "hdef_t"]
             exclude_origin = true
             contains       = {
-              "accept"         = ["image/web", "image/png"]
-              "accept-encoding = ["br", "zstd"]
-              "some-header"    = ["some-value", "some-other-value"]
+              "accept"          = ["image/web", "image/png"]
+              "accept-encoding" = ["br", "zstd"]
+              "some-header"     = ["some-value", "some-other-value"]
             }
           }
           cookie {
@@ -607,6 +607,7 @@ Optional:
 Optional:
 
 - `check_presence` (Set of String) List of headers to check for presence in the custom key.
+- `contains` (Map of Set of String) Dictionary of headers mapping to lists of values to check for presence in the custom key.
 - `exclude_origin` (Boolean) Exclude the origin header from the custom key.
 - `include` (Set of String) List of headers to include in the custom key.
 

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -300,6 +300,11 @@ resource "cloudflare_ruleset" "cache_settings_example" {
             include        = ["habc", "hdef"]
             check_presence = ["habc_t", "hdef_t"]
             exclude_origin = true
+            contains       = {
+              "accept"         = ["image/web", "image/png"]
+              "accept-encoding = ["br", "zstd"]
+              "some-header"    = ["some-value", "some-other-value"]
+            }
           }
           cookie {
             include        = ["cabc", "cdef"]

--- a/examples/resources/cloudflare_ruleset/resource.tf
+++ b/examples/resources/cloudflare_ruleset/resource.tf
@@ -275,6 +275,11 @@ resource "cloudflare_ruleset" "cache_settings_example" {
             include        = ["habc", "hdef"]
             check_presence = ["habc_t", "hdef_t"]
             exclude_origin = true
+            contains       = {
+              "accept"         = ["image/web", "image/png"]
+              "accept-encoding = ["br", "zstd"]
+              "some-header"    = ["some-value", "some-other-value"]
+            }
           }
           cookie {
             include        = ["cabc", "cdef"]

--- a/examples/resources/cloudflare_ruleset/resource.tf
+++ b/examples/resources/cloudflare_ruleset/resource.tf
@@ -276,9 +276,9 @@ resource "cloudflare_ruleset" "cache_settings_example" {
             check_presence = ["habc_t", "hdef_t"]
             exclude_origin = true
             contains       = {
-              "accept"         = ["image/web", "image/png"]
-              "accept-encoding = ["br", "zstd"]
-              "some-header"    = ["some-value", "some-other-value"]
+              "accept"          = ["image/web", "image/png"]
+              "accept-encoding" = ["br", "zstd"]
+              "some-header"     = ["some-value", "some-other-value"]
             }
           }
           cookie {

--- a/internal/framework/service/rulesets/model.go
+++ b/internal/framework/service/rulesets/model.go
@@ -196,9 +196,10 @@ type ActionParameterCacheKeyCustomKeyQueryStringModel struct {
 }
 
 type ActionParameterCacheKeyCustomKeyHeaderModel struct {
-	Include       types.Set  `tfsdk:"include"`
-	CheckPresence types.Set  `tfsdk:"check_presence"`
-	ExcludeOrigin types.Bool `tfsdk:"exclude_origin"`
+	Include       types.Set            `tfsdk:"include"`
+	CheckPresence types.Set            `tfsdk:"check_presence"`
+	ExcludeOrigin types.Bool           `tfsdk:"exclude_origin"`
+	Contains      map[string]types.Set `tfsdk:"contains"`
 }
 
 type ActionParameterCacheKeyCustomKeyCookieModel struct {

--- a/internal/framework/service/rulesets/resource_test.go
+++ b/internal/framework/service/rulesets/resource_test.go
@@ -1875,6 +1875,9 @@ func TestAccCloudflareRuleset_CacheSettingsAllEnabled(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.check_presence.0", "habc_t"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.check_presence.1", "hdef_t"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.*", "image/web"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.cookie.0.include.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.cookie.0.include.0", "cabc"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.cookie.0.include.1", "cdef"),
@@ -1950,6 +1953,7 @@ func TestAccCloudflareRuleset_CacheSettingsOnlyExludeOrigin(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.check_presence.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "true"),
 				),
 			},
@@ -2580,6 +2584,9 @@ func TestAccCloudflareRuleset_CacheSettingsHandleDefaultHeaderExcludeOrigin(t *t
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.0", "x-test"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.1", "x-test2"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.*", "image/web"),
 				),
 			},
 			{
@@ -2599,6 +2606,9 @@ func TestAccCloudflareRuleset_CacheSettingsHandleDefaultHeaderExcludeOrigin(t *t
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.0", "x-test"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.1", "x-test2"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.*", "image/web"),
 				),
 			},
 			{
@@ -2618,6 +2628,9 @@ func TestAccCloudflareRuleset_CacheSettingsHandleDefaultHeaderExcludeOrigin(t *t
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.0", "x-test"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.include.1", "x-test2"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.*", "image/web"),
 				),
 			},
 		},
@@ -4110,6 +4123,11 @@ func testAccCloudflareRulesetCacheSettingsAllEnabled(rnd, accountID, zoneID stri
 					include = ["habc", "hdef"]
 					check_presence = ["habc_t", "hdef_t"]
 					exclude_origin = true
+					contains       = {
+						"accept"          = ["image/web", "image/png"]
+						"accept-encoding" = ["br", "zstd"]
+						"some-header"     = ["some-value", "some-other-value"]
+					}
 				}
 				cookie {
 					include = ["cabc", "cdef"]
@@ -4786,6 +4804,11 @@ func testAccCloudflareRulesetCacheSettingsHandleDefaultHeaderExcludeOrigin(rnd, 
 				  header {
 					check_presence = ["x-forwarded-for"]
 					include        = ["x-test", "x-test2"]
+					contains       = {
+						"accept"          = ["image/web", "image/png"]
+						"accept-encoding" = ["br", "zstd"]
+						"some-header"     = ["some-value", "some-other-value"]
+					}
 				  }
 		      }
 			}
@@ -4820,6 +4843,11 @@ func testAccCloudflareRulesetCacheSettingsHandleHeaderExcludeOriginSet(rnd, zone
 					check_presence = ["x-forwarded-for"]
 					include        = ["x-test", "x-test2"]
 					exclude_origin = true
+					contains       = {
+						"accept"         = ["image/web", "image/png"]
+						"accept-encoding" = ["br", "zstd"]
+						"some-header"    = ["some-value", "some-other-value"]
+					}
 				  }
 		      }
 			}
@@ -4854,6 +4882,11 @@ func testAccCloudflareRulesetCacheSettingsHandleHeaderExcludeOriginFalse(rnd, zo
 					check_presence = ["x-forwarded-for"]
 					include        = ["x-test", "x-test2"]
 					exclude_origin = false
+					contains       = {
+						"accept"         = ["image/web", "image/png"]
+						"accept-encoding" = ["br", "zstd"]
+						"some-header"    = ["some-value", "some-other-value"]
+					}
 				  }
 		      }
 			}

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -643,6 +643,13 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 																				defaults.DefaultBool(false),
 																			},
 																		},
+																		"contains": schema.MapAttribute{
+																			ElementType: types.SetType{
+																				ElemType: types.StringType,
+																			},
+																			Optional:            true,
+																			MarkdownDescription: "Dictionary of headers mapping to lists of values to check for presence in the custom key.",
+																		},
 																	},
 																},
 																Validators: []validator.List{

--- a/internal/sdkv2provider/data_source_rulesets.go
+++ b/internal/sdkv2provider/data_source_rulesets.go
@@ -766,6 +766,17 @@ func resourceCloudflareRulesetSchema() map[string]*schema.Schema {
 																		Optional:    true,
 																		Description: "Exclude the origin header from the custom key.",
 																	},
+																	"contains": {
+																		Type:        schema.TypeMap,
+																		Optional:    true,
+																		Description: "Dictionary of headers mapping to lists of values to check for presence in the custom key.",
+																		Elem: &schema.Schema{
+																			Type: schema.TypeSet,
+																			Elem: &schema.Schema{
+																				Type: schema.TypeString,
+																			},
+																		},
+																	},
 																},
 															},
 														},


### PR DESCRIPTION
### Notes
The Cloudflare CDN team has introduced changes to the Cache Rules API so customers can shard cache based on headers they include in the cache_key.custom_key.header.contains field of their cache rules. I am working on Terraform support and need this change to go in first.

### Description
This change adds support for a new field. It is required for the Terraform provider support to work.

### Has your change been tested?
Unit tests in this PR.

### Screenshots (if appropriate):
I added tests in this PR but I also used the terraform provider locally to create a Cache Rule with `terraform` directly:

```
terraform {
  required_providers {
    cloudflare = {
      source  = "cloudflare/cloudflare"
    }
  }
}

variable "cloudflare_api_token" {
  sensitive = true
}

provider "cloudflare" {
  api_token = var.cloudflare_api_token
}

resource "cloudflare_ruleset" "contains_ruleset" {
    zone_id     = "<my-zone>"
    name        = "My Custom Ruleset"
    description = "set cache settings for the request"
    kind        = "zone"
    phase       = "http_request_cache_settings"
    rules {
        action      = "set_cache_settings"
        description = "example"
        enabled     = true
        expression  = "(http.host eq \"example.com\" and starts_with(http.request.uri.path, \"/example\"))"
        action_parameters {
            cache = true
            edge_ttl {
                mode    = "override_origin"
                default = 7200
            }
            cache_key {
                custom_key {
                    header {
                        check_presence = ["x-forwarded-for"]
                        include        = ["x-test", "x-test2"]
                        exclude_origin = false
                        contains       = {
                            "accept"         = ["image/web", "image/png"]
                            "accept-encoding" = ["br", "zstd"]
                            "some-header"    = ["some-value", "some-other-value"]
                        }
                    }
                }
            }
        }
    }
}
```
This is from the network trace in the cloudflare dashboard.

![Screenshot 2024-08-28 at 3 24 59 PM](https://github.com/user-attachments/assets/da0a2a91-8ff0-485c-8cf0-2ca985a90d45)

