### PR TITLE
fix: add nil check for ZoneSettingsOverrideUpgrade

### DIFF
--- a/.changelog/3829.txt
+++ b/.changelog/3829.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_zone_settings_override: fix migration process with nil initial_settings
+```

--- a/internal/sdkv2provider/resource_cloudflare_zone_settings_override_migrate.go
+++ b/internal/sdkv2provider/resource_cloudflare_zone_settings_override_migrate.go
@@ -43,7 +43,9 @@ func resourceCloudflareZoneSettingsOverrideStateUpgradeV1(
 	}
 
 	upgrade := func(state map[string]interface{}, name string) map[string]interface{} {
-		delete(state[name].([]interface{})[0].(map[string]interface{}), "mobile_redirect")
+		if val, ok := state[name]; ok && val != nil {
+			delete(state[name].([]interface{})[0].(map[string]interface{}), "mobile_redirect")
+		}
 		return state
 	}
 
@@ -89,7 +91,9 @@ func resourceCloudflareZoneSettingsOverrideStateUpgradeV2(
 	}
 
 	upgrade := func(state map[string]interface{}, name string) map[string]interface{} {
-		delete(state[name].([]interface{})[0].(map[string]interface{}), "minify")
+		if val, ok := state[name]; ok && val != nil {
+			delete(state[name].([]interface{})[0].(map[string]interface{}), "minify")
+		}
 		return state
 	}
 


### PR DESCRIPTION
The current code is not checking bounds and when the `initial_settings` variable is `nil`, which is a situation that can happen when upgrading from older versions. This is causing a panic and was preventing me from upgrading, shown as below.

```
Stack trace from the terraform-provider-cloudflare_v4.40.0 plugin:

panic: interface conversion: interface {} is nil, not []interface {}

goroutine 58 [running]:
github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider.resourceCloudflareZoneSettingsOverrideStateUpgradeV1.func1(...)
        github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider/resource_cloudflare_zone_settings_override_migrate.go:46
github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider.resourceCloudflareZoneSettingsOverrideStateUpgradeV1({0x0?, 0x0?}, 0x14000afea80, {0x0?, 0x0?})
        github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider/resource_cloudflare_zone_settings_override_migrate.go:51 +0x1a4
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).upgradeJSONState(0x1400000c2e8, {0x10654e8c8, 0x14000c427e0}, 0xd?, 0x10599d9cf?, 0x14?)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/grpc_provider.go:491 +0x88
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).UpgradeResourceState(0x1400000c2e8, {0x10654e8c8?, 0x14000c426f0?}, 0x1400190cba0)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/grpc_provider.go:367 +0x384
github.com/hashicorp/terraform-plugin-mux/tf5to6server.v5tov6Server.UpgradeResourceState({{0x10655dd58?, 0x1400000c2e8?}}, {0x10654e8c8?, 0x14000c426f0?}, 0x1400190cb60?)
        github.com/hashicorp/terraform-plugin-mux@v0.16.0/tf5to6server/tf5to6server.go:175 +0x148
github.com/hashicorp/terraform-plugin-mux/tf6muxserver.(*muxServer).UpgradeResourceState(0x10654e900?, {0x10654e8c8?, 0x14000c423f0?}, 0x1400190cb60)
        github.com/hashicorp/terraform-plugin-mux@v0.16.0/tf6muxserver/mux_server_UpgradeResourceState.go:36 +0x18c
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).UpgradeResourceState(0x140005f3900, {0x10654e8c8?, 0x14000649b90?}, 0x14001196780)
        github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov6/tf6server/server.go:751 +0x210
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_UpgradeResourceState_Handler({0x106453bc0?, 0x140005f3900}, {0x10654e8c8, 0x14000649b90}, 0x14000acc600, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:446 +0x164
google.golang.org/grpc.(*Server).processUnaryRPC(0x140000eb000, {0x10654e8c8, 0x14000649ad0}, {0x106556ea0, 0x140000de300}, 0x140019558c0, 0x14000a1eae0, 0x107357a58, 0x0)
        google.golang.org/grpc@v1.63.2/server.go:1369 +0xba0
google.golang.org/grpc.(*Server).handleStream(0x140000eb000, {0x106556ea0, 0x140000de300}, 0x140019558c0)
        google.golang.org/grpc@v1.63.2/server.go:1780 +0xc80
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.63.2/server.go:1019 +0x8c
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 43
        google.golang.org/grpc@v1.63.2/server.go:1030 +0x150

Error: The terraform-provider-cloudflare_v4.40.0 plugin crashed!
```

This change adds `nil` check to prevent that crash from happening.