### PR TITLE
Fix acceptance tests for `account` and `tiered_cache`

### DIFF
--- a/internal/services/account/data_source_test.go
+++ b/internal/services/account/data_source_test.go
@@ -43,7 +43,7 @@ func testAccCloudflareAccountsSize(n string) resource.TestCheckFunc {
 			err          error
 		)
 
-		if accountsSize, err = strconv.Atoi(a["accounts.#"]); err != nil {
+		if accountsSize, err = strconv.Atoi(a["%"]); err != nil {
 			return err
 		}
 

--- a/internal/services/tiered_cache/resource_test.go
+++ b/internal/services/tiered_cache/resource_test.go
@@ -24,30 +24,10 @@ func TestAccCloudflareTieredCache_Smart(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testTieredCacheConfig(rnd, zoneID, "smart"),
+				Config: testTieredCacheConfig(rnd, zoneID, "on"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, consts.ZoneIDSchemaKey, zoneID),
-					resource.TestCheckResourceAttr(name, "cache_type", "smart"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccCloudflareTieredCache_Generic(t *testing.T) {
-	rnd := utils.GenerateRandomResourceName()
-	name := "cloudflare_tiered_cache." + rnd
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testTieredCacheConfig(rnd, zoneID, "generic"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, consts.ZoneIDSchemaKey, zoneID),
-					resource.TestCheckResourceAttr(name, "cache_type", "generic"),
+					resource.TestCheckResourceAttr(name, "value", "on"),
 				),
 			},
 		},

--- a/internal/services/tiered_cache/testdata/tieredcacheconfig.tf
+++ b/internal/services/tiered_cache/testdata/tieredcacheconfig.tf
@@ -1,5 +1,5 @@
 
 resource "cloudflare_tiered_cache" "%[1]s" {
 	zone_id = "%[2]s"
-	cache_type = "%[3]s"
+	value = "on"
 }


### PR DESCRIPTION
Fixes for `account` and `tiered_cache` acceptance tests. The result for `account` is a map now, so counting elements in a map uses `%`. The `result.#` syntax is for lists and sets.

The tiered cache resource used to be a mix of 3 distinct resources. They've been split out into separate resources for v5, so that test doesn't belong in this resource anymore.