### PR TITLE
docs: add informational note for cloudflare_managed_headers

### DIFF
--- a/.changelog/3909.txt
+++ b/.changelog/3909.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_managed_headers: add note for docs on where to find the available Managed Transforms
+```

--- a/internal/sdkv2provider/resource_cloudflare_managed_headers.go
+++ b/internal/sdkv2provider/resource_cloudflare_managed_headers.go
@@ -24,6 +24,8 @@ func resourceCloudflareManagedHeaders() *schema.Resource {
 			The [Cloudflare Managed Headers](https://developers.cloudflare.com/rules/transform/managed-transforms/)
 			allows you to add or remove some predefined headers to one's
 			requests or origin responses.
+
+			-> You can find which headers are available with the [List Managed Transforms API](https://developers.cloudflare.com/api/operations/managed-transforms-list-managed-transforms).
 		`),
 	}
 }


### PR DESCRIPTION
This change makes it easier for the user on how to find the Managed Transforms that can be used (it will include a blue [callout](https://developer.hashicorp.com/terraform/registry/providers/docs#callouts))