### PR TITLE
resource/rulesets: add cache_reserve terraform support and fix typo

### DIFF
--- a/.changelog/3923.txt
+++ b/.changelog/3923.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/rulesets: add cache_reserve terraform support and fix typo
+```

--- a/docs/data-sources/rulesets.md
+++ b/docs/data-sources/rulesets.md
@@ -90,6 +90,7 @@ Read-Only:
 - `browser_ttl` (List of Object) (see [below for nested schema](#nestedobjatt--rulesets--rules--action_parameters--browser_ttl))
 - `cache` (Boolean)
 - `cache_key` (List of Object) (see [below for nested schema](#nestedobjatt--rulesets--rules--action_parameters--cache_key))
+- `cache_reserve` (List of Object) (see [below for nested schema](#nestedobjatt--rulesets--rules--action_parameters--cache_reserve))
 - `content` (String)
 - `content_type` (String)
 - `cookie_fields` (Set of String)
@@ -162,6 +163,14 @@ Read-Only:
 - `cache_deception_armor` (Boolean)
 - `custom_key` (List of Object) (see [below for nested schema](#nestedobjatt--rulesets--rules--action_parameters--version--custom_key))
 - `ignore_query_strings_order` (Boolean)
+
+<a id="nestedobjatt--rulesets--rules--action_parameters--cache_reserve"></a>
+### Nested Schema for `rulesets.rules.action_parameters.version`
+
+Read-Only:
+
+- `eligible` (Boolean)
+- `minimum_file_size` (Number)
 
 <a id="nestedobjatt--rulesets--rules--action_parameters--version--custom_key"></a>
 ### Nested Schema for `rulesets.rules.action_parameters.version.custom_key`

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -301,7 +301,7 @@ resource "cloudflare_ruleset" "cache_settings_example" {
             check_presence = ["habc_t", "hdef_t"]
             exclude_origin = true
             contains       = {
-              "accept"          = ["image/web", "image/png"]
+              "accept"          = ["image/webp", "image/png"]
               "accept-encoding" = ["br", "zstd"]
               "some-header"     = ["some-value", "some-other-value"]
             }
@@ -495,6 +495,7 @@ Optional:
 - `browser_ttl` (Block List) List of browser TTL parameters to apply to the request. (see [below for nested schema](#nestedblock--rules--action_parameters--browser_ttl))
 - `cache` (Boolean) Whether to cache if expression matches.
 - `cache_key` (Block List) List of cache key parameters to apply to the request. (see [below for nested schema](#nestedblock--rules--action_parameters--cache_key))
+- `cache_reserve` (Block List) List of cache reserve parameters to apply to the request (see [below for nested schema](#nestedblock--rules--action_parameters--cache_reserve))
 - `content` (String) Content of the custom error response.
 - `content_type` (String) Content-Type of the custom error response.
 - `cookie_fields` (Set of String) List of cookie values to include as part of custom fields logging.
@@ -580,6 +581,18 @@ Optional:
 - `cache_deception_armor` (Boolean) Cache deception armor.
 - `custom_key` (Block List) Custom key parameters for the request. (see [below for nested schema](#nestedblock--rules--action_parameters--cache_key--custom_key))
 - `ignore_query_strings_order` (Boolean) Ignore query strings order.
+
+<a id="nestedblock--rules--action_parameters--cache_reserve"></a>
+### Nested Schema for `rules.action_parameters.cache_reserve`
+
+Required:
+
+- `eligible` (Boolean) Determines whether Cloudflare will write the eligible resource to cache reserve.
+
+Optional:
+
+- `minimum_file_size` (Number) The minimum file size, in bytes, eligible for storage in cache reserve. If omitted and "eligible" is true, Cloudflare will use 0 bytes by default.
+
 
 <a id="nestedblock--rules--action_parameters--cache_key--custom_key"></a>
 ### Nested Schema for `rules.action_parameters.cache_key.custom_key`

--- a/examples/resources/cloudflare_ruleset/resource.tf
+++ b/examples/resources/cloudflare_ruleset/resource.tf
@@ -276,7 +276,7 @@ resource "cloudflare_ruleset" "cache_settings_example" {
             check_presence = ["habc_t", "hdef_t"]
             exclude_origin = true
             contains       = {
-              "accept"          = ["image/web", "image/png"]
+              "accept"          = ["image/webp", "image/png"]
               "accept-encoding" = ["br", "zstd"]
               "some-header"     = ["some-value", "some-other-value"]
             }
@@ -293,6 +293,10 @@ resource "cloudflare_ruleset" "cache_settings_example" {
             resolved = true
           }
         }
+      }
+      cache_reserve = {
+        eligible = true
+        minimum_file_size = 100000
       }
       origin_error_page_passthru = false
     }

--- a/internal/framework/service/rulesets/model.go
+++ b/internal/framework/service/rulesets/model.go
@@ -37,6 +37,7 @@ type ActionParametersModel struct {
 	BrowserTTL               []*ActionParameterBrowserTTLModel            `tfsdk:"browser_ttl"`
 	Cache                    types.Bool                                   `tfsdk:"cache"`
 	CacheKey                 []*ActionParameterCacheKeyModel              `tfsdk:"cache_key"`
+	CacheReserve             []*ActionParameterCacheReserveModel          `tfsdk:"cache_reserve"`
 	Content                  types.String                                 `tfsdk:"content"`
 	ContentType              types.String                                 `tfsdk:"content_type"`
 	CookieFields             types.Set                                    `tfsdk:"cookie_fields"`
@@ -180,6 +181,11 @@ type ActionParameterCacheKeyModel struct {
 	IgnoreQueryStringsOrder types.Bool                               `tfsdk:"ignore_query_strings_order"`
 	CacheDeceptionArmor     types.Bool                               `tfsdk:"cache_deception_armor"`
 	CustomKey               []*ActionParameterCacheKeyCustomKeyModel `tfsdk:"custom_key"`
+}
+
+type ActionParameterCacheReserveModel struct {
+	Eligible        types.Bool  `tfsdk:"eligible"`
+	MinimumFileSize types.Int64 `tfsdk:"minimum_file_size"`
 }
 
 type ActionParameterCacheKeyCustomKeyModel struct {

--- a/internal/framework/service/rulesets/resource.go
+++ b/internal/framework/service/rulesets/resource.go
@@ -590,6 +590,17 @@ func toRulesetResourceModel(ctx context.Context, zoneID, accountID basetypes.Str
 				}
 			}
 
+			if ruleResponse.ActionParameters.CacheReserve != nil {
+				eligible := flatteners.Bool(ruleResponse.ActionParameters.CacheReserve.Eligible)
+				rule.ActionParameters[0].CacheReserve = []*ActionParameterCacheReserveModel{{
+					Eligible: eligible,
+				}}
+
+				if eligible.ValueBool() {
+					rule.ActionParameters[0].CacheReserve[0].MinimumFileSize = flatteners.Int64(int64(cfv1.Uint(ruleResponse.ActionParameters.CacheReserve.MinimumFileSize)))
+				}
+			}
+
 			if ruleResponse.ActionParameters.EdgeTTL != nil {
 				var defaultVal basetypes.Int64Value
 				if cfv1.Uint(ruleResponse.ActionParameters.EdgeTTL.Default) > 0 {
@@ -1239,6 +1250,16 @@ func (r *RulesModel) toRulesetRule(ctx context.Context) cfv1.RulesetRule {
 			}
 
 			rr.ActionParameters.CacheKey = &key
+		}
+
+		if len(ap.CacheReserve) > 0 {
+			rr.ActionParameters.CacheReserve = &cfv1.RulesetRuleActionParametersCacheReserve{
+				Eligible: cfv1.BoolPtr(ap.CacheReserve[0].Eligible.ValueBool()),
+			}
+
+			if !ap.CacheReserve[0].MinimumFileSize.IsNull() {
+				rr.ActionParameters.CacheReserve.MinimumFileSize = cfv1.UintPtr(uint(ap.CacheReserve[0].MinimumFileSize.ValueInt64()))
+			}
 		}
 
 		if len(ap.EdgeTTL) > 0 {

--- a/internal/framework/service/rulesets/resource_test.go
+++ b/internal/framework/service/rulesets/resource_test.go
@@ -1877,7 +1877,7 @@ func TestAccCloudflareRuleset_CacheSettingsAllEnabled(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "true"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.*", "image/web"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.*", "image/webp"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.cookie.0.include.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.cookie.0.include.0", "cabc"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.cookie.0.include.1", "cdef"),
@@ -1887,6 +1887,8 @@ func TestAccCloudflareRuleset_CacheSettingsAllEnabled(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.user.0.device_type", "true"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.user.0.geo", "false"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.host.0.resolved", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_reserve.0.eligible", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_reserve.0.minimum_file_size", "100000"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.origin_cache_control", "true"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.origin_error_page_passthru", "false"),
 				),
@@ -1930,6 +1932,35 @@ func TestAccCloudflareRuleset_CacheSettingsOptionalsEmpty(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareRuleset_CacheSettingsCacheReserveFalse(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	resourceName := "cloudflare_ruleset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareRulesetCacheSettingsCacheReserveFalse(rnd, "cache reserve false", zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "cache reserve false"),
+					resource.TestCheckResourceAttr(resourceName, "description", rnd+" ruleset description"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "zone"),
+					resource.TestCheckResourceAttr(resourceName, "phase", "http_request_cache_settings"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action", "set_cache_settings"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.description", rnd+" set cache settings rule"),
+
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_reserve.0.eligible", "false"),
+					resource.TestCheckNoResourceAttr(resourceName, "rules.0.action_parameters.0.cache_reserve.0.minimum_file_size"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudflareRuleset_CacheSettingsOnlyExludeOrigin(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
@@ -1955,6 +1986,8 @@ func TestAccCloudflareRuleset_CacheSettingsOnlyExludeOrigin(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.check_presence.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_reserve.0.eligible", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_reserve.0.minimum_file_size", "100000"),
 				),
 			},
 		},
@@ -2586,7 +2619,7 @@ func TestAccCloudflareRuleset_CacheSettingsHandleDefaultHeaderExcludeOrigin(t *t
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "false"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.*", "image/web"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.*", "image/webp"),
 				),
 			},
 			{
@@ -2608,7 +2641,7 @@ func TestAccCloudflareRuleset_CacheSettingsHandleDefaultHeaderExcludeOrigin(t *t
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "false"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.*", "image/web"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.*", "image/webp"),
 				),
 			},
 			{
@@ -2630,7 +2663,7 @@ func TestAccCloudflareRuleset_CacheSettingsHandleDefaultHeaderExcludeOrigin(t *t
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.exclude_origin", "true"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.*", "image/web"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "rules.0.action_parameters.0.cache_key.0.custom_key.0.header.0.contains.accept.*", "image/webp"),
 				),
 			},
 		},
@@ -4124,7 +4157,7 @@ func testAccCloudflareRulesetCacheSettingsAllEnabled(rnd, accountID, zoneID stri
 					check_presence = ["habc_t", "hdef_t"]
 					exclude_origin = true
 					contains       = {
-						"accept"          = ["image/web", "image/png"]
+						"accept"          = ["image/webp", "image/png"]
 						"accept-encoding" = ["br", "zstd"]
 						"some-header"     = ["some-value", "some-other-value"]
 					}
@@ -4142,8 +4175,35 @@ func testAccCloudflareRulesetCacheSettingsAllEnabled(rnd, accountID, zoneID stri
 				}
 			}
 		}
+		cache_reserve {
+			eligible = true
+			minimum_file_size = 100000
+		}
 		origin_cache_control = true
 		origin_error_page_passthru = false
+      }
+	  expression = "true"
+	  description = "%[1]s set cache settings rule"
+	  enabled = true
+    }
+  }`, rnd, accountID, zoneID)
+}
+
+func testAccCloudflareRulesetCacheSettingsCacheReserveFalse(rnd, accountID, zoneID string) string {
+	return fmt.Sprintf(`
+  resource "cloudflare_ruleset" "%[1]s" {
+	zone_id     = "%[3]s"
+    name        = "%[2]s"
+    description = "%[1]s ruleset description"
+    kind        = "zone"
+    phase       = "http_request_cache_settings"
+
+    rules {
+      action = "set_cache_settings"
+      action_parameters {
+		cache_reserve {
+			eligible = false
+		}
       }
 	  expression = "true"
 	  description = "%[1]s set cache settings rule"
@@ -4204,6 +4264,10 @@ func testAccCloudflareRulesetCacheSettingsOnlyExludeOrigin(rnd, accountID, zoneI
 					exclude_origin = true
 				}
 			}
+		}
+		cache_reserve {
+			eligible = true
+			minimum_file_size = 100000
 		}
       }
 	  expression = "true"
@@ -4805,7 +4869,7 @@ func testAccCloudflareRulesetCacheSettingsHandleDefaultHeaderExcludeOrigin(rnd, 
 					check_presence = ["x-forwarded-for"]
 					include        = ["x-test", "x-test2"]
 					contains       = {
-						"accept"          = ["image/web", "image/png"]
+						"accept"          = ["image/webp", "image/png"]
 						"accept-encoding" = ["br", "zstd"]
 						"some-header"     = ["some-value", "some-other-value"]
 					}
@@ -4844,7 +4908,7 @@ func testAccCloudflareRulesetCacheSettingsHandleHeaderExcludeOriginSet(rnd, zone
 					include        = ["x-test", "x-test2"]
 					exclude_origin = true
 					contains       = {
-						"accept"         = ["image/web", "image/png"]
+						"accept"         = ["image/webp", "image/png"]
 						"accept-encoding" = ["br", "zstd"]
 						"some-header"    = ["some-value", "some-other-value"]
 					}
@@ -4883,7 +4947,7 @@ func testAccCloudflareRulesetCacheSettingsHandleHeaderExcludeOriginFalse(rnd, zo
 					include        = ["x-test", "x-test2"]
 					exclude_origin = false
 					contains       = {
-						"accept"         = ["image/web", "image/png"]
+						"accept"         = ["image/webp", "image/png"]
 						"accept-encoding" = ["br", "zstd"]
 						"some-header"    = ["some-value", "some-other-value"]
 					}

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -725,6 +725,24 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 											listvalidator.SizeAtMost(1),
 										},
 									},
+									"cache_reserve": schema.ListNestedBlock{
+										MarkdownDescription: "List of cache reserve parameters to apply to the request.",
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"eligible": schema.BoolAttribute{
+													Required:            true,
+													MarkdownDescription: "Determines whether Cloudflare will write the eligible resource to cache reserve.",
+												},
+												"minimum_file_size": schema.Int64Attribute{
+													Optional:            true,
+													MarkdownDescription: "The minimum file size, in bytes, eligible for storage in cache reserve. If omitted and \"eligible\" is true, Cloudflare will use 0 bytes by default.",
+												},
+											},
+										},
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+									},
 									"from_list": schema.ListNestedBlock{
 										MarkdownDescription: "Use a list to lookup information for the action.",
 										NestedObject: schema.NestedBlockObject{

--- a/internal/sdkv2provider/data_source_rulesets.go
+++ b/internal/sdkv2provider/data_source_rulesets.go
@@ -852,6 +852,26 @@ func resourceCloudflareRulesetSchema() map[string]*schema.Schema {
 										},
 									},
 								},
+								"cache_reserve": {
+									Type:        schema.TypeList,
+									MaxItems:    1,
+									Optional:    true,
+									Description: "List of cache reserve parameters to apply to the request.",
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"eligible": {
+												Type:        schema.TypeBool,
+												Required:    true,
+												Description: "Determines whether Cloudflare will write the eligible resource to cache reserve.",
+											},
+											"minimum_file_size": {
+												Type:        schema.TypeInt,
+												Optional:    true,
+												Description: "The minimum file size, in bytes, eligible for storage in cache reserve. If omitted and \"eligible\" is true, Cloudflare will use 0 bytes by default.",
+											},
+										},
+									},
+								},
 								"origin_cache_control": {
 									Type:        schema.TypeBool,
 									Optional:    true,


### PR DESCRIPTION
Cache Reserve support is missing from the ruleset terraform provider. Per #3244, Cache Reserve is already supported in cloudflare-go.

Separately, there is a small typo in the example I added in a previous commit. I was able to verify that the terraform provider created a resource in my personal account. Here is the terraform config:

```
terraform {
  required_providers {
    cloudflare = {
      source  = "cloudflare/cloudflare"
    }
  }
}

variable "cloudflare_api_token" {
  sensitive = true
}

provider "cloudflare" {
  api_token = var.cloudflare_api_token
}

resource "cloudflare_ruleset" "contains_ruleset" {
    zone_id     = "<snip>"
    name        = "My Custom Ruleset"
    description = "set cache settings for the request"
    kind        = "zone"
    phase       = "http_request_cache_settings"
    rules {
        action      = "set_cache_settings"
        description = "example"
        enabled     = true
        expression  = "(http.host eq \"example.com\" and starts_with(http.request.uri.path, \"/example\"))"
        action_parameters {
            cache = true
            edge_ttl {
                mode    = "override_origin"
                default = 7200
            }
            cache_key {
                custom_key {
                    header {
                        check_presence = ["x-forwarded-for"]
                        include        = ["x-test", "x-test2"]
                        exclude_origin = false
                        contains       = {
                            "accept"         = ["image/web", "image/png"]
                            "accept-encoding" = ["br", "zstd"]
                            "some-header"    = ["some-value", "some-other-value"]
                        }
                    }
                }
            }
            cache_reserve {
              eligible = true
              minimum_file_size = 100000
            }
        }
    }
}
```

In the CF dashboard, I opened the network trace and found the corresponding result here:

![Screenshot 2024-09-09 at 12 31 48 PM](https://github.com/user-attachments/assets/29451118-bfe5-435c-88df-cb34663e77c3)

resolves #3244