### PR TITLE
Add missing docs for admin override

### DIFF
--- a/.changelog/3931.txt
+++ b/.changelog/3931.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/zero_trust_gateway_settings: Add missing disable_for_time example field
+```

--- a/docs/resources/zero_trust_gateway_settings.md
+++ b/docs/resources/zero_trust_gateway_settings.md
@@ -50,6 +50,7 @@ resource "cloudflare_zero_trust_gateway_settings" "example" {
     udp        = true
     root_ca    = true
     virtual_ip = false
+    disable_for_time = 3600
   }
 
   url_browser_isolation_enabled = true

--- a/examples/resources/cloudflare_zero_trust_gateway_settings/resource.tf
+++ b/examples/resources/cloudflare_zero_trust_gateway_settings/resource.tf
@@ -34,6 +34,7 @@ resource "cloudflare_zero_trust_gateway_settings" "example" {
     udp        = true
     root_ca    = true
     virtual_ip = false
+    disable_for_time = 3600
   }
 
   url_browser_isolation_enabled = true


### PR DESCRIPTION
Add missing schema examples for disable_for_time admin override feature for WARP clients.

Strangely, [previously merged docs](https://github.com/cloudflare/terraform-provider-cloudflare/pull/3526) for this feature do not appear in [the Terraform Registry](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/teams_account). Wondering if this is possibly due the field not being present in the schema example?