### PR TITLE
Add support for ai_bots_protection field in the cloudflare bot manage…

### DIFF
--- a/.changelog/3960.txt
+++ b/.changelog/3960.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_bot_management: Add support for ai_bots_protection settings
+```

--- a/docs/resources/bot_management.md
+++ b/docs/resources/bot_management.md
@@ -39,6 +39,7 @@ resource "cloudflare_bot_management" "example" {
 
 ### Optional
 
+- `ai_bots_protection` (String) Enable rule to block AI Scrapers and Crawlers.
 - `auto_update_model` (Boolean) Automatically update to the newest bot detection models created by Cloudflare as they are released. [Learn more.](https://developers.cloudflare.com/bots/reference/machine-learning-models#model-versions-and-release-notes).
 - `enable_js` (Boolean) Use lightweight, invisible JavaScript detections to improve Bot Management. [Learn more about JavaScript Detections](https://developers.cloudflare.com/bots/reference/javascript-detections/).
 - `fight_mode` (Boolean) Whether to enable Bot Fight Mode.

--- a/internal/sdkv2provider/resource_cloudflare_bot_management.go
+++ b/internal/sdkv2provider/resource_cloudflare_bot_management.go
@@ -86,6 +86,10 @@ func resourceCloudflareBotManagementRead(ctx context.Context, d *schema.Resource
 		d.Set("using_latest_model", bm.UsingLatestModel)
 	}
 
+	if bm.AIBotsProtection != nil {
+		d.Set("ai_bots_protection", bm.AIBotsProtection)
+	}
+
 	return nil
 }
 
@@ -151,5 +155,8 @@ func buildBotManagementParams(d *schema.ResourceData) cloudflare.UpdateBotManage
 		bm.AutoUpdateModel = cloudflare.BoolPtr(val.(bool))
 	}
 
+	if val, exists := d.GetOkExists("ai_bots_protection"); exists {
+		bm.AIBotsProtection = cloudflare.StringPtr(val.(string))
+	}
 	return bm
 }

--- a/internal/sdkv2provider/resource_cloudflare_bot_management_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_bot_management_test.go
@@ -95,7 +95,7 @@ func testCloudflareBotManagementSBFM(resourceName, rnd string, bm cloudflare.Bot
 		sbfm_verified_bots = "%[6]s"
 		sbfm_static_resource_protection = "%[7]t"
 		optimize_wordpress = "%[8]t",
-		ai_bots_protection = "%[9]t"
+		ai_bots_protection = "%[9]s"
 	}
 `, resourceName, rnd,
 		*bm.EnableJS, *bm.SBFMDefinitelyAutomated,
@@ -112,7 +112,7 @@ func testCloudflareBotManagementEntSubscription(resourceName, rnd string, bm clo
 
 		suppress_session_score = "%[4]t"
 		auto_update_model = "%[5]t",
-		ai_bots_protection = '%[6]t'
+		ai_bots_protection = '%[6]s'
 	}
 `, resourceName, rnd,
 		*bm.EnableJS, *bm.SuppressSessionScore, *bm.AutoUpdateModel, *bm.AIBotsProtection)

--- a/internal/sdkv2provider/resource_cloudflare_bot_management_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_bot_management_test.go
@@ -94,7 +94,7 @@ func testCloudflareBotManagementSBFM(resourceName, rnd string, bm cloudflare.Bot
 		sbfm_likely_automated = "%[5]s"
 		sbfm_verified_bots = "%[6]s"
 		sbfm_static_resource_protection = "%[7]t"
-		optimize_wordpress = "%[8]t",
+		optimize_wordpress = "%[8]t"
 		ai_bots_protection = "%[9]s"
 	}
 `, resourceName, rnd,
@@ -111,7 +111,7 @@ func testCloudflareBotManagementEntSubscription(resourceName, rnd string, bm clo
 		enable_js = "%[3]t"
 
 		suppress_session_score = "%[4]t"
-		auto_update_model = "%[5]t",
+		auto_update_model = "%[5]t"
 		ai_bots_protection = '%[6]s'
 	}
 `, resourceName, rnd,

--- a/internal/sdkv2provider/resource_cloudflare_bot_management_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_bot_management_test.go
@@ -23,6 +23,7 @@ func TestAccCloudflareBotManagement_SBFM(t *testing.T) {
 		SBFMVerifiedBots:             cloudflare.StringPtr("allow"),
 		SBFMStaticResourceProtection: cloudflare.BoolPtr(false),
 		OptimizeWordpress:            cloudflare.BoolPtr(true),
+		AIBotsProtection:             cloudflare.StringPtr("block"),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -39,6 +40,7 @@ func TestAccCloudflareBotManagement_SBFM(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceID, "sbfm_verified_bots", "allow"),
 					resource.TestCheckResourceAttr(resourceID, "sbfm_static_resource_protection", "false"),
 					resource.TestCheckResourceAttr(resourceID, "optimize_wordpress", "true"),
+					resource.TestCheckResourceAttr(resourceID, "ai_bots_protection", "block"),
 				),
 			},
 			{
@@ -59,6 +61,7 @@ func TestAccCloudflareBotManagement_Unentitled(t *testing.T) {
 		EnableJS:             cloudflare.BoolPtr(true),
 		SuppressSessionScore: cloudflare.BoolPtr(false),
 		AutoUpdateModel:      cloudflare.BoolPtr(false),
+		AIBotsProtection:     cloudflare.StringPtr("disabled"),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -72,6 +75,7 @@ func TestAccCloudflareBotManagement_Unentitled(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceID, "enable_js", "true"),
 					resource.TestCheckResourceAttr(resourceID, "suppress_session_score", "false"),
 					resource.TestCheckResourceAttr(resourceID, "auto_update_model", "false"),
+					resource.TestCheckResourceAttr(resourceID, "ai_bots_protection", "disabled"),
 				),
 				ExpectError: regexp.MustCompile("zone not entitled to disable"),
 			},
@@ -90,12 +94,13 @@ func testCloudflareBotManagementSBFM(resourceName, rnd string, bm cloudflare.Bot
 		sbfm_likely_automated = "%[5]s"
 		sbfm_verified_bots = "%[6]s"
 		sbfm_static_resource_protection = "%[7]t"
-		optimize_wordpress = "%[8]t"
+		optimize_wordpress = "%[8]t",
+        ai_bots_protection = "%[9]t"
 	}
 `, resourceName, rnd,
 		*bm.EnableJS, *bm.SBFMDefinitelyAutomated,
 		*bm.SBFMLikelyAutomated, *bm.SBFMVerifiedBots,
-		*bm.SBFMStaticResourceProtection, *bm.OptimizeWordpress)
+		*bm.SBFMStaticResourceProtection, *bm.OptimizeWordpress, *bm.AIBotsProtection)
 }
 
 func testCloudflareBotManagementEntSubscription(resourceName, rnd string, bm cloudflare.BotManagement) string {
@@ -106,8 +111,9 @@ func testCloudflareBotManagementEntSubscription(resourceName, rnd string, bm clo
 		enable_js = "%[3]t"
 
 		suppress_session_score = "%[4]t"
-		auto_update_model = "%[5]t"
+		auto_update_model = "%[5]t",
+        ai_bots_protection = '%[6]t'
 	}
 `, resourceName, rnd,
-		*bm.EnableJS, *bm.SuppressSessionScore, *bm.AutoUpdateModel)
+		*bm.EnableJS, *bm.SuppressSessionScore, *bm.AutoUpdateModel, *bm.AIBotsProtection)
 }

--- a/internal/sdkv2provider/resource_cloudflare_bot_management_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_bot_management_test.go
@@ -95,7 +95,7 @@ func testCloudflareBotManagementSBFM(resourceName, rnd string, bm cloudflare.Bot
 		sbfm_verified_bots = "%[6]s"
 		sbfm_static_resource_protection = "%[7]t"
 		optimize_wordpress = "%[8]t",
-        ai_bots_protection = "%[9]t"
+		ai_bots_protection = "%[9]t"
 	}
 `, resourceName, rnd,
 		*bm.EnableJS, *bm.SBFMDefinitelyAutomated,
@@ -112,7 +112,7 @@ func testCloudflareBotManagementEntSubscription(resourceName, rnd string, bm clo
 
 		suppress_session_score = "%[4]t"
 		auto_update_model = "%[5]t",
-        ai_bots_protection = '%[6]t'
+		ai_bots_protection = '%[6]t'
 	}
 `, resourceName, rnd,
 		*bm.EnableJS, *bm.SuppressSessionScore, *bm.AutoUpdateModel, *bm.AIBotsProtection)

--- a/internal/sdkv2provider/resource_cloudflare_bot_management_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_bot_management_test.go
@@ -112,7 +112,7 @@ func testCloudflareBotManagementEntSubscription(resourceName, rnd string, bm clo
 
 		suppress_session_score = "%[4]t"
 		auto_update_model = "%[5]t"
-		ai_bots_protection = '%[6]s'
+		ai_bots_protection = "%[6]s"
 	}
 `, resourceName, rnd,
 		*bm.EnableJS, *bm.SuppressSessionScore, *bm.AutoUpdateModel, *bm.AIBotsProtection)

--- a/internal/sdkv2provider/schema_cloudflare_bot_management.go
+++ b/internal/sdkv2provider/schema_cloudflare_bot_management.go
@@ -3,6 +3,7 @@ package sdkv2provider
 import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceCloudflareBotManagementSchema() map[string]*schema.Schema {
@@ -62,6 +63,13 @@ func resourceCloudflareBotManagementSchema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Computed:    true,
 			Description: "A read-only field that indicates whether the zone currently is running the latest ML model.",
+		},
+		"ai_bots_protection": {
+			Type:         schema.TypeString,
+			Computed:     true,
+			Optional:     true,
+			Description:  "Enable rule to block AI Scrapers and Crawlers.",
+			ValidateFunc: validation.StringInSlice([]string{"block", "disabled"}, false),
 		},
 	}
 }


### PR DESCRIPTION
**Can only be reviewed after cloudflare-go dependency bumped to v0.104.0.**

Added support for ai_bots_protection in the cloudflare bot management resource.  This setting was added to cloudflare-go in [this PR](https://github.com/cloudflare/cloudflare-go/pull/2974).


