### PR TITLE
Add resource cloudflare_page_shield

### DIFF
--- a/.changelog/4007.txt
+++ b/.changelog/4007.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+cloudflare_page_shield
+```

--- a/internal/sdkv2provider/provider.go
+++ b/internal/sdkv2provider/provider.go
@@ -276,6 +276,7 @@ func New(version string) func() *schema.Provider {
 				"cloudflare_observatory_scheduled_test":                      resourceCloudflareObservatoryScheduledTest(),
 				"cloudflare_origin_ca_certificate":                           resourceCloudflareOriginCACertificate(),
 				"cloudflare_page_rule":                                       resourceCloudflarePageRule(),
+				"cloudflare_page_shield":                                     resourceCloudflarePageShield(),
 				"cloudflare_pages_domain":                                    resourceCloudflarePagesDomain(),
 				"cloudflare_pages_project":                                   resourceCloudflarePagesProject(),
 				"cloudflare_queue":                                           resourceCloudflareQueue(),

--- a/internal/sdkv2provider/resource_cloudflare_page_shield.go
+++ b/internal/sdkv2provider/resource_cloudflare_page_shield.go
@@ -1,0 +1,93 @@
+package sdkv2provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceCloudflarePageShield() *schema.Resource {
+	return &schema.Resource{
+		Schema:        resourceCloudflarePageShieldSchema(),
+		CreateContext: resourceCloudflarePageShieldCreate,
+		ReadContext:   resourceCloudflarePageShieldRead,
+		UpdateContext: resourceCloudflarePageShieldCreate,
+		DeleteContext: resourceCloudflarePageShieldDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCloudflarePageShieldImport,
+		},
+		Description: "Provides the ability to manage Page Shield.",
+	}
+}
+
+func resourceCloudflarePageShieldCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*cloudflare.API)
+
+	newPageShield := cloudflare.UpdatePageShieldSettingsParams{
+		Enabled:                        cloudflare.BoolPtr(d.Get("enabled").(bool)),
+		UseCloudflareReportingEndpoint: cloudflare.BoolPtr(d.Get("use_cloudflare_reporting_endpoint").(bool)),
+		UseConnectionURLPath:           cloudflare.BoolPtr(d.Get("use_connection_url_path").(bool)),
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Creating Cloudflare Page Shield from struct: %+v", newPageShield))
+
+	zoneID := d.Get(consts.ZoneIDSchemaKey).(string)
+	_, err := client.UpdatePageShieldSettings(ctx, cloudflare.ZoneIdentifier(zoneID), newPageShield)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(zoneID)
+	return resourceCloudflareAccessRuleRead(ctx, d, meta)
+}
+
+func resourceCloudflarePageShieldRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*cloudflare.API)
+
+	zoneID := d.Get(consts.ZoneIDSchemaKey).(string)
+	response, err := client.GetPageShieldSettings(ctx, cloudflare.ZoneIdentifier(zoneID), cloudflare.GetPageShieldSettingsParams{})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(zoneID)
+	d.Set("enabled", response.PageShield.Enabled)
+	d.Set("use_cloudflare_reporting_endpoint", response.PageShield.UseCloudflareReportingEndpoint)
+	d.Set("use_connection_url_path", response.PageShield.UseConnectionURLPath)
+
+	return nil
+}
+
+func resourceCloudflarePageShieldDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*cloudflare.API)
+
+	tflog.Info(ctx, "Disabling Page Shield")
+
+	// There is no DELETE endpoint for schema validation settings,
+	// so terraform should reset the state to default settings
+	params := cloudflare.UpdatePageShieldSettingsParams{
+		Enabled:                        cloudflare.BoolPtr(false),
+		UseCloudflareReportingEndpoint: cloudflare.BoolPtr(true),
+		UseConnectionURLPath:           cloudflare.BoolPtr(false),
+	}
+
+	zoneID := d.Get(consts.ZoneIDSchemaKey).(string)
+	_, err := client.UpdatePageShieldSettings(ctx, cloudflare.ZoneIdentifier(zoneID), params)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceCloudflarePageShieldImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set(consts.ZoneIDSchemaKey, d.Id())
+
+	resourceCloudflarePageShieldRead(ctx, d, meta)
+	return []*schema.ResourceData{d}, nil
+}

--- a/internal/sdkv2provider/resource_cloudflare_page_shield.go
+++ b/internal/sdkv2provider/resource_cloudflare_page_shield.go
@@ -68,7 +68,7 @@ func resourceCloudflarePageShieldDelete(ctx context.Context, d *schema.ResourceD
 
 	tflog.Info(ctx, "Disabling Page Shield")
 
-	// There is no DELETE endpoint for schema validation settings,
+	// There is no DELETE endpoint for Page Shield settings,
 	// so terraform should reset the state to default settings
 	params := cloudflare.UpdatePageShieldSettingsParams{
 		Enabled:                        cloudflare.BoolPtr(false),

--- a/internal/sdkv2provider/resource_cloudflare_page_shield_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_page_shield_test.go
@@ -78,7 +78,7 @@ func testAccCheckPageShieldDelete(s *terraform.State) error {
 
 func testAccCloudflarePageShieldDefaultEnabledSet(resourceName, zone string) string {
 	return fmt.Sprintf(`
-	resource "cloudflare_api_shield_schema_validation_settings" "%[1]s" {
+	resource "cloudflare_page_shield" "%[1]s" {
 		zone_id = "%[2]s"
 	}
 `, resourceName, zone)
@@ -86,7 +86,7 @@ func testAccCloudflarePageShieldDefaultEnabledSet(resourceName, zone string) str
 
 func testAccCloudflarePageShieldAllFieldsSet(resourceName, zone string) string {
 	return fmt.Sprintf(`
-	resource "cloudflare_api_shield_schema_validation_settings" "%[1]s" {
+	resource "cloudflare_page_shield" "%[1]s" {
 		zone_id = "%[2]s"
         use_cloudflare_reporting_endpoint = true
         use_connection_url_path = true

--- a/internal/sdkv2provider/resource_cloudflare_page_shield_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_page_shield_test.go
@@ -1,0 +1,95 @@
+package sdkv2provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccCloudflarePageShield_Create(t *testing.T) {
+	rnd := generateRandomResourceName()
+	resourceID := "cloudflare_page_shield." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckPageShieldDelete,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflarePageShieldDefaultEnabledSet(rnd, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceID, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceID, "enabled", "true"),
+				),
+			},
+			{
+				Config: testAccCloudflarePageShieldAllFieldsSet(rnd, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceID, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceID, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceID, "use_cloudflare_reporting_endpoint", "true"),
+					resource.TestCheckResourceAttr(resourceID, "use_connection_url_path", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPageShieldDelete(s *terraform.State) error {
+	client := testAccProvider.Meta().(*cloudflare.API)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_page_shield" {
+			continue
+		}
+
+		result, err := client.GetPageShieldSettings(
+			context.Background(),
+			cloudflare.ZoneIdentifier(rs.Primary.Attributes[consts.ZoneIDSchemaKey]),
+			cloudflare.GetPageShieldSettingsParams{},
+		)
+		if err != nil {
+			return fmt.Errorf("encountered error getting schema validation settings: %w", err)
+		}
+
+		if *result.PageShield.Enabled != false {
+			return fmt.Errorf("expected enabled to be 'false' but got: %s", strconv.FormatBool(*result.PageShield.Enabled))
+		}
+
+		if *result.PageShield.UseCloudflareReportingEndpoint != true {
+			return fmt.Errorf("expected use_cloudflare_reporting_endpoint to be 'true' but got: %s", strconv.FormatBool(*result.PageShield.UseCloudflareReportingEndpoint))
+		}
+
+		if *result.PageShield.UseConnectionURLPath != false {
+			return fmt.Errorf("expected use_connection_url_path to be 'false' but got: %s", strconv.FormatBool(*result.PageShield.UseConnectionURLPath))
+		}
+	}
+
+	return nil
+}
+
+func testAccCloudflarePageShieldDefaultEnabledSet(resourceName, zone string) string {
+	return fmt.Sprintf(`
+	resource "cloudflare_api_shield_schema_validation_settings" "%[1]s" {
+		zone_id = "%[2]s"
+	}
+`, resourceName, zone)
+}
+
+func testAccCloudflarePageShieldAllFieldsSet(resourceName, zone string) string {
+	return fmt.Sprintf(`
+	resource "cloudflare_api_shield_schema_validation_settings" "%[1]s" {
+		zone_id = "%[2]s"
+        use_cloudflare_reporting_endpoint = true
+        use_connection_url_path = true
+	}
+`, resourceName, zone)
+}

--- a/internal/sdkv2provider/resource_cloudflare_page_shield_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_page_shield_test.go
@@ -57,7 +57,7 @@ func testAccCheckPageShieldDelete(s *terraform.State) error {
 			cloudflare.GetPageShieldSettingsParams{},
 		)
 		if err != nil {
-			return fmt.Errorf("encountered error getting schema validation settings: %w", err)
+			return fmt.Errorf("encountered error getting page shield: %w", err)
 		}
 
 		if *result.PageShield.Enabled != false {

--- a/internal/sdkv2provider/schema_cloudflare_page_shield.go
+++ b/internal/sdkv2provider/schema_cloudflare_page_shield.go
@@ -1,0 +1,33 @@
+package sdkv2provider
+
+import (
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceCloudflarePageShieldSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		consts.ZoneIDSchemaKey: {
+			Description: consts.ZoneIDSchemaDescription,
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+		},
+		"enabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "When true, indicates that Page Shield is enabled.",
+			Default:     true,
+		},
+		"use_cloudflare_reporting_endpoint": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "When true, CSP reports will be sent to https://csp-reporting.cloudflare.com/cdn-cgi/script_monitor/report",
+		},
+		"use_connection_url_path": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "When true, the paths associated with connections URLs will also be analyzed.",
+		},
+	}
+}


### PR DESCRIPTION
Existing API: https://github.com/cloudflare/cloudflare-go/blob/8743749c8ce71e82a506005135ac90f1120fc061/page_shield.go#L12
API documentation: https://developers.cloudflare.com/api/operations/page-shield-get-settings

Adds support for managing Page Shield configuration via terraform.