### PR TITLE
Implement "import" for cloudflare_api_token

### DIFF
--- a/.changelog/4015.txt
+++ b/.changelog/4015.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_api_token: Allow importing
+```

--- a/internal/sdkv2provider/resource_cloudflare_api_token.go
+++ b/internal/sdkv2provider/resource_cloudflare_api_token.go
@@ -21,6 +21,9 @@ func resourceCloudflareApiToken() *schema.Resource {
 		ReadContext:   resourceCloudflareApiTokenRead,
 		UpdateContext: resourceCloudflareApiTokenUpdate,
 		DeleteContext: resourceCloudflareApiTokenDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCloudflareApiTokenImport,
+		},
 		Description: heredoc.Doc(`
 			Provides a resource which manages Cloudflare API tokens.
 
@@ -229,4 +232,16 @@ func resourceCloudflareApiTokenDelete(ctx context.Context, d *schema.ResourceDat
 	}
 
 	return nil
+}
+
+func resourceCloudflareApiTokenImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	tokenID := d.Id()
+
+	tflog.Info(ctx, fmt.Sprintf("Importing Cloudflare API token: id %s", tokenID))
+
+	if err := resourceCloudflareApiTokenRead(ctx, d, meta); err != nil {
+		return nil, errors.New(err[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
This is a pretty mechanical clone of other importers, and I want to see how it fares on the CI/CD.

Note that this is against v4.41.0, because master is right now broken:

```
==> Running go vet .
# github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider
internal/sdkv2provider/resource_cloudflare_record.go:57:3: unknown field ZoneID in struct literal of type cloudflare.CreateDNSRecordParams
internal/sdkv2provider/resource_cloudflare_record.go:109:119: newRecord.ZoneID undefined (type cloudflare.CreateDNSRecordParams has no field or method ZoneID)
internal/sdkv2provider/resource_cloudflare_record.go:142:77: newRecord.ZoneID undefined (type cloudflare.CreateDNSRecordParams has no field or method ZoneID)
internal/sdkv2provider/resource_cloudflare_record.go:418:53: record.ZoneName undefined (type cloudflare.DNSRecord has no field or method ZoneName)
# github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider
# [github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider]
vet: internal/sdkv2provider/resource_cloudflare_record.go:57:3: unknown field ZoneID in struct literal of type cloudflare.CreateDNSRecordParams

Vet found suspicious constructs. Please check the reported constructs
and fix them if necessary before submitting the code for review.
make: *** [GNUmakefile:63: vet] Error 1
```