### PR TITLE
resource/cloudflare_record: remove internal references to deprecated ZoneID and ZoneName fields

### DIFF
--- a/.changelog/4018.txt
+++ b/.changelog/4018.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_record: remove internal references to deprecated ZoneID and ZoneName fields
+```

--- a/internal/sdkv2provider/resource_cloudflare_record_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_record_test.go
@@ -420,7 +420,7 @@ func TestAccCloudflareRecord_CreateAfterManualDestroy(t *testing.T) {
 				Config: testAccCheckCloudflareRecordConfigBasic(zoneID, name, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareRecordExists(name, &afterCreate),
-					testAccManuallyDeleteRecord(&afterCreate),
+					testAccManuallyDeleteRecord(&afterCreate, zoneID),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -775,10 +775,10 @@ func testAccCheckCloudflareRecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccManuallyDeleteRecord(record *cloudflare.DNSRecord) resource.TestCheckFunc {
+func testAccManuallyDeleteRecord(record *cloudflare.DNSRecord, zoneID string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*cloudflare.API)
-		err := client.DeleteDNSRecord(context.Background(), cloudflare.ZoneIdentifier(record.ZoneID), record.ID)
+		err := client.DeleteDNSRecord(context.Background(), cloudflare.ZoneIdentifier(zoneID), record.ID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
These were removed from the Go library and we only use them internally.