### PR TITLE
Fix the deprecation notice for cloudflare_access_application

### DIFF
--- a/.changelog/4044.txt
+++ b/.changelog/4044.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_access_application: fix the name of the new resource to use when upgrading
+```

--- a/internal/sdkv2provider/resource_cloudflare_access_application.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_application.go
@@ -29,7 +29,7 @@ func resourceCloudflareAccessApplication() *schema.Resource {
 			Applications are used to restrict access to a whole application using an
 			authorisation gateway managed by Cloudflare.
 		`),
-		DeprecationMessage: "`cloudflare_access_application` is now deprecated and will be removed in the next major version. Use `zero_trust_access_application` instead.",
+		DeprecationMessage: "`cloudflare_access_application` is now deprecated and will be removed in the next major version. Use `cloudflare_zero_trust_access_application` instead.",
 	}
 }
 


### PR DESCRIPTION
Providing the correct replacement resource for `cloudflare_access_application`

Fixes: https://github.com/cloudflare/terraform-provider-cloudflare/issues/4043