### PR TITLE
Add acceptance tests for secondary DNS resources

### DIFF
--- a/internal/services/secondary_dns_acl/resource_test.go
+++ b/internal/services/secondary_dns_acl/resource_test.go
@@ -1,0 +1,104 @@
+package secondary_dns_acl_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v2"
+	"github.com/cloudflare/cloudflare-go/v2/secondary_dns"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("cloudflare_secondary_dns_acl", &resource.Sweeper{
+		Name: "cloudflare_secondary_dns_acl",
+		F:    testSweepCloudflareSecondaryDNSACL,
+	})
+}
+
+func testSweepCloudflareSecondaryDNSACL(r string) error {
+	ctx := context.Background()
+	client := acctest.SharedV2Client()
+
+	// Clean up the account level acls
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		return errors.New("CLOUDFLARE_ACCOUNT_ID must be set")
+	}
+
+	acls, err := client.SecondaryDNS.ACLs.List(context.Background(), secondary_dns.ACLListParams{AccountID: cloudflare.F(accountID)})
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to fetch Cloudflare secondary DNS ACLs: %s", err))
+	}
+
+	if len(acls.Result) == 0 {
+		log.Print("[DEBUG] No Cloudflare ACLs to sweep")
+		return nil
+	}
+
+	for _, acl := range acls.Result {
+		tflog.Info(ctx, fmt.Sprintf("Deleting Cloudflare ACL ID: %s", acl.ID))
+		//nolint:errcheck
+		client.SecondaryDNS.ACLs.Delete(context.TODO(), acl.ID, secondary_dns.ACLDeleteParams{AccountID: cloudflare.F(accountID)})
+	}
+
+	return nil
+}
+
+func TestAccCloudflareSecondaryDNSACL_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_secondary_dns_acl." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSecondaryDNSACLConfig(rnd, accountID, rnd, "1.2.3.4/32"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "ip_range", "1.2.3.4/32"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSecondaryDNSACL_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_secondary_dns_acl." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSecondaryDNSACLConfig(rnd, accountID, rnd, "1.2.3.4/32"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "ip_range", "1.2.3.4/32"),
+				),
+			},
+			{
+				Config: testSecondaryDNSACLConfig(rnd, accountID, rnd, "1.2.3.5/32"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "ip_range", "1.2.3.5/32"),
+				),
+			},
+		},
+	})
+}
+
+func testSecondaryDNSACLConfig(resourceID, accountID, name, ipRange string) string {
+	return acctest.LoadTestCase("acl.tf", resourceID, accountID, name, ipRange)
+}

--- a/internal/services/secondary_dns_acl/testdata/acl.tf
+++ b/internal/services/secondary_dns_acl/testdata/acl.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_secondary_dns_acl" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[3]s"
+  ip_range = "%[4]s"
+}

--- a/internal/services/secondary_dns_incoming/resource_test.go
+++ b/internal/services/secondary_dns_incoming/resource_test.go
@@ -1,0 +1,141 @@
+package secondary_dns_incoming_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v2"
+	"github.com/cloudflare/cloudflare-go/v2/secondary_dns"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("cloudflare_secondary_dns_incoming", &resource.Sweeper{
+		Name: "cloudflare_secondary_dns_incoming",
+		F:    testSweepCloudflareSecondaryDNSIncoming,
+	})
+}
+
+func testSweepCloudflareSecondaryDNSIncoming(r string) error {
+	ctx := context.Background()
+	client := acctest.SharedV2Client()
+
+	// Clean up the connections between peers and zones
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	if zoneID == "" {
+		return errors.New("CLOUDFLARE_ZONE_ID must be set")
+	}
+
+	incomingZone, err := client.SecondaryDNS.Incoming.Get(context.Background(), secondary_dns.IncomingGetParams{ZoneID: cloudflare.F(zoneID)})
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to fetch Cloudflare incoming secondary zones: %s", err))
+	}
+
+	if len(incomingZone.Peers) == 0 {
+		log.Print("[DEBUG] No Cloudflare peers connected to zones records to sweep")
+		return nil
+	}
+
+	_, err = client.SecondaryDNS.Incoming.Update(context.Background(), secondary_dns.IncomingUpdateParams{ZoneID: cloudflare.F(zoneID), Peers: cloudflare.F([]interface{}{})})
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to clear peers on incoming zone: %s", err))
+	}
+
+	return nil
+}
+
+func TestAccCloudflareSecondaryDNSIncoming_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	name := "cloudflare_secondary_dns_incoming." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	client := acctest.SharedV2Client()
+
+	// Make a new peer that we can connect our zone to
+	peerObj := secondary_dns.PeerParam{
+		Port: cloudflare.F(float64(53)),
+		Name: cloudflare.F("terraform-peer"),
+		IP:   cloudflare.F("1.2.3.4"),
+	}
+	peer, err := client.SecondaryDNS.Peers.New(context.Background(), secondary_dns.PeerNewParams{AccountID: cloudflare.F(accountID), Body: peerObj})
+	if err != nil {
+		tflog.Error(context.Background(), fmt.Sprintf("Failed to bootstrap Cloudflare DNS peer: %s", err))
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSecondaryDNSIncomingConfig(rnd, zoneName, zoneID, 300, peer.ID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", zoneName),
+					resource.TestCheckResourceAttr(name, "auto_refresh_seconds", "300"),
+					resource.TestCheckResourceAttr(name, "peers.0", peer.ID),
+				),
+			},
+		},
+	})
+	// Delete the original peer after we are done
+	_, err = client.SecondaryDNS.Peers.Delete(context.Background(), peer.ID, secondary_dns.PeerDeleteParams{AccountID: cloudflare.F(accountID)})
+	if err != nil {
+		tflog.Error(context.Background(), fmt.Sprintf("Failed to cleanup Cloudflare DNS peer in incoming test: %s", err))
+	}
+}
+
+func TestAccCloudflareSecondaryDNSIncoming_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	name := "cloudflare_secondary_dns_incoming." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	client := acctest.SharedV2Client()
+
+	// Make a new peer that we can connect our zone to
+	peerObj := secondary_dns.PeerParam{
+		Port: cloudflare.F(float64(53)),
+		Name: cloudflare.F("terraform-peer"),
+		IP:   cloudflare.F("1.2.3.4"),
+	}
+	peer, err := client.SecondaryDNS.Peers.New(context.Background(), secondary_dns.PeerNewParams{AccountID: cloudflare.F(accountID), Body: peerObj})
+	if err != nil {
+		tflog.Error(context.Background(), fmt.Sprintf("Failed to bootstrap Cloudflare DNS peer: %s", err))
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSecondaryDNSIncomingConfig(rnd, zoneName, zoneID, 300, peer.ID),
+			},
+			{
+				Config: testSecondaryDNSIncomingConfig(rnd, zoneName, zoneID, 500, peer.ID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", zoneName),
+					resource.TestCheckResourceAttr(name, "auto_refresh_seconds", "500"),
+					resource.TestCheckResourceAttr(name, "peers.0", peer.ID),
+				),
+			},
+		},
+	})
+	// Delete the original peer after we are done
+	_, err = client.SecondaryDNS.Peers.Delete(context.Background(), peer.ID, secondary_dns.PeerDeleteParams{AccountID: cloudflare.F(accountID)})
+	if err != nil {
+		tflog.Error(context.Background(), fmt.Sprintf("Failed to cleanup Cloudflare DNS peer in incoming test: %s", err))
+	}
+}
+
+func testSecondaryDNSIncomingConfig(resourceID, zoneName, zoneID string, autoRefreshSeconds int, peers string) string {
+	return acctest.LoadTestCase("incoming.tf", resourceID, zoneID, autoRefreshSeconds, zoneName, peers)
+}

--- a/internal/services/secondary_dns_incoming/testdata/incoming.tf
+++ b/internal/services/secondary_dns_incoming/testdata/incoming.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_secondary_dns_incoming" "%[1]s" {
+  zone_id = "%[2]s"
+  auto_refresh_seconds = "%[3]d"
+  name = "%[4]s"
+  peers = ["%[5]s"]
+}

--- a/internal/services/secondary_dns_outgoing/resource_test.go
+++ b/internal/services/secondary_dns_outgoing/resource_test.go
@@ -1,0 +1,147 @@
+package secondary_dns_outgoing_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v2"
+	"github.com/cloudflare/cloudflare-go/v2/secondary_dns"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("cloudflare_secondary_dns_outgoing", &resource.Sweeper{
+		Name: "cloudflare_secondary_dns_outgoing",
+		F:    testSweepCloudflareSecondaryDNSOutgoing,
+	})
+}
+
+func testSweepCloudflareSecondaryDNSOutgoing(r string) error {
+	ctx := context.Background()
+	client := acctest.SharedV2Client()
+
+	// Clean up the connections between peers and zones
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	if zoneID == "" {
+		return errors.New("CLOUDFLARE_ZONE_ID must be set")
+	}
+
+	outgoingZone, err := client.SecondaryDNS.Outgoing.Get(context.Background(), secondary_dns.OutgoingGetParams{ZoneID: cloudflare.F(zoneID)})
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to fetch Cloudflare outgoing secondary zones: %s", err))
+	}
+
+	if len(outgoingZone.Peers) == 0 {
+		log.Print("[DEBUG] No Cloudflare peers connected to zones records to sweep")
+		return nil
+	}
+
+	_, err = client.SecondaryDNS.Outgoing.Update(context.Background(), secondary_dns.OutgoingUpdateParams{ZoneID: cloudflare.F(zoneID), Peers: cloudflare.F([]interface{}{})})
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to clear peers on outgoing zone: %s", err))
+	}
+
+	return nil
+}
+
+func TestAccCloudflareSecondaryDNSOutgoing_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	name := "cloudflare_secondary_dns_outgoing." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	client := acctest.SharedV2Client()
+
+	// Make a new peer that we can connect our zone to
+	peerObj := secondary_dns.PeerParam{
+		Port: cloudflare.F(float64(53)),
+		Name: cloudflare.F("terraform-peer"),
+		IP:   cloudflare.F("1.2.3.4"),
+	}
+	peer, err := client.SecondaryDNS.Peers.New(context.Background(), secondary_dns.PeerNewParams{AccountID: cloudflare.F(accountID), Body: peerObj})
+	if err != nil {
+		tflog.Error(context.Background(), fmt.Sprintf("Failed to bootstrap Cloudflare DNS peer: %s", err))
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSecondaryDNSOutgoingConfig(rnd, zoneName, zoneID, peer.ID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", zoneName),
+					resource.TestCheckResourceAttr(name, "peers.0", peer.ID),
+				),
+			},
+		},
+	})
+	// Delete the original peer after we are done
+	_, err = client.SecondaryDNS.Peers.Delete(context.Background(), peer.ID, secondary_dns.PeerDeleteParams{AccountID: cloudflare.F(accountID)})
+	if err != nil {
+		tflog.Error(context.Background(), fmt.Sprintf("Failed to cleanup Cloudflare DNS peer in outgoing test: %s", err))
+	}
+}
+
+func TestAccCloudflareSecondaryDNSOutgoing_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	name := "cloudflare_secondary_dns_outgoing." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	client := acctest.SharedV2Client()
+
+	// Make a new peer that we can connect our zone to
+	peerObj := secondary_dns.PeerParam{
+		Port: cloudflare.F(float64(53)),
+		Name: cloudflare.F("terraform-peer"),
+		IP:   cloudflare.F("1.2.3.4"),
+	}
+	peer1, err := client.SecondaryDNS.Peers.New(context.Background(), secondary_dns.PeerNewParams{AccountID: cloudflare.F(accountID), Body: peerObj})
+	if err != nil {
+		tflog.Error(context.Background(), fmt.Sprintf("Failed to bootstrap Cloudflare DNS peer: %s", err))
+	}
+	peerObj.IP = cloudflare.F("1.2.3.6")
+	peer2, err := client.SecondaryDNS.Peers.New(context.Background(), secondary_dns.PeerNewParams{AccountID: cloudflare.F(accountID), Body: peerObj})
+	if err != nil {
+		tflog.Error(context.Background(), fmt.Sprintf("Failed to bootstrap Cloudflare DNS peer: %s", err))
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSecondaryDNSOutgoingConfig(rnd, zoneName, zoneID, peer1.ID),
+			},
+			{
+				Config: testSecondaryDNSOutgoingConfig(rnd, zoneName, zoneID, peer2.ID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", zoneName),
+					resource.TestCheckResourceAttr(name, "peers.0", peer2.ID),
+				),
+			},
+		},
+	})
+	// Delete the original peers after we are done
+	for _, id := range []string{peer1.ID, peer2.ID} {
+		_, err = client.SecondaryDNS.Peers.Delete(context.Background(), id, secondary_dns.PeerDeleteParams{AccountID: cloudflare.F(accountID)})
+		if err != nil {
+			tflog.Error(context.Background(), fmt.Sprintf("Failed to cleanup Cloudflare DNS peer in outgoing test: %s", err))
+		}
+	}
+
+}
+
+func testSecondaryDNSOutgoingConfig(resourceID, zoneName, zoneID string, peers string) string {
+	return acctest.LoadTestCase("outgoing.tf", resourceID, zoneID, zoneName, peers)
+}

--- a/internal/services/secondary_dns_outgoing/testdata/outgoing.tf
+++ b/internal/services/secondary_dns_outgoing/testdata/outgoing.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_secondary_dns_outgoing" "%[1]s" {
+  zone_id = "%[2]s"
+  name = "%[3]s"
+  peers = ["%[4]s"]
+}

--- a/internal/services/secondary_dns_peer/resource_test.go
+++ b/internal/services/secondary_dns_peer/resource_test.go
@@ -1,0 +1,125 @@
+package secondary_dns_peer_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v2"
+	"github.com/cloudflare/cloudflare-go/v2/secondary_dns"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("cloudflare_secondary_dns_peer", &resource.Sweeper{
+		Name: "cloudflare_secondary_dns_peer",
+		F:    testSweepCloudflareSecondaryDNSPeer,
+	})
+}
+
+func testSweepCloudflareSecondaryDNSPeer(r string) error {
+	ctx := context.Background()
+	client := acctest.SharedV2Client()
+
+	// Clean up the account level peers
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		return errors.New("CLOUDFLARE_ACCOUNT_ID must be set")
+	}
+
+	peers, err := client.SecondaryDNS.Peers.List(context.Background(), secondary_dns.PeerListParams{AccountID: cloudflare.F(accountID)})
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to fetch Cloudflare peers: %s", err))
+	}
+
+	if len(peers.Result) == 0 {
+		log.Print("[DEBUG] No Cloudflare peers records to sweep")
+		return nil
+	}
+
+	for _, peer := range peers.Result {
+		tflog.Info(ctx, fmt.Sprintf("Deleting Cloudflare peer ID: %s", peer.ID))
+		//nolint:errcheck
+		client.SecondaryDNS.Peers.Delete(context.TODO(), peer.ID, secondary_dns.PeerDeleteParams{AccountID: cloudflare.F(accountID)})
+	}
+
+	return nil
+}
+
+func TestAccCloudflareSecondaryDNSPeer_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_secondary_dns_peer." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	client := acctest.SharedV2Client()
+
+	// Make a new TSIG that we can connect our peer to
+	tsigObj := secondary_dns.TSIGParam{
+		Algo: cloudflare.F("hmac-sha512."),
+		Name: cloudflare.F("terraform-tsig"),
+	}
+	tsig, err := client.SecondaryDNS.TSIGs.New(context.Background(), secondary_dns.TSIGNewParams{AccountID: cloudflare.F(accountID), TSIG: tsigObj})
+	if err != nil {
+		tflog.Error(context.Background(), fmt.Sprintf("Failed to bootstrap Cloudflare DNS tsig: %s", err))
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSecondaryDNSPeerConfig(rnd, accountID, rnd, "1.2.3.4", tsig.ID, 53, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "ip", "1.2.3.4"),
+					resource.TestCheckResourceAttr(name, "ixfr_enable", "true"),
+					resource.TestCheckResourceAttr(name, "port", "53"),
+					resource.TestCheckResourceAttr(name, "tsig_id", tsig.ID),
+				),
+			},
+		},
+	})
+
+	// Delete the original tsig after we are done
+	_, err = client.SecondaryDNS.TSIGs.Delete(context.Background(), tsig.ID, secondary_dns.TSIGDeleteParams{AccountID: cloudflare.F(accountID)})
+	if err != nil {
+		tflog.Error(context.Background(), fmt.Sprintf("Failed to cleanup Cloudflare DNS tsig in peer test: %s", err))
+	}
+}
+
+func TestAccCloudflareSecondaryDNSPeer_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_secondary_dns_peer." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSecondaryDNSPeerNoTsigConfig(rnd, accountID, rnd, "1.2.3.4", 53),
+			},
+			{
+				Config: testSecondaryDNSPeerNoTsigConfig(rnd, accountID, rnd, "1.2.3.5", 53),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "ip", "1.2.3.5"),
+					resource.TestCheckResourceAttr(name, "port", "53"),
+				),
+			},
+		},
+	})
+}
+
+func testSecondaryDNSPeerConfig(resourceID, accountID, name, ip, tsigID string, port int, ixfrEnable bool) string {
+	return acctest.LoadTestCase("peer.tf", resourceID, accountID, name, ip, ixfrEnable, port, tsigID)
+}
+
+func testSecondaryDNSPeerNoTsigConfig(resourceID, accountID, name, ip string, port int) string {
+	return acctest.LoadTestCase("peer_no_tsig.tf", resourceID, accountID, name, ip, port)
+}

--- a/internal/services/secondary_dns_peer/testdata/peer.tf
+++ b/internal/services/secondary_dns_peer/testdata/peer.tf
@@ -1,0 +1,8 @@
+resource "cloudflare_secondary_dns_peer" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[3]s"
+  ip = "%[4]s"
+  ixfr_enable = "%[5]t"
+  port = "%[6]d"
+  tsig_id = "%[7]s"
+}

--- a/internal/services/secondary_dns_peer/testdata/peer_no_tsig.tf
+++ b/internal/services/secondary_dns_peer/testdata/peer_no_tsig.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_secondary_dns_peer" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[3]s"
+  ip = "%[4]s"
+  port = "%[5]d"
+}

--- a/internal/services/secondary_dns_tsig/resource_test.go
+++ b/internal/services/secondary_dns_tsig/resource_test.go
@@ -1,0 +1,102 @@
+package secondary_dns_tsig_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v2"
+	"github.com/cloudflare/cloudflare-go/v2/secondary_dns"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("cloudflare_secondary_dns_tsig", &resource.Sweeper{
+		Name: "cloudflare_secondary_dns_tsig",
+		F:    testSweepCloudflareSecondaryDNSTSIG,
+	})
+}
+
+func testSweepCloudflareSecondaryDNSTSIG(r string) error {
+	ctx := context.Background()
+	client := acctest.SharedV2Client()
+
+	// Clean up the account level tsigs
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		return errors.New("CLOUDFLARE_ACCOUNT_ID must be set")
+	}
+
+	tsigs, err := client.SecondaryDNS.TSIGs.List(context.Background(), secondary_dns.TSIGListParams{AccountID: cloudflare.F(accountID)})
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to fetch Cloudflare tsigs: %s", err))
+	}
+
+	if len(tsigs.Result) == 0 {
+		log.Print("[DEBUG] No Cloudflare tsigs records to sweep")
+		return nil
+	}
+
+	for _, tsig := range tsigs.Result {
+		tflog.Info(ctx, fmt.Sprintf("Deleting Cloudflare tsig ID: %s", tsig.ID))
+		//nolint:errcheck
+		client.SecondaryDNS.TSIGs.Delete(context.TODO(), tsig.ID, secondary_dns.TSIGDeleteParams{AccountID: cloudflare.F(accountID)})
+	}
+
+	return nil
+}
+
+func TestAccCloudflareSecondaryDNSTSIG_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_secondary_dns_tsig." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSecondaryDNSTSIGConfig(rnd, accountID, rnd, "hmac-sha512.", "caf79a7804b04337c9c66ccd7bef9190a1e1679b5dd03d8aa10f7ad45e1a9dab92b417896c15d4d007c7c14194538d2a5d0feffdecc5a7f0e1c570cfa700837c"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "algo", "hmac-sha512."),
+					resource.TestCheckResourceAttr(name, "secret", "caf79a7804b04337c9c66ccd7bef9190a1e1679b5dd03d8aa10f7ad45e1a9dab92b417896c15d4d007c7c14194538d2a5d0feffdecc5a7f0e1c570cfa700837c"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSecondaryDNSTSIG_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_secondary_dns_tsig." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSecondaryDNSTSIGConfig(rnd, accountID, rnd, "hmac-sha512.", "baf79a7804b04337c9c66ccd7bef9190a1e1679b5dd03d8aa10f7ad45e1a9dab92b417896c15d4d007c7c14194538d2a5d0feffdecc5a7f0e1c570cfa700837c"),
+			},
+			{
+				Config: testSecondaryDNSTSIGConfig(rnd, accountID, rnd, "hmac-sha512.", "caf79a7804b04337c9c66ccd7bef9190a1e1679b5dd03d8aa10f7ad45e1a9dab92b417896c15d4d007c7c14194538d2a5d0feffdecc5a7f0e1c570cfa700837c"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "algo", "hmac-sha512."),
+					resource.TestCheckResourceAttr(name, "secret", "caf79a7804b04337c9c66ccd7bef9190a1e1679b5dd03d8aa10f7ad45e1a9dab92b417896c15d4d007c7c14194538d2a5d0feffdecc5a7f0e1c570cfa700837c"),
+				),
+			},
+		},
+	})
+}
+
+func testSecondaryDNSTSIGConfig(resourceID, accountID, name, algo, secret string) string {
+	return acctest.LoadTestCase("tsig.tf", resourceID, accountID, name, algo, secret)
+}

--- a/internal/services/secondary_dns_tsig/testdata/tsig.tf
+++ b/internal/services/secondary_dns_tsig/testdata/tsig.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_secondary_dns_tsig" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[3]s"
+  algo = "%[4]s"
+  secret = "%[5]s"
+}


### PR DESCRIPTION
This adds tests for:

1. ACLs
2. TSIGs
3. Peers
4. Incoming zones
5. Outgoing zones

I've used the v2 SDK to avoid those TODOs in the future 😁 

```
TF_ACC=1 go test ./internal/services/secondary_dns_acl -run "^TestAccCloudflareSecondaryDNSACL_" -v -count 1
=== RUN   TestAccCloudflareSecondaryDNSACL_Basic
--- PASS: TestAccCloudflareSecondaryDNSACL_Basic (3.39s)
=== RUN   TestAccCloudflareSecondaryDNSACL_Update
--- PASS: TestAccCloudflareSecondaryDNSACL_Update (5.74s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/secondary_dns_acl 10.356s
```

```
TF_ACC=1 go test ./internal/services/secondary_dns_tsig -run "^TestAccCloudflareSecondaryDNSTSIG_" -v -count 1
=== RUN   TestAccCloudflareSecondaryDNSTSIG_Basic
--- PASS: TestAccCloudflareSecondaryDNSTSIG_Basic (3.16s)
=== RUN   TestAccCloudflareSecondaryDNSTSIG_Update
--- PASS: TestAccCloudflareSecondaryDNSTSIG_Update (5.82s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/secondary_dns_tsig
```

```
TF_ACC=1 go test ./internal/services/secondary_dns_peer -run "^TestAccCloudflareSecondaryDNSPeer_" -v -count 1
=== RUN   TestAccCloudflareSecondaryDNSPeer_Basic
--- PASS: TestAccCloudflareSecondaryDNSPeer_Basic (4.26s)
=== RUN   TestAccCloudflareSecondaryDNSPeer_Update
--- PASS: TestAccCloudflareSecondaryDNSPeer_Update (5.66s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/secondary_dns_peer        11.434s
```

```
 TF_ACC=1 go test ./internal/services/secondary_dns_incoming -run "^TestAccCloudflareSecondaryDNSIncoming_" -v -count 1
=== RUN   TestAccCloudflareSecondaryDNSIncoming_Basic
--- PASS: TestAccCloudflareSecondaryDNSIncoming_Basic (4.72s)
=== RUN   TestAccCloudflareSecondaryDNSIncoming_Update
--- PASS: TestAccCloudflareSecondaryDNSIncoming_Update (7.78s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/secondary_dns_incoming    13.686s
```

```
 TF_ACC=1 go test ./internal/services/secondary_dns_outgoing -run "^TestAccCloudflareSecondaryDNSOutgoing_" -v -count 1
=== RUN   TestAccCloudflareSecondaryDNSOutgoing_Basic
--- PASS: TestAccCloudflareSecondaryDNSOutgoing_Basic (4.61s)
=== RUN   TestAccCloudflareSecondaryDNSOutgoing_Update
--- PASS: TestAccCloudflareSecondaryDNSOutgoing_Update (8.16s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/secondary_dns_outgoing    13.739s
```