### PR TITLE
fix: repair ruleset custom code

### DIFF
--- a/internal/services/ruleset/model.go
+++ b/internal/services/ruleset/model.go
@@ -35,72 +35,72 @@ func (m RulesetModel) MarshalJSONForUpdate(state RulesetModel) (data []byte, err
 }
 
 type RulesetRulesModel struct {
-	LastUpdated      timetypes.RFC3339                                           `tfsdk:"last_updated" json:"last_updated,computed" format:"date-time"`
-	Version          types.String                                                `tfsdk:"version" json:"version,computed"`
-	ID               types.String                                                `tfsdk:"id" json:"id,computed"`
-	Action           types.String                                                `tfsdk:"action" json:"action,computed_optional"`
-	ActionParameters customfield.NestedObject[RulesetRulesActionParametersModel] `tfsdk:"action_parameters" json:"action_parameters,computed_optional"`
-	Categories       customfield.List[types.String]                              `tfsdk:"categories" json:"categories,computed"`
-	Description      types.String                                                `tfsdk:"description" json:"description,computed_optional"`
-	Enabled          types.Bool                                                  `tfsdk:"enabled" json:"enabled,computed_optional"`
-	Expression       types.String                                                `tfsdk:"expression" json:"expression,computed_optional"`
-	Logging          customfield.NestedObject[RulesetRulesLoggingModel]          `tfsdk:"logging" json:"logging,computed_optional"`
-	Ref              types.String                                                `tfsdk:"ref" json:"ref,computed_optional"`
+	LastUpdated      timetypes.RFC3339                  `tfsdk:"last_updated" json:"last_updated,computed" format:"date-time"`
+	Version          types.String                       `tfsdk:"version" json:"version,computed"`
+	ID               types.String                       `tfsdk:"id" json:"id,computed"`
+	Action           types.String                       `tfsdk:"action" json:"action,computed_optional"`
+	ActionParameters *RulesetRulesActionParametersModel `tfsdk:"action_parameters" json:"action_parameters,optional"`
+	Categories       customfield.List[types.String]     `tfsdk:"categories" json:"categories,computed"`
+	Description      types.String                       `tfsdk:"description" json:"description,computed_optional"`
+	Enabled          types.Bool                         `tfsdk:"enabled" json:"enabled,computed_optional"`
+	Expression       types.String                       `tfsdk:"expression" json:"expression,computed_optional"`
+	Logging          *RulesetRulesLoggingModel          `tfsdk:"logging" json:"logging,optional"`
+	Ref              types.String                       `tfsdk:"ref" json:"ref,computed_optional"`
 }
 
 type RulesetRulesActionParametersModel struct {
-	Response                 *RulesetRulesActionParametersResponseModel          `tfsdk:"response" json:"response,optional"`
-	Algorithms               *[]*RulesetRulesActionParametersAlgorithmsModel     `tfsdk:"algorithms" json:"algorithms,optional"`
-	ID                       types.String                                        `tfsdk:"id" json:"id,optional"`
-	MatchedData              *RulesetRulesActionParametersMatchedDataModel       `tfsdk:"matched_data" json:"matched_data,optional"`
-	Overrides                *RulesetRulesActionParametersOverridesModel         `tfsdk:"overrides" json:"overrides,optional"`
-	FromList                 *RulesetRulesActionParametersFromListModel          `tfsdk:"from_list" json:"from_list,optional"`
-	FromValue                *RulesetRulesActionParametersFromValueModel         `tfsdk:"from_value" json:"from_value,optional"`
-	Headers                  map[string]RulesetRulesActionParametersHeadersModel `tfsdk:"headers" json:"headers,optional"`
-	URI                      *RulesetRulesActionParametersURIModel               `tfsdk:"uri" json:"uri,optional"`
-	HostHeader               types.String                                        `tfsdk:"host_header" json:"host_header,optional"`
-	Origin                   *RulesetRulesActionParametersOriginModel            `tfsdk:"origin" json:"origin,optional"`
-	SNI                      *RulesetRulesActionParametersSNIModel               `tfsdk:"sni" json:"sni,optional"`
-	Increment                types.Int64                                         `tfsdk:"increment" json:"increment,optional"`
-	Content                  types.String                                        `tfsdk:"content" json:"content,optional"`
-	ContentType              types.String                                        `tfsdk:"content_type" json:"content_type,optional"`
-	StatusCode               types.Float64                                       `tfsdk:"status_code" json:"status_code,optional"`
-	AutomaticHTTPSRewrites   types.Bool                                          `tfsdk:"automatic_https_rewrites" json:"automatic_https_rewrites,optional"`
-	Autominify               *RulesetRulesActionParametersAutominifyModel        `tfsdk:"autominify" json:"autominify,optional"`
-	BIC                      types.Bool                                          `tfsdk:"bic" json:"bic,optional"`
-	DisableApps              types.Bool                                          `tfsdk:"disable_apps" json:"disable_apps,optional"`
-	DisableRUM               types.Bool                                          `tfsdk:"disable_rum" json:"disable_rum,optional"`
-	DisableZaraz             types.Bool                                          `tfsdk:"disable_zaraz" json:"disable_zaraz,optional"`
-	EmailObfuscation         types.Bool                                          `tfsdk:"email_obfuscation" json:"email_obfuscation,optional"`
-	Fonts                    types.Bool                                          `tfsdk:"fonts" json:"fonts,optional"`
-	HotlinkProtection        types.Bool                                          `tfsdk:"hotlink_protection" json:"hotlink_protection,optional"`
-	Mirage                   types.Bool                                          `tfsdk:"mirage" json:"mirage,optional"`
-	OpportunisticEncryption  types.Bool                                          `tfsdk:"opportunistic_encryption" json:"opportunistic_encryption,optional"`
-	Polish                   types.String                                        `tfsdk:"polish" json:"polish,optional"`
-	RocketLoader             types.Bool                                          `tfsdk:"rocket_loader" json:"rocket_loader,optional"`
-	SecurityLevel            types.String                                        `tfsdk:"security_level" json:"security_level,optional"`
-	ServerSideExcludes       types.Bool                                          `tfsdk:"server_side_excludes" json:"server_side_excludes,optional"`
-	SSL                      types.String                                        `tfsdk:"ssl" json:"ssl,optional"`
-	SXG                      types.Bool                                          `tfsdk:"sxg" json:"sxg,optional"`
-	Phases                   *[]types.String                                     `tfsdk:"phases" json:"phases,optional"`
-	Products                 *[]types.String                                     `tfsdk:"products" json:"products,optional"`
-	Rules                    map[string]*[]types.String                          `tfsdk:"rules" json:"rules,optional"`
-	Ruleset                  types.String                                        `tfsdk:"ruleset" json:"ruleset,optional"`
-	Rulesets                 *[]types.String                                     `tfsdk:"rulesets" json:"rulesets,optional"`
-	AdditionalCacheablePorts *[]types.Int64                                      `tfsdk:"additional_cacheable_ports" json:"additional_cacheable_ports,optional"`
-	BrowserTTL               *RulesetRulesActionParametersBrowserTTLModel        `tfsdk:"browser_ttl" json:"browser_ttl,optional"`
-	Cache                    types.Bool                                          `tfsdk:"cache" json:"cache,optional"`
-	CacheKey                 *RulesetRulesActionParametersCacheKeyModel          `tfsdk:"cache_key" json:"cache_key,optional"`
-	CacheReserve             *RulesetRulesActionParametersCacheReserveModel      `tfsdk:"cache_reserve" json:"cache_reserve,optional"`
-	EdgeTTL                  *RulesetRulesActionParametersEdgeTTLModel           `tfsdk:"edge_ttl" json:"edge_ttl,optional"`
-	OriginCacheControl       types.Bool                                          `tfsdk:"origin_cache_control" json:"origin_cache_control,optional"`
-	OriginErrorPagePassthru  types.Bool                                          `tfsdk:"origin_error_page_passthru" json:"origin_error_page_passthru,optional"`
-	ReadTimeout              types.Int64                                         `tfsdk:"read_timeout" json:"read_timeout,optional"`
-	RespectStrongEtags       types.Bool                                          `tfsdk:"respect_strong_etags" json:"respect_strong_etags,optional"`
-	ServeStale               *RulesetRulesActionParametersServeStaleModel        `tfsdk:"serve_stale" json:"serve_stale,optional"`
-	CookieFields             *[]*RulesetRulesActionParametersCookieFieldsModel   `tfsdk:"cookie_fields" json:"cookie_fields,optional"`
-	RequestFields            *[]*RulesetRulesActionParametersRequestFieldsModel  `tfsdk:"request_fields" json:"request_fields,optional"`
-	ResponseFields           *[]*RulesetRulesActionParametersResponseFieldsModel `tfsdk:"response_fields" json:"response_fields,optional"`
+	Response                 *RulesetRulesActionParametersResponseModel           `tfsdk:"response" json:"response,optional"`
+	Algorithms               *[]*RulesetRulesActionParametersAlgorithmsModel      `tfsdk:"algorithms" json:"algorithms,optional"`
+	ID                       types.String                                         `tfsdk:"id" json:"id,optional"`
+	MatchedData              *RulesetRulesActionParametersMatchedDataModel        `tfsdk:"matched_data" json:"matched_data,optional"`
+	Overrides                *RulesetRulesActionParametersOverridesModel          `tfsdk:"overrides" json:"overrides,optional"`
+	FromList                 *RulesetRulesActionParametersFromListModel           `tfsdk:"from_list" json:"from_list,optional"`
+	FromValue                *RulesetRulesActionParametersFromValueModel          `tfsdk:"from_value" json:"from_value,optional"`
+	Headers                  *map[string]RulesetRulesActionParametersHeadersModel `tfsdk:"headers" json:"headers,computed_optional"`
+	URI                      *RulesetRulesActionParametersURIModel                `tfsdk:"uri" json:"uri,optional"`
+	HostHeader               types.String                                         `tfsdk:"host_header" json:"host_header,optional"`
+	Origin                   *RulesetRulesActionParametersOriginModel             `tfsdk:"origin" json:"origin,optional"`
+	SNI                      *RulesetRulesActionParametersSNIModel                `tfsdk:"sni" json:"sni,optional"`
+	Increment                types.Int64                                          `tfsdk:"increment" json:"increment,optional"`
+	Content                  types.String                                         `tfsdk:"content" json:"content,optional"`
+	ContentType              types.String                                         `tfsdk:"content_type" json:"content_type,optional"`
+	StatusCode               types.Float64                                        `tfsdk:"status_code" json:"status_code,optional"`
+	AutomaticHTTPSRewrites   types.Bool                                           `tfsdk:"automatic_https_rewrites" json:"automatic_https_rewrites,optional"`
+	Autominify               *RulesetRulesActionParametersAutominifyModel         `tfsdk:"autominify" json:"autominify,optional"`
+	BIC                      types.Bool                                           `tfsdk:"bic" json:"bic,optional"`
+	DisableApps              types.Bool                                           `tfsdk:"disable_apps" json:"disable_apps,optional"`
+	DisableRUM               types.Bool                                           `tfsdk:"disable_rum" json:"disable_rum,optional"`
+	DisableZaraz             types.Bool                                           `tfsdk:"disable_zaraz" json:"disable_zaraz,optional"`
+	EmailObfuscation         types.Bool                                           `tfsdk:"email_obfuscation" json:"email_obfuscation,optional"`
+	Fonts                    types.Bool                                           `tfsdk:"fonts" json:"fonts,optional"`
+	HotlinkProtection        types.Bool                                           `tfsdk:"hotlink_protection" json:"hotlink_protection,optional"`
+	Mirage                   types.Bool                                           `tfsdk:"mirage" json:"mirage,optional"`
+	OpportunisticEncryption  types.Bool                                           `tfsdk:"opportunistic_encryption" json:"opportunistic_encryption,optional"`
+	Polish                   types.String                                         `tfsdk:"polish" json:"polish,optional"`
+	RocketLoader             types.Bool                                           `tfsdk:"rocket_loader" json:"rocket_loader,optional"`
+	SecurityLevel            types.String                                         `tfsdk:"security_level" json:"security_level,optional"`
+	ServerSideExcludes       types.Bool                                           `tfsdk:"server_side_excludes" json:"server_side_excludes,optional"`
+	SSL                      types.String                                         `tfsdk:"ssl" json:"ssl,optional"`
+	SXG                      types.Bool                                           `tfsdk:"sxg" json:"sxg,optional"`
+	Phases                   *[]types.String                                      `tfsdk:"phases" json:"phases,optional"`
+	Products                 *[]types.String                                      `tfsdk:"products" json:"products,optional"`
+	Rules                    customfield.Map[customfield.List[types.String]]      `tfsdk:"rules" json:"rules,optional"`
+	Ruleset                  types.String                                         `tfsdk:"ruleset" json:"ruleset,optional"`
+	Rulesets                 *[]types.String                                      `tfsdk:"rulesets" json:"rulesets,optional"`
+	AdditionalCacheablePorts *[]types.Int64                                       `tfsdk:"additional_cacheable_ports" json:"additional_cacheable_ports,optional"`
+	BrowserTTL               *RulesetRulesActionParametersBrowserTTLModel         `tfsdk:"browser_ttl" json:"browser_ttl,optional"`
+	Cache                    types.Bool                                           `tfsdk:"cache" json:"cache,optional"`
+	CacheKey                 *RulesetRulesActionParametersCacheKeyModel           `tfsdk:"cache_key" json:"cache_key,optional"`
+	CacheReserve             *RulesetRulesActionParametersCacheReserveModel       `tfsdk:"cache_reserve" json:"cache_reserve,optional"`
+	EdgeTTL                  *RulesetRulesActionParametersEdgeTTLModel            `tfsdk:"edge_ttl" json:"edge_ttl,optional"`
+	OriginCacheControl       types.Bool                                           `tfsdk:"origin_cache_control" json:"origin_cache_control,optional"`
+	OriginErrorPagePassthru  types.Bool                                           `tfsdk:"origin_error_page_passthru" json:"origin_error_page_passthru,optional"`
+	ReadTimeout              types.Int64                                          `tfsdk:"read_timeout" json:"read_timeout,optional"`
+	RespectStrongEtags       types.Bool                                           `tfsdk:"respect_strong_etags" json:"respect_strong_etags,optional"`
+	ServeStale               *RulesetRulesActionParametersServeStaleModel         `tfsdk:"serve_stale" json:"serve_stale,optional"`
+	CookieFields             *[]*RulesetRulesActionParametersCookieFieldsModel    `tfsdk:"cookie_fields" json:"cookie_fields,optional"`
+	RequestFields            *[]*RulesetRulesActionParametersRequestFieldsModel   `tfsdk:"request_fields" json:"request_fields,optional"`
+	ResponseFields           *[]*RulesetRulesActionParametersResponseFieldsModel  `tfsdk:"response_fields" json:"response_fields,optional"`
 }
 
 type RulesetRulesActionParametersResponseModel struct {
@@ -261,9 +261,9 @@ type RulesetRulesActionParametersEdgeTTLModel struct {
 }
 
 type RulesetRulesActionParametersEdgeTTLStatusCodeTTLModel struct {
-	Value           types.Int64                                                                                    `tfsdk:"value" json:"value,required"`
-	StatusCodeRange customfield.NestedObject[RulesetRulesActionParametersEdgeTTLStatusCodeTTLStatusCodeRangeModel] `tfsdk:"status_code_range" json:"status_code_range,computed_optional"`
-	StatusCode      types.Int64                                                                                    `tfsdk:"status_code" json:"status_code,computed_optional"`
+	Value           types.Int64                                                           `tfsdk:"value" json:"value,required"`
+	StatusCodeRange *RulesetRulesActionParametersEdgeTTLStatusCodeTTLStatusCodeRangeModel `tfsdk:"status_code_range" json:"status_code_range,optional"`
+	StatusCode      types.Int64                                                           `tfsdk:"status_code" json:"status_code,computed_optional"`
 }
 
 type RulesetRulesActionParametersEdgeTTLStatusCodeTTLStatusCodeRangeModel struct {

--- a/internal/services/ruleset/model.go
+++ b/internal/services/ruleset/model.go
@@ -35,19 +35,19 @@ func (m RulesetModel) MarshalJSONForUpdate(state RulesetModel) (data []byte, err
 }
 
 type RulesetRulesModel struct {
-	LastUpdated      timetypes.RFC3339                  `tfsdk:"last_updated" json:"last_updated,computed" format:"date-time"`
-	Version          types.String                       `tfsdk:"version" json:"version,computed"`
-	ID               types.String                       `tfsdk:"id" json:"id,computed"`
-	Action           types.String                       `tfsdk:"action" json:"action,computed_optional"`
-	ActionParameters *RulesetRulesActionParametersModel `tfsdk:"action_parameters" json:"action_parameters,optional"`
-	Categories       customfield.List[types.String]     `tfsdk:"categories" json:"categories,computed"`
-	Description      types.String                       `tfsdk:"description" json:"description,computed_optional"`
-	Enabled          types.Bool                         `tfsdk:"enabled" json:"enabled,computed_optional"`
-  ExposedCredentialCheck *RulesetRulesExposedCredentialCheckModel `tfsdk:"exposed_credential_check" json:"exposed_credential_check,optional"`
-	Expression       types.String                       `tfsdk:"expression" json:"expression,computed_optional"`
-	Logging          *RulesetRulesLoggingModel          `tfsdk:"logging" json:"logging,optional"`
-  Ratelimit              *RulesetRulesRatelimitModel              `tfsdk:"ratelimit" json:"ratelimit,optional"`
-	Ref              types.String                       `tfsdk:"ref" json:"ref,computed_optional"`
+	LastUpdated            timetypes.RFC3339                        `tfsdk:"last_updated" json:"last_updated,computed" format:"date-time"`
+	Version                types.String                             `tfsdk:"version" json:"version,computed"`
+	ID                     types.String                             `tfsdk:"id" json:"id,computed"`
+	Action                 types.String                             `tfsdk:"action" json:"action,computed_optional"`
+	ActionParameters       *RulesetRulesActionParametersModel       `tfsdk:"action_parameters" json:"action_parameters,optional"`
+	Categories             customfield.List[types.String]           `tfsdk:"categories" json:"categories,computed"`
+	Description            types.String                             `tfsdk:"description" json:"description,computed_optional"`
+	Enabled                types.Bool                               `tfsdk:"enabled" json:"enabled,computed_optional"`
+	ExposedCredentialCheck *RulesetRulesExposedCredentialCheckModel `tfsdk:"exposed_credential_check" json:"exposed_credential_check,optional"`
+	Expression             types.String                             `tfsdk:"expression" json:"expression,computed_optional"`
+	Logging                *RulesetRulesLoggingModel                `tfsdk:"logging" json:"logging,optional"`
+	Ratelimit              *RulesetRulesRatelimitModel              `tfsdk:"ratelimit" json:"ratelimit,optional"`
+	Ref                    types.String                             `tfsdk:"ref" json:"ref,computed_optional"`
 }
 
 type RulesetRulesActionParametersModel struct {

--- a/internal/services/ruleset/schema.go
+++ b/internal/services/ruleset/schema.go
@@ -106,7 +106,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"id": schema.StringAttribute{
 							Description: "The unique ID of the rule.",
-							Optional:    true,
+							Computed:    true,
 						},
 						"action": schema.StringAttribute{
 							Description: "The action to perform when the rule matches.",
@@ -345,7 +345,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"operation": schema.StringAttribute{
-												Required: true,
+												Computed: true,
+												Optional: true,
 												Validators: []validator.String{
 													stringvalidator.OneOfCaseInsensitive("remove", "set"),
 												},
@@ -617,6 +618,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								"rules": schema.MapAttribute{
 									Description: "A mapping of ruleset IDs to a list of rule IDs in that ruleset to skip the execution of. This option is incompatible with the ruleset option.",
 									Optional:    true,
+									CustomType:  customfield.NewMapType[customfield.List[types.String]](ctx),
 									ElementType: types.ListType{
 										ElemType: types.StringType,
 									},
@@ -804,7 +806,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										},
 										"minimum_file_size": schema.Int64Attribute{
 											Description: "The minimum file size eligible for store in cache reserve.",
-											Required:    true,
+											Optional:    true,
 										},
 									},
 								},
@@ -814,7 +816,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									Attributes: map[string]schema.Attribute{
 										"default": schema.Int64Attribute{
 											Description: "The TTL (in seconds) if you choose override_origin mode.",
-											Required:    true,
+											Optional:    true,
 											Validators: []validator.Int64{
 												int64validator.Between(0, math.MaxInt64),
 											},
@@ -832,7 +834,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										},
 										"status_code_ttl": schema.ListNestedAttribute{
 											Description: "List of single status codes, or status code ranges to apply the selected mode",
-											Required:    true,
+											Optional:    true,
 											NestedObject: schema.NestedAttributeObject{
 												Attributes: map[string]schema.Attribute{
 													"value": schema.Int64Attribute{
@@ -845,15 +847,15 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 														Attributes: map[string]schema.Attribute{
 															"from": schema.Int64Attribute{
 																Description: "response status code lower bound",
-																Required:    true,
+																Optional:    true,
 															},
 															"to": schema.Int64Attribute{
 																Description: "response status code upper bound",
-																Required:    true,
+																Optional:    true,
 															},
 														},
 													},
-													"status_code_value": schema.Int64Attribute{
+													"status_code": schema.Int64Attribute{
 														Description: "Set the ttl for responses with this specific status code",
 														Optional:    true,
 													},
@@ -961,6 +963,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"ref": schema.StringAttribute{
 							Description: "The reference of the rule (the rule ID by default).",
 							Optional:    true,
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/services/ruleset/schema.go
+++ b/internal/services/ruleset/schema.go
@@ -106,11 +106,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"id": schema.StringAttribute{
 							Description: "The unique ID of the rule.",
-							Computed:    true,
+							Optional:    true,
 						},
 						"action": schema.StringAttribute{
 							Description: "The action to perform when the rule matches.",
-							Computed:    true,
 							Optional:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOfCaseInsensitive(
@@ -137,15 +136,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"action_parameters": schema.SingleNestedAttribute{
 							Description: "The parameters configuring the rule's action.",
-							Computed:    true,
 							Optional:    true,
-							CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"response": schema.SingleNestedAttribute{
 									Description: "The response to show when the block is applied.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersResponseModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"content": schema.StringAttribute{
 											Description: "The content to return.",
@@ -166,14 +161,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"algorithms": schema.ListNestedAttribute{
 									Description: "Custom order for compression algorithms.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersAlgorithmsModel](ctx),
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"name": schema.StringAttribute{
 												Description: "Name of compression algorithm to enable.",
-												Computed:    true,
 												Optional:    true,
 												Validators: []validator.String{
 													stringvalidator.OneOfCaseInsensitive(
@@ -190,14 +182,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"id": schema.StringAttribute{
 									Description: "The ID of the ruleset to execute.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"matched_data": schema.SingleNestedAttribute{
 									Description: "The configuration to use for matched data logging.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersMatchedDataModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"public_key": schema.StringAttribute{
 											Description: "The public key to encrypt matched data logs with.",
@@ -207,20 +196,15 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"overrides": schema.SingleNestedAttribute{
 									Description: "A set of overrides to apply to the target ruleset.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersOverridesModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"action": schema.StringAttribute{
 											Description: "An action to override all rules with. This option has lower precedence than rule and category overrides.",
-											Computed:    true,
 											Optional:    true,
 										},
 										"categories": schema.ListNestedAttribute{
 											Description: "A list of category-level overrides. This option has the second-highest precedence after rule-level overrides.",
-											Computed:    true,
 											Optional:    true,
-											CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersOverridesCategoriesModel](ctx),
 											NestedObject: schema.NestedAttributeObject{
 												Attributes: map[string]schema.Attribute{
 													"category": schema.StringAttribute{
@@ -229,17 +213,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 													},
 													"action": schema.StringAttribute{
 														Description: "The action to override rules in the category with.",
-														Computed:    true,
 														Optional:    true,
 													},
 													"enabled": schema.BoolAttribute{
 														Description: "Whether to enable execution of rules in the category.",
-														Computed:    true,
 														Optional:    true,
 													},
 													"sensitivity_level": schema.StringAttribute{
 														Description: "The sensitivity level to use for rules in the category.",
-														Computed:    true,
 														Optional:    true,
 														Validators: []validator.String{
 															stringvalidator.OneOfCaseInsensitive(
@@ -259,9 +240,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										},
 										"rules": schema.ListNestedAttribute{
 											Description: "A list of rule-level overrides. This option has the highest precedence.",
-											Computed:    true,
 											Optional:    true,
-											CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersOverridesRulesModel](ctx),
 											NestedObject: schema.NestedAttributeObject{
 												Attributes: map[string]schema.Attribute{
 													"id": schema.StringAttribute{
@@ -270,22 +249,18 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 													},
 													"action": schema.StringAttribute{
 														Description: "The action to override the rule with.",
-														Computed:    true,
 														Optional:    true,
 													},
 													"enabled": schema.BoolAttribute{
 														Description: "Whether to enable execution of the rule.",
-														Computed:    true,
 														Optional:    true,
 													},
 													"score_threshold": schema.Int64Attribute{
 														Description: "The score threshold to use for the rule.",
-														Computed:    true,
 														Optional:    true,
 													},
 													"sensitivity_level": schema.StringAttribute{
 														Description: "The sensitivity level to use for the rule.",
-														Computed:    true,
 														Optional:    true,
 														Validators: []validator.String{
 															stringvalidator.OneOfCaseInsensitive(
@@ -301,7 +276,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										},
 										"sensitivity_level": schema.StringAttribute{
 											Description: "A sensitivity level to set for all rules. This option has lower precedence than rule and category overrides and is only applicable for DDoS phases.",
-											Computed:    true,
 											Optional:    true,
 											Validators: []validator.String{
 												stringvalidator.OneOfCaseInsensitive(
@@ -316,36 +290,28 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"from_list": schema.SingleNestedAttribute{
 									Description: "Serve a redirect based on a bulk list lookup.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersFromListModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"key": schema.StringAttribute{
 											Description: "Expression that evaluates to the list lookup key.",
-											Computed:    true,
 											Optional:    true,
 										},
 										"name": schema.StringAttribute{
 											Description: "The name of the list to match against.",
-											Computed:    true,
 											Optional:    true,
 										},
 									},
 								},
 								"from_value": schema.SingleNestedAttribute{
 									Description: "Serve a redirect based on the request properties.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersFromValueModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"preserve_query_string": schema.BoolAttribute{
 											Description: "Keep the query string of the original request.",
-											Computed:    true,
 											Optional:    true,
 										},
 										"status_code": schema.Float64Attribute{
 											Description: "The status code to be used for the redirect.",
-											Computed:    true,
 											Optional:    true,
 											Validators: []validator.Float64{
 												float64validator.OneOf(
@@ -359,18 +325,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										},
 										"target_url": schema.SingleNestedAttribute{
 											Description: "The URL to redirect the request to.",
-											Computed:    true,
 											Optional:    true,
-											CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersFromValueTargetURLModel](ctx),
 											Attributes: map[string]schema.Attribute{
 												"value": schema.StringAttribute{
 													Description: "The URL to redirect the request to.",
-													Computed:    true,
 													Optional:    true,
 												},
 												"expression": schema.StringAttribute{
 													Description: "An expression to evaluate to get the URL to redirect the request to.",
-													Computed:    true,
 													Optional:    true,
 												},
 											},
@@ -379,26 +341,21 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"headers": schema.MapNestedAttribute{
 									Description: "Map of request headers to modify.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectMapType[RulesetRulesActionParametersHeadersModel](ctx),
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"operation": schema.StringAttribute{
-												Computed: true,
-												Optional: true,
+												Required: true,
 												Validators: []validator.String{
 													stringvalidator.OneOfCaseInsensitive("remove", "set"),
 												},
 											},
 											"value": schema.StringAttribute{
 												Description: "Static value for the header.",
-												Computed:    true,
 												Optional:    true,
 											},
 											"expression": schema.StringAttribute{
 												Description: "Expression for the header value.",
-												Computed:    true,
 												Optional:    true,
 											},
 										},
@@ -406,42 +363,32 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"uri": schema.SingleNestedAttribute{
 									Description: "URI to rewrite the request to.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersURIModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"path": schema.SingleNestedAttribute{
 											Description: "Path portion rewrite.",
-											Computed:    true,
 											Optional:    true,
-											CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersURIPathModel](ctx),
 											Attributes: map[string]schema.Attribute{
 												"value": schema.StringAttribute{
 													Description: "Predefined replacement value.",
-													Computed:    true,
 													Optional:    true,
 												},
 												"expression": schema.StringAttribute{
 													Description: "Expression to evaluate for the replacement value.",
-													Computed:    true,
 													Optional:    true,
 												},
 											},
 										},
 										"query": schema.SingleNestedAttribute{
 											Description: "Query portion rewrite.",
-											Computed:    true,
 											Optional:    true,
-											CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersURIQueryModel](ctx),
 											Attributes: map[string]schema.Attribute{
 												"value": schema.StringAttribute{
 													Description: "Predefined replacement value.",
-													Computed:    true,
 													Optional:    true,
 												},
 												"expression": schema.StringAttribute{
 													Description: "Expression to evaluate for the replacement value.",
-													Computed:    true,
 													Optional:    true,
 												},
 											},
@@ -450,23 +397,18 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"host_header": schema.StringAttribute{
 									Description: "Rewrite the HTTP Host header.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"origin": schema.SingleNestedAttribute{
 									Description: "Override the IP/TCP destination.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersOriginModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"host": schema.StringAttribute{
 											Description: "Override the resolved hostname.",
-											Computed:    true,
 											Optional:    true,
 										},
 										"port": schema.Float64Attribute{
 											Description: "Override the destination port.",
-											Computed:    true,
 											Optional:    true,
 											Validators: []validator.Float64{
 												float64validator.Between(1, 65535),
@@ -476,9 +418,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"sni": schema.SingleNestedAttribute{
 									Description: "Override the Server Name Indication (SNI).",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersSNIModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"value": schema.StringAttribute{
 											Description: "The SNI override.",
@@ -488,17 +428,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"increment": schema.Int64Attribute{
 									Description: "Increment contains the delta to change the score and can be either positive or negative.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"content": schema.StringAttribute{
 									Description: "Error response content.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"content_type": schema.StringAttribute{
 									Description: "Content-type header to set with the response.",
-									Computed:    true,
 									Optional:    true,
 									Validators: []validator.String{
 										stringvalidator.OneOfCaseInsensitive(
@@ -511,7 +448,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"status_code": schema.Float64Attribute{
 									Description: "The status code to use for the error.",
-									Computed:    true,
 									Optional:    true,
 									Validators: []validator.Float64{
 										float64validator.Between(400, 999),
@@ -519,80 +455,64 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"automatic_https_rewrites": schema.BoolAttribute{
 									Description: "Turn on or off Automatic HTTPS Rewrites.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"autominify": schema.SingleNestedAttribute{
 									Description: "Select which file extensions to minify automatically.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersAutominifyModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"css": schema.BoolAttribute{
 											Description: "Minify CSS files.",
-											Computed:    true,
 											Optional:    true,
 										},
 										"html": schema.BoolAttribute{
 											Description: "Minify HTML files.",
-											Computed:    true,
 											Optional:    true,
 										},
 										"js": schema.BoolAttribute{
 											Description: "Minify JS files.",
-											Computed:    true,
 											Optional:    true,
 										},
 									},
 								},
 								"bic": schema.BoolAttribute{
 									Description: "Turn on or off Browser Integrity Check.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"disable_apps": schema.BoolAttribute{
 									Description: "Turn off all active Cloudflare Apps.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"disable_rum": schema.BoolAttribute{
 									Description: "Turn off Real User Monitoring (RUM).",
-									Computed:    true,
 									Optional:    true,
 								},
 								"disable_zaraz": schema.BoolAttribute{
 									Description: "Turn off Zaraz.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"email_obfuscation": schema.BoolAttribute{
 									Description: "Turn on or off Email Obfuscation.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"fonts": schema.BoolAttribute{
 									Description: "Turn on or off Cloudflare Fonts.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"hotlink_protection": schema.BoolAttribute{
 									Description: "Turn on or off the Hotlink Protection.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"mirage": schema.BoolAttribute{
 									Description: "Turn on or off Mirage.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"opportunistic_encryption": schema.BoolAttribute{
 									Description: "Turn on or off Opportunistic Encryption.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"polish": schema.StringAttribute{
 									Description: "Configure the Polish level.",
-									Computed:    true,
 									Optional:    true,
 									Validators: []validator.String{
 										stringvalidator.OneOfCaseInsensitive(
@@ -604,12 +524,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"rocket_loader": schema.BoolAttribute{
 									Description: "Turn on or off Rocket Loader",
-									Computed:    true,
 									Optional:    true,
 								},
 								"security_level": schema.StringAttribute{
 									Description: "Configure the Security Level.",
-									Computed:    true,
 									Optional:    true,
 									Validators: []validator.String{
 										stringvalidator.OneOfCaseInsensitive(
@@ -624,12 +542,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"server_side_excludes": schema.BoolAttribute{
 									Description: "Turn on or off Server Side Excludes.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"ssl": schema.StringAttribute{
 									Description: "Configure the SSL level.",
-									Computed:    true,
 									Optional:    true,
 									Validators: []validator.String{
 										stringvalidator.OneOfCaseInsensitive(
@@ -643,12 +559,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"sxg": schema.BoolAttribute{
 									Description: "Turn on or off Signed Exchanges (SXG).",
-									Computed:    true,
 									Optional:    true,
 								},
 								"phases": schema.ListAttribute{
 									Description: "A list of phases to skip the execution of. This option is incompatible with the ruleset and rulesets options.",
-									Computed:    true,
 									Optional:    true,
 									Validators: []validator.List{
 										listvalidator.ValueStringsAre(
@@ -680,12 +594,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 											),
 										),
 									},
-									CustomType:  customfield.NewListType[types.String](ctx),
 									ElementType: types.StringType,
 								},
 								"products": schema.ListAttribute{
 									Description: "A list of legacy security products to skip the execution of.",
-									Computed:    true,
 									Optional:    true,
 									Validators: []validator.List{
 										listvalidator.ValueStringsAre(
@@ -700,21 +612,17 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 											),
 										),
 									},
-									CustomType:  customfield.NewListType[types.String](ctx),
 									ElementType: types.StringType,
 								},
 								"rules": schema.MapAttribute{
 									Description: "A mapping of ruleset IDs to a list of rule IDs in that ruleset to skip the execution of. This option is incompatible with the ruleset option.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewMapType[customfield.List[types.String]](ctx),
 									ElementType: types.ListType{
 										ElemType: types.StringType,
 									},
 								},
 								"ruleset": schema.StringAttribute{
 									Description: "A ruleset to skip the execution of. This option is incompatible with the rulesets, rules and phases options.",
-									Computed:    true,
 									Optional:    true,
 									Validators: []validator.String{
 										stringvalidator.OneOfCaseInsensitive("current"),
@@ -722,23 +630,17 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"rulesets": schema.ListAttribute{
 									Description: "A list of ruleset IDs to skip the execution of. This option is incompatible with the ruleset and phases options.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewListType[types.String](ctx),
 									ElementType: types.StringType,
 								},
 								"additional_cacheable_ports": schema.ListAttribute{
 									Description: "List of additional ports that caching can be enabled on.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewListType[types.Int64](ctx),
 									ElementType: types.Int64Type,
 								},
 								"browser_ttl": schema.SingleNestedAttribute{
 									Description: "Specify how long client browsers should cache the response. Cloudflare cache purge will not purge content cached on client browsers, so high browser TTLs may lead to stale content.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersBrowserTTLModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"mode": schema.StringAttribute{
 											Description: "Determines which browser ttl mode to use.",
@@ -753,151 +655,113 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										},
 										"default": schema.Int64Attribute{
 											Description: "The TTL (in seconds) if you choose override_origin mode.",
-											Computed:    true,
 											Optional:    true,
 										},
 									},
 								},
 								"cache": schema.BoolAttribute{
 									Description: "Mark whether the request’s response from origin is eligible for caching. Caching itself will still depend on the cache-control header and your other caching configurations.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"cache_key": schema.SingleNestedAttribute{
 									Description: "Define which components of the request are included or excluded from the cache key Cloudflare uses to store the response in cache.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"cache_by_device_type": schema.BoolAttribute{
 											Description: "Separate cached content based on the visitor’s device type",
-											Computed:    true,
 											Optional:    true,
 										},
 										"cache_deception_armor": schema.BoolAttribute{
 											Description: "Protect from web cache deception attacks while allowing static assets to be cached",
-											Computed:    true,
 											Optional:    true,
 										},
 										"custom_key": schema.SingleNestedAttribute{
 											Description: "Customize which components of the request are included or excluded from the cache key.",
-											Computed:    true,
 											Optional:    true,
-											CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyModel](ctx),
 											Attributes: map[string]schema.Attribute{
 												"cookie": schema.SingleNestedAttribute{
 													Description: "The cookies to include in building the cache key.",
-													Computed:    true,
 													Optional:    true,
-													CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyCookieModel](ctx),
 													Attributes: map[string]schema.Attribute{
 														"check_presence": schema.ListAttribute{
 															Description: "Checks for the presence of these cookie names. The presence of these cookies is used in building the cache key.",
-															Computed:    true,
 															Optional:    true,
-															CustomType:  customfield.NewListType[types.String](ctx),
 															ElementType: types.StringType,
 														},
 														"include": schema.ListAttribute{
 															Description: "Include these cookies' names and their values.",
-															Computed:    true,
 															Optional:    true,
-															CustomType:  customfield.NewListType[types.String](ctx),
 															ElementType: types.StringType,
 														},
 													},
 												},
 												"header": schema.SingleNestedAttribute{
 													Description: "The header names and values to include in building the cache key.",
-													Computed:    true,
 													Optional:    true,
-													CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyHeaderModel](ctx),
 													Attributes: map[string]schema.Attribute{
 														"check_presence": schema.ListAttribute{
 															Description: "Checks for the presence of these header names. The presence of these headers is used in building the cache key.",
-															Computed:    true,
 															Optional:    true,
-															CustomType:  customfield.NewListType[types.String](ctx),
 															ElementType: types.StringType,
 														},
 														"contains": schema.MapAttribute{
 															Description: "For each header name and list of values combination, check if the request header contains any of the values provided. The presence of the request header and whether any of the values provided are contained in the request header value is used in building the cache key.",
-															Computed:    true,
 															Optional:    true,
-															CustomType:  customfield.NewMapType[customfield.List[types.String]](ctx),
 															ElementType: types.ListType{
 																ElemType: types.StringType,
 															},
 														},
 														"exclude_origin": schema.BoolAttribute{
 															Description: "Whether or not to include the origin header. A value of true will exclude the origin header in the cache key.",
-															Computed:    true,
 															Optional:    true,
 														},
 														"include": schema.ListAttribute{
 															Description: "Include these headers' names and their values.",
-															Computed:    true,
 															Optional:    true,
-															CustomType:  customfield.NewListType[types.String](ctx),
 															ElementType: types.StringType,
 														},
 													},
 												},
 												"host": schema.SingleNestedAttribute{
 													Description: "Whether to use the original host or the resolved host in the cache key.",
-													Computed:    true,
 													Optional:    true,
-													CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyHostModel](ctx),
 													Attributes: map[string]schema.Attribute{
 														"resolved": schema.BoolAttribute{
 															Description: "Use the resolved host in the cache key. A value of true will use the resolved host, while a value or false will use the original host.",
-															Computed:    true,
 															Optional:    true,
 														},
 													},
 												},
 												"query_string": schema.SingleNestedAttribute{
 													Description: "Use the presence or absence of parameters in the query string to build the cache key.",
-
-													Optional:   true,
-													CustomType: customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyQueryStringModel](ctx),
+													Optional:    true,
 													Attributes: map[string]schema.Attribute{
 														"exclude": schema.SingleNestedAttribute{
 															Description: "build the cache key using all query string parameters EXCECPT these excluded parameters",
-															Computed:    true,
 															Optional:    true,
-															CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyQueryStringExcludeModel](ctx),
 															Attributes: map[string]schema.Attribute{
 																"all": schema.BoolAttribute{
 																	Description: "Exclude all query string parameters from use in building the cache key.",
-																	Computed:    true,
 																	Optional:    true,
 																},
 																"list": schema.ListAttribute{
 																	Description: "A list of query string parameters NOT used to build the cache key. All parameters present in the request but missing in this list will be used to build the cache key.",
-																	Computed:    true,
 																	Optional:    true,
-																	CustomType:  customfield.NewListType[types.String](ctx),
 																	ElementType: types.StringType,
 																},
 															},
 														},
 														"include": schema.SingleNestedAttribute{
 															Description: "build the cache key using a list of query string parameters that ARE in the request.",
-															Computed:    true,
 															Optional:    true,
-															CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyQueryStringIncludeModel](ctx),
 															Attributes: map[string]schema.Attribute{
 																"all": schema.BoolAttribute{
 																	Description: "Use all query string parameters in the cache key.",
-																	Computed:    true,
 																	Optional:    true,
 																},
 																"list": schema.ListAttribute{
 																	Description: "A list of query string parameters used to build the cache key.",
-																	Computed:    true,
 																	Optional:    true,
-																	CustomType:  customfield.NewListType[types.String](ctx),
 																	ElementType: types.StringType,
 																},
 															},
@@ -906,23 +770,18 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 												},
 												"user": schema.SingleNestedAttribute{
 													Description: "Characteristics of the request user agent used in building the cache key.",
-													Computed:    true,
 													Optional:    true,
-													CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyUserModel](ctx),
 													Attributes: map[string]schema.Attribute{
 														"device_type": schema.BoolAttribute{
 															Description: "Use the user agent's device type in the cache key.",
-															Computed:    true,
 															Optional:    true,
 														},
 														"geo": schema.BoolAttribute{
 															Description: "Use the user agents's country in the cache key.",
-															Computed:    true,
 															Optional:    true,
 														},
 														"lang": schema.BoolAttribute{
 															Description: "Use the user agent's language in the cache key.",
-															Computed:    true,
 															Optional:    true,
 														},
 													},
@@ -931,16 +790,13 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										},
 										"ignore_query_strings_order": schema.BoolAttribute{
 											Description: "Treat requests with the same query parameters the same, regardless of the order those query parameters are in. A value of true ignores the query strings' order.",
-											Computed:    true,
 											Optional:    true,
 										},
 									},
 								},
 								"cache_reserve": schema.SingleNestedAttribute{
 									Description: "Mark whether the request's response from origin is eligible for  Cache Reserve (requires a Cache Reserve add-on plan).",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheReserveModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"eligible": schema.BoolAttribute{
 											Description: "Determines whether cache reserve is enabled. If this is true and a request meets eligibility criteria, Cloudflare will write the resource to cache reserve.",
@@ -948,19 +804,17 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										},
 										"minimum_file_size": schema.Int64Attribute{
 											Description: "The minimum file size eligible for store in cache reserve.",
-											Optional:    true,
+											Required:    true,
 										},
 									},
 								},
 								"edge_ttl": schema.SingleNestedAttribute{
 									Description: "TTL (Time to Live) specifies the maximum time to cache a resource in the Cloudflare edge network.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersEdgeTTLModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"default": schema.Int64Attribute{
 											Description: "The TTL (in seconds) if you choose override_origin mode.",
-											Optional:    true,
+											Required:    true,
 											Validators: []validator.Int64{
 												int64validator.Between(0, math.MaxInt64),
 											},
@@ -978,7 +832,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										},
 										"status_code_ttl": schema.ListNestedAttribute{
 											Description: "List of single status codes, or status code ranges to apply the selected mode",
-											Optional:    true,
+											Required:    true,
 											NestedObject: schema.NestedAttributeObject{
 												Attributes: map[string]schema.Attribute{
 													"value": schema.Int64Attribute{
@@ -987,23 +841,20 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 													},
 													"status_code_range": schema.SingleNestedAttribute{
 														Description: "The range of status codes used to apply the selected mode.",
-														Computed:    true,
 														Optional:    true,
-														CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersEdgeTTLStatusCodeTTLStatusCodeRangeModel](ctx),
 														Attributes: map[string]schema.Attribute{
 															"from": schema.Int64Attribute{
 																Description: "response status code lower bound",
-																Optional:    true,
+																Required:    true,
 															},
 															"to": schema.Int64Attribute{
 																Description: "response status code upper bound",
-																Optional:    true,
+																Required:    true,
 															},
 														},
 													},
-													"status_code": schema.Int64Attribute{
+													"status_code_value": schema.Int64Attribute{
 														Description: "Set the ttl for responses with this specific status code",
-														Computed:    true,
 														Optional:    true,
 													},
 												},
@@ -1013,29 +864,23 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"origin_cache_control": schema.BoolAttribute{
 									Description: "When enabled, Cloudflare will aim to strictly adhere to RFC 7234.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"origin_error_page_passthru": schema.BoolAttribute{
 									Description: "Generate Cloudflare error pages from issues sent from the origin server. When on, error pages will trigger for issues from the origin",
-									Computed:    true,
 									Optional:    true,
 								},
 								"read_timeout": schema.Int64Attribute{
 									Description: "Define a timeout value between two successive read operations to your origin server. Historically, the timeout value between two read options from Cloudflare to an origin server is 100 seconds. If you are attempting to reduce HTTP 524 errors because of timeouts from an origin server, try increasing this timeout value.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"respect_strong_etags": schema.BoolAttribute{
 									Description: "Specify whether or not Cloudflare should respect strong ETag (entity tag) headers. When off, Cloudflare converts strong ETag headers to weak ETag headers.",
-									Computed:    true,
 									Optional:    true,
 								},
 								"serve_stale": schema.SingleNestedAttribute{
 									Description: "Define if Cloudflare should serve stale content while getting the latest content from the origin. If on, Cloudflare will not serve stale content while getting the latest content from the origin.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersServeStaleModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"disable_stale_while_updating": schema.BoolAttribute{
 											Description: "Defines whether Cloudflare should serve stale content while updating. If true, Cloudflare will not serve stale content while getting the latest content from the origin.",
@@ -1045,9 +890,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"cookie_fields": schema.ListNestedAttribute{
 									Description: "The cookie fields to log.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersCookieFieldsModel](ctx),
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"name": schema.StringAttribute{
@@ -1059,9 +902,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"request_fields": schema.ListNestedAttribute{
 									Description: "The request fields to log.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersRequestFieldsModel](ctx),
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"name": schema.StringAttribute{
@@ -1073,9 +914,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"response_fields": schema.ListNestedAttribute{
 									Description: "The response fields to log.",
-									Computed:    true,
 									Optional:    true,
-									CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersResponseFieldsModel](ctx),
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"name": schema.StringAttribute{
@@ -1107,14 +946,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"expression": schema.StringAttribute{
 							Description: "The expression defining which traffic will match the rule.",
-							Computed:    true,
 							Optional:    true,
 						},
 						"logging": schema.SingleNestedAttribute{
 							Description: "An object configuring the rule's logging behavior.",
-							Computed:    true,
 							Optional:    true,
-							CustomType:  customfield.NewNestedObjectType[RulesetRulesLoggingModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"enabled": schema.BoolAttribute{
 									Description: "Whether to generate a log when the rule matches.",
@@ -1124,7 +960,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"ref": schema.StringAttribute{
 							Description: "The reference of the rule (the rule ID by default).",
-							Computed:    true,
 							Optional:    true,
 						},
 					},


### PR DESCRIPTION
This change updates the model and schema to roughly match the custom code changes that were made prior to codegen updating the configurability for many properties.

The same ruleset tests now pass that were passing before.