### PR TITLE
Support SentinelOne's operational_state integration field

### DIFF
--- a/.changelog/4200.txt
+++ b/.changelog/4200.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_device_posture_rule: Add support for SentinelOne posture check operational_state field
+```

--- a/docs/resources/device_posture_rule.md
+++ b/docs/resources/device_posture_rule.md
@@ -81,6 +81,7 @@ Optional:
 - `locations` (Block List) List of operating system locations to check for a client certificate.. (see [below for nested schema](#nestedblock--input--locations))
 - `network_status` (String) The network status from SentinelOne. Available values: `connected`, `disconnected`, `disconnecting`, `connecting`.
 - `operator` (String) The version comparison operator. Available values: `>`, `>=`, `<`, `<=`, `==`.
+- `operational_state` (String) The current operational state of a SentinelOne Agent.
 - `os` (String) OS signal score from Crowdstrike. Value must be between 1 and 100.
 - `os_distro_name` (String) The operating system excluding version information.
 - `os_distro_revision` (String) The operating system version excluding OS name information or release name.

--- a/docs/resources/zero_trust_device_posture_rule.md
+++ b/docs/resources/zero_trust_device_posture_rule.md
@@ -81,6 +81,7 @@ Optional:
 - `locations` (Block List) List of operating system locations to check for a client certificate.. (see [below for nested schema](#nestedblock--input--locations))
 - `network_status` (String) The network status from SentinelOne. Available values: `connected`, `disconnected`, `disconnecting`, `connecting`.
 - `operator` (String) The version comparison operator. Available values: `>`, `>=`, `<`, `<=`, `==`.
+- `operational_state` (String) The current operational state of a SentinelOne Agent.
 - `os` (String) OS signal score from Crowdstrike. Value must be between 1 and 100.
 - `os_distro_name` (String) The operating system excluding version information.
 - `os_distro_revision` (String) The operating system version excluding OS name information or release name.

--- a/internal/sdkv2provider/resource_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/resource_cloudflare_device_posture_rule.go
@@ -263,6 +263,9 @@ func setDevicePostureRuleInput(rule *cloudflare.DevicePostureRule, d *schema.Res
 		if activeThreats, ok := d.GetOk("input.0.active_threats"); ok {
 			input.ActiveThreats = activeThreats.(int)
 		}
+		if operationalState, ok := d.GetOk("input.0.operational_state"); ok {
+			input.OperationalState = operationalState.(*string)
+		}
 		if networkStatus, ok := d.GetOk("input.0.network_status"); ok {
 			input.NetworkStatus = networkStatus.(string)
 		}
@@ -385,6 +388,7 @@ func convertInputToSchema(input cloudflare.DevicePostureRuleInput) []map[string]
 		"certificate_id":     input.CertificateID,
 		"cn":                 input.CommonName,
 		"active_threats":     input.ActiveThreats,
+		"operational_state":  input.OperationalState,
 		"network_status":     input.NetworkStatus,
 		"infected":           input.Infected,
 		"is_active":          input.IsActive,

--- a/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
+++ b/internal/sdkv2provider/schema_cloudflare_device_posture_rule.go
@@ -217,6 +217,12 @@ func resourceCloudflareDevicePostureRuleSchema() map[string]*schema.Schema {
 						Optional:    true,
 						Description: "The number of active threats from SentinelOne.",
 					},
+					"operational_state": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice([]string{"na", "partially_disabled", "auto_fully_disabled", "fully_disabled", "auto_partially_disabled", "disabled_error", "db_corruption"}, true),
+						Description:  fmt.Sprintf("The current operational state of a SentinelOne Agent. %s", renderAvailableDocumentationValuesStringSlice([]string{"na", "partially_disabled", "auto_fully_disabled", "fully_disabled", "auto_partially_disabled", "disabled_error", "db_corruption"})),
+					},
 					"network_status": {
 						Type:         schema.TypeString,
 						Optional:     true,


### PR DESCRIPTION
Add support for the operational_state SentinelOne Agent field for ZT Dash admins to use in Service Provider Posture Rules. This PR is dependent on a cloudflare-go PR being merged: https://github.com/cloudflare/cloudflare-go/pull/3234