### PR TITLE
fix: add SSL.com as valid certificate authority for cloudflare_certificate_pack

### DIFF
--- a/.changelog/4267.txt
+++ b/.changelog/4267.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:enhancement
 resource/cloudflare_certificate_pack: Add SSL.com as valid certificate authority
 ```

--- a/.changelog/4267.txt
+++ b/.changelog/4267.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_certificate_pack: Add SSL.com as valid certificate authority
+```

--- a/docs/resources/certificate_pack.md
+++ b/docs/resources/certificate_pack.md
@@ -51,7 +51,7 @@ resource "cloudflare_certificate_pack" "example" {
 
 ### Required
 
-- `certificate_authority` (String) Which certificate authority to issue the certificate pack. Available values: `digicert`, `lets_encrypt`, `google`. **Modifying this attribute will force creation of a new resource.**
+- `certificate_authority` (String) Which certificate authority to issue the certificate pack. Available values: `digicert`, `lets_encrypt`, `google`, `ssl_com`. **Modifying this attribute will force creation of a new resource.**
 - `hosts` (Set of String) List of hostnames to provision the certificate pack for. The zone name must be included as a host. Note: If using Let's Encrypt, you cannot use individual subdomains and only a wildcard for subdomain is available. **Modifying this attribute will force creation of a new resource.**
 - `type` (String) Certificate pack configuration type. Available values: `advanced`. **Modifying this attribute will force creation of a new resource.**
 - `validation_method` (String) Which validation method to use in order to prove domain ownership. Available values: `txt`, `http`, `email`. **Modifying this attribute will force creation of a new resource.**

--- a/docs/resources/device_posture_rule.md
+++ b/docs/resources/device_posture_rule.md
@@ -80,8 +80,8 @@ Optional:
 - `last_seen` (String) The duration of time that the host was last seen from Crowdstrike. Must be in the format `1h` or `30m`. Valid units are `d`, `h` and `m`.
 - `locations` (Block List) List of operating system locations to check for a client certificate.. (see [below for nested schema](#nestedblock--input--locations))
 - `network_status` (String) The network status from SentinelOne. Available values: `connected`, `disconnected`, `disconnecting`, `connecting`.
+- `operational_state` (String) The current operational state of a SentinelOne Agent. Available values: `na`, `partially_disabled`, `auto_fully_disabled`, `fully_disabled`, `auto_partially_disabled`, `disabled_error`, `db_corruption`.
 - `operator` (String) The version comparison operator. Available values: `>`, `>=`, `<`, `<=`, `==`.
-- `operational_state` (String) The current operational state of a SentinelOne Agent.
 - `os` (String) OS signal score from Crowdstrike. Value must be between 1 and 100.
 - `os_distro_name` (String) The operating system excluding version information.
 - `os_distro_revision` (String) The operating system version excluding OS name information or release name.

--- a/docs/resources/zero_trust_device_posture_rule.md
+++ b/docs/resources/zero_trust_device_posture_rule.md
@@ -80,8 +80,8 @@ Optional:
 - `last_seen` (String) The duration of time that the host was last seen from Crowdstrike. Must be in the format `1h` or `30m`. Valid units are `d`, `h` and `m`.
 - `locations` (Block List) List of operating system locations to check for a client certificate.. (see [below for nested schema](#nestedblock--input--locations))
 - `network_status` (String) The network status from SentinelOne. Available values: `connected`, `disconnected`, `disconnecting`, `connecting`.
+- `operational_state` (String) The current operational state of a SentinelOne Agent. Available values: `na`, `partially_disabled`, `auto_fully_disabled`, `fully_disabled`, `auto_partially_disabled`, `disabled_error`, `db_corruption`.
 - `operator` (String) The version comparison operator. Available values: `>`, `>=`, `<`, `<=`, `==`.
-- `operational_state` (String) The current operational state of a SentinelOne Agent.
 - `os` (String) OS signal score from Crowdstrike. Value must be between 1 and 100.
 - `os_distro_name` (String) The operating system excluding version information.
 - `os_distro_revision` (String) The operating system version excluding OS name information or release name.

--- a/internal/sdkv2provider/schema_cloudflare_certificate_pack.go
+++ b/internal/sdkv2provider/schema_cloudflare_certificate_pack.go
@@ -50,7 +50,7 @@ func resourceCloudflareCertificatePackSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validation.StringInSlice([]string{"digicert", "lets_encrypt", "google"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"digicert", "lets_encrypt", "google", ssl_com"}, false),
 			Default:      nil,
 			Description:  fmt.Sprintf("Which certificate authority to issue the certificate pack. %s", renderAvailableDocumentationValuesStringSlice([]string{"digicert", "lets_encrypt", "google"})),
 		},

--- a/internal/sdkv2provider/schema_cloudflare_certificate_pack.go
+++ b/internal/sdkv2provider/schema_cloudflare_certificate_pack.go
@@ -50,9 +50,9 @@ func resourceCloudflareCertificatePackSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validation.StringInSlice([]string{"digicert", "lets_encrypt", "google", ssl_com"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"digicert", "lets_encrypt", "google", "ssl_com"}, false),
 			Default:      nil,
-			Description:  fmt.Sprintf("Which certificate authority to issue the certificate pack. %s", renderAvailableDocumentationValuesStringSlice([]string{"digicert", "lets_encrypt", "google"})),
+			Description:  fmt.Sprintf("Which certificate authority to issue the certificate pack. %s", renderAvailableDocumentationValuesStringSlice([]string{"digicert", "lets_encrypt", "google", "ssl_com"})),
 		},
 		"validation_records": {
 			Type:     schema.TypeList,


### PR DESCRIPTION
### What

Add `ssl_com` to the [slice](https://github.com/cloudflare/terraform-provider-cloudflare/blob/master/internal/sdkv2provider/schema_cloudflare_certificate_pack.go#L53) containing valid certificate authorities that can be used to manage a `cloudflare_certificate_pack` resource

### Why

- SSL.com should be a valid CA for advanced certificates since it shows as an option for these certificates in the dashboard
- A certificate created with this CA shows the value `ssl_com` in the [API endpoint](https://api.cloudflare.com/client/v4/zones/zone_id/ssl/certificate_packs) that lists certificate packs
- Fixes #4266