### PR TITLE
fix: unexpected validation error when ttl is set with variable

### DIFF
--- a/.changelog/4414.txt
+++ b/.changelog/4414.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: unexpected validation error when ttl default is set with variable 
+```

--- a/internal/framework/service/rulesets/validators.go
+++ b/internal/framework/service/rulesets/validators.go
@@ -62,6 +62,9 @@ func (v EdgeTTLValidator) ValidateObject(ctx context.Context, req validator.Obje
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if parameter.Default.IsUnknown() {
+		return
+	}
 
 	if parameter.Mode.ValueString() == "override_origin" {
 		if parameter.Default.ValueInt64() <= 0 {
@@ -103,6 +106,9 @@ func (v BrowserTTLValidator) ValidateObject(ctx context.Context, req validator.O
 	diag := req.ConfigValue.As(ctx, &parameter, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true, UnhandledUnknownAsEmpty: true})
 	resp.Diagnostics.Append(diag...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+	if parameter.Default.IsUnknown() {
 		return
 	}
 

--- a/internal/framework/service/rulesets/validators_test.go
+++ b/internal/framework/service/rulesets/validators_test.go
@@ -61,6 +61,30 @@ func TestEdgeTTLValidation(t *testing.T) {
 				}
 			})
 
+			t.Run("passes when ttl is unknown", func(t *testing.T) {
+				t.Parallel()
+
+				mode := "override_origin"
+				_, statusCodeAttr, listType := constructStatusTTLObject()
+				resp := &validator.ObjectResponse{}
+				req := validator.ObjectRequest{
+					Path: path.Root("edge_ttl"),
+					ConfigValue: types.ObjectValueMust(
+						map[string]attr.Type{"mode": types.StringType, "status_code_ttl": listType, "default": types.Int64Type},
+						map[string]attr.Value{"mode": types.StringValue(mode), "status_code_ttl": statusCodeAttr, "default": types.Int64Unknown()},
+					),
+				}
+				edgeValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: nil,
+				}
+
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+
 			t.Run("passes valid ttl values", func(t *testing.T) {
 				t.Parallel()
 
@@ -157,6 +181,29 @@ func TestBrowserTTLValidation(t *testing.T) {
 						diag.NewAttributeErrorDiagnostic(path.Root("browser_ttl"), "invalid configuration", "using mode 'override_origin' requires setting a default for ttl"),
 					},
 				}
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+
+			t.Run("passes when ttl is unknown", func(t *testing.T) {
+				t.Parallel()
+
+				mode := "override_origin"
+				resp := &validator.ObjectResponse{}
+				req := validator.ObjectRequest{
+					Path: path.Root("brower_ttl"),
+					ConfigValue: types.ObjectValueMust(
+						map[string]attr.Type{"mode": types.StringType, "default": types.Int64Type},
+						map[string]attr.Value{"mode": types.StringValue(mode), "default": types.Int64Unknown()},
+					),
+				}
+				browserValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: nil,
+				}
+
 				if diff := cmp.Diff(resp, expected); diff != "" {
 					t.Errorf("unexpected difference: %s", diff)
 				}


### PR DESCRIPTION
When `default` is set with variable, it will be `unknown` in the request sent to the plugin, so the validation will fail. With this change, the plugin can handle this case correctly.

The validation still works when mode is `override_origin` and default is not set(which will be `null`) or `<=0`.

fixes: #4412