### PR TITLE
DLP-2423: Include more fields in 'entry' set hash function in cloudflare_zero_trust_dlp_profile

### DIFF
--- a/.changelog/4464.txt
+++ b/.changelog/4464.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_zero_trust_dlp_profile: Include more fields in `entry` set hash function
+```

--- a/internal/sdkv2provider/schema_cloudflare_dlp_profile.go
+++ b/internal/sdkv2provider/schema_cloudflare_dlp_profile.go
@@ -2,6 +2,7 @@ package sdkv2provider
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -62,8 +63,9 @@ func resourceCloudflareDLPEntrySchema() map[string]*schema.Schema {
 // to provide a stable hash for profile entries and prevent spurious differences
 // between the state/infra.
 func hashResourceCloudflareDLPEntry(i interface{}) int {
-	v := i.(map[string]interface{})
-	return schema.HashString(v["name"])
+	v := maps.Clone(i.(map[string]interface{}))
+	delete(v, "id")
+	return schema.HashResource(&schema.Resource{Schema: resourceCloudflareDLPEntrySchema()})(v)
 }
 
 func resourceCloudflareDLPContextAwarenessSchema() map[string]*schema.Schema {


### PR DESCRIPTION
Currently, the custom set hash function on values in the `entry` set only uses the `name` field. Start using every field (except ID) to properly detect changes to more fields without causing plan instability