### PR TITLE
test(workers_kv): get tests passing

### DIFF
--- a/internal/services/workers_kv/model.go
+++ b/internal/services/workers_kv/model.go
@@ -19,7 +19,7 @@ type WorkersKVModel struct {
 	KeyName     types.String `tfsdk:"key_name" path:"key_name,required"`
 	AccountID   types.String `tfsdk:"account_id" path:"account_id,required"`
 	NamespaceID types.String `tfsdk:"namespace_id" path:"namespace_id,required"`
-	Metadata    types.String `tfsdk:"metadata" json:"metadata,required"`
+	Metadata    types.String `tfsdk:"metadata" json:"metadata,optional"`
 	Value       types.String `tfsdk:"value" json:"value,required"`
 }
 

--- a/internal/services/workers_kv/resource.go
+++ b/internal/services/workers_kv/resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/cloudflare/cloudflare-go/v3"
 	"github.com/cloudflare/cloudflare-go/v3/kv"
@@ -15,6 +16,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -63,21 +65,18 @@ func (r *WorkersKVResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	dataBytes, contentType, err := data.MarshalMultipart()
-	if err != nil {
-		resp.Diagnostics.AddError("failed to serialize multipart http request", err.Error())
-		return
-	}
+	data.KeyName = types.StringValue(url.PathEscape(data.KeyName.ValueString()))
+
 	res := new(http.Response)
 	env := WorkersKVResultEnvelope{*data}
-	_, err = r.client.KV.Namespaces.Values.Update(
+	_, err := r.client.KV.Namespaces.Values.Update(
 		ctx,
 		data.NamespaceID.ValueString(),
 		data.KeyName.ValueString(),
 		kv.NamespaceValueUpdateParams{
 			AccountID: cloudflare.F(data.AccountID.ValueString()),
 		},
-		option.WithRequestBody(contentType, dataBytes),
+		option.WithRequestBody("application/octet-stream", []byte(data.Value.ValueString())),
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)
@@ -114,21 +113,17 @@ func (r *WorkersKVResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	dataBytes, contentType, err := data.MarshalMultipart()
-	if err != nil {
-		resp.Diagnostics.AddError("failed to serialize multipart http request", err.Error())
-		return
-	}
+	data.KeyName = types.StringValue(url.PathEscape(data.KeyName.ValueString()))
 	res := new(http.Response)
 	env := WorkersKVResultEnvelope{*data}
-	_, err = r.client.KV.Namespaces.Values.Update(
+	_, err := r.client.KV.Namespaces.Values.Update(
 		ctx,
 		data.NamespaceID.ValueString(),
 		data.KeyName.ValueString(),
 		kv.NamespaceValueUpdateParams{
 			AccountID: cloudflare.F(data.AccountID.ValueString()),
 		},
-		option.WithRequestBody(contentType, dataBytes),
+		option.WithRequestBody("application/octet-stream", []byte(data.Value.ValueString())),
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)

--- a/internal/services/workers_kv/schema.go
+++ b/internal/services/workers_kv/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"metadata": schema.StringAttribute{
 				Description: "Arbitrary JSON to be associated with a key/value pair.",
-				Required:    true,
+				Optional:    true,
 			},
 			"value": schema.StringAttribute{
 				Description: "A byte sequence to be stored, up to 25 MiB in length.",


### PR DESCRIPTION
Get workers KV resources passing with just text-like data. We can explore multipart uploads at a later date.