### PR TITLE
Use configured client_secret in state to properly handle changes

### DIFF
--- a/.changelog/4500.txt
+++ b/.changelog/4500.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_zero_trust_access_identity_provider: Fix `client_secret` attribute always causing update, even when not changed
+```

--- a/internal/sdkv2provider/resource_cloudflare_access_identity_provider.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_identity_provider.go
@@ -76,7 +76,7 @@ func resourceCloudflareAccessIdentityProviderRead(ctx context.Context, d *schema
 	d.Set("name", accessIdentityProvider.Name)
 	d.Set("type", accessIdentityProvider.Type)
 
-	config := convertAccessIDPConfigStructToSchema(accessIdentityProvider.Config)
+	config := convertAccessIDPConfigStructToSchema(d.Get("config.0.client_secret").(string), accessIdentityProvider.Config)
 	if configErr := d.Set("config", config); configErr != nil {
 		return diag.FromErr(fmt.Errorf("error setting Access Identity Provider configuration: %w", configErr))
 	}
@@ -285,7 +285,7 @@ func convertScimConfigSchemaToStruct(d *schema.ResourceData) cloudflare.AccessId
 	return ScimConfig
 }
 
-func convertAccessIDPConfigStructToSchema(options cloudflare.AccessIdentityProviderConfiguration) []interface{} {
+func convertAccessIDPConfigStructToSchema(clientSecret string, options cloudflare.AccessIdentityProviderConfiguration) []interface{} {
 	attributes := make([]string, 0)
 	for _, value := range options.Attributes {
 		attributes = append(attributes, value)
@@ -301,7 +301,7 @@ func convertAccessIDPConfigStructToSchema(options cloudflare.AccessIdentityProvi
 		"centrify_app_id":            options.CentrifyAppID,
 		"certs_url":                  options.CertsURL,
 		"client_id":                  options.ClientID,
-		"client_secret":              options.ClientSecret,
+		"client_secret":              clientSecret,
 		"claims":                     options.Claims,
 		"scopes":                     options.Scopes,
 		"directory_id":               options.DirectoryID,

--- a/internal/sdkv2provider/resource_cloudflare_access_identity_provider_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_identity_provider_test.go
@@ -262,11 +262,12 @@ func TestAccCloudflareAccessIdentityProvider_OAuth_Import(t *testing.T) {
 				Check:  checkFn,
 			},
 			{
-				ImportState:         true,
-				ImportStateVerify:   true,
-				ResourceName:        resourceName,
-				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
-				Check:               checkFn,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config.0.client_secret"},
+				ResourceName:            resourceName,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
+				Check:                   checkFn,
 			},
 		},
 	})

--- a/internal/sdkv2provider/schema_cloudflare_access_identity_provider.go
+++ b/internal/sdkv2provider/schema_cloudflare_access_identity_provider.go
@@ -83,14 +83,9 @@ func resourceCloudflareAccessIdentityProviderSchema() map[string]*schema.Schema 
 						Optional: true,
 					},
 					"client_secret": {
-						Type:     schema.TypeString,
-						Optional: true,
-						// client_secret is a write only operation from the Cloudflare API
-						// and once it's set, it is no longer accessible. To avoid storing
-						// it and messing up the state, hardcode in the concealed version.
-						StateFunc: func(val interface{}) string {
-							return CONCEALED_STRING
-						},
+						Type:      schema.TypeString,
+						Optional:  true,
+						Sensitive: true,
 					},
 					"claims": {
 						Type:     schema.TypeList,


### PR DESCRIPTION
This is an attempt to solve the issue reported here: https://github.com/cloudflare/terraform-provider-cloudflare/issues/4497

It should also fix an issue we experienced earlier (but which is now "replaced" with the issue listed above) where changes to the `client_secret` didn't trigger changes to the `cloudflare_zero_trust_access_identity_provider` resource.

This PR will change the resource so the `client_secret` is stored in state, so it can properly detect if the field has changed, and can trigger updates to the resource.