### PR TITLE
Don't set items for lists when not needed

### DIFF
--- a/.changelog/4511.txt
+++ b/.changelog/4511.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_list: Don't read list items if there are none configured
+```

--- a/internal/framework/service/list/resource.go
+++ b/internal/framework/service/list/resource.go
@@ -99,15 +99,17 @@ func (r *ListResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	state.Description = types.StringValue(list.Description)
 	state.Kind = types.StringValue(list.Kind)
 
-	items, err := r.client.V1.ListListItems(ctx, cloudflare.AccountIdentifier(state.AccountID.ValueString()), cloudflare.ListListItemsParams{
-		ID: state.ID.ValueString(),
-	})
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading List Items", err.Error())
-		return
-	}
+	if len(state.Items) > 0 {
+		items, err := r.client.V1.ListListItems(ctx, cloudflare.AccountIdentifier(state.AccountID.ValueString()), cloudflare.ListListItemsParams{
+			ID: state.ID.ValueString(),
+		})
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading List Items", err.Error())
+			return
+		}
 
-	state.Items = buildListItemModels(items)
+		state.Items = buildListItemModels(items)
+	}
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
Fixes #4469

Before, the `cloudflare_list` resource would always read the items from a list, even if they were not configured. With this change, items from the list are not read if there are none in the model. Similar to the [SDKV2 resource](https://github.com/cloudflare/terraform-provider-cloudflare/blob/d0edea1ef8e34bec96b84f54632a67fe9e5999c4/internal/sdkv2provider/resource_cloudflare_list.go#L106-L108).

The best way to test this is the `list_item` tests, as they will fail without this change.