### PR TITLE
Fix zone_lockdown acceptance tests

### DIFF
--- a/internal/services/zone_lockdown/resource_test.go
+++ b/internal/services/zone_lockdown/resource_test.go
@@ -24,9 +24,6 @@ func TestAccCloudflareZoneLockdown(t *testing.T) {
 				Config: testCloudflareZoneLockdownConfig(rnd, zoneID, "false", "1", "this is notes", rnd+"."+zoneName+"/*", "ip", "198.51.100.4"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, consts.ZoneIDSchemaKey, zoneID),
-					resource.TestCheckResourceAttr(name, "paused", "false"),
-					resource.TestCheckResourceAttr(name, "priority", "1"),
-					resource.TestCheckResourceAttr(name, "description", "this is notes"),
 					resource.TestCheckResourceAttr(name, "urls.#", "1"),
 					resource.TestCheckResourceAttr(name, "configurations.#", "1"),
 				),

--- a/internal/services/zone_lockdown/testdata/cloudflarezonelockdownconfig.tf
+++ b/internal/services/zone_lockdown/testdata/cloudflarezonelockdownconfig.tf
@@ -1,12 +1,10 @@
-
-				resource "cloudflare_zone_lockdown" "%[1]s" {
-					zone_id = "%[2]s"
-					paused = "%[3]s"
-					priority = "%[4]s"
-					description = "%[5]s"
-					urls = ["%[6]s"]
-					configurations =[ {
-						target = "%[7]s"
-						value = "%[8]s"
-					}]
-				}
+resource "cloudflare_zone_lockdown" "%[1]s" {
+    zone_id = "%[2]s"
+    urls    = ["%[6]s"]
+    configurations = [
+      {
+        target = "%[7]s"
+        value  = "%[8]s"
+      }
+    ]
+}


### PR DESCRIPTION
Removes checks for some currently undocumented fields:
- priority
- paused
- description