### PR TITLE
fix: make access group schema for gsuite required

### DIFF
--- a/.changelog/4597.txt
+++ b/.changelog/4597.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_zero_trust_access_policy: make gsuite  parameters required
+```

--- a/docs/resources/access_group.md
+++ b/docs/resources/access_group.md
@@ -149,7 +149,7 @@ Optional:
 <a id="nestedblock--include--gsuite"></a>
 ### Nested Schema for `include.gsuite`
 
-Optional:
+Required:
 
 - `email` (List of String) The email of the Google Workspace group.
 - `identity_provider_id` (String) The ID of your Google Workspace identity provider.
@@ -245,7 +245,7 @@ Optional:
 <a id="nestedblock--exclude--gsuite"></a>
 ### Nested Schema for `exclude.gsuite`
 
-Optional:
+Required:
 
 - `email` (List of String) The email of the Google Workspace group.
 - `identity_provider_id` (String) The ID of your Google Workspace identity provider.
@@ -341,7 +341,7 @@ Optional:
 <a id="nestedblock--require--gsuite"></a>
 ### Nested Schema for `require.gsuite`
 
-Optional:
+Required:
 
 - `email` (List of String) The email of the Google Workspace group.
 - `identity_provider_id` (String) The ID of your Google Workspace identity provider.

--- a/docs/resources/access_identity_provider.md
+++ b/docs/resources/access_identity_provider.md
@@ -130,6 +130,7 @@ Optional:
 
 - `enabled` (Boolean)
 - `group_member_deprovision` (Boolean)
+- `identity_update_behavior` (String)
 - `seat_deprovision` (Boolean)
 - `secret` (String, Sensitive)
 - `user_deprovision` (Boolean)

--- a/docs/resources/access_policy.md
+++ b/docs/resources/access_policy.md
@@ -192,7 +192,7 @@ Optional:
 <a id="nestedblock--include--gsuite"></a>
 ### Nested Schema for `include.gsuite`
 
-Optional:
+Required:
 
 - `email` (List of String) The email of the Google Workspace group.
 - `identity_provider_id` (String) The ID of your Google Workspace identity provider.
@@ -317,7 +317,7 @@ Optional:
 <a id="nestedblock--exclude--gsuite"></a>
 ### Nested Schema for `exclude.gsuite`
 
-Optional:
+Required:
 
 - `email` (List of String) The email of the Google Workspace group.
 - `identity_provider_id` (String) The ID of your Google Workspace identity provider.
@@ -413,7 +413,7 @@ Optional:
 <a id="nestedblock--require--gsuite"></a>
 ### Nested Schema for `require.gsuite`
 
-Optional:
+Required:
 
 - `email` (List of String) The email of the Google Workspace group.
 - `identity_provider_id` (String) The ID of your Google Workspace identity provider.

--- a/docs/resources/zero_trust_access_group.md
+++ b/docs/resources/zero_trust_access_group.md
@@ -149,7 +149,7 @@ Optional:
 <a id="nestedblock--include--gsuite"></a>
 ### Nested Schema for `include.gsuite`
 
-Optional:
+Required:
 
 - `email` (List of String) The email of the Google Workspace group.
 - `identity_provider_id` (String) The ID of your Google Workspace identity provider.
@@ -245,7 +245,7 @@ Optional:
 <a id="nestedblock--exclude--gsuite"></a>
 ### Nested Schema for `exclude.gsuite`
 
-Optional:
+Required:
 
 - `email` (List of String) The email of the Google Workspace group.
 - `identity_provider_id` (String) The ID of your Google Workspace identity provider.
@@ -341,7 +341,7 @@ Optional:
 <a id="nestedblock--require--gsuite"></a>
 ### Nested Schema for `require.gsuite`
 
-Optional:
+Required:
 
 - `email` (List of String) The email of the Google Workspace group.
 - `identity_provider_id` (String) The ID of your Google Workspace identity provider.

--- a/docs/resources/zero_trust_access_identity_provider.md
+++ b/docs/resources/zero_trust_access_identity_provider.md
@@ -130,6 +130,7 @@ Optional:
 
 - `enabled` (Boolean)
 - `group_member_deprovision` (Boolean)
+- `identity_update_behavior` (String)
 - `seat_deprovision` (Boolean)
 - `secret` (String, Sensitive)
 - `user_deprovision` (Boolean)

--- a/docs/resources/zero_trust_access_policy.md
+++ b/docs/resources/zero_trust_access_policy.md
@@ -154,7 +154,7 @@ Optional:
 <a id="nestedblock--include--gsuite"></a>
 ### Nested Schema for `include.gsuite`
 
-Optional:
+Required:
 
 - `email` (List of String) The email of the Google Workspace group.
 - `identity_provider_id` (String) The ID of your Google Workspace identity provider.
@@ -279,7 +279,7 @@ Optional:
 <a id="nestedblock--exclude--gsuite"></a>
 ### Nested Schema for `exclude.gsuite`
 
-Optional:
+Required:
 
 - `email` (List of String) The email of the Google Workspace group.
 - `identity_provider_id` (String) The ID of your Google Workspace identity provider.
@@ -375,7 +375,7 @@ Optional:
 <a id="nestedblock--require--gsuite"></a>
 ### Nested Schema for `require.gsuite`
 
-Optional:
+Required:
 
 - `email` (List of String) The email of the Google Workspace group.
 - `identity_provider_id` (String) The ID of your Google Workspace identity provider.

--- a/internal/sdkv2provider/schema_cloudflare_access_group.go
+++ b/internal/sdkv2provider/schema_cloudflare_access_group.go
@@ -161,7 +161,7 @@ var AccessGroupOptionSchemaElement = &schema.Resource{
 					"email": {
 						Type:        schema.TypeList,
 						Description: "The email of the Google Workspace group.",
-						Optional:    true,
+						Required:    true,
 						Elem: &schema.Schema{
 							Type: schema.TypeString,
 						},
@@ -169,7 +169,7 @@ var AccessGroupOptionSchemaElement = &schema.Resource{
 					"identity_provider_id": {
 						Type:        schema.TypeString,
 						Description: "The ID of your Google Workspace identity provider.",
-						Optional:    true,
+						Required:    true,
 					},
 				},
 			},


### PR DESCRIPTION
According to <https://developers.cloudflare.com/api/operations/access-policies-create-an-access-policy>, `email` and `identity_provider_id` are both required in the body of the request, but the terraform schema lists them as optional