### PR TITLE
Add 'zero_trust_device_default_profile_certificates' acceptance tests

### DIFF
--- a/internal/services/zero_trust_device_default_profile_certificates/resource_test.go
+++ b/internal/services/zero_trust_device_default_profile_certificates/resource_test.go
@@ -1,0 +1,51 @@
+package zero_trust_device_default_profile_certificates_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccCloudflareDeviceDefaultProfileCertificates_Create(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_zero_trust_device_default_profile_certificates.%s", rnd)
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testCloudflareDevicePolicyCertificates(rnd, zoneID, true),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.DumpState,
+					resource.TestCheckResourceAttr(name, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(name, "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testCloudflareDevicePolicyCertificates(rnd, zoneID string, enable bool) string {
+	return fmt.Sprintf(`
+resource "cloudflare_zero_trust_device_default_profile_certificates" "%[1]s" {
+	zone_id = "%[2]s"
+	enabled = %[3]t
+}
+`, rnd, zoneID, enable)
+}


### PR DESCRIPTION
The tests won't pass until an internal PR gets merged and released.