### PR TITLE
feat: add r2 oc region to accepted location hints

### DIFF
--- a/.changelog/4660.txt
+++ b/.changelog/4660.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_r2_bucket: Added support for Oceania region in location hints.
+```

--- a/docs/resources/r2_bucket.md
+++ b/docs/resources/r2_bucket.md
@@ -29,7 +29,7 @@ resource "cloudflare_r2_bucket" "example" {
 
 ### Optional
 
-- `location` (String) The location hint of the R2 bucket. Available values: `WNAM`, `ENAM`, `WEUR`, `EEUR`, `APAC`
+- `location` (String) The location hint of the R2 bucket. Available values: `WNAM`, `ENAM`, `WEUR`, `EEUR`, `APAC`, `OC`
 
 ### Read-Only
 

--- a/internal/framework/service/r2_bucket/schema.go
+++ b/internal/framework/service/r2_bucket/schema.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-var locationHints = []string{"WNAM", "ENAM", "WEUR", "EEUR", "APAC"}
+var locationHints = []string{"WNAM", "ENAM", "WEUR", "EEUR", "APAC", "OC"}
 
 func (r *R2BucketResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{


### PR DESCRIPTION
This adds the new R2 Oceania region to the list of supported location hints in the provider