### PR TITLE
AUTH-6588 Support Access apps `destinations` field

### DIFF
--- a/.changelog/4649.txt
+++ b/.changelog/4649.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_authenticated_origin_pulls: Fix issue where resources are disabled instead of being destroyed on `tf destroy`
+```

--- a/.changelog/4661.txt
+++ b/.changelog/4661.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/access_application: add support for destinations and domain_type
+```

--- a/docs/resources/access_application.md
+++ b/docs/resources/access_application.md
@@ -90,7 +90,9 @@ resource "cloudflare_zero_trust_access_application" "infra-app-example" {
 - `custom_deny_url` (String) Option that redirects to a custom URL when a user is denied access to the application via identity based rules.
 - `custom_non_identity_deny_url` (String) Option that redirects to a custom URL when a user is denied access to the application via non identity rules.
 - `custom_pages` (Set of String) The custom pages selected for the application.
+- `destinations` (Block List) A destination secured by Access. Only present for self_hosted, vnc, and ssh applications. Always includes the value set as `domain`. Supersedes `self_hosted_domains` to allow for more flexibility in defining different types of destinations. Conflicts with `self_hosted_domains`. (see [below for nested schema](#nestedblock--destinations))
 - `domain` (String) The primary hostname and path that Access will secure. If the app is visible in the App Launcher dashboard, this is the domain that will be displayed.
+- `domain_type` (String) The type of the primary domain. Available values: `public`, `private`.
 - `enable_binding_cookie` (Boolean) Option to provide increased security against compromised authorization tokens and CSRF attacks by requiring an additional "binding" cookie on requests. Defaults to `false`.
 - `footer_links` (Block Set) The footer links of the app launcher. (see [below for nested schema](#nestedblock--footer_links))
 - `header_bg_color` (String) The background color of the header bar in the app launcher.
@@ -103,7 +105,7 @@ resource "cloudflare_zero_trust_access_application" "infra-app-example" {
 - `saas_app` (Block List, Max: 1) SaaS configuration for the Access Application. (see [below for nested schema](#nestedblock--saas_app))
 - `same_site_cookie_attribute` (String) Defines the same-site cookie setting for access tokens. Available values: `none`, `lax`, `strict`.
 - `scim_config` (Block List, Max: 1) Configuration for provisioning to this application via SCIM. This is currently in closed beta. (see [below for nested schema](#nestedblock--scim_config))
-- `self_hosted_domains` (Set of String) List of domains that access will secure. Only present for self_hosted, vnc, and ssh applications. Always includes the value set as `domain`.
+- `self_hosted_domains` (Set of String, Deprecated) List of public domains secured by Access. Only present for self_hosted, vnc, and ssh applications. Always includes the value set as `domain`. Deprecated in favor of `destinations` and will be removed in the next major version. Conflicts with `destinations`.
 - `service_auth_401_redirect` (Boolean) Option to return a 401 status code in service authentication rules on failed requests. Defaults to `false`.
 - `session_duration` (String) How often a user will be forced to re-authorise. Must be in the format `48h` or `2h45m`. Defaults to `24h`.
 - `skip_app_launcher_login_page` (Boolean) Option to skip the App Launcher landing page. Defaults to `false`.
@@ -131,6 +133,18 @@ Optional:
 - `allowed_methods` (Set of String) List of methods to expose via CORS.
 - `allowed_origins` (Set of String) List of origins permitted to make CORS requests.
 - `max_age` (Number) The maximum time a preflight request will be cached.
+
+
+<a id="nestedblock--destinations"></a>
+### Nested Schema for `destinations`
+
+Required:
+
+- `uri` (String) The URI of the destination. Public destinations can include a domain and path with wildcards. Private destinations are an early access feature and gated behind a feature flag. Private destinations support private IPv4, IPv6, and Server Name Indications (SNI) with optional port ranges.
+
+Optional:
+
+- `type` (String) The destination type. Available values: `public`, `private`. Defaults to `public`.
 
 
 <a id="nestedblock--footer_links"></a>

--- a/docs/resources/zero_trust_access_application.md
+++ b/docs/resources/zero_trust_access_application.md
@@ -71,7 +71,9 @@ resource "cloudflare_zero_trust_access_application" "staging_app" {
 - `custom_deny_url` (String) Option that redirects to a custom URL when a user is denied access to the application via identity based rules.
 - `custom_non_identity_deny_url` (String) Option that redirects to a custom URL when a user is denied access to the application via non identity rules.
 - `custom_pages` (Set of String) The custom pages selected for the application.
+- `destinations` (Block List) A destination secured by Access. Only present for self_hosted, vnc, and ssh applications. Always includes the value set as `domain`. Supersedes `self_hosted_domains` to allow for more flexibility in defining different types of destinations. Conflicts with `self_hosted_domains`. (see [below for nested schema](#nestedblock--destinations))
 - `domain` (String) The primary hostname and path that Access will secure. If the app is visible in the App Launcher dashboard, this is the domain that will be displayed.
+- `domain_type` (String) The type of the primary domain. Available values: `public`, `private`.
 - `enable_binding_cookie` (Boolean) Option to provide increased security against compromised authorization tokens and CSRF attacks by requiring an additional "binding" cookie on requests. Defaults to `false`.
 - `footer_links` (Block Set) The footer links of the app launcher. (see [below for nested schema](#nestedblock--footer_links))
 - `header_bg_color` (String) The background color of the header bar in the app launcher.
@@ -84,7 +86,7 @@ resource "cloudflare_zero_trust_access_application" "staging_app" {
 - `saas_app` (Block List, Max: 1) SaaS configuration for the Access Application. (see [below for nested schema](#nestedblock--saas_app))
 - `same_site_cookie_attribute` (String) Defines the same-site cookie setting for access tokens. Available values: `none`, `lax`, `strict`.
 - `scim_config` (Block List, Max: 1) Configuration for provisioning to this application via SCIM. This is currently in closed beta. (see [below for nested schema](#nestedblock--scim_config))
-- `self_hosted_domains` (Set of String) List of domains that access will secure. Only present for self_hosted, vnc, and ssh applications. Always includes the value set as `domain`.
+- `self_hosted_domains` (Set of String, Deprecated) List of public domains secured by Access. Only present for self_hosted, vnc, and ssh applications. Always includes the value set as `domain`. Deprecated in favor of `destinations` and will be removed in the next major version. Conflicts with `destinations`.
 - `service_auth_401_redirect` (Boolean) Option to return a 401 status code in service authentication rules on failed requests. Defaults to `false`.
 - `session_duration` (String) How often a user will be forced to re-authorise. Must be in the format `48h` or `2h45m`. Defaults to `24h`.
 - `skip_app_launcher_login_page` (Boolean) Option to skip the App Launcher landing page. Defaults to `false`.
@@ -112,6 +114,18 @@ Optional:
 - `allowed_methods` (Set of String) List of methods to expose via CORS.
 - `allowed_origins` (Set of String) List of origins permitted to make CORS requests.
 - `max_age` (Number) The maximum time a preflight request will be cached.
+
+
+<a id="nestedblock--destinations"></a>
+### Nested Schema for `destinations`
+
+Required:
+
+- `uri` (String) The URI of the destination. Public destinations can include a domain and path with wildcards. Private destinations are an early access feature and gated behind a feature flag. Private destinations support private IPv4, IPv6, and Server Name Indications (SNI) with optional port ranges.
+
+Optional:
+
+- `type` (String) The destination type. Available values: `public`, `private`. Defaults to `public`.
 
 
 <a id="nestedblock--footer_links"></a>

--- a/internal/sdkv2provider/resource_cloudflare_access_application_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_application_test.go
@@ -948,6 +948,58 @@ func TestAccCloudflareAccessApplication_WithTargetContexts(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareAccessApplication_WithDestinations(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_zero_trust_access_application.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCloudflareAccessApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareAccessApplicationWithDestinations(rnd, domain, cloudflare.AccountIdentifier(accountID)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "destinations.#", "2"),
+					resource.TestCheckResourceAttr(name, "destinations.0.type", "public"),
+					resource.TestCheckResourceAttr(name, "destinations.0.uri", fmt.Sprintf("d1.%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(name, "destinations.1.type", "public"),
+					resource.TestCheckResourceAttr(name, "destinations.1.uri", fmt.Sprintf("d2.%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "type", "self_hosted"),
+					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
+					resource.TestCheckResourceAttr(name, "cors_headers.#", "0"),
+					resource.TestCheckResourceAttr(name, "sass_app.#", "0"),
+					resource.TestCheckResourceAttr(name, "auto_redirect_to_identity", "false"),
+				),
+			},
+			{
+				Config: testAccCloudflareAccessApplicationWithDestinations2(rnd, domain, cloudflare.AccountIdentifier(accountID)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "destinations.#", "2"),
+					resource.TestCheckResourceAttr(name, "destinations.0.type", "public"),
+					resource.TestCheckResourceAttr(name, "destinations.0.uri", fmt.Sprintf("d3.%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(name, "destinations.1.type", "public"),
+					resource.TestCheckResourceAttr(name, "destinations.1.uri", fmt.Sprintf("d4.%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "type", "self_hosted"),
+					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
+					resource.TestCheckResourceAttr(name, "cors_headers.#", "0"),
+					resource.TestCheckResourceAttr(name, "sass_app.#", "0"),
+					resource.TestCheckResourceAttr(name, "auto_redirect_to_identity", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudflareAccessApplication_WithSelfHostedDomains(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_zero_trust_access_application.%s", rnd)
@@ -1439,6 +1491,42 @@ resource "cloudflare_zero_trust_access_application" "%[1]s" {
       values = ["tfgo-acc-test"]
     }
   }
+}
+`, rnd, domain, identifier.Type, identifier.Identifier)
+}
+
+func testAccCloudflareAccessApplicationWithDestinations(rnd string, domain string, identifier *cloudflare.ResourceContainer) string {
+	return fmt.Sprintf(`
+resource "cloudflare_zero_trust_access_application" "%[1]s" {
+  %[3]s_id                  = "%[4]s"
+  name                      = "%[1]s"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+	destinations {
+	  uri = "d1.%[1]s.%[2]s"
+	}
+	destinations {
+	  uri = "d2.%[1]s.%[2]s"
+	}
+}
+`, rnd, domain, identifier.Type, identifier.Identifier)
+}
+
+func testAccCloudflareAccessApplicationWithDestinations2(rnd string, domain string, identifier *cloudflare.ResourceContainer) string {
+	return fmt.Sprintf(`
+resource "cloudflare_zero_trust_access_application" "%[1]s" {
+  %[3]s_id                  = "%[4]s"
+  name                      = "%[1]s"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+	destinations {
+	  uri = "d3.%[1]s.%[2]s"
+	}
+	destinations {
+	  uri = "d4.%[1]s.%[2]s"
+	}
 }
 `, rnd, domain, identifier.Type, identifier.Identifier)
 }

--- a/internal/sdkv2provider/resource_cloudflare_authenticated_origin_pulls.go
+++ b/internal/sdkv2provider/resource_cloudflare_authenticated_origin_pulls.go
@@ -48,7 +48,7 @@ func resourceCloudflareAuthenticatedOriginPullsCreate(ctx context.Context, d *sc
 		conf := []cloudflare.PerHostnameAuthenticatedOriginPullsConfig{{
 			CertID:   aopCert,
 			Hostname: hostname,
-			Enabled:  isEnabled,
+			Enabled:  &isEnabled,
 		}}
 		_, err := client.EditPerHostnameAuthenticatedOriginPullsConfig(ctx, zoneID, conf)
 		if err != nil {
@@ -123,7 +123,7 @@ func resourceCloudflareAuthenticatedOriginPullsDelete(ctx context.Context, d *sc
 		conf := []cloudflare.PerHostnameAuthenticatedOriginPullsConfig{{
 			CertID:   aopCert,
 			Hostname: hostname,
-			Enabled:  false,
+			Enabled:  nil,
 		}}
 		_, err := client.EditPerHostnameAuthenticatedOriginPullsConfig(ctx, zoneID, conf)
 		if err != nil {


### PR DESCRIPTION
Adds support for the Access app `destinations` field, but still keeps the deprecated `self_hosted_domains` field around for backwards compatibility. Since cloudflare-go now only supports the new field, everything is implemented in terms of `destinations` under the hood.