### PR TITLE
Access IDP scim_config.identity_update_behavior is computed

### DIFF
--- a/internal/sdkv2provider/schema_cloudflare_access_identity_provider.go
+++ b/internal/sdkv2provider/schema_cloudflare_access_identity_provider.go
@@ -2,9 +2,10 @@ package sdkv2provider
 
 import (
 	"fmt"
+	"slices"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"slices"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -219,6 +220,7 @@ func resourceCloudflareAccessIdentityProviderSchema() map[string]*schema.Schema 
 					"identity_update_behavior": {
 						Type:     schema.TypeString,
 						Optional: true,
+						Computed: true,
 						ValidateDiagFunc: func(val interface{}, path cty.Path) diag.Diagnostics {
 							s, ok := val.(string)
 


### PR DESCRIPTION
Makes `identity_update_behavior` a computed field because it has a default value of `"reauth"` when `group_member_deprovision` is enabled.

This was confusing the provider and breaking an acceptance test: https://github.com/cloudflare/terraform-provider-cloudflare/pull/4661#issuecomment-2499334884