### PR TITLE
resource/cloudflare_ruleset: improve unknown value handling

### DIFF
--- a/internal/framework/service/rulesets/model.go
+++ b/internal/framework/service/rulesets/model.go
@@ -14,7 +14,6 @@ type RulesetResourceModel struct {
 }
 
 type RulesModel struct {
-	Version                types.String                   `tfsdk:"version"`
 	Action                 types.String                   `tfsdk:"action"`
 	ActionParameters       []*ActionParametersModel       `tfsdk:"action_parameters"`
 	Description            types.String                   `tfsdk:"description"`
@@ -22,7 +21,6 @@ type RulesModel struct {
 	ExposedCredentialCheck []*ExposedCredentialCheckModel `tfsdk:"exposed_credential_check"`
 	Expression             types.String                   `tfsdk:"expression"`
 	ID                     types.String                   `tfsdk:"id"`
-	LastUpdated            types.String                   `tfsdk:"last_updated"`
 	Logging                []*LoggingModel                `tfsdk:"logging"`
 	Ratelimit              []*RatelimitModel              `tfsdk:"ratelimit"`
 	Ref                    types.String                   `tfsdk:"ref"`

--- a/internal/framework/service/rulesets/resource.go
+++ b/internal/framework/service/rulesets/resource.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-	"time"
 
 	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/expanders"
@@ -321,13 +320,6 @@ func toRulesetResourceModel(ctx context.Context, zoneID, accountID basetypes.Str
 			Expression:  flatteners.String(ruleResponse.Expression),
 			Description: types.StringValue(ruleResponse.Description),
 			Enabled:     flatteners.Bool(ruleResponse.Enabled),
-			Version:     flatteners.String(cfv1.String(ruleResponse.Version)),
-		}
-
-		if ruleResponse.LastUpdated != nil {
-			rule.LastUpdated = types.StringValue(ruleResponse.LastUpdated.String())
-		} else {
-			rule.LastUpdated = types.StringNull()
 		}
 
 		// action_parameters
@@ -810,10 +802,13 @@ func (r *RulesModel) toRulesetRule(ctx context.Context) cfv1.RulesetRule {
 	rr := cfv1.RulesetRule{
 		ID:          r.ID.ValueString(),
 		Ref:         r.Ref.ValueString(),
-		Version:     r.Version.ValueStringPointer(),
 		Action:      r.Action.ValueString(),
 		Expression:  r.Expression.ValueString(),
 		Description: r.Description.ValueString(),
+	}
+
+	if !r.Ref.IsNull() {
+		rr.Ref = r.Ref.ValueString()
 	}
 
 	if !r.Enabled.IsNull() {
@@ -1370,15 +1365,6 @@ func (r *RulesModel) toRulesetRule(ctx context.Context) cfv1.RulesetRule {
 		rr.ExposedCredentialCheck = &cfv1.RulesetRuleExposedCredentialCheck{
 			UsernameExpression: e.UsernameExpression.ValueString(),
 			PasswordExpression: e.PasswordExpression.ValueString(),
-		}
-	}
-
-	if !r.LastUpdated.IsNull() {
-		if lastUpdated, err := time.Parse(
-			"2006-01-02 15:04:05.999999999 -0700 MST",
-			r.LastUpdated.ValueString(),
-		); err == nil {
-			rr.LastUpdated = &lastUpdated
 		}
 	}
 

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -108,15 +108,17 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 						consts.IDSchemaKey: schema.StringAttribute{
 							Computed:            true,
 							MarkdownDescription: "Unique rule identifier.",
-						},
-						"version": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Version of the ruleset to deploy.",
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"ref": schema.StringAttribute{
 							Optional:            true,
 							Computed:            true,
 							MarkdownDescription: "Rule reference.",
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"enabled": schema.BoolAttribute{
 							Optional:            true,
@@ -144,10 +146,6 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 								stringvalidator.OneOfCaseInsensitive(cfv1.RulesetRuleActionValues()...),
 							},
 							Optional: true,
-						},
-						"last_updated": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "The most recent update to this rule.",
 						},
 					},
 					Blocks: map[string]schema.Block{


### PR DESCRIPTION
Within the rulesets schema, we have a handful of fields that are
`Computed`. The expectation of this directive is that it is a
value not known at run time and may be provided by the remote.
However, this premise will break down and not work correctly if
the value is ever provided to the plan since the value is no
longer "unknown". This subtle bug is one part of what is
contributing to the additional output toil in #2690. To address
this, I've removed the lines that modified these values and
were being supplied to the plan operation.

This takes the confusing and bloated output from looking like this:

```
Terraform will perform the following actions:

  # cloudflare_ruleset.rate_limiting_example will be updated in-place
  ~ resource "cloudflare_ruleset" "rate_limiting_example" {
        id          = "87e1099f077f4e49bbfbe159217ff605"
        name        = "restrict API requests count"
        # (4 unchanged attributes hidden)

      ~ rules {
          ~ id           = "e3b97fdf354c4c24a7ac091c3537fbc5" -> (known after apply)
          ~ last_updated = "2024-01-31 04:02:55.651275 +0000 UTC" -> (known after apply)
          ~ ref          = "e3b97fdf354c4c24a7ac091c3537fbc5" -> (known after apply)
          ~ version      = "1" -> (known after apply)
            # (4 unchanged attributes hidden)

            # (1 unchanged block hidden)
        }
      + rules {
          + action       = "block"
          + description  = "rate limit for API"
          + enabled      = true
          + expression   = "(http.request.uri.path matches \"^/api0/\")"
          + id           = (known after apply)
          + last_updated = (known after apply)
          + ref          = (known after apply)
          + version      = (known after apply)

          + ratelimit {
              + characteristics     = [
                  + "cf.colo.id",
                  + "ip.src",
                ]
              + mitigation_timeout  = 600
              + period              = 60
              + requests_per_period = 100
              + requests_to_origin  = false
            }
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

To a clearer and more concise output:

```
Terraform will perform the following actions:

  # cloudflare_ruleset.rate_limiting_example will be updated in-place
  ~ resource "cloudflare_ruleset" "rate_limiting_example" {
        id          = "87e1099f077f4e49bbfbe159217ff605"
        name        = "restrict API requests count"
        # (4 unchanged attributes hidden)

      ~ rules {
            id           = "39ed6015367444e3905d838cadc1b9c2"
          + last_updated = (known after apply)
          + version      = (known after apply)
            # (5 unchanged attributes hidden)

            # (1 unchanged block hidden)
        }
      + rules {
          + action       = "block"
          + description  = "rate limit for API"
          + enabled      = true
          + expression   = "(http.request.uri.path matches \"^/api0/\")"
          + id           = (known after apply)
          + last_updated = (known after apply)
          + ref          = (known after apply)
          + version      = (known after apply)

          + ratelimit {
              + characteristics     = [
                  + "cf.colo.id",
                  + "ip.src",
                ]
              + mitigation_timeout  = 600
              + period              = 60
              + requests_per_period = 100
              + requests_to_origin  = false
            }
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

The second part of this confusing output is the `last_updated` and
`version` output. The `last_updated` is pretty self explanatory
however, there are some minor but important details about the version
field here. Within ERE, it captures and is tied to a particular state
of the ruleset rule at any point and is incremented when changes are
detected to any parts of the rule. The nuance here is that ERE does
not perform a diff of the current state and what is proposed.
Instead, it autoincrements this field even if the payload is identical.
So why is this important for the Terraform resource? Well, since we
use explicit ordering via `ListNestedObject` schema attribute, we are
sending all rules to the API even when only a single one changes to
ensure we maintain the correctness the end user expects. Doing this
causes the `last_updated` and `version` fields to always show as
unknown values and result in updates.

While the `last_updated` and `version` fields are useful in a context
where you may reuse the `version`, value, it's not in Terraform. To
remove that part of the diff, we're going to just remove them entirely
from the schema. Given that users couldn't be using them in a
configuration, we're going to release this within a minor version
handling the cleanup internally to the provider.

Supersedes #3091

Closes #2690