### PR TITLE
Rewire page_rule resource

### DIFF
--- a/internal/services/page_rule/custom.go
+++ b/internal/services/page_rule/custom.go
@@ -66,9 +66,9 @@ func (m PageRuleModel) marshalActions(b []byte) (data []byte, err error) {
 	}
 
 	T.Actions, err = m.Actions.Encode()
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
 	return json.Marshal(T)
 }
@@ -101,8 +101,8 @@ func (m *PageRuleActionsModel) Encode() (encoded []map[string]any, err error) {
 	case !m.DisableApps.IsNull():
 		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDDisableApps, "value": m.DisableApps.ValueBool()})
 	default:
-    // TODO: Throw error for unknown page rule
-        return nil, errors.New("missing or unknown page rule")
+		// TODO: Throw error for unknown page rule
+		return nil, errors.New("missing or unknown page rule")
 	}
 
 	return

--- a/internal/services/page_rule/custom.go
+++ b/internal/services/page_rule/custom.go
@@ -1,0 +1,89 @@
+package page_rule
+
+import (
+	"encoding/json"
+
+	"github.com/cloudflare/cloudflare-go/v3"
+	"github.com/cloudflare/cloudflare-go/v3/pagerules"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func (m PageRuleModel) marshalCustom() (data []byte, err error) {
+	if data, err = apijson.MarshalRoot(m); err != nil {
+		return
+	}
+	if data, err = m.marshalTargets(data); err != nil {
+		return
+	}
+	if data, err = m.marshalActions(data); err != nil {
+		return
+	}
+	return
+}
+
+func (m PageRuleModel) marshalTargets(b []byte) (data []byte, err error) {
+	var T struct {
+		ID         string `json:"id,omitempty"`
+		ZoneID     string `json:"zone_id,omitempty"`
+		Priority   int64  `json:"priority,omitempty"`
+		Status     string `json:"status,omitempty"`
+		CreatedOn  string `json:"created_on,omitempty"`
+		ModifiedOn string `json:"modified_on,omitempty"`
+		Target     string `json:"target,omitempty"`
+		Targets    []any  `json:"targets,omitempty"`
+	}
+	if err = json.Unmarshal(b, &T); err != nil {
+		return nil, err
+	}
+	T.Targets = []any{
+		map[string]any{
+			"target": "url",
+			"constraint": map[string]any{
+				"operator": "matches",
+				"value":    T.Target,
+			},
+		},
+	}
+	T.Target = ""
+	return json.Marshal(T)
+}
+
+func (m PageRuleModel) marshalActions(b []byte) (data []byte, err error) {
+	var T struct {
+		ID         string           `json:"id,omitempty"`
+		ZoneID     string           `json:"zone_id,omitempty"`
+		Priority   int64            `json:"priority,omitempty"`
+		Status     string           `json:"status,omitempty"`
+		CreatedOn  string           `json:"created_on,omitempty"`
+		ModifiedOn string           `json:"modified_on,omitempty"`
+		Targets    []any            `json:"targets,omitempty"`
+		Actions    []map[string]any `json:"actions,omitempty"`
+	}
+	if err = json.Unmarshal(b, &T); err != nil {
+		return nil, err
+	}
+	T.Actions = []map[string]any{
+		{"id": "disable_apps"},
+	}
+	return json.Marshal(T)
+}
+
+func (m PageRuleModel) PageruleNewParams() pagerules.PageruleNewParams {
+	return pagerules.PageruleNewParams{
+		ZoneID: cloudflare.F(m.ZoneID.ValueString()),
+		// Targets: cloudflare.F([]pagerules.TargetParam{
+		// 	{
+		// 		Constraint: cloudflare.F(pagerules.TargetConstraintParam{
+		// 			Operator: cloudflare.F(pagerules.TargetConstraintOperatorMatches),
+		// 			Value:    cloudflare.F(m.Target.String()),
+		// 		}),
+		// 	},
+		// }),
+		// Actions: cloudflare.F([]pagerules.PageruleNewParamsActionUnion{}),
+	}
+}
+
+type PageRuleActionsModel struct {
+	AutomaticHTTPSRewrites types.String `tfsdk:"automatic_https_rewrites" json:"automatic_https_rewrites,optional"`
+}

--- a/internal/services/page_rule/model.go
+++ b/internal/services/page_rule/model.go
@@ -13,24 +13,21 @@ type PageRuleResultEnvelope struct {
 }
 
 type PageRuleModel struct {
-	ID         types.String          `tfsdk:"id" json:"id,computed"`
-	ZoneID     types.String          `tfsdk:"zone_id" path:"zone_id,required"`
-	Priority   types.Int64           `tfsdk:"priority" json:"priority,computed_optional"`
-	Status     types.String          `tfsdk:"status" json:"status,computed_optional"`
-	CreatedOn  timetypes.RFC3339     `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
-	ModifiedOn timetypes.RFC3339     `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
-	Target     types.String          `tfsdk:"target" json:"target,required"`
-	Actions    *PageRuleActionsmodel `tfsdk:"actions" json:"actions,required"`
+	ID         types.String      `tfsdk:"id" json:"id,computed"`
+	ZoneID     types.String      `tfsdk:"zone_id" path:"zone_id,required"`
+	Priority   types.Int64       `tfsdk:"priority" json:"priority,computed_optional"`
+	Status     types.String      `tfsdk:"status" json:"status,computed_optional"`
+	CreatedOn  timetypes.RFC3339 `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
+	ModifiedOn timetypes.RFC3339 `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
+
+	Target  types.String          `tfsdk:"target" json:"target,required"`
+	Actions *PageRuleActionsModel `tfsdk:"actions" json:"actions,required"`
 }
 
 func (m PageRuleModel) MarshalJSON() (data []byte, err error) {
-	return apijson.MarshalRoot(m)
+	return m.marshalCustom()
 }
 
 func (m PageRuleModel) MarshalJSONForUpdate(state PageRuleModel) (data []byte, err error) {
 	return apijson.MarshalForUpdate(m, state)
-}
-
-type PageRuleActionsmodel struct {
-	AutomaticHTTPSRewrites types.String `tfsdk:"automatic_https_rewrites" json:"automatic_https_rewrites,optional"`
 }

--- a/internal/services/page_rule/model.go
+++ b/internal/services/page_rule/model.go
@@ -13,12 +13,14 @@ type PageRuleResultEnvelope struct {
 }
 
 type PageRuleModel struct {
-	ID         types.String      `tfsdk:"id" json:"id,computed"`
-	ZoneID     types.String      `tfsdk:"zone_id" path:"zone_id,required"`
-	Priority   types.Int64       `tfsdk:"priority" json:"priority,computed_optional"`
-	Status     types.String      `tfsdk:"status" json:"status,computed_optional"`
-	CreatedOn  timetypes.RFC3339 `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
-	ModifiedOn timetypes.RFC3339 `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
+	ID         types.String          `tfsdk:"id" json:"id,computed"`
+	ZoneID     types.String          `tfsdk:"zone_id" path:"zone_id,required"`
+	Priority   types.Int64           `tfsdk:"priority" json:"priority,computed_optional"`
+	Status     types.String          `tfsdk:"status" json:"status,computed_optional"`
+	CreatedOn  timetypes.RFC3339     `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
+	ModifiedOn timetypes.RFC3339     `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
+	Target     types.String          `tfsdk:"target" json:"target,required"`
+	Actions    *PageRuleActionsmodel `tfsdk:"actions" json:"actions,required"`
 }
 
 func (m PageRuleModel) MarshalJSON() (data []byte, err error) {
@@ -27,4 +29,8 @@ func (m PageRuleModel) MarshalJSON() (data []byte, err error) {
 
 func (m PageRuleModel) MarshalJSONForUpdate(state PageRuleModel) (data []byte, err error) {
 	return apijson.MarshalForUpdate(m, state)
+}
+
+type PageRuleActionsmodel struct {
+	AutomaticHTTPSRewrites types.String `tfsdk:"automatic_https_rewrites" json:"automatic_https_rewrites,optional"`
 }

--- a/internal/services/page_rule/resource.go
+++ b/internal/services/page_rule/resource.go
@@ -73,9 +73,7 @@ func (r *PageRuleResource) Create(ctx context.Context, req resource.CreateReques
 	env := PageRuleResultEnvelope{*data}
 	_, err = r.client.Pagerules.New(
 		ctx,
-		pagerules.PageruleNewParams{
-			ZoneID: cloudflare.F(data.ZoneID.ValueString()),
-		},
+		data.PageruleNewParams(),
 		option.WithRequestBody("application/json", dataBytes),
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),

--- a/internal/services/page_rule/resource_test.go
+++ b/internal/services/page_rule/resource_test.go
@@ -84,7 +84,7 @@ func TestAccCloudflarePageRule_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Config: testAccCheckCloudflarePageRuleConfigBasic(zoneID, target, rnd),
-				Config: buildPageRuleConfig(rnd, zoneID, `automatic_https_rewrites = "on"`, target),
+				Config: buildPageRuleConfig(rnd, zoneID, `disable_apps = true`, target),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
 					// testAccCheckCloudflarePageRuleAttributesBasic(&pageRule),

--- a/internal/services/page_rule/resource_test.go
+++ b/internal/services/page_rule/resource_test.go
@@ -83,7 +83,8 @@ func TestAccCloudflarePageRule_Basic(t *testing.T) {
 		CheckDestroy:             testAccCheckCloudflarePageRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudflarePageRuleConfigBasic(zoneID, target, rnd),
+				// Config: testAccCheckCloudflarePageRuleConfigBasic(zoneID, target, rnd),
+				Config: buildPageRuleConfig(rnd, zoneID, `automatic_https_rewrites = "on"`, target),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
 					// testAccCheckCloudflarePageRuleAttributesBasic(&pageRule),

--- a/internal/services/page_rule/resource_test.go
+++ b/internal/services/page_rule/resource_test.go
@@ -89,7 +89,7 @@ func TestAccCloudflarePageRule_Basic(t *testing.T) {
 					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
 					// testAccCheckCloudflarePageRuleAttributesBasic(&pageRule),
 					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
-					resource.TestCheckResourceAttr(resourceName, "target", fmt.Sprintf("%s/", target)),
+					resource.TestCheckResourceAttr(resourceName, "target", fmt.Sprintf("%s", target)),
 				),
 			},
 		},

--- a/internal/services/page_rule/schema.go
+++ b/internal/services/page_rule/schema.go
@@ -56,6 +56,20 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:    true,
 				CustomType:  timetypes.RFC3339Type{},
 			},
+			"target": schema.StringAttribute{
+				Required: true,
+			},
+			"actions": schema.SingleNestedAttribute{
+				Required:   true,
+				Attributes: map[string]schema.Attribute{
+					"automatic_https_rewrites": schema.StringAttribute{
+						Optional: true,
+						Validators: []validator.String{
+							stringvalidator.OneOfCaseInsensitive("on", "off"),
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/internal/services/page_rule/schema.go
+++ b/internal/services/page_rule/schema.go
@@ -60,13 +60,16 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Required: true,
 			},
 			"actions": schema.SingleNestedAttribute{
-				Required:   true,
+				Required: true,
 				Attributes: map[string]schema.Attribute{
 					"automatic_https_rewrites": schema.StringAttribute{
 						Optional: true,
 						Validators: []validator.String{
 							stringvalidator.OneOfCaseInsensitive("on", "off"),
 						},
+					},
+					"disable_apps": schema.BoolAttribute{
+						Optional: true,
 					},
 				},
 			},

--- a/internal/services/page_rule/testdata/buildpageruleconfig.tf
+++ b/internal/services/page_rule/testdata/buildpageruleconfig.tf
@@ -1,8 +1,7 @@
-
-		resource "cloudflare_page_rule" "%[1]s" {
-			zone_id = "%[2]s"
-			target = "%[3]s"
-			actions {
-				%[4]s
-			}
-		}
+resource "cloudflare_page_rule" "%[1]s" {
+	zone_id = "%[2]s"
+	target  = "%[3]s"
+	actions = {
+		%[4]s
+	}
+}


### PR DESCRIPTION
- adds `actions` and `target` field as custom code
- adds `PageRuleActionsModel` to hold all page rules actions
- updates `TestAccCloudflarePageRule_Basic` to use the (currently) one known page rule action