### PR TITLE
Update provider versioning link for milestone closed comments

### DIFF
--- a/.github/workflows/milestone-closed.yml
+++ b/.github/workflows/milestone-closed.yml
@@ -20,7 +20,7 @@ jobs:
           body: |
             This functionality has been released in [${{ github.event.milestone.title }} of the Terraform Cloudflare Provider](https://github.com/${{ github.repository }}/releases/tag/${{ github.event.milestone.title }}).
 
-            Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading.
+            Please see the [Terraform documentation on provider versioning](https://developer.hashicorp.com/terraform/language/providers/requirements#version-constraints) or reach out if you need any assistance upgrading.
 
             For further feature requests or bug reports with this functionality, please create a [new GitHub issue](https://github.com/${{ github.repository }}/issues/new/choose) following the template. Thank you!
             


### PR DESCRIPTION
Minor workflow fix. 

The previous link is to the deprecated `version` attribute for the `provider` configuration block. There is more recent documentation in the section on `required_providers`.

Sorry, as I'm not a contributor I can't add the label to skip the changelog entry.