### PR TITLE
resource/cloudflare_ruleset: Improve diffs when only some rules are changed

### DIFF
--- a/.changelog/4697.txt
+++ b/.changelog/4697.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/cloudflare_ruleset: improve diffs when only some rules are changed
+```
+
+```release-note:note
+resource/cloudflare_ruleset: rules must now be given an explicit `ref` to avoid their IDs changing across ruleset updates, see https://developers.cloudflare.com/terraform/troubleshooting/rule-id-changes/
+```

--- a/internal/framework/service/rulesets/model.go
+++ b/internal/framework/service/rulesets/model.go
@@ -27,7 +27,6 @@ type RulesModel struct {
 }
 
 type ActionParametersModel struct {
-	Version                  types.String                                 `tfsdk:"version"`
 	AdditionalCacheablePorts types.Set                                    `tfsdk:"additional_cacheable_ports"`
 	AutomaticHTTPSRewrites   types.Bool                                   `tfsdk:"automatic_https_rewrites"`
 	AutoMinify               []*ActionParameterAutoMinifyModel            `tfsdk:"autominify"`

--- a/internal/framework/service/rulesets/model.go
+++ b/internal/framework/service/rulesets/model.go
@@ -14,7 +14,6 @@ type RulesetResourceModel struct {
 }
 
 type RulesModel struct {
-	Version                types.String                   `tfsdk:"version"`
 	Action                 types.String                   `tfsdk:"action"`
 	ActionParameters       []*ActionParametersModel       `tfsdk:"action_parameters"`
 	Description            types.String                   `tfsdk:"description"`
@@ -22,7 +21,6 @@ type RulesModel struct {
 	ExposedCredentialCheck []*ExposedCredentialCheckModel `tfsdk:"exposed_credential_check"`
 	Expression             types.String                   `tfsdk:"expression"`
 	ID                     types.String                   `tfsdk:"id"`
-	LastUpdated            types.String                   `tfsdk:"last_updated"`
 	Logging                []*LoggingModel                `tfsdk:"logging"`
 	Ratelimit              []*RatelimitModel              `tfsdk:"ratelimit"`
 	Ref                    types.String                   `tfsdk:"ref"`

--- a/internal/framework/service/rulesets/resource.go
+++ b/internal/framework/service/rulesets/resource.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-	"time"
 
 	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/expanders"
@@ -313,13 +312,6 @@ func toRulesetResourceModel(ctx context.Context, zoneID, accountID basetypes.Str
 			Expression:  flatteners.String(ruleResponse.Expression),
 			Description: types.StringValue(ruleResponse.Description),
 			Enabled:     flatteners.Bool(ruleResponse.Enabled),
-			Version:     flatteners.String(cfv1.String(ruleResponse.Version)),
-		}
-
-		if ruleResponse.LastUpdated != nil {
-			rule.LastUpdated = types.StringValue(ruleResponse.LastUpdated.String())
-		} else {
-			rule.LastUpdated = types.StringNull()
 		}
 
 		// action_parameters
@@ -797,7 +789,6 @@ func (r *RulesModel) toRulesetRule(ctx context.Context) cfv1.RulesetRule {
 	rr := cfv1.RulesetRule{
 		ID:          r.ID.ValueString(),
 		Ref:         r.Ref.ValueString(),
-		Version:     r.Version.ValueStringPointer(),
 		Action:      r.Action.ValueString(),
 		Expression:  r.Expression.ValueString(),
 		Description: r.Description.ValueString(),
@@ -1357,15 +1348,6 @@ func (r *RulesModel) toRulesetRule(ctx context.Context) cfv1.RulesetRule {
 		rr.ExposedCredentialCheck = &cfv1.RulesetRuleExposedCredentialCheck{
 			UsernameExpression: e.UsernameExpression.ValueString(),
 			PasswordExpression: e.PasswordExpression.ValueString(),
-		}
-	}
-
-	if !r.LastUpdated.IsNull() {
-		if lastUpdated, err := time.Parse(
-			"2006-01-02 15:04:05.999999999 -0700 MST",
-			r.LastUpdated.ValueString(),
-		); err == nil {
-			rr.LastUpdated = &lastUpdated
 		}
 	}
 

--- a/internal/framework/service/rulesets/resource.go
+++ b/internal/framework/service/rulesets/resource.go
@@ -343,7 +343,6 @@ func toRulesetResourceModel(ctx context.Context, zoneID, accountID basetypes.Str
 				OriginErrorPagePassthru: flatteners.Bool(ruleResponse.ActionParameters.OriginErrorPagePassthru),
 				RespectStrongEtags:      flatteners.Bool(ruleResponse.ActionParameters.RespectStrongETags),
 				ReadTimeout:             flatteners.Int64(int64(cfv1.Uint(ruleResponse.ActionParameters.ReadTimeout))),
-				Version:                 flatteners.String(cfv1.String(ruleResponse.ActionParameters.Version)),
 			})
 
 			if !reflect.ValueOf(ruleResponse.ActionParameters.Polish).IsNil() {
@@ -840,12 +839,6 @@ func (r *RulesModel) toRulesetRule(ctx context.Context) cfv1.RulesetRule {
 
 		if !ap.Ruleset.IsNull() {
 			rr.ActionParameters.Ruleset = ap.Ruleset.ValueString()
-		}
-
-		if !ap.Version.IsNull() {
-			if ap.Version.ValueString() != "" {
-				rr.ActionParameters.Version = cfv1.StringPtr(ap.Version.ValueString())
-			}
 		}
 
 		if !ap.Increment.IsNull() {

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -109,10 +109,6 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 							Computed:            true,
 							MarkdownDescription: "Unique rule identifier.",
 						},
-						"version": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Version of the ruleset to deploy.",
-						},
 						"ref": schema.StringAttribute{
 							Optional:            true,
 							Computed:            true,
@@ -144,10 +140,6 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 								stringvalidator.OneOfCaseInsensitive(cfv1.RulesetRuleActionValues()...),
 							},
 							Optional: true,
-						},
-						"last_updated": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "The most recent update to this rule.",
 						},
 					},
 					Blocks: map[string]schema.Block{

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -303,11 +303,6 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 										Optional:            true,
 										MarkdownDescription: "Pass-through error page for origin.",
 									},
-									"version": schema.StringAttribute{
-										Computed:            true,
-										Optional:            true,
-										MarkdownDescription: "Version of the ruleset to deploy.",
-									},
 								},
 								Blocks: map[string]schema.Block{
 									"algorithms": schema.ListNestedBlock{


### PR DESCRIPTION
#### Remove version in ruleset rule action parameters

This action parameter is used within the execute action, but cannot
actually be set to anything other than `latest`.

Removing this field from Terraform prevents an issue where it shows up
in diffs, due to it being a computed attribute.

#### Prevent ruleset rule IDs incorrectly showing as changed in diffs

In the Rulesets API, it is possible to prevent rule IDs from changing
across updates by using rule refs. If a rule's ref does not change as
part of an update, then neither will its ID.

However, Terraform does not know this and always reports that rule IDs
may change, which creates very large diffs. In this change, we use a
resource plan modifier to "teach" Terraform this rule.

#### Remove `version` and `last_updated` fields from ruleset rules

These fields frequently change, leading to verbose diffs in plans. Since
these fields are not really useful within Terraform, we remove them from
the schema completely to prevent them from "polluting" diffs.

This also matches the behavior we have for the ruleset-level `version`
and `last_updated` fields, which are also not represented in the
Terraform schema.

#### Remove logic to preserve ruleset rule refs

This logic tries to detect which rules are the same as before during an
update, and preserve the refs (and therefore IDs) of these rules.

However, this logic is fallible, since we cannot know the user's true
intention, and makes it difficult for us to remove the `version` and
`last_updated` fields from rules.

If users want to preserve rule refs across updates, they can now
actually use the `ref` field directly—and there is no need for this
remapping logic anymore.

Closes #2690