### PR TITLE
Add tests for all stand-alone actions

### DIFF
--- a/internal/services/page_rule/custom.go
+++ b/internal/services/page_rule/custom.go
@@ -2,7 +2,6 @@ package page_rule
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/cloudflare/cloudflare-go/v3"
 	"github.com/cloudflare/cloudflare-go/v3/pagerules"
@@ -14,16 +13,23 @@ func (m PageRuleModel) marshalCustom() (data []byte, err error) {
 	if data, err = apijson.MarshalRoot(m); err != nil {
 		return
 	}
-	if data, err = m.marshalTargets(data); err != nil {
-		return
-	}
-	if data, err = m.marshalActions(data); err != nil {
+	if data, err = m.marshalTargetsAndActions(data); err != nil {
 		return
 	}
 	return
 }
 
-func (m PageRuleModel) marshalTargets(b []byte) (data []byte, err error) {
+func (m PageRuleModel) marshalCustomForUpdate(state PageRuleModel) (data []byte, err error) {
+	if data, err = apijson.MarshalForUpdate(m, state); err != nil {
+		return
+	}
+	if data, err = m.marshalTargetsAndActions(data); err != nil {
+		return
+	}
+	return
+}
+
+func (m PageRuleModel) marshalTargetsAndActions(b []byte) (data []byte, err error) {
 	var T struct {
 		ID         string `json:"id,omitempty"`
 		ZoneID     string `json:"zone_id,omitempty"`
@@ -33,10 +39,12 @@ func (m PageRuleModel) marshalTargets(b []byte) (data []byte, err error) {
 		ModifiedOn string `json:"modified_on,omitempty"`
 		Target     string `json:"target,omitempty"`
 		Targets    []any  `json:"targets,omitempty"`
+		Actions    any    `json:"actions,omitempty"`
 	}
 	if err = json.Unmarshal(b, &T); err != nil {
 		return nil, err
 	}
+
 	T.Targets = []any{
 		map[string]any{
 			"target": "url",
@@ -46,24 +54,7 @@ func (m PageRuleModel) marshalTargets(b []byte) (data []byte, err error) {
 			},
 		},
 	}
-	T.Target = ""
-	return json.Marshal(T)
-}
-
-func (m PageRuleModel) marshalActions(b []byte) (data []byte, err error) {
-	var T struct {
-		ID         string           `json:"id,omitempty"`
-		ZoneID     string           `json:"zone_id,omitempty"`
-		Priority   int64            `json:"priority,omitempty"`
-		Status     string           `json:"status,omitempty"`
-		CreatedOn  string           `json:"created_on,omitempty"`
-		ModifiedOn string           `json:"modified_on,omitempty"`
-		Targets    []any            `json:"targets,omitempty"`
-		Actions    []map[string]any `json:"actions,omitempty"`
-	}
-	if err = json.Unmarshal(b, &T); err != nil {
-		return nil, err
-	}
+	T.Target = "" // omitempty
 
 	T.Actions, err = m.Actions.Encode()
 	if err != nil {
@@ -90,20 +81,32 @@ func (m PageRuleModel) PageruleNewParams() pagerules.PageruleNewParams {
 
 type PageRuleActionsModel struct {
 	AutomaticHTTPSRewrites types.String `tfsdk:"automatic_https_rewrites" json:"automatic_https_rewrites,optional"`
+	AlwaysUseHTTPS         types.Bool   `tfsdk:"always_use_https" json:"always_use_https,optional"`
 	DisableApps            types.Bool   `tfsdk:"disable_apps" json:"disable_apps,optional"`
+	DisablePerformance     types.Bool   `tfsdk:"disable_performance" json:"disable_performance,optional"`
+	DisableSecurity        types.Bool   `tfsdk:"disable_security" json:"disable_security,optional"`
+	DisableZaraz           types.Bool   `tfsdk:"disable_zaraz" json:"disable_zaraz,optional"`
 }
 
 func (m *PageRuleActionsModel) Encode() (encoded []map[string]any, err error) {
-
-	switch {
-	case !m.AutomaticHTTPSRewrites.IsNull():
-		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDAutomaticHTTPSRewrites, "value": m.AutomaticHTTPSRewrites.String()})
-	case !m.DisableApps.IsNull():
-		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDDisableApps, "value": m.DisableApps.ValueBool()})
-	default:
-		// TODO: Throw error for unknown page rule
-		return nil, errors.New("missing or unknown page rule")
+	encoded = []map[string]any{}
+	if m.AlwaysUseHTTPS.ValueBool() {
+		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDAlwaysUseHTTPS})
 	}
-
+	if !m.AutomaticHTTPSRewrites.IsNull() {
+		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDAutomaticHTTPSRewrites, "value": m.AutomaticHTTPSRewrites.String()})
+	}
+	if m.DisableApps.ValueBool() {
+		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDDisableApps, "value": m.DisableApps.ValueBool()})
+	}
+	if m.DisablePerformance.ValueBool() {
+		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDDisablePerformance})
+	}
+	if m.DisableSecurity.ValueBool() {
+		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDDisableSecurity})
+	}
+	if m.DisableZaraz.ValueBool() {
+		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDDisableZaraz})
+	}
 	return
 }

--- a/internal/services/page_rule/custom.go
+++ b/internal/services/page_rule/custom.go
@@ -3,7 +3,6 @@ package page_rule
 import (
 	"encoding/json"
 
-	"github.com/cloudflare/cloudflare-go/v3"
 	"github.com/cloudflare/cloudflare-go/v3/pagerules"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -62,21 +61,6 @@ func (m PageRuleModel) marshalTargetsAndActions(b []byte) (data []byte, err erro
 	}
 
 	return json.Marshal(T)
-}
-
-func (m PageRuleModel) PageruleNewParams() pagerules.PageruleNewParams {
-	return pagerules.PageruleNewParams{
-		ZoneID: cloudflare.F(m.ZoneID.ValueString()),
-		Targets: cloudflare.F([]pagerules.TargetParam{
-			{
-				Constraint: cloudflare.F(pagerules.TargetConstraintParam{
-					Operator: cloudflare.F(pagerules.TargetConstraintOperatorMatches),
-					Value:    cloudflare.F(m.Target.String()),
-				}),
-			},
-		}),
-		Actions: cloudflare.F([]pagerules.PageruleNewParamsActionUnion{}),
-	}
 }
 
 type PageRuleActionsModel struct {

--- a/internal/services/page_rule/model.go
+++ b/internal/services/page_rule/model.go
@@ -3,7 +3,6 @@
 package page_rule
 
 import (
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -29,5 +28,5 @@ func (m PageRuleModel) MarshalJSON() (data []byte, err error) {
 }
 
 func (m PageRuleModel) MarshalJSONForUpdate(state PageRuleModel) (data []byte, err error) {
-	return apijson.MarshalForUpdate(m, state)
+	return m.marshalCustomForUpdate(state)
 }

--- a/internal/services/page_rule/resource.go
+++ b/internal/services/page_rule/resource.go
@@ -73,7 +73,9 @@ func (r *PageRuleResource) Create(ctx context.Context, req resource.CreateReques
 	env := PageRuleResultEnvelope{*data}
 	_, err = r.client.Pagerules.New(
 		ctx,
-		data.PageruleNewParams(),
+		pagerules.PageruleNewParams{
+			ZoneID: cloudflare.F(data.ZoneID.ValueString()),
+		},
 		option.WithRequestBody("application/json", dataBytes),
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),

--- a/internal/services/page_rule/resource_test.go
+++ b/internal/services/page_rule/resource_test.go
@@ -121,6 +121,164 @@ func TestAccCloudflarePageRule_FullySpecified(t *testing.T) {
 	})
 }
 
+func TestAccCloudflarePageRule_AlwaysUseHTTPS(t *testing.T) {
+	t.Skip("unable to set always_use_https")
+	var pageRule cloudflare.PageRule
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_page_rule." + rnd
+	target := fmt.Sprintf("%s.%s", rnd, domain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflarePageRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: buildPageRuleConfig(rnd, zoneID, `always_use_https = true`, target),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "actions.always_use_https", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflarePageRule_DisableApps(t *testing.T) {
+	var pageRule cloudflare.PageRule
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_page_rule." + rnd
+	target := fmt.Sprintf("%s.%s", rnd, domain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflarePageRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: buildPageRuleConfig(rnd, zoneID, `disable_apps = true`, target),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "actions.disable_apps", "true"),
+				),
+			},
+			{
+				Config: buildPageRuleConfig(rnd, zoneID, `disable_apps = false`, target),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "actions.disable_apps", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflarePageRule_DisablePerformance(t *testing.T) {
+	var pageRule cloudflare.PageRule
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_page_rule." + rnd
+	target := fmt.Sprintf("%s.%s", rnd, domain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflarePageRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: buildPageRuleConfig(rnd, zoneID, `disable_performance = true`, target),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "actions.disable_performance", "true"),
+				),
+			},
+			{
+				Config: buildPageRuleConfig(rnd, zoneID, `disable_performance = false`, target),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "actions.disable_performance", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflarePageRule_DisableSecurity(t *testing.T) {
+	var pageRule cloudflare.PageRule
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_page_rule." + rnd
+	target := fmt.Sprintf("%s.%s", rnd, domain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflarePageRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: buildPageRuleConfig(rnd, zoneID, `disable_security = true`, target),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "actions.disable_security", "true"),
+				),
+			},
+			{
+				Config: buildPageRuleConfig(rnd, zoneID, `disable_security = false`, target),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "actions.disable_security", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflarePageRule_DisableZaraz(t *testing.T) {
+	var pageRule cloudflare.PageRule
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_page_rule." + rnd
+	target := fmt.Sprintf("%s.%s", rnd, domain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflarePageRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: buildPageRuleConfig(rnd, zoneID, `disable_zaraz = true`, target),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "actions.disable_zaraz", "true"),
+				),
+			},
+			{
+				Config: buildPageRuleConfig(rnd, zoneID, `disable_zaraz = false`, target),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "actions.disable_zaraz", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudflarePageRule_ForwardingOnly(t *testing.T) {
 	var pageRule cloudflare.PageRule
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
@@ -170,32 +328,6 @@ func TestAccCloudflarePageRule_ForwardingAndOthers(t *testing.T) {
 				),
 
 				ExpectError: regexp.MustCompile("\"forwarding_url\" cannot be set with any other actions"),
-			},
-		},
-	})
-}
-
-func TestAccCloudflarePageRule_DisableZaraz(t *testing.T) {
-	var pageRule cloudflare.PageRule
-	domain := os.Getenv("CLOUDFLARE_DOMAIN")
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
-	rnd := utils.GenerateRandomResourceName()
-	resourceName := "cloudflare_page_rule." + rnd
-	target := fmt.Sprintf("%s.%s", rnd, domain)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckCloudflarePageRuleDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckCloudflarePageRuleConfigDisableZaraz(zoneID, target, rnd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
-					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
-					resource.TestCheckResourceAttr(resourceName, "target", fmt.Sprintf("%s/", target)),
-					resource.TestCheckResourceAttr(resourceName, "actions.0.disable_zaraz", "true"),
-				),
 			},
 		},
 	})
@@ -1032,10 +1164,6 @@ func testAccCheckCloudflarePageRuleConfigForwardingAndOthers(zoneID, target, rnd
 	return acctest.LoadTestCase("pageruleconfigforwardingandothers.tf", zoneID, target, rnd)
 }
 
-func testAccCheckCloudflarePageRuleConfigDisableZaraz(zoneID, target, rnd string) string {
-	return acctest.LoadTestCase("pageruleconfigdisablezaraz.tf", zoneID, target, rnd)
-}
-
 func testAccCheckCloudflarePageRuleConfigWithEdgeCacheTtl(zoneID, target, rnd string) string {
 	return acctest.LoadTestCase("pageruleconfigwithedgecachettl.tf", zoneID, target, rnd)
 }
@@ -1083,6 +1211,7 @@ func testAccCheckCloudflarePageRuleConfigCacheKeyFieldsIncludeMultipleValuesQuer
 func testAccCheckCloudflarePageRuleConfigCacheTTLByStatus(zoneID, target, rnd string) string {
 	return acctest.LoadTestCase("pageruleconfigcachettlbystatus.tf", zoneID, target, rnd)
 }
+
 func buildPageRuleConfig(rnd, zoneID, actions, target string) string {
 	return acctest.LoadTestCase("buildpageruleconfig.tf",
 		rnd,

--- a/internal/services/page_rule/schema.go
+++ b/internal/services/page_rule/schema.go
@@ -62,6 +62,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"actions": schema.SingleNestedAttribute{
 				Required: true,
 				Attributes: map[string]schema.Attribute{
+					"always_use_https": schema.BoolAttribute{
+						Optional: true,
+					},
 					"automatic_https_rewrites": schema.StringAttribute{
 						Optional: true,
 						Validators: []validator.String{
@@ -69,6 +72,15 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 					},
 					"disable_apps": schema.BoolAttribute{
+						Optional: true,
+					},
+					"disable_performance": schema.BoolAttribute{
+						Optional: true,
+					},
+					"disable_security": schema.BoolAttribute{
+						Optional: true,
+					},
+					"disable_zaraz": schema.BoolAttribute{
 						Optional: true,
 					},
 				},

--- a/internal/services/page_rule/testdata/pageruleconfigdisablezaraz.tf
+++ b/internal/services/page_rule/testdata/pageruleconfigdisablezaraz.tf
@@ -1,8 +1,0 @@
-
-resource "cloudflare_page_rule" "%[3]s" {
-	zone_id = "%[1]s"
-	target = "%[2]s"
-	actions =[ {
-		disable_zaraz = true
-	}]
-}


### PR DESCRIPTION
- handles and tests all stand-alone actions: `always_use_https`, `disable_apps`, `disable_performance`, `disable_security`, `disable_zaraz`
- adds `PageRuleModel.marshalCustomForUpdate` to encode update scenarios
- combines `PageRuleModel.marshalTargets` and `PageRuleModel.marshalActions` into a single method
- drops the switch in `PageRuleActionsModel.Encode` to allow setting multiple settings at once

Note: `always_use_https` is not an available setting in the current test account so the test is skipped.

---

```shell
mgirouard@sixteen:~/src/terraform-provider-cloudflare$ TF_ACC=1 go test -v ./internal/services/page_rule/ -run "^TestAccCloudflarePageRule_Disable" -v -count=1
=== RUN   TestAccCloudflarePageRule_DisableApps
--- PASS: TestAccCloudflarePageRule_DisableApps (6.30s)
=== RUN   TestAccCloudflarePageRule_DisablePerformance
--- PASS: TestAccCloudflarePageRule_DisablePerformance (5.61s)
=== RUN   TestAccCloudflarePageRule_DisableSecurity
--- PASS: TestAccCloudflarePageRule_DisableSecurity (5.45s)
=== RUN   TestAccCloudflarePageRule_DisableZaraz
--- PASS: TestAccCloudflarePageRule_DisableZaraz (5.42s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/page_rule 22.809s
```