### PR TITLE
Update issue sync owners of Pages/Workers

### DIFF
--- a/tools/cmd/sync-github-issue-to-jira/main.go
+++ b/tools/cmd/sync-github-issue-to-jira/main.go
@@ -128,7 +128,7 @@ var (
 			owner:    "opayne",
 		},
 		"service/workers": {
-			teamName: "Workers Core Platform",
+			teamName: "Workers Deploy & Config",
 			owner:    "laszlo",
 		},
 		"service/tunnel": {
@@ -152,8 +152,8 @@ var (
 			owner:    "njones",
 		},
 		"service/pages": {
-			teamName: "Workers Builds & Automation",
-			owner:    "nrogers",
+			teamName: "Workers Deploy & Config",
+			owner:    "laszlo",
 		},
 		"service/bot_management": {
 			teamName: "Bot Management",


### PR DESCRIPTION
Deploy & Config own Pages/Workers APIs and should be the owners on these escalated issues.