### PR TITLE
add forwarding_url page rule and fix ForwardOnly test

### DIFF
--- a/internal/services/page_rule/custom.go
+++ b/internal/services/page_rule/custom.go
@@ -1,11 +1,14 @@
 package page_rule
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/cloudflare/cloudflare-go/v3/pagerules"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 func (m PageRuleModel) marshalCustom() (data []byte, err error) {
@@ -63,36 +66,42 @@ func (m PageRuleModel) marshalTargetsAndActions(b []byte) (data []byte, err erro
 	return json.Marshal(T)
 }
 
+type PageRuleActionsForwardingURLModel struct {
+	URL        types.String `tfsdk:"url" json:"url,required"`
+	StatusCode types.Int64  `tfsdk:"status_code" json:"status_code,required"`
+}
+
 type PageRuleActionsModel struct {
-	AlwaysUseHTTPS          types.Bool   `tfsdk:"always_use_https" json:"always_use_https,optional"`
-	AutomaticHTTPSRewrites  types.String `tfsdk:"automatic_https_rewrites" json:"automatic_https_rewrites,optional"`
-	BrowserCheck            types.String `tfsdk:"browser_check" json:"browser_check,optional"`
-	BypassCacheOnCookie     types.String `tfsdk:"bypass_cache_on_cookie" json:"bypass_cache_on_cookie,optional"`
-	CacheByDeviceType       types.String `tfsdk:"cache_by_device_type" json:"cache_by_device_type,optional"`
-	CacheDeceptionArmor     types.String `tfsdk:"cache_deception_armor" json:"cache_deception_armor,optional"`
-	CacheLevel              types.String `tfsdk:"cache_level" json:"cache_level,optional"`
-	CacheOnCookie           types.String `tfsdk:"cache_on_cookie" json:"cache_on_cookie,optional"`
-	DisableApps             types.Bool   `tfsdk:"disable_apps" json:"disable_apps,optional"`
-	DisablePerformance      types.Bool   `tfsdk:"disable_performance" json:"disable_performance,optional"`
-	DisableSecurity         types.Bool   `tfsdk:"disable_security" json:"disable_security,optional"`
-	DisableZaraz            types.Bool   `tfsdk:"disable_zaraz" json:"disable_zaraz,optional"`
-	EmailObfuscation        types.String `tfsdk:"email_obfuscation" json:"email_obfuscation,optional"`
-	ExplicitCacheControl    types.String `tfsdk:"explicit_cache_control" json:"explicit_cache_control,optional"`
-	HostHeaderOverride      types.String `tfsdk:"host_header_override" json:"host_header_override,optional"`
-	IPGeolocation           types.String `tfsdk:"ip_geolocation" json:"ip_geolocation,optional"`
-	Mirage                  types.String `tfsdk:"mirage" json:"mirage,optional"`
-	OpportunisticEncryption types.String `tfsdk:"opportunistic_encryption" json:"opportunistic_encryption,optional"`
-	OriginErrorPagePassThru types.String `tfsdk:"origin_error_page_pass_thru" json:"origin_error_page_pass_thru,optional"`
-	Polish                  types.String `tfsdk:"polish" json:"polish,optional"`
-	ResolveOverride         types.String `tfsdk:"resolve_override" json:"resolve_override,optional"`
-	RespectStrongEtag       types.String `tfsdk:"respect_strong_etag" json:"respect_strong_etag,optional"`
-	ResponseBuffering       types.String `tfsdk:"response_buffering" json:"response_buffering,optional"`
-	RocketLoader            types.String `tfsdk:"rocket_loader" json:"rocket_loader,optional"`
-	SSL                     types.String `tfsdk:"ssl" json:"ssl,optional"`
-	SecurityLevel           types.String `tfsdk:"security_level" json:"security_level,optional"`
-	SortQueryStringForCache types.String `tfsdk:"sort_query_string_for_cache" json:"sort_query_string_for_cache,optional"`
-	TrueClientIPHeader      types.String `tfsdk:"true_client_ip_header" json:"true_client_ip_header,optional"`
-	WAF                     types.String `tfsdk:"waf" json:"waf,optional"`
+	AlwaysUseHTTPS          types.Bool                                                  `tfsdk:"always_use_https" json:"always_use_https,optional"`
+	AutomaticHTTPSRewrites  types.String                                                `tfsdk:"automatic_https_rewrites" json:"automatic_https_rewrites,optional"`
+	BrowserCheck            types.String                                                `tfsdk:"browser_check" json:"browser_check,optional"`
+	BypassCacheOnCookie     types.String                                                `tfsdk:"bypass_cache_on_cookie" json:"bypass_cache_on_cookie,optional"`
+	CacheByDeviceType       types.String                                                `tfsdk:"cache_by_device_type" json:"cache_by_device_type,optional"`
+	CacheDeceptionArmor     types.String                                                `tfsdk:"cache_deception_armor" json:"cache_deception_armor,optional"`
+	CacheLevel              types.String                                                `tfsdk:"cache_level" json:"cache_level,optional"`
+	CacheOnCookie           types.String                                                `tfsdk:"cache_on_cookie" json:"cache_on_cookie,optional"`
+	DisableApps             types.Bool                                                  `tfsdk:"disable_apps" json:"disable_apps,optional"`
+	DisablePerformance      types.Bool                                                  `tfsdk:"disable_performance" json:"disable_performance,optional"`
+	DisableSecurity         types.Bool                                                  `tfsdk:"disable_security" json:"disable_security,optional"`
+	DisableZaraz            types.Bool                                                  `tfsdk:"disable_zaraz" json:"disable_zaraz,optional"`
+	EmailObfuscation        types.String                                                `tfsdk:"email_obfuscation" json:"email_obfuscation,optional"`
+	ExplicitCacheControl    types.String                                                `tfsdk:"explicit_cache_control" json:"explicit_cache_control,optional"`
+	ForwardingURL           customfield.NestedObject[PageRuleActionsForwardingURLModel] `tfsdk:"forwarding_url" json:"forwarding_url,optional"`
+	HostHeaderOverride      types.String                                                `tfsdk:"host_header_override" json:"host_header_override,optional"`
+	IPGeolocation           types.String                                                `tfsdk:"ip_geolocation" json:"ip_geolocation,optional"`
+	Mirage                  types.String                                                `tfsdk:"mirage" json:"mirage,optional"`
+	OpportunisticEncryption types.String                                                `tfsdk:"opportunistic_encryption" json:"opportunistic_encryption,optional"`
+	OriginErrorPagePassThru types.String                                                `tfsdk:"origin_error_page_pass_thru" json:"origin_error_page_pass_thru,optional"`
+	Polish                  types.String                                                `tfsdk:"polish" json:"polish,optional"`
+	ResolveOverride         types.String                                                `tfsdk:"resolve_override" json:"resolve_override,optional"`
+	RespectStrongEtag       types.String                                                `tfsdk:"respect_strong_etag" json:"respect_strong_etag,optional"`
+	ResponseBuffering       types.String                                                `tfsdk:"response_buffering" json:"response_buffering,optional"`
+	RocketLoader            types.String                                                `tfsdk:"rocket_loader" json:"rocket_loader,optional"`
+	SSL                     types.String                                                `tfsdk:"ssl" json:"ssl,optional"`
+	SecurityLevel           types.String                                                `tfsdk:"security_level" json:"security_level,optional"`
+	SortQueryStringForCache types.String                                                `tfsdk:"sort_query_string_for_cache" json:"sort_query_string_for_cache,optional"`
+	TrueClientIPHeader      types.String                                                `tfsdk:"true_client_ip_header" json:"true_client_ip_header,optional"`
+	WAF                     types.String                                                `tfsdk:"waf" json:"waf,optional"`
 }
 
 func (m *PageRuleActionsModel) Encode() (encoded []map[string]any, err error) {
@@ -138,6 +147,17 @@ func (m *PageRuleActionsModel) Encode() (encoded []map[string]any, err error) {
 	}
 	if !m.ExplicitCacheControl.IsNull() {
 		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDExplicitCacheControl, "value": m.ExplicitCacheControl.ValueString()})
+	}
+	if !m.ForwardingURL.IsNull() {
+		var fw PageRuleActionsForwardingURLModel
+		m.ForwardingURL.As(context.TODO(), &fw, basetypes.ObjectAsOptions{})
+		encoded = append(encoded, map[string]any{
+			"id": pagerules.PageRuleActionsIDForwardingURL,
+			"value": map[string]any{
+				"url":         fw.URL.ValueString(),
+				"status_code": fw.StatusCode.ValueInt64(),
+			},
+		})
 	}
 	if !m.HostHeaderOverride.IsNull() {
 		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDHostHeaderOverride, "value": m.HostHeaderOverride.ValueString()})

--- a/internal/services/page_rule/resource_test.go
+++ b/internal/services/page_rule/resource_test.go
@@ -297,8 +297,8 @@ func TestAccCloudflarePageRule_ForwardingOnly(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
 					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
-					resource.TestCheckResourceAttr(resourceName, "target", fmt.Sprintf("%s/", target)),
-					resource.TestCheckResourceAttr(resourceName, "actions.0.forwarding_url.0.url", fmt.Sprintf("http://%s/forward", rnd+"."+domain)),
+					resource.TestCheckResourceAttr(resourceName, "target", fmt.Sprintf("%s", target)),
+					resource.TestCheckResourceAttr(resourceName, "actions.forwarding_url.url", fmt.Sprintf("http://%s/forward", rnd+"."+domain)),
 				),
 			},
 		},

--- a/internal/services/page_rule/schema.go
+++ b/internal/services/page_rule/schema.go
@@ -5,6 +5,7 @@ package page_rule
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -117,6 +118,18 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Optional: true,
 						Validators: []validator.String{
 							stringvalidator.OneOfCaseInsensitive("on", "off"),
+						},
+					},
+					"forwarding_url": schema.SingleNestedAttribute{
+						Optional:   true,
+						CustomType: customfield.NewNestedObjectType[PageRuleActionsForwardingURLModel](ctx),
+						Attributes: map[string]schema.Attribute{
+							"url": schema.StringAttribute{
+								Required: true,
+							},
+							"status_code": schema.Int64Attribute{
+								Required: true,
+							},
 						},
 					},
 					"host_header_override": schema.StringAttribute{

--- a/internal/services/page_rule/testdata/pageruleconfigforwardingonly.tf
+++ b/internal/services/page_rule/testdata/pageruleconfigforwardingonly.tf
@@ -1,12 +1,12 @@
 
 resource "cloudflare_page_rule" "%[3]s" {
-	zone_id = "%[1]s"
-	target = "%[2]s"
-	actions =[ {
-		// on/off options cannot even be set to off without causing error
-		forwarding_url =[ {
-			url = "http://%[4]s/forward"
-			status_code = 301
-		}]
-	}]
+  zone_id = "%[1]s"
+  target  = "%[2]s"
+  actions = {
+    // on/off options cannot even be set to off without causing error
+    forwarding_url = {
+      url         = "http://%[4]s/forward"
+      status_code = 301
+    }
+  }
 }


### PR DESCRIPTION
This PR gets `forwarding_url` implemented and resolves the Acceptance test for `ForwardingOnly`. I'm still working through `ForwardingAndOthers`

```
➜ TF_ACC=1 go test ./internal/services/page_rule/ -run "^TestAccCloudflarePageRule_Forwarding.*" -v -count=1
=== RUN   TestAccCloudflarePageRule_ForwardingOnly
--- PASS: TestAccCloudflarePageRule_ForwardingOnly (4.64s)
```