### PR TITLE
fix FowardingAndOthers test

### DIFF
--- a/internal/services/page_rule/resource_test.go
+++ b/internal/services/page_rule/resource_test.go
@@ -319,15 +319,14 @@ func TestAccCloudflarePageRule_ForwardingAndOthers(t *testing.T) {
 		CheckDestroy:             testAccCheckCloudflarePageRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudflarePageRuleConfigForwardingAndOthers(zoneID, target, rnd),
+				Config: testAccCheckCloudflarePageRuleConfigForwardingAndOthers(zoneID, target, rnd, rnd+"."+domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
 					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
 					resource.TestCheckResourceAttr(resourceName, "target", target),
-					resource.TestCheckResourceAttr(resourceName, "target", fmt.Sprintf("%s/", target)),
+					resource.TestCheckResourceAttr(resourceName, "target", fmt.Sprintf("%s", target)),
 				),
-
-				ExpectError: regexp.MustCompile("\"forwarding_url\" cannot be set with any other actions"),
+				ExpectError: regexp.MustCompile(`\\"forwarding_url\\"\s+may not be used with \\"any setting\\"`),
 			},
 		},
 	})
@@ -2033,8 +2032,8 @@ func testAccCheckCloudflarePageRuleConfigForwardingOnly(zoneID, target, rnd, zon
 	return acctest.LoadTestCase("pageruleconfigforwardingonly.tf", zoneID, target, rnd, zoneName)
 }
 
-func testAccCheckCloudflarePageRuleConfigForwardingAndOthers(zoneID, target, rnd string) string {
-	return acctest.LoadTestCase("pageruleconfigforwardingandothers.tf", zoneID, target, rnd)
+func testAccCheckCloudflarePageRuleConfigForwardingAndOthers(zoneID, target, rnd, zoneName string) string {
+	return acctest.LoadTestCase("pageruleconfigforwardingandothers.tf", zoneID, target, rnd, zoneName)
 }
 
 func testAccCheckCloudflarePageRuleConfigWithEdgeCacheTtl(zoneID, target, rnd string) string {

--- a/internal/services/page_rule/testdata/pageruleconfigforwardingandothers.tf
+++ b/internal/services/page_rule/testdata/pageruleconfigforwardingandothers.tf
@@ -1,12 +1,12 @@
 
 resource "cloudflare_page_rule" "%[3]s" {
-	zone_id = "%[1]s"
-	target = "%[2]s"
-	actions =[ {
-		disable_security = true
-		forwarding_url =[ {
-			url = "http://%s/forward"
-			status_code = 301
-		}]
-	}]
+  zone_id = "%[1]s"
+  target  = "%[2]s"
+  actions = {
+    disable_security = true
+    forwarding_url = {
+      url         = "http://%[4]s/forward"
+      status_code = 301
+    }
+  }
 }


### PR DESCRIPTION
This aims to fix the FowardingAndOthers Acceptance test. 
```
=== RUN   TestAccCloudflarePageRule_ForwardingAndOthers
--- PASS: TestAccCloudflarePageRule_ForwardingAndOthers (1.46s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/page_rule 4.233s
```

Terraform does some weird things with the API output, but essentially it makes it a multi line object with various unnecessary whitespace causing issues with regexp.

```
  error=
  | exit status 1
  |
  | Error: failed to make http request
  |
  |   with cloudflare_page_rule.nkcfpuwhfo,
  |   on terraform_plugin_test.tf line 12, in resource "cloudflare_page_rule" "nkcfpuwhfo":
  |   12: resource "cloudflare_page_rule" "nkcfpuwhfo" {
  |
  | POST
  | "https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/pagerules":
  | 400 Bad Request {"success":false,"errors":[{"code":1004,"message":"Page Rule
  | validation failed: See messages for
  | details."}],"messages":[{"code":1,"message":".settings: \"forwarding_url\"
  | may not be used with \"any setting\"","type":null}],"result":null}
```