### PR TITLE
add edge_cache_ttl page rule and fix EdgeCacheTTLNotClobbered test

### DIFF
--- a/internal/services/page_rule/custom.go
+++ b/internal/services/page_rule/custom.go
@@ -84,6 +84,7 @@ type PageRuleActionsModel struct {
 	DisablePerformance      types.Bool                                                  `tfsdk:"disable_performance" json:"disable_performance,optional"`
 	DisableSecurity         types.Bool                                                  `tfsdk:"disable_security" json:"disable_security,optional"`
 	DisableZaraz            types.Bool                                                  `tfsdk:"disable_zaraz" json:"disable_zaraz,optional"`
+	EdgeCacheTTL            types.Int64                                                 `tfsdk:"edge_cache_ttl" json:"edge_cache_ttl,optional"`
 	EmailObfuscation        types.String                                                `tfsdk:"email_obfuscation" json:"email_obfuscation,optional"`
 	ExplicitCacheControl    types.String                                                `tfsdk:"explicit_cache_control" json:"explicit_cache_control,optional"`
 	ForwardingURL           customfield.NestedObject[PageRuleActionsForwardingURLModel] `tfsdk:"forwarding_url" json:"forwarding_url,optional"`
@@ -141,6 +142,9 @@ func (m *PageRuleActionsModel) Encode() (encoded []map[string]any, err error) {
 	}
 	if m.DisableZaraz.ValueBool() {
 		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDDisableZaraz})
+	}
+	if !m.EdgeCacheTTL.IsNull() {
+		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDEdgeCacheTTL, "value": m.EdgeCacheTTL.ValueInt64()})
 	}
 	if !m.EmailObfuscation.IsNull() {
 		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDEmailObfuscation, "value": m.EmailObfuscation.ValueString()})

--- a/internal/services/page_rule/resource_test.go
+++ b/internal/services/page_rule/resource_test.go
@@ -1531,14 +1531,14 @@ func TestAccCloudflarePageRule_EdgeCacheTTLNotClobbered(t *testing.T) {
 				Config: testAccCheckCloudflarePageRuleConfigWithEdgeCacheTtl(zoneID, target, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists(resourceName, &before),
-					resource.TestCheckResourceAttr(resourceName, "actions.0.edge_cache_ttl", "10"),
+					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "7200"),
 				),
 			},
 			{
 				Config: testAccCheckCloudflarePageRuleConfigWithEdgeCacheTtlAndAlwaysOnline(zoneID, target, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists(resourceName, &after),
-					resource.TestCheckResourceAttr(resourceName, "actions.0.edge_cache_ttl", "10"),
+					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "7200"),
 				),
 			},
 		},

--- a/internal/services/page_rule/resource_test.go
+++ b/internal/services/page_rule/resource_test.go
@@ -1531,14 +1531,14 @@ func TestAccCloudflarePageRule_EdgeCacheTTLNotClobbered(t *testing.T) {
 				Config: testAccCheckCloudflarePageRuleConfigWithEdgeCacheTtl(zoneID, target, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists(resourceName, &before),
-					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "7200"),
+					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "10"),
 				),
 			},
 			{
 				Config: testAccCheckCloudflarePageRuleConfigWithEdgeCacheTtlAndAlwaysOnline(zoneID, target, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists(resourceName, &after),
-					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "7200"),
+					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "10"),
 				),
 			},
 		},

--- a/internal/services/page_rule/schema.go
+++ b/internal/services/page_rule/schema.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -113,6 +114,13 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 					"disable_zaraz": schema.BoolAttribute{
 						Optional: true,
+					},
+					"edge_cache_ttl": schema.Int64Attribute{
+						Optional: true,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(7200),
+							int64validator.AtMost(2419200),
+						},
 					},
 					"email_obfuscation": schema.StringAttribute{
 						Optional: true,

--- a/internal/services/page_rule/schema.go
+++ b/internal/services/page_rule/schema.go
@@ -118,7 +118,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"edge_cache_ttl": schema.Int64Attribute{
 						Optional: true,
 						Validators: []validator.Int64{
-							int64validator.AtLeast(7200),
+							int64validator.AtLeast(0),
 							int64validator.AtMost(2419200),
 						},
 					},

--- a/internal/services/page_rule/testdata/pageruleconfigwithedgecachettl.tf
+++ b/internal/services/page_rule/testdata/pageruleconfigwithedgecachettl.tf
@@ -1,9 +1,9 @@
 
-resource "cloudflare_page_rule" "%[3]s" {
-	zone_id = "%[1]s"
-	target = "%[2]s"
-	actions =[ {
-		ssl = "flexible"
-		edge_cache_ttl = 10
-	}]
+resource "cloudflare_page_rule" "%[3]s"{
+  zone_id = "%[1]s"
+  target  = "%[2]s"
+  actions = {
+    ssl            = "flexible"
+    edge_cache_ttl = 7200
+  }
 }

--- a/internal/services/page_rule/testdata/pageruleconfigwithedgecachettl.tf
+++ b/internal/services/page_rule/testdata/pageruleconfigwithedgecachettl.tf
@@ -4,6 +4,6 @@ resource "cloudflare_page_rule" "%[3]s"{
   target  = "%[2]s"
   actions = {
     ssl            = "flexible"
-    edge_cache_ttl = 7200
+    edge_cache_ttl = 10
   }
 }

--- a/internal/services/page_rule/testdata/pageruleconfigwithedgecachettlandalwaysonline.tf
+++ b/internal/services/page_rule/testdata/pageruleconfigwithedgecachettlandalwaysonline.tf
@@ -1,8 +1,8 @@
 
 resource "cloudflare_page_rule" "%[3]s" {
-	zone_id = "%[1]s"
-	target = "%[2]s"
-	actions =[ {
-		edge_cache_ttl = 10
-	}]
+  zone_id = "%[1]s"
+  target  = "%[2]s"
+  actions = {
+    edge_cache_ttl = 7200
+  }
 }

--- a/internal/services/page_rule/testdata/pageruleconfigwithedgecachettlandalwaysonline.tf
+++ b/internal/services/page_rule/testdata/pageruleconfigwithedgecachettlandalwaysonline.tf
@@ -3,6 +3,6 @@ resource "cloudflare_page_rule" "%[3]s" {
   zone_id = "%[1]s"
   target  = "%[2]s"
   actions = {
-    edge_cache_ttl = 7200
+    edge_cache_ttl = 10
   }
 }


### PR DESCRIPTION
This PR aims to add Edge Cache TTL Page rule and update its Acceptance tests.
```
➜ TF_ACC=1 go test ./internal/services/page_rule/ -run "^TestAccCloudflarePageRule_EdgeCacheTTL" -v -count=1
=== RUN   TestAccCloudflarePageRule_EdgeCacheTTLNotClobbered
--- PASS: TestAccCloudflarePageRule_EdgeCacheTTLNotClobbered (6.28s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/page_rule 9.016s
```