### PR TITLE
add browser cache ttl and fix accompanying tests

### DIFF
--- a/internal/services/page_rule/custom.go
+++ b/internal/services/page_rule/custom.go
@@ -74,6 +74,7 @@ type PageRuleActionsForwardingURLModel struct {
 type PageRuleActionsModel struct {
 	AlwaysUseHTTPS          types.Bool                                                  `tfsdk:"always_use_https" json:"always_use_https,optional"`
 	AutomaticHTTPSRewrites  types.String                                                `tfsdk:"automatic_https_rewrites" json:"automatic_https_rewrites,optional"`
+	BrowserCacheTTL         types.Int64                                                 `tfsdk:"browser_cache_ttl" json:"browser_cache_ttl,optional"`
 	BrowserCheck            types.String                                                `tfsdk:"browser_check" json:"browser_check,optional"`
 	BypassCacheOnCookie     types.String                                                `tfsdk:"bypass_cache_on_cookie" json:"bypass_cache_on_cookie,optional"`
 	CacheByDeviceType       types.String                                                `tfsdk:"cache_by_device_type" json:"cache_by_device_type,optional"`
@@ -111,6 +112,9 @@ func (m *PageRuleActionsModel) Encode() (encoded []map[string]any, err error) {
 	}
 	if !m.AutomaticHTTPSRewrites.IsNull() {
 		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDAutomaticHTTPSRewrites, "value": m.AutomaticHTTPSRewrites.String()})
+	}
+	if !m.BrowserCacheTTL.IsNull() {
+		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDBrowserCacheTTL, "value": m.BrowserCacheTTL.ValueInt64()})
 	}
 	if !m.BrowserCheck.IsNull() {
 		encoded = append(encoded, map[string]any{"id": pagerules.PageRuleActionsIDBrowserCheck, "value": m.BrowserCheck.ValueString()})

--- a/internal/services/page_rule/resource_test.go
+++ b/internal/services/page_rule/resource_test.go
@@ -1422,7 +1422,7 @@ func TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues(t *testing.T)
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
 				testAccCheckCloudflarePageRuleHasAction(&pageRule, "browser_cache_ttl", float64(1)),
-				resource.TestCheckResourceAttr(resourceName, "actions.0.browser_cache_ttl", "1"),
+				resource.TestCheckResourceAttr(resourceName, "actions.browser_cache_ttl", "1"),
 			),
 		},
 	})
@@ -1440,7 +1440,7 @@ func TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders
 			Config: buildPageRuleConfig(rnd, zoneID, "browser_cache_ttl = 0", target),
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
-				resource.TestCheckResourceAttr(resourceName, "actions.0.browser_cache_ttl", "0"),
+				resource.TestCheckResourceAttr(resourceName, "actions.browser_cache_ttl", "0"),
 				testAccCheckCloudflarePageRuleHasAction(&pageRule, "browser_cache_ttl", float64(0)),
 			),
 		},
@@ -1464,7 +1464,7 @@ func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLToSameValue(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
 				testAccCheckCloudflarePageRuleHasAction(&pageRule, "browser_cache_ttl", float64(1)),
-				resource.TestCheckResourceAttr(resourceName, "actions.0.browser_cache_ttl", "1"),
+				resource.TestCheckResourceAttr(resourceName, "actions.browser_cache_ttl", "1"),
 			),
 		},
 	})
@@ -1486,7 +1486,7 @@ func TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
 				testAccCheckCloudflarePageRuleHasAction(&pageRule, "browser_cache_ttl", float64(0)),
-				resource.TestCheckResourceAttr(resourceName, "actions.0.browser_cache_ttl", "0"),
+				resource.TestCheckResourceAttr(resourceName, "actions.browser_cache_ttl", "0"),
 			),
 		},
 	})
@@ -1507,7 +1507,7 @@ func TestAccCloudflarePageRule_DeletesBrowserCacheTTLThatRespectsExistingHeaders
 			Config: buildPageRuleConfig(rnd, zoneID, `browser_check = "on"`, target),
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
-				resource.TestCheckResourceAttr(resourceName, "actions.0.browser_cache_ttl", ""),
+				resource.TestCheckNoResourceAttr(resourceName, "actions.browser_cache_ttl"),
 			),
 		},
 	})

--- a/internal/services/page_rule/schema.go
+++ b/internal/services/page_rule/schema.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -70,6 +71,13 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Optional: true,
 						Validators: []validator.String{
 							stringvalidator.OneOfCaseInsensitive("on", "off"),
+						},
+					},
+					"browser_cache_ttl": schema.Int64Attribute{
+						Optional: true,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+							int64validator.AtMost(31536000),
 						},
 					},
 					"browser_check": schema.StringAttribute{


### PR DESCRIPTION
add BrowserCacheTTL to Page Rules and update the tests
```
➜ TF_ACC=1 go test ./internal/services/page_rule/ -run "^TestAccCloudflarePageRule_.*BrowserCacheTTL.*" -v -count=1
=== RUN   TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues
--- PASS: TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues (3.85s)
=== RUN   TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders
--- PASS: TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders (3.46s)
=== RUN   TestAccCloudflarePageRule_UpdatesBrowserCacheTTLToSameValue
--- PASS: TestAccCloudflarePageRule_UpdatesBrowserCacheTTLToSameValue (5.87s)
=== RUN   TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders
--- PASS: TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders (5.52s)
=== RUN   TestAccCloudflarePageRule_DeletesBrowserCacheTTLThatRespectsExistingHeaders
--- PASS: TestAccCloudflarePageRule_DeletesBrowserCacheTTLThatRespectsExistingHeaders (6.28s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/page_rule 29.312s
```