### PR TITLE
feat(rulesets): improve handling of `id` and `ref` unknown values

### DIFF
--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -109,10 +109,16 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 						consts.IDSchemaKey: schema.StringAttribute{
 							Computed:            true,
 							MarkdownDescription: "Unique rule identifier.",
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"ref": schema.StringAttribute{
-							Optional:            true,
-							Computed:            true,
+							Optional: true,
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 							MarkdownDescription: "Rule reference.",
 						},
 						"enabled": schema.BoolAttribute{


### PR DESCRIPTION
Updates the schema definition to apply
`stringplanmodifier.UseStateForUnknown` on the values as once they are set, they should not be changing and we can safely rely on the values.

This is the last piece of the rulesets drift issue.