### PR TITLE
convert cache key fields and cache ttl by status to their new formats

### DIFF
--- a/.grit/patterns/cloudflare_terraform_v5_attribute_renames_config.grit
+++ b/.grit/patterns/cloudflare_terraform_v5_attribute_renames_config.grit
@@ -49,13 +49,13 @@ pattern cloudflare_terraform_v5_attribute_renames_config() {
                             $ele <: contains `codes = $code` => . ,
                             $ele <: contains `ttl = $ttl` => .,
                             $ele => `$code => $ttl`,
-                        } 
-                    }, 
+                        }
+                    },
                     $cttl_ele <: contains `,` =>.
                 },
             },
         }
-    }
+    },
 
     // cloudflare_teams_list & cloudflare_zero_trust_list
     `items = [$items]` as $all_items where {

--- a/.grit/patterns/cloudflare_terraform_v5_attribute_renames_config.grit
+++ b/.grit/patterns/cloudflare_terraform_v5_attribute_renames_config.grit
@@ -38,22 +38,12 @@ pattern cloudflare_terraform_v5_attribute_renames_config() {
     `default_pool_ids = $v` as $attribute => `default_pools = $v` where { $attribute <: within `resource "cloudflare_load_balancer" $_ { $_ }` },
 
     // cloudflare_page_rule
-    `ignore = true` as $attribute => `exclude = ["*"]` where and { $attribute <: within `resource "cloudflare_page_rule" $_ { $_ }`, $attribute <: within `cache_key_fields { $_ }`, $attribute <: within `query_string { $_ }` },
-    `ignore = false` as $attribute => `include = ["*"]` where and { $attribute <: within `resource "cloudflare_page_rule" $_ { $_ }`, $attribute <: within `cache_key_fields { $_ }`, $attribute <: within `query_string { $_ }` },
     `resource "cloudflare_page_rule" $_ { $body }` where {
-        $body <: contains `actions = [ $actions ]` where {
-            $actions <: contains `$cttl` where {
-                $cttl <: contains `cache_ttl_by_status = $cttl_ele` where {
-                    $cttl_ele <: contains `[ $old ]` where {
-                        $old <: some bubble `$ele` where {
-                            $ele <: contains `codes = $code` => . ,
-                            $ele <: contains `ttl = $ttl` => .,
-                            $ele => `$code => $ttl`,
-                        }
-                    },
-                    $cttl_ele <: contains `,` =>.
-                },
-            },
+        $body <: contains `cache_key_fields = $ckf` where {
+            $ckf <: contains `query_string = $qs` where and {
+                $qs <: contains `ignore = false` => `include = ["*"]`,
+                $qs <: contains `ignore = true` => `exclude = ["*"]`,
+            }
         }
     },
 

--- a/.grit/patterns/cloudflare_terraform_v5_attribute_renames_config.grit
+++ b/.grit/patterns/cloudflare_terraform_v5_attribute_renames_config.grit
@@ -37,6 +37,26 @@ pattern cloudflare_terraform_v5_attribute_renames_config() {
     `fallback_pool_id = $v` as $attribute => `fallback_pool = $v` where { $attribute <: within `resource "cloudflare_load_balancer" $_ { $_ }` },
     `default_pool_ids = $v` as $attribute => `default_pools = $v` where { $attribute <: within `resource "cloudflare_load_balancer" $_ { $_ }` },
 
+    // cloudflare_page_rule
+    `ignore = true` as $attribute => `exclude = ["*"]` where and { $attribute <: within `resource "cloudflare_page_rule" $_ { $_ }`, $attribute <: within `cache_key_fields { $_ }`, $attribute <: within `query_string { $_ }` },
+    `ignore = false` as $attribute => `include = ["*"]` where and { $attribute <: within `resource "cloudflare_page_rule" $_ { $_ }`, $attribute <: within `cache_key_fields { $_ }`, $attribute <: within `query_string { $_ }` },
+    `resource "cloudflare_page_rule" $_ { $body }` where {
+        $body <: contains `actions = [ $actions ]` where {
+            $actions <: contains `$cttl` where {
+                $cttl <: contains `cache_ttl_by_status = $cttl_ele` where {
+                    $cttl_ele <: contains `[ $old ]` where {
+                        $old <: some bubble `$ele` where {
+                            $ele <: contains `codes = $code` => . ,
+                            $ele <: contains `ttl = $ttl` => .,
+                            $ele => `$code => $ttl`,
+                        } 
+                    }, 
+                    $cttl_ele <: contains `,` =>.
+                },
+            },
+        }
+    }
+
     // cloudflare_teams_list & cloudflare_zero_trust_list
     `items = [$items]` as $all_items where {
         $values = [],

--- a/templates/guides/version-5-upgrade.md
+++ b/templates/guides/version-5-upgrade.md
@@ -1244,40 +1244,23 @@ resource "cloudflare_api_token" "example" {
 
 ## cloudflare_page_rule
 
-- ``
+- `ignore = true` is now `exclude = ["*"]`
+- `ignore = false` is now `include = ["*"]`
+- `cache_ttl_by_status` is now a map (`cache_ttl_by_status = { ... }`) instead of a list of objects (`cache_ttl_by_status = [{ ... }]`)
 
 Before
 
 ```
 resource "cloudflare_page_rule" "example" {
+  target = "example.com"
   actions = [
     {
-      cache_ttl_by_status = [
-        {
-          codes = "200-299"
-          ttl   = 300
-        },
-        {
-          codes = "300-399"
-          ttl   = 60
-        },
-        {
-          codes = "400-403"
-          ttl   = -1
-        },
-        {
-          codes = "404"
-          ttl   = 30
-        },
-        {
-          codes = "405-499"
-          ttl   = -1
-        },
-        {
-          codes = "500-599"
-          ttl   = 0
+      cache_key_fields = {
+        query_string = {
+            ignore = true
+            ignore = false
         }
-      ]
+      }
     }
   ]
 }
@@ -1287,18 +1270,17 @@ After
 
 ```
 resource "cloudflare_page_rule" "example" {
-  actions = {
-    cache_ttl_by_status = {
-      "100-149" = "no-cache"
-      "150-199" = "no-store"
-      "200-299" = 300
-      "300-399" = 60
-      "400-403" = -1
-      "404" = 30
-      "405-499" = -1
-      "500-599" = 0
+  target = "example.com"
+  actions = [
+    {
+      cache_key_fields = {
+        query_string = {
+            exclude = ["*"]
+            include = ["*"]
+        }
+      }
     }
-  }
+  ]
 }
 ```
 

--- a/templates/guides/version-5-upgrade.md
+++ b/templates/guides/version-5-upgrade.md
@@ -1242,6 +1242,66 @@ resource "cloudflare_api_token" "example" {
 - `colo_names` is now `scope.colo_names`
 - `colo_regions` is now `scope.colo_regions`
 
+## cloudflare_page_rule
+
+- ``
+
+Before
+
+```
+resource "cloudflare_page_rule" "example" {
+  actions = [
+    {
+      cache_ttl_by_status = [
+        {
+          codes = "200-299"
+          ttl   = 300
+        },
+        {
+          codes = "300-399"
+          ttl   = 60
+        },
+        {
+          codes = "400-403"
+          ttl   = -1
+        },
+        {
+          codes = "404"
+          ttl   = 30
+        },
+        {
+          codes = "405-499"
+          ttl   = -1
+        },
+        {
+          codes = "500-599"
+          ttl   = 0
+        }
+      ]
+    }
+  ]
+}
+```
+
+After
+
+```
+resource "cloudflare_page_rule" "example" {
+  actions = {
+    cache_ttl_by_status = {
+      "100-149" = "no-cache"
+      "150-199" = "no-store"
+      "200-299" = 300
+      "300-399" = 60
+      "400-403" = -1
+      "404" = 30
+      "405-499" = -1
+      "500-599" = 0
+    }
+  }
+}
+```
+
 [GritQL]: https://www.grit.io/
 [install Grit]: https://docs.grit.io/cli/quickstart
 [migrating renamed resources]: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/guides/migrating-renamed-resources


### PR DESCRIPTION
This PR aims to add support for transforming attribute for the page rules `cache_key_fields` and `cache_ttl_by_status` actions.

For `cache_key_fields` we're looking to migrate
```
query_string {
    ignore = true // or
    ignore = false
} 
```
to
```
query_string {
   exclude = ["*"] // or
   include = ["*"]
} 
```

As for `cache_ttl_by_status` we're looking to transform 
```
resource "cloudflare_page_rule" {
	actions = [ 
        {
		cache_ttl_by_status = [ 
                  {
			codes = "200-299"
			ttl = 300
		},
                {
                          codes = "300-399"
                          ttl = 60
                },
                {
                          codes = "400-403"
                          ttl = -1
                },
                {
                          codes = "404"
                          ttl = 30
                },
                {
                          codes = "405-499"
                          ttl = -1
                },
                {
                          codes = "500-599"
                          ttl = 0
                }
            ]
	}
  ]
}
```
to
```
resource "cloudflare_page_rule"{
  actions = {
    cache_ttl_by_status = {
        "100-149" = "no-cache"
        "150-199" = "no-store"
        "200-299" = 300
        "300-399" = 60
        "400-403" = -1
        "404" = 30
        "405-499" = -1
        "500-599" = 0
    }
  }
}
```

Proof `cache_ttl_by_status` works:
![image](https://github.com/user-attachments/assets/3f2b5d8a-e681-4939-82ac-fae20c1a0457)
