### PR TITLE
[Docs] Update deprecation date

### DIFF
--- a/docs/resources/filter.md
+++ b/docs/resources/filter.md
@@ -13,7 +13,7 @@ Filter expressions that can be referenced across multiple features,
 e.g. Firewall Rules. See [what is a filter](https://developers.cloudflare.com/firewall/api/cf-filters/what-is-a-filter/)
 for more details and available fields and operators.
 
-~> `cloudflare_filter` is in a deprecation phase until January 15th, 2025.
+~> `cloudflare_filter` is in a deprecation phase until June 15th, 2025.
   During this time period, this resource is still fully
   supported but you are strongly advised to move to the
   `cloudflare_ruleset` resource. Full details can be found in the

--- a/docs/resources/firewall_rule.md
+++ b/docs/resources/firewall_rule.md
@@ -20,7 +20,7 @@ rule creation.
 Filter expressions needs to be created first before using Firewall
 Rule.
 
-~> `cloudflare_firewall_rule` is in a deprecation phase until January 15th, 2025.
+~> `cloudflare_firewall_rule` is in a deprecation phase until June 15th, 2025.
   During this time period, this resource is still
   fully supported but you are strongly advised  to move to the
   `cloudflare_ruleset` resource. Full details can be found in the

--- a/docs/resources/rate_limit.md
+++ b/docs/resources/rate_limit.md
@@ -13,7 +13,7 @@ Provides a Cloudflare rate limit resource for a given zone. This can
 be used to limit the traffic you receive zone-wide, or matching more
 specific types of requests/responses.
 
-~> `cloudflare_rate_limit` is in a deprecation phase until January 15th, 2025.
+~> `cloudflare_rate_limit` is in a deprecation phase until June 15th, 2025.
   During this time period, this resource is still
   fully supported but you are strongly advised to move to the
   `cloudflare_ruleset` resource. Full details can be found in the

--- a/internal/sdkv2provider/resource_cloudflare_filter.go
+++ b/internal/sdkv2provider/resource_cloudflare_filter.go
@@ -30,7 +30,7 @@ func resourceCloudflareFilter() *schema.Resource {
 			for more details and available fields and operators.
 		`),
 		DeprecationMessage: heredoc.Doc(fmt.Sprintf(`
-			%s resource is in a deprecation phase until January 15th, 2025.
+			%s resource is in a deprecation phase until June 15th, 2025.
 			During this time period, this resource is still fully supported
 			but you are strongly advised to move to the %s resource.
 

--- a/internal/sdkv2provider/resource_cloudflare_firewall_rule.go
+++ b/internal/sdkv2provider/resource_cloudflare_firewall_rule.go
@@ -35,7 +35,7 @@ func resourceCloudflareFirewallRule() *schema.Resource {
 			Rule.
 		`),
 		DeprecationMessage: heredoc.Doc(fmt.Sprintf(`
-			%s resource is in a deprecation phase until January 15th, 2025.
+			%s resource is in a deprecation phase until June 15th, 2025.
 			During this time period, this resource is still fully supported
 			but you are strongly advised to move to the %s resource.
 

--- a/internal/sdkv2provider/resource_cloudflare_rate_limit.go
+++ b/internal/sdkv2provider/resource_cloudflare_rate_limit.go
@@ -30,7 +30,7 @@ func resourceCloudflareRateLimit() *schema.Resource {
 			specific types of requests/responses.
 		`),
 		DeprecationMessage: heredoc.Doc(fmt.Sprintf(`
-			%s resource is in a deprecation phase until January 15th, 2025.
+			%s resource is in a deprecation phase until June 15th, 2025.
 			During this time period, this resource is still fully supported
 			but you are strongly advised to move to the %s resource.
 

--- a/templates/resources/filter.md.tmpl
+++ b/templates/resources/filter.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 {{ .Description | trimspace }}
 
-~> `cloudflare_filter` is in a deprecation phase until January 15th, 2025.
+~> `cloudflare_filter` is in a deprecation phase until June 15th, 2025.
   During this time period, this resource is still fully
   supported but you are strongly advised to move to the
   `cloudflare_ruleset` resource. Full details can be found in the

--- a/templates/resources/firewall_rule.md.tmpl
+++ b/templates/resources/firewall_rule.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 {{ .Description | trimspace }}
 
-~> `cloudflare_firewall_rule` is in a deprecation phase until January 15th, 2025.
+~> `cloudflare_firewall_rule` is in a deprecation phase until June 15th, 2025.
   During this time period, this resource is still
   fully supported but you are strongly advised  to move to the
   `cloudflare_ruleset` resource. Full details can be found in the

--- a/templates/resources/rate_limit.md.tmpl
+++ b/templates/resources/rate_limit.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 {{ .Description | trimspace }}
 
-~> `cloudflare_rate_limit` is in a deprecation phase until January 15th, 2025.
+~> `cloudflare_rate_limit` is in a deprecation phase until June 15th, 2025.
   During this time period, this resource is still
   fully supported but you are strongly advised to move to the
   `cloudflare_ruleset` resource. Full details can be found in the


### PR DESCRIPTION
The deprecation date of the following resources has been updated:
* `cloudflare_filter`
* `cloudflare_firewall_rule`
* `cloudflare_rate_limit`

The Developer Docs have the correct date already (2025-06-15):
* https://developers.cloudflare.com/waf/reference/migration-guides/firewall-rules-to-custom-rules/
* https://developers.cloudflare.com/waf/reference/migration-guides/old-rate-limiting-deprecation/
