### PR TITLE
[Docs] cloud_connector_rules: Add link to Dev Docs

### DIFF
--- a/docs/resources/cloud_connector_rules.md
+++ b/docs/resources/cloud_connector_rules.md
@@ -2,12 +2,12 @@
 page_title: "cloudflare_cloud_connector_rules Resource - Cloudflare"
 subcategory: ""
 description: |-
-  The Cloud Connector Rules add link to doc resource allows you to create and manage cloud connector rules for a zone.
+  The Cloud Connector Rules resource allows you to create and manage cloud connector rules for a zone.
 ---
 
 # cloudflare_cloud_connector_rules (Resource)
 
-The [Cloud Connector Rules](add link to doc) resource allows you to create and manage cloud connector rules for a zone.
+The [Cloud Connector Rules](https://developers.cloudflare.com/rules/cloud-connector/) resource allows you to create and manage cloud connector rules for a zone.
 
 ## Example Usage
 

--- a/internal/framework/service/cloud_connector_rules/schema.go
+++ b/internal/framework/service/cloud_connector_rules/schema.go
@@ -19,7 +19,7 @@ import (
 func (r *CloudConnectorRulesResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: heredoc.Doc(`
-			The [Cloud Connector Rules](add link to doc) resource allows you to create and manage cloud connector rules for a zone.
+			The [Cloud Connector Rules](https://developers.cloudflare.com/rules/cloud-connector/) resource allows you to create and manage cloud connector rules for a zone.
 		`),
 		Version: 1,
 


### PR DESCRIPTION
Replaces placeholder text with real link to Dev Docs.