### PR TITLE
Adds Terraform 1.5 import syntax

### DIFF
--- a/.changelog/4790.txt
+++ b/.changelog/4790.txt
@@ -1,0 +1,3 @@
+```release-note:dependency
+Improves documentation to include new import options for Terraform 1.5.0
+```

--- a/docs/resources/access_application.md
+++ b/docs/resources/access_application.md
@@ -356,3 +356,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_access_application.example <account_id>/<application_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_access_application.example
+    id = "<account_id>/<application_id>"
+}
+```

--- a/docs/resources/access_ca_certificate.md
+++ b/docs/resources/access_ca_certificate.md
@@ -63,3 +63,16 @@ $ terraform import cloudflare_access_ca_certificate.example account/<account_id>
 # Zone level CA certificate import.
 $ terraform import cloudflare_access_ca_certificate.example account/<zone_id>/<application_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_access_ca_certificate.example
+    id = "account/<account_id>/<application_id>"
+}
+
+import {
+    to = cloudflare_access_ca_certificate.example
+    id = "zone/<zone_id>/<application_id>"
+}
+```

--- a/docs/resources/access_group.md
+++ b/docs/resources/access_group.md
@@ -372,3 +372,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_access_group.example <account_id>/<group_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_access_group.example
+    id = "<account_id>/<group_id>"
+}
+```

--- a/docs/resources/access_identity_provider.md
+++ b/docs/resources/access_identity_provider.md
@@ -142,3 +142,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_access_identity_provider.example <account_id>/<identity_provider_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_access_identity_provider.example
+    id = "<account_id>/<identity_provider_id>"
+}
+```

--- a/docs/resources/access_mutual_tls_certificate.md
+++ b/docs/resources/access_mutual_tls_certificate.md
@@ -63,3 +63,11 @@ $ terraform import cloudflare_access_mutual_tls_certificate.example account/<acc
 # Zone level import.
 $ terraform import cloudflare_access_mutual_tls_certificate.example zone/<zone_id>/<mutual_tls_certificate_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_access_mutual_tls_certificate.example
+    id = "zone/<zone_id>/<mutual_tls_certificate_id>"
+}
+```

--- a/docs/resources/access_mutual_tls_hostname_settings.md
+++ b/docs/resources/access_mutual_tls_hostname_settings.md
@@ -53,3 +53,17 @@ $ terraform import cloudflare_access_mutual_tls_hostname_settings.example accoun
 # Zone level mTLS hostname settings import.
 $ terraform import cloudflare_access_mutual_tls_hostname_settings.example zone/<zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+
+```terraform
+import {
+  to = cloudflare_access_mutual_tls_hostname_settings.example
+  id = "account/<account_id>"
+}
+
+import {
+  to = cloudflare_access_mutual_tls_hostname_settings.example
+  id = "zone/<zone_id>"
+}
+```

--- a/docs/resources/access_organization.md
+++ b/docs/resources/access_organization.md
@@ -82,3 +82,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_access_organization.example <account_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_access_organization.example
+    id = "<account_id>"
+}
+```

--- a/docs/resources/access_policy.md
+++ b/docs/resources/access_policy.md
@@ -449,3 +449,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_access_policy.example account/<account_id>/<application_id>/<policy_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_access_policy.example
+    id = "account/<account_id>/<application_id>/<policy_id>"
+}
+```

--- a/docs/resources/access_rule.md
+++ b/docs/resources/access_rule.md
@@ -96,3 +96,11 @@ $ terraform import cloudflare_access_rule.default zone/<zone_id>/<rule_id>
 # Account level access rule import.
 $ terraform import cloudflare_access_rule.default account/<account_id>/<rule_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_access_rule.default
+    id = "account/<account_id>/<rule_id>"
+}
+```

--- a/docs/resources/access_service_token.md
+++ b/docs/resources/access_service_token.md
@@ -66,3 +66,11 @@ Import is supported using the following syntax:
 # resource should you need to reference it in other resources.
 $ terraform import cloudflare_access_service_token.example <account_id>/<service_token_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_access_service_token.example
+    id = "<account_id>/<service_token_id>"
+}
+```

--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -43,3 +43,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_account.example <account_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_account.example
+    id = "<account_id>"
+}
+```

--- a/docs/resources/account_member.md
+++ b/docs/resources/account_member.md
@@ -45,3 +45,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_account_member.example <account_id>/<member_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_account_member.example
+    id = "<account_id>/<member_id>"
+}
+```

--- a/docs/resources/address_map.md
+++ b/docs/resources/address_map.md
@@ -81,3 +81,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_address_map.example <account_id>/<address_map_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_address_map.example
+    id = "<account_id>/<address_map_id>"
+}
+```

--- a/docs/resources/argo.md
+++ b/docs/resources/argo.md
@@ -43,3 +43,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_argo.example <zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_argo.example
+    id = "<zone_id>"
+}
+```

--- a/docs/resources/authenticated_origin_pulls.md
+++ b/docs/resources/authenticated_origin_pulls.md
@@ -82,3 +82,11 @@ $ terraform import cloudflare_authenticated_origin_pulls.example <zone_id>/<cert
 # per hostname
 $ terraform import cloudflare_authenticated_origin_pulls.example <zone_id>/<certificate_id>/<hostname>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_authenticated_origin_pulls.example
+    id = "<zone_id>/<certificate_id>/<hostname>"
+}
+```

--- a/docs/resources/authenticated_origin_pulls_certificate.md
+++ b/docs/resources/authenticated_origin_pulls_certificate.md
@@ -70,3 +70,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_authenticated_origin_pulls_certificate.example <zone_id>/<certificate_type>/<certificate_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_authenticated_origin_pulls_certificate.example
+    id = "<zone_id>/<certificate_type>/<certificate_id>"
+}
+```

--- a/docs/resources/bot_management.md
+++ b/docs/resources/bot_management.md
@@ -62,3 +62,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_bot_management.example <zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_bot_management.example
+    id = "<zone_id>"
+}
+```

--- a/docs/resources/byo_ip_prefix.md
+++ b/docs/resources/byo_ip_prefix.md
@@ -45,3 +45,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_byo_ip_prefix.example <account_id>/<prefix_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_byo_ip_prefix.example
+    id = "<account_id>/<prefix_id>"
+}
+```

--- a/docs/resources/certificate_pack.md
+++ b/docs/resources/certificate_pack.md
@@ -98,5 +98,13 @@ Import is supported using the following syntax:
 $ terraform import cloudflare_certificate_pack.example <zone_id>/<certificate_pack_id>
 ```
 
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_certificate_pack.example
+    id = "<zone_id>/<certificate_pack_id>"
+}
+```
+
 While supported, importing isn't recommended and it is advised to replace the
 certificate entirely instead.

--- a/docs/resources/custom_hostname.md
+++ b/docs/resources/custom_hostname.md
@@ -103,3 +103,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_custom_hostname.example 1d5fdc9e88c8a8c4518b068cd94331fe/0d89c70d-ad9f-4843-b99f-6cc0252067e9
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_custom_hostname.example
+    id = "1d5fdc9e88c8a8c4518b068cd94331fe/0d89c70d-ad9f-4843-b99f-6cc0252067e9"
+}
+```

--- a/docs/resources/custom_hostname_fallback_origin.md
+++ b/docs/resources/custom_hostname_fallback_origin.md
@@ -37,3 +37,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_custom_hostname_fallback_origin.example <zone_id>/<fallback_hostname>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_custom_hostname_fallback_origin.example
+    id = "<zone_id>/<fallback_hostname>"
+}
+```

--- a/docs/resources/custom_pages.md
+++ b/docs/resources/custom_pages.md
@@ -44,3 +44,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_custom_pages.example <resource_level>/<resource_id>/<custom_page_type>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_custom_pages.example
+    id = "<resource_level>/<resource_id>/<custom_page_type>"
+}
+```

--- a/docs/resources/custom_ssl.md
+++ b/docs/resources/custom_ssl.md
@@ -77,3 +77,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_custom_ssl.example <zone_id>/<certificate_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_custom_ssl.example
+    id = "<zone_id>/<certificate_id>"
+}
+```

--- a/docs/resources/device_dex_test.md
+++ b/docs/resources/device_dex_test.md
@@ -62,3 +62,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_device_dex_test.example <account_id>/<device_dex_test_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_device_dex_test.example
+    id = "<account_id>/<device_dex_test_id>"
+}
+```

--- a/docs/resources/device_managed_networks.md
+++ b/docs/resources/device_managed_networks.md
@@ -51,3 +51,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_device_managed_networks.example <account_id>/<device_managed_networks_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_device_managed_networks.example
+    id = "<account_id>/<device_managed_networks_id>"
+}
+```

--- a/docs/resources/device_policy_certificates.md
+++ b/docs/resources/device_policy_certificates.md
@@ -40,3 +40,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_device_policy_certificates.example <zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_device_policy_certificates.example
+    id = "<zone_id>"
+}
+```

--- a/docs/resources/device_posture_integration.md
+++ b/docs/resources/device_posture_integration.md
@@ -69,3 +69,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_device_posture_integration.example <account_id>/<device_posture_integration_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_device_posture_integration.example
+    id = "<account_id>/<device_posture_integration_id>"
+}
+```

--- a/docs/resources/device_posture_rule.md
+++ b/docs/resources/device_posture_rule.md
@@ -124,3 +124,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_device_posture_rule.example <account_id>/<device_posture_rule_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_device_posture_rule.example
+    id = "<account_id>/<device_posture_rule_id>"
+}
+```

--- a/docs/resources/device_settings_policy.md
+++ b/docs/resources/device_settings_policy.md
@@ -74,3 +74,11 @@ Import is supported using the following syntax:
 # For default device settings policies you must use "default" as the policy ID.
 $ terraform import cloudflare_device_settings_policy.example <account_id>/<device_policy_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_device_settings_policy.example
+    id = "<account_id>/<device_policy_id>"
+}
+```

--- a/docs/resources/dlp_profile.md
+++ b/docs/resources/dlp_profile.md
@@ -146,3 +146,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_dlp_profile.example <account_id>/<dlp_profile_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_dlp_profile.example
+    id = "<account_id>/<dlp_profile_id>"
+}
+```

--- a/docs/resources/email_routing_address.md
+++ b/docs/resources/email_routing_address.md
@@ -40,3 +40,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_email_routing_address.example <account_id>/<email_routing_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_email_routing_address.example
+    id = "<account_id>/<email_routing_id>"
+}
+```

--- a/docs/resources/email_routing_rule.md
+++ b/docs/resources/email_routing_rule.md
@@ -80,3 +80,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_email_routing_rule.example <zone_id>/<email_routing_rule_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_email_routing_rule.example
+    id = "<zone_id>/<email_routing_rule_id>"
+}
+```

--- a/docs/resources/fallback_domain.md
+++ b/docs/resources/fallback_domain.md
@@ -98,3 +98,11 @@ Import is supported using the following syntax:
 # Fallback Domains for default device policies must use "default" as the policy ID.
 $ terraform import cloudflare_fallback_domain.example <account_id>/<policy_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_fallback_domain.example
+    id = "<account_id>/<policy_id>"
+}
+```

--- a/docs/resources/filter.md
+++ b/docs/resources/filter.md
@@ -54,3 +54,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_filter.example <zone_id>/<filter_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_filter.example
+    id = "<zone_id>/<filter_id>"
+}
+```

--- a/docs/resources/firewall_rule.md
+++ b/docs/resources/firewall_rule.md
@@ -69,3 +69,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_firewall_rule.example <zone_id>/<firewall_rule_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_firewall_rule.example
+    id = "<zone_id>/<firewall_rule_id>"
+}
+```

--- a/docs/resources/gre_tunnel.md
+++ b/docs/resources/gre_tunnel.md
@@ -57,3 +57,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_gre_tunnel.example <account_id>/<tunnel_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_gre_tunnel.example
+    id = "<account_id>/<tunnel_id>"
+}
+```

--- a/docs/resources/healthcheck.md
+++ b/docs/resources/healthcheck.md
@@ -128,3 +128,11 @@ Import is supported using the following syntax:
 # Use the Zone ID and Healthcheck ID to import.
 $ terraform import cloudflare_healthcheck.example <zone_id>/<healthcheck_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_healthcheck.example
+    id = "<zone_id>/<healthcheck_id>"
+}
+```

--- a/docs/resources/hostname_tls_setting.md
+++ b/docs/resources/hostname_tls_setting.md
@@ -42,3 +42,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_hostname_tls_setting.example <zone_id>/<hostname>/<setting_name>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_hostname_tls_setting.example
+    id = "<zone_id>/<hostname>/<setting_name>"
+}
+```

--- a/docs/resources/hostname_tls_setting_ciphers.md
+++ b/docs/resources/hostname_tls_setting_ciphers.md
@@ -44,3 +44,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_hostname_tls_setting_ciphers.example <zone_id>/<hostname>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_hostname_tls_setting_ciphers.example
+    id = "<zone_id>/<hostname>"
+}
+```

--- a/docs/resources/hyperdrive_config.md
+++ b/docs/resources/hyperdrive_config.md
@@ -73,3 +73,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_hyperdrive_config.example <account_id>/<hyperdrive_config_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_hyperdrive_config.example
+    id = "<account_id>/<hyperdrive_config_id>"
+}
+```

--- a/docs/resources/infrastructure_access_target.md
+++ b/docs/resources/infrastructure_access_target.md
@@ -85,3 +85,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_infrastructure_access_target.example <account_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_infrastructure_access_target.example
+    id = "<account_id>"
+}
+```

--- a/docs/resources/ipsec_tunnel.md
+++ b/docs/resources/ipsec_tunnel.md
@@ -64,3 +64,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_ipsec_tunnel.example <account_id>/<tunnel_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_ipsec_tunnel.example
+    id = "<account_id>/<tunnel_id>"
+}
+```

--- a/docs/resources/keyless_certificate.md
+++ b/docs/resources/keyless_certificate.md
@@ -50,3 +50,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_keyless_certificate.example <zone_id>/<keyless_certificate_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_keyless_certificate.example
+    id = "<zone_id>/<keyless_certificate_id>"
+}
+```

--- a/docs/resources/list.md
+++ b/docs/resources/list.md
@@ -189,3 +189,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_list.example <account_id>/<list_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_list.example
+    id = "<account_id>/<list_id>"
+}
+```

--- a/docs/resources/list_item.md
+++ b/docs/resources/list_item.md
@@ -135,3 +135,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_list_item.example <account_id>/<list_id>/<item_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_list_item.example
+    id = "<account_id>/<list_id>/<item_id>"
+}
+```

--- a/docs/resources/load_balancer.md
+++ b/docs/resources/load_balancer.md
@@ -288,3 +288,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_load_balancer.example <zone_id>/<load_balancer_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_load_balancer.example
+    id = "<zone_id>/<load_balancer_id>"
+}
+```

--- a/docs/resources/load_balancer_monitor.md
+++ b/docs/resources/load_balancer_monitor.md
@@ -98,3 +98,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_load_balancer_monitor.example <account_id>/<load_balancer_monitor_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_load_balancer_monitor.example
+    id = "<account_id>/<load_balancer_monitor_id>"
+}
+```

--- a/docs/resources/load_balancer_pool.md
+++ b/docs/resources/load_balancer_pool.md
@@ -129,3 +129,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_load_balancer_pool.example <account_id>/<load_balancer_pool_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_load_balancer_pool.example
+    id = "<account_id>/<load_balancer_pool_id>"
+}
+```

--- a/docs/resources/logpull_retention.md
+++ b/docs/resources/logpull_retention.md
@@ -36,3 +36,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_logpull_retention.example <zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_logpull_retention.example
+    id = "<zone_id>"
+}
+```

--- a/docs/resources/logpush_job.md
+++ b/docs/resources/logpush_job.md
@@ -164,3 +164,11 @@ $ terraform import cloudflare_logpush_job.example account/<account_id>/<job_id>
 # Import a zone-scoped job.
 $ terraform import cloudflare_logpush_job.example zone/<zone_id>/<job_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_logpush_job.example
+    id = "zone/<zone_id>/<job_id>"
+}
+```

--- a/docs/resources/magic_firewall_ruleset.md
+++ b/docs/resources/magic_firewall_ruleset.md
@@ -54,6 +54,6 @@ The **rules** block is a list of maps with the following attributes:
 
 An existing Magic Firewall Ruleset can be imported using the account ID and ruleset ID
 
-```
+```shell
 $ terraform import cloudflare_magic_firewall_ruleset.example d41d8cd98f00b204e9800998ecf8427e/cb029e245cfdd66dc8d2e570d5dd3322
 ```

--- a/docs/resources/magic_firewall_ruleset.md
+++ b/docs/resources/magic_firewall_ruleset.md
@@ -57,3 +57,11 @@ An existing Magic Firewall Ruleset can be imported using the account ID and rule
 ```shell
 $ terraform import cloudflare_magic_firewall_ruleset.example d41d8cd98f00b204e9800998ecf8427e/cb029e245cfdd66dc8d2e570d5dd3322
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_magic_firewall_ruleset.example
+    id = "d41d8cd98f00b204e9800998ecf8427e/cb029e245cfdd66dc8d2e570d5dd3322"
+}
+```

--- a/docs/resources/magic_wan_gre_tunnel.md
+++ b/docs/resources/magic_wan_gre_tunnel.md
@@ -57,3 +57,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_magic_wan_gre_tunnel.example <account_id>/<tunnel_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_magic_wan_gre_tunnel.example
+    id = "<account_id>/<tunnel_id>"
+}
+```

--- a/docs/resources/magic_wan_ipsec_tunnel.md
+++ b/docs/resources/magic_wan_ipsec_tunnel.md
@@ -64,3 +64,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_magic_wan_ipsec_tunnel.example <account_id>/<tunnel_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_magic_wan_ipsec_tunnel.example
+    id = "<account_id>/<tunnel_id>"
+}
+```

--- a/docs/resources/magic_wan_static_route.md
+++ b/docs/resources/magic_wan_static_route.md
@@ -59,3 +59,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_magic_wan_static_route.example <account_id>/<static_route_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_magic_wan_static_route.example
+    id = "<account_id>/<static_route_id>"
+}
+```

--- a/docs/resources/mtls_certificate.md
+++ b/docs/resources/mtls_certificate.md
@@ -50,3 +50,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_mtls_certificate.example <account_id>/<mtls_certificate_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_mtls_certificate.example
+    id = "<account_id>/<mtls_certificate_id>"
+}
+```

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -169,3 +169,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_notification_policy.example <account_id>/<policy_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_notification_policy.example
+    id = "<account_id>/<policy_id>"
+}
+```

--- a/docs/resources/notification_policy_webhooks.md
+++ b/docs/resources/notification_policy_webhooks.md
@@ -47,3 +47,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_notification_policy_webhooks.example <account_id>/<notification_webhook_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_notification_policy_webhooks.example
+    id = "<account_id>/<notification_webhook_id>"
+}
+```

--- a/docs/resources/observatory_scheduled_test.md
+++ b/docs/resources/observatory_scheduled_test.md
@@ -51,3 +51,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_observatory_scheduled_test.example <zone_id>:<url>:<region>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_observatory_scheduled_test.example
+    id = "<zone_id>:<url>:<region>"
+}
+```

--- a/docs/resources/origin_ca_certificate.md
+++ b/docs/resources/origin_ca_certificate.md
@@ -63,3 +63,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_origin_ca_certificate.example <certificate_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_origin_ca_certificate.example
+    id = "<certificate_id>"
+}
+```

--- a/docs/resources/page_rule.md
+++ b/docs/resources/page_rule.md
@@ -247,6 +247,6 @@ The following attributes are exported:
 
 Page rules can be imported using a composite ID formed of zone ID and page rule ID, e.g.
 
-```
+```shell
 $ terraform import cloudflare_page_rule.default d41d8cd98f00b204e9800998ecf8427e/ch8374ftwdghsif43
 ```

--- a/docs/resources/page_rule.md
+++ b/docs/resources/page_rule.md
@@ -250,3 +250,11 @@ Page rules can be imported using a composite ID formed of zone ID and page rule 
 ```shell
 $ terraform import cloudflare_page_rule.default d41d8cd98f00b204e9800998ecf8427e/ch8374ftwdghsif43
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_page_rule.default
+    id = "d41d8cd98f00b204e9800998ecf8427e/ch8374ftwdghsif43"
+}
+```

--- a/docs/resources/pages_domain.md
+++ b/docs/resources/pages_domain.md
@@ -42,3 +42,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_pages_domain.example <account_id>/<project_name>/<domain-name>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_pages_domain.example
+    id = "<account_id>/<project_name>/<domain-name>"
+}
+```

--- a/docs/resources/pages_project.md
+++ b/docs/resources/pages_project.md
@@ -361,3 +361,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_pages_project.example <account_id>/<project_name>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_pages_project.example
+    id = "<account_id>/<project_name>"
+}
+```

--- a/docs/resources/queue.md
+++ b/docs/resources/queue.md
@@ -36,3 +36,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_queue.example <account_id>/<queue_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_queue.example
+    id = "<account_id>/<queue_id>"
+}
+```

--- a/docs/resources/rate_limit.md
+++ b/docs/resources/rate_limit.md
@@ -152,3 +152,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_rate_limit.example <zone_id>/<rate_limit_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_rate_limit.example
+    id = "<zone_id>/<rate_limit_id>"
+}
+```

--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -130,3 +130,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_record.example <zone_id>/<record_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_record.example
+    id = "<zone_id>/<record_id>"
+}
+```

--- a/docs/resources/regional_tiered_cache.md
+++ b/docs/resources/regional_tiered_cache.md
@@ -38,3 +38,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_regional_tiered_cache.example <zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_regional_tiered_cache.example
+    id = "<zone_id>"
+}
+```

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -867,3 +867,11 @@ $ terraform import cloudflare_ruleset.example account/<account_id>/<ruleset_id>
 # Import a zone scoped Ruleset configuration.
 $ terraform import cloudflare_ruleset.example zone/<zone_id>/<ruleset_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_ruleset.example
+    id = "zone/<zone_id>/<ruleset_id>"
+}
+```

--- a/docs/resources/spectrum_application.md
+++ b/docs/resources/spectrum_application.md
@@ -107,3 +107,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_spectrum_application.example <zone_id>/<spectrum_application_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_spectrum_application.example
+    id = "<zone_id>/<spectrum_application_id>"
+}
+```

--- a/docs/resources/split_tunnel.md
+++ b/docs/resources/split_tunnel.md
@@ -100,3 +100,11 @@ Import is supported using the following syntax:
 # Split Tunnels for default device policies must use "default" as the policy ID.
 $ terraform import cloudflare_split_tunnel.example <account_id>/<policy_id>/<mode>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_split_tunnel.example
+    id = "<account_id>/<policy_id>/<mode>"
+}
+```

--- a/docs/resources/static_route.md
+++ b/docs/resources/static_route.md
@@ -59,3 +59,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_static_route.example <account_id>/<static_route_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_static_route.example
+    id = "<account_id>/<static_route_id>"
+}
+```

--- a/docs/resources/teams_account.md
+++ b/docs/resources/teams_account.md
@@ -275,3 +275,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_teams_account.example <account_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_teams_account.example
+    id = "<account_id>"
+}
+```

--- a/docs/resources/teams_list.md
+++ b/docs/resources/teams_list.md
@@ -58,3 +58,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_teams_list.example <account_id>/<teams_list_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_teams_list.example
+    id = "<account_id>/<teams_list_id>"
+}
+```

--- a/docs/resources/teams_location.md
+++ b/docs/resources/teams_location.md
@@ -70,3 +70,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_teams_location.example <account_id>/<teams_location_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_teams_location.example
+    id = "<account_id>/<teams_location_id>"
+}
+```

--- a/docs/resources/teams_proxy_endpoint.md
+++ b/docs/resources/teams_proxy_endpoint.md
@@ -43,3 +43,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_teams_proxy_endpoint.example <account_id>/<proxy_endpoint_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_teams_proxy_endpoint.example
+    id = "<account_id>/<proxy_endpoint_id>"
+}
+```

--- a/docs/resources/teams_rule.md
+++ b/docs/resources/teams_rule.md
@@ -198,3 +198,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_teams_rule.example <account_id>/<teams_rule_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_teams_rule.example
+    id = "<account_id>/<teams_rule_id>"
+}
+```

--- a/docs/resources/total_tls.md
+++ b/docs/resources/total_tls.md
@@ -41,3 +41,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_total_tls.example <zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_total_tls.example
+    id = "<zone_id>"
+}
+```

--- a/docs/resources/tunnel.md
+++ b/docs/resources/tunnel.md
@@ -48,3 +48,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_tunnel.example <account_id>/<tunnel_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_tunnel.example
+    id = "<account_id>/<tunnel_id>"
+}
+```

--- a/docs/resources/tunnel_config.md
+++ b/docs/resources/tunnel_config.md
@@ -210,3 +210,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_tunnel_config.example <account_id>/<tunnel_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_tunnel_config.example
+    id = "<account_id>/<tunnel_id>"
+}
+```

--- a/docs/resources/tunnel_route.md
+++ b/docs/resources/tunnel_route.md
@@ -65,3 +65,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_tunnel_route.example <account_id>/<network_cidr>/<virtual_network_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_tunnel_route.example
+    id = "<account_id>/<network_cidr>/<virtual_network_id>"
+}
+```

--- a/docs/resources/tunnel_virtual_network.md
+++ b/docs/resources/tunnel_virtual_network.md
@@ -48,3 +48,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_tunnel_virtual_network.example <account_id>/<vnet_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_tunnel_virtual_network.example
+    id = "<account_id>/<vnet_id>"
+}
+```

--- a/docs/resources/turnstile_widget.md
+++ b/docs/resources/turnstile_widget.md
@@ -49,3 +49,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_turnstile_widget.example <account_id>/<site_key>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_turnstile_widget.example
+    id = "<account_id>/<site_key>"
+}
+```

--- a/docs/resources/user_agent_blocking_rule.md
+++ b/docs/resources/user_agent_blocking_rule.md
@@ -64,3 +64,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_user_agent_blocking_rule.example <zone_id>/<user_agent_blocking_rule_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_user_agent_blocking_rule.example
+    id = "<zone_id>/<user_agent_blocking_rule_id>"
+}
+```

--- a/docs/resources/waiting_room.md
+++ b/docs/resources/waiting_room.md
@@ -97,3 +97,11 @@ Import is supported using the following syntax:
 # Use the Zone ID and Waiting Room ID to import.
 $ terraform import cloudflare_waiting_room.default <zone_id>/<waiting_room_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_waiting_room.default
+    id = "<zone_id>/<waiting_room_id>"
+}
+```

--- a/docs/resources/waiting_room_event.md
+++ b/docs/resources/waiting_room_event.md
@@ -59,3 +59,11 @@ Import is supported using the following syntax:
 # Use the Zone ID, Waiting Room ID, and Event ID to import.
 $ terraform import cloudflare_waiting_room_event.default <zone_id>/<waiting_room_id>/<waiting_room_event_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_waiting_room_event.default
+    id = "<zone_id>/<waiting_room_id>/<waiting_room_event_id>"
+}
+```

--- a/docs/resources/waiting_room_rules.md
+++ b/docs/resources/waiting_room_rules.md
@@ -72,3 +72,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_waiting_room_event.default <zone_id>/<waiting_room_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_waiting_room_event.default
+    id = "<zone_id>/<waiting_room_id>"
+}
+```

--- a/docs/resources/waiting_room_settings.md
+++ b/docs/resources/waiting_room_settings.md
@@ -39,3 +39,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_waiting_room_settings.example <zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_waiting_room_settings.example
+    id = "<zone_id>"
+}
+```

--- a/docs/resources/web_analytics_rule.md
+++ b/docs/resources/web_analytics_rule.md
@@ -62,3 +62,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_web_analytics_rule.example <account_id>/<ruleset_id>/<rule_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_web_analytics_rule.example
+    id = "<account_id>/<ruleset_id>/<rule_id>"
+}
+```

--- a/docs/resources/web_analytics_site.md
+++ b/docs/resources/web_analytics_site.md
@@ -54,3 +54,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_web_analytics_site.example <account_id>/<site_tag>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_web_analytics_site.example
+    id = "<account_id>/<site_tag>"
+}
+```

--- a/docs/resources/worker_cron_trigger.md
+++ b/docs/resources/worker_cron_trigger.md
@@ -53,3 +53,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_worker_cron_trigger.example <account_id>/<script_name>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_worker_cron_trigger.example
+    id = "<account_id>/<script_name>"
+}
+```

--- a/docs/resources/worker_domain.md
+++ b/docs/resources/worker_domain.md
@@ -44,3 +44,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_worker_domain.example <account_id>/<worker_domain_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_worker_domain.example
+    id = "<account_id>/<worker_domain_id>"
+}
+```

--- a/docs/resources/worker_route.md
+++ b/docs/resources/worker_route.md
@@ -46,3 +46,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_worker_route.example <zone_id>/<route_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_worker_route.example
+    id = "<zone_id>/<route_id>"
+}
+```

--- a/docs/resources/worker_script.md
+++ b/docs/resources/worker_script.md
@@ -201,3 +201,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_worker_script.example <account_id>/<script_name>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_worker_script.example
+    id = "<account_id>/<script_name>"
+}
+```

--- a/docs/resources/worker_secret.md
+++ b/docs/resources/worker_secret.md
@@ -40,3 +40,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_worker_secret.example <account_id>/<script_name>/<secret_name>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_worker_secret.example
+    id = "<account_id>/<script_name>/<secret_name>"
+}
+```

--- a/docs/resources/workers_cron_trigger.md
+++ b/docs/resources/workers_cron_trigger.md
@@ -53,3 +53,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_workers_cron_trigger.example <account_id>/<script_name>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_workers_cron_trigger.example
+    id = "<account_id>/<script_name>"
+}
+```

--- a/docs/resources/workers_domain.md
+++ b/docs/resources/workers_domain.md
@@ -44,3 +44,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_workers_domain.example <account_id>/<worker_domain_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_workers_domain.example
+    id = "<account_id>/<worker_domain_id>"
+}
+```

--- a/docs/resources/workers_for_platforms_dispatch_namespace.md
+++ b/docs/resources/workers_for_platforms_dispatch_namespace.md
@@ -46,3 +46,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_workers_for_platforms_dispatch_namespace.example <account_id>/<namespace_name>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_workers_for_platforms_dispatch_namespace.example
+    id = "<account_id>/<namespace_name>"
+}
+```

--- a/docs/resources/workers_for_platforms_namespace.md
+++ b/docs/resources/workers_for_platforms_namespace.md
@@ -46,3 +46,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_workers_for_platforms_namespace.example <account_id>/<namespace_name>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_workers_for_platforms_namespace.example
+    id = "<account_id>/<namespace_name>"
+}
+```

--- a/docs/resources/workers_kv.md
+++ b/docs/resources/workers_kv.md
@@ -45,3 +45,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_workers_kv.example <account_id>/<namespace_id>/<key_name>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_workers_kv.example
+    id = "<account_id>/<namespace_id>/<key_name>"
+}
+```

--- a/docs/resources/workers_kv_namespace.md
+++ b/docs/resources/workers_kv_namespace.md
@@ -36,3 +36,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_workers_kv_namespace.example <account_id>/<namespace_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_workers_kv_namespace.example
+    id = "<account_id>/<namespace_id>"
+}
+```

--- a/docs/resources/workers_route.md
+++ b/docs/resources/workers_route.md
@@ -46,3 +46,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_workers_route.example <zone_id>/<route_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_workers_route.example
+    id = "<zone_id>/<route_id>"
+}
+```

--- a/docs/resources/workers_script.md
+++ b/docs/resources/workers_script.md
@@ -201,3 +201,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_workers_script.example <account_id>/<script_name>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_workers_script.example
+    id = "<account_id>/<script_name>"
+}
+```

--- a/docs/resources/workers_secret.md
+++ b/docs/resources/workers_secret.md
@@ -40,3 +40,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_workers_secret.example <account_id>/<script_name>/<secret_name>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_workers_secret.example
+    id = "<account_id>/<script_name>/<secret_name>"
+}
+```

--- a/docs/resources/zero_trust_access_application.md
+++ b/docs/resources/zero_trust_access_application.md
@@ -337,3 +337,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_access_application.example <account_id>/<application_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_access_application.example
+    id = "<account_id>/<application_id>"
+}
+```

--- a/docs/resources/zero_trust_access_group.md
+++ b/docs/resources/zero_trust_access_group.md
@@ -372,3 +372,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_access_group.example <account_id>/<group_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_access_group.example
+    id = "<account_id>/<group_id>"
+}
+```

--- a/docs/resources/zero_trust_access_identity_provider.md
+++ b/docs/resources/zero_trust_access_identity_provider.md
@@ -142,3 +142,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_access_identity_provider.example <account_id>/<identity_provider_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_access_identity_provider.example
+    id = "<account_id>/<identity_provider_id>"
+}
+```

--- a/docs/resources/zero_trust_access_mtls_certificate.md
+++ b/docs/resources/zero_trust_access_mtls_certificate.md
@@ -63,3 +63,11 @@ $ terraform import cloudflare_zero_sd -t_access_mtls_certificate.example account
 # Zone level import.
 $ terraform import cloudflare_zero_sd -t_access_mtls_certificate.example zone/<zone_id>/<mutual_tls_certificate_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_sd
+    id = "-t_access_mtls_certificate.example"
+}
+```

--- a/docs/resources/zero_trust_access_mtls_hostname_settings.md
+++ b/docs/resources/zero_trust_access_mtls_hostname_settings.md
@@ -53,3 +53,11 @@ $ terraform import cloudflare_zero_trust_access_mtls_hostname_settings.example a
 # Zone level mTLS hostname settings import.
 $ terraform import cloudflare_zero_trust_access_mtls_hostname_settings.example zone/<zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_access_mtls_hostname_settings.example
+    id = "zone/<zone_id>"
+}
+```

--- a/docs/resources/zero_trust_access_policy.md
+++ b/docs/resources/zero_trust_access_policy.md
@@ -410,3 +410,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_access_policy.example account/<account_id>/<application_id>/<policy_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_access_policy.example
+    id = "account/<account_id>/<application_id>/<policy_id>"
+}
+```

--- a/docs/resources/zero_trust_access_service_token.md
+++ b/docs/resources/zero_trust_access_service_token.md
@@ -66,3 +66,11 @@ Import is supported using the following syntax:
 # resource should you need to reference it in other resources.
 $ terraform import cloudflare_zero_trust_access_service_token.example <account_id>/<service_token_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_access_service_token.example
+    id = "<account_id>/<service_token_id>"
+}
+```

--- a/docs/resources/zero_trust_access_short_lived_certificate.md
+++ b/docs/resources/zero_trust_access_short_lived_certificate.md
@@ -63,3 +63,11 @@ $ terraform import cloudflare_zero_trust_access_short_lived_certificate.example 
 # Zone level CA certificate import.
 $ terraform import cloudflare_zero_trust_access_short_lived_certificate.example account/<zone_id>/<application_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_access_short_lived_certificate.example
+    id = "account/<zone_id>/<application_id>"
+}
+```

--- a/docs/resources/zero_trust_device_certificates.md
+++ b/docs/resources/zero_trust_device_certificates.md
@@ -40,3 +40,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_device_certificates.example <zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_device_certificates.example
+    id = "<zone_id>"
+}
+```

--- a/docs/resources/zero_trust_device_managed_networks.md
+++ b/docs/resources/zero_trust_device_managed_networks.md
@@ -51,3 +51,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_device_managed_networks.example <account_id>/<device_managed_networks_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_device_managed_networks.example
+    id = "<account_id>/<device_managed_networks_id>"
+}
+```

--- a/docs/resources/zero_trust_device_posture_integration.md
+++ b/docs/resources/zero_trust_device_posture_integration.md
@@ -69,3 +69,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_device_posture_integration.example <account_id>/<device_posture_integration_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_device_posture_integration.example
+    id = "<account_id>/<device_posture_integration_id>"
+}
+```

--- a/docs/resources/zero_trust_device_posture_rule.md
+++ b/docs/resources/zero_trust_device_posture_rule.md
@@ -124,3 +124,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_device_posture_rule.example <account_id>/<device_posture_rule_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_device_posture_rule.example
+    id = "<account_id>/<device_posture_rule_id>"
+}
+```

--- a/docs/resources/zero_trust_device_profiles.md
+++ b/docs/resources/zero_trust_device_profiles.md
@@ -73,3 +73,11 @@ Import is supported using the following syntax:
 # For default device settings policies you must use "default" as the policy ID.
 $ terraform import cloudflare_zero_trust_device_profiles.example <account_id>/<device_policy_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_device_profiles.example
+    id = "<account_id>/<device_policy_id>"
+}
+```

--- a/docs/resources/zero_trust_dex_test.md
+++ b/docs/resources/zero_trust_dex_test.md
@@ -62,3 +62,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_dex_test.example <account_id>/<device_dex_test_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_dex_test.example
+    id = "<account_id>/<device_dex_test_id>"
+}
+```

--- a/docs/resources/zero_trust_dlp_profile.md
+++ b/docs/resources/zero_trust_dlp_profile.md
@@ -146,3 +146,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_dlp_profile.example <account_id>/<dlp_profile_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_dlp_profile.example
+    id = "<account_id>/<dlp_profile_id>"
+}
+```

--- a/docs/resources/zero_trust_dns_location.md
+++ b/docs/resources/zero_trust_dns_location.md
@@ -70,3 +70,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_dns_location.example <account_id>/<teams_location_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_dns_location.example
+    id = "<account_id>/<teams_location_id>"
+}
+```

--- a/docs/resources/zero_trust_gateway_policy.md
+++ b/docs/resources/zero_trust_gateway_policy.md
@@ -198,3 +198,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_gateway_policy.example <account_id>/<teams_rule_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_gateway_policy.example
+    id = "<account_id>/<teams_rule_id>"
+}
+```

--- a/docs/resources/zero_trust_gateway_proxy_endpoint.md
+++ b/docs/resources/zero_trust_gateway_proxy_endpoint.md
@@ -43,3 +43,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_gateway_proxy_endpoint.example <account_id>/<proxy_endpoint_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_gateway_proxy_endpoint.example
+    id = "<account_id>/<proxy_endpoint_id>"
+}
+```

--- a/docs/resources/zero_trust_gateway_settings.md
+++ b/docs/resources/zero_trust_gateway_settings.md
@@ -275,3 +275,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_gateway_settings.example <account_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_gateway_settings.example
+    id = "<account_id>"
+}
+```

--- a/docs/resources/zero_trust_infrastructure_access_target.md
+++ b/docs/resources/zero_trust_infrastructure_access_target.md
@@ -85,3 +85,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_infrastructure_access_target.example <account_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_infrastructure_access_target.example
+    id = "<account_id>"
+}
+```

--- a/docs/resources/zero_trust_list.md
+++ b/docs/resources/zero_trust_list.md
@@ -58,3 +58,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_list.example <account_id>/<teams_list_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_list.example
+    id = "<account_id>/<teams_list_id>"
+}
+```

--- a/docs/resources/zero_trust_tunnel_cloudflared.md
+++ b/docs/resources/zero_trust_tunnel_cloudflared.md
@@ -48,3 +48,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_tunnel_cloudflared.example <account_id>/<tunnel_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_tunnel_cloudflared.example
+    id = "<account_id>/<tunnel_id>"
+}
+```

--- a/docs/resources/zero_trust_tunnel_cloudflared_config.md
+++ b/docs/resources/zero_trust_tunnel_cloudflared_config.md
@@ -210,3 +210,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_tunnel_cloudflared_config.example <account_id>/<tunnel_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_tunnel_cloudflared_config.example
+    id = "<account_id>/<tunnel_id>"
+}
+```

--- a/docs/resources/zero_trust_tunnel_route.md
+++ b/docs/resources/zero_trust_tunnel_route.md
@@ -65,3 +65,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_tunnel_route.example <account_id>/<network_cidr>/<virtual_network_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_tunnel_route.example
+    id = "<account_id>/<network_cidr>/<virtual_network_id>"
+}
+```

--- a/docs/resources/zero_trust_tunnel_virtual_network.md
+++ b/docs/resources/zero_trust_tunnel_virtual_network.md
@@ -48,3 +48,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zero_trust_tunnel_virtual_network.example <account_id>/<vnet_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zero_trust_tunnel_virtual_network.example
+    id = "<account_id>/<vnet_id>"
+}
+```

--- a/docs/resources/zone.md
+++ b/docs/resources/zone.md
@@ -54,3 +54,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zone.example <zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zone.example
+    id = "<zone_id>"
+}
+```

--- a/docs/resources/zone_cache_reserve.md
+++ b/docs/resources/zone_cache_reserve.md
@@ -43,3 +43,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zone_cache_reserve.example <zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zone_cache_reserve.example
+    id = "<zone_id>"
+}
+```

--- a/docs/resources/zone_dnssec.md
+++ b/docs/resources/zone_dnssec.md
@@ -52,3 +52,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zone_dnssec.example <zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zone_dnssec.example
+    id = "<zone_id>"
+}
+```

--- a/docs/resources/zone_hold.md
+++ b/docs/resources/zone_hold.md
@@ -43,3 +43,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zone_hold.example <zone_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zone_hold.example
+    id = "<zone_id>"
+}
+```

--- a/docs/resources/zone_lockdown.md
+++ b/docs/resources/zone_lockdown.md
@@ -68,3 +68,11 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_zone_lockdown.example <zone_id>/<lockdown_id>
 ```
+
+For terraform 1.5 and later, you should use an [`import` block](https://developer.hashicorp.com/terraform/language/import):
+```terraform
+import {
+    to = cloudflare_zone_lockdown.example
+    id = "<zone_id>/<lockdown_id>"
+}
+```


### PR DESCRIPTION
Terraform 1.5 and later supports importing resources in code, and it's nice to have the syntax in the documentation.

This adds a line to the existing import section that shows how to import each resource via the new import block.