### PR TITLE
resource/cloudflare_teams_location: remove unusable `policy_ids`

### DIFF
--- a/.changelog/4817.txt
+++ b/.changelog/4817.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/cloudflare_teams_location: remove unusable `policy_ids` attribute
+```

--- a/docs/resources/teams_location.md
+++ b/docs/resources/teams_location.md
@@ -50,7 +50,6 @@ resource "cloudflare_teams_location" "example" {
 - `id` (String) The ID of this resource.
 - `ip` (String) Client IP address.
 - `ipv4_destination` (String) IP to direct all IPv4 DNS queries to.
-- `policy_ids` (List of String)
 
 <a id="nestedblock--networks"></a>
 ### Nested Schema for `networks`

--- a/docs/resources/zero_trust_dns_location.md
+++ b/docs/resources/zero_trust_dns_location.md
@@ -50,7 +50,6 @@ resource "cloudflare_zero_trust_dns_location" "example" {
 - `id` (String) The ID of this resource.
 - `ip` (String) Client IP address.
 - `ipv4_destination` (String) IP to direct all IPv4 DNS queries to.
-- `policy_ids` (List of String)
 
 <a id="nestedblock--networks"></a>
 ### Nested Schema for `networks`

--- a/internal/sdkv2provider/resource_cloudflare_teams_location.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_location.go
@@ -68,9 +68,6 @@ func resourceCloudflareTeamsLocationRead(ctx context.Context, d *schema.Resource
 	if err := d.Set("networks", flattenTeamsLocationNetworks(location.Networks)); err != nil {
 		return diag.FromErr(fmt.Errorf("error parsing Location networks"))
 	}
-	if err := d.Set("policy_ids", location.PolicyIDs); err != nil {
-		return diag.FromErr(fmt.Errorf("error parsing Location policy IDs"))
-	}
 	if err := d.Set("ip", location.Ip); err != nil {
 		return diag.FromErr(fmt.Errorf("error parsing Location IP"))
 	}

--- a/internal/sdkv2provider/schema_cloudflare_teams_location.go
+++ b/internal/sdkv2provider/schema_cloudflare_teams_location.go
@@ -45,11 +45,6 @@ func resourceCloudflareTeamsLocationSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Indicator that this location needs to resolve EDNS queries.",
 		},
-		"policy_ids": {
-			Type:     schema.TypeList,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-			Computed: true,
-		},
 		"ip": {
 			Type:        schema.TypeString,
 			Computed:    true,


### PR DESCRIPTION
This field was removed from the product and API long ago and no longer does anything. It should have been deprecated long ago.

Seeing how it's no longer usable, remove it from the schema to prevent confusion.