### PR TITLE
feat(r2_bucket): support `jurisdiction` handling

### DIFF
--- a/internal/services/r2_bucket/model.go
+++ b/internal/services/r2_bucket/model.go
@@ -16,6 +16,7 @@ type R2BucketModel struct {
 	Name         types.String `tfsdk:"name" json:"name,required"`
 	AccountID    types.String `tfsdk:"account_id" path:"account_id,required"`
 	Location     types.String `tfsdk:"location" json:"locationHint,optional"`
+	Jurisdiction types.String `tfsdk:"jurisdiction" json:"-,computed_optional"`
 	StorageClass types.String `tfsdk:"storage_class" json:"storageClass,computed_optional"`
 	CreationDate types.String `tfsdk:"creation_date" json:"creation_date,computed"`
 }

--- a/internal/services/r2_bucket/resource.go
+++ b/internal/services/r2_bucket/resource.go
@@ -23,6 +23,8 @@ var _ resource.ResourceWithConfigure = (*R2BucketResource)(nil)
 var _ resource.ResourceWithModifyPlan = (*R2BucketResource)(nil)
 var _ resource.ResourceWithImportState = (*R2BucketResource)(nil)
 
+const jurisdictionHTTPHeaderName = "cf-r2-jurisdiction"
+
 func NewResource() resource.Resource {
 	return &R2BucketResource{}
 }
@@ -76,6 +78,7 @@ func (r *R2BucketResource) Create(ctx context.Context, req resource.CreateReques
 		r2.BucketNewParams{
 			AccountID: cloudflare.F(data.AccountID.ValueString()),
 		},
+		option.WithHeader(jurisdictionHTTPHeaderName, data.Jurisdiction.ValueString()),
 		option.WithRequestBody("application/json", dataBytes),
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
@@ -125,6 +128,7 @@ func (r *R2BucketResource) Update(ctx context.Context, req resource.UpdateReques
 		r2.BucketNewParams{
 			AccountID: cloudflare.F(data.Name.ValueString()),
 		},
+		option.WithHeader(jurisdictionHTTPHeaderName, data.Jurisdiction.ValueString()),
 		option.WithRequestBody("application/json", dataBytes),
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
@@ -162,6 +166,7 @@ func (r *R2BucketResource) Read(ctx context.Context, req resource.ReadRequest, r
 		r2.BucketGetParams{
 			AccountID: cloudflare.F(data.AccountID.ValueString()),
 		},
+		option.WithHeader(jurisdictionHTTPHeaderName, data.Jurisdiction.ValueString()),
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)
@@ -201,6 +206,7 @@ func (r *R2BucketResource) Delete(ctx context.Context, req resource.DeleteReques
 		r2.BucketDeleteParams{
 			AccountID: cloudflare.F(data.AccountID.ValueString()),
 		},
+		option.WithHeader(jurisdictionHTTPHeaderName, data.Jurisdiction.ValueString()),
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)
 	if err != nil {

--- a/internal/services/r2_bucket/resource_test.go
+++ b/internal/services/r2_bucket/resource_test.go
@@ -153,10 +153,37 @@ func TestAccCloudflareR2Bucket_Minimum(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareR2Bucket_Jurisdiction(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_r2_bucket." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareR2BucketJurisdiction(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rnd),
+					resource.TestCheckResourceAttr(resourceName, "id", rnd),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCloudflareR2BucketMinimum(rnd, accountID string) string {
 	return acctest.LoadTestCase("r2bucketminimum.tf", rnd, accountID)
 }
 
 func testAccCheckCloudflareR2BucketBasic(rnd, accountID string) string {
 	return acctest.LoadTestCase("r2bucketbasic.tf", rnd, accountID)
+}
+
+func testAccCheckCloudflareR2BucketJurisdiction(rnd, accountID string) string {
+	return acctest.LoadTestCase("jurisdiction.tf", rnd, accountID)
 }

--- a/internal/services/r2_bucket/schema.go
+++ b/internal/services/r2_bucket/schema.go
@@ -47,6 +47,19 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					),
 				},
 			},
+			"jurisdiction": schema.StringAttribute{
+				Description: "Jurisdiction of the bucket",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("default"),
+				Validators: []validator.String{
+					stringvalidator.OneOfCaseInsensitive(
+						"default",
+						"eu",
+						"fedramp",
+					),
+				},
+			},
 			"storage_class": schema.StringAttribute{
 				Description: "Storage class for newly uploaded objects, unless specified otherwise.",
 				Computed:    true,

--- a/internal/services/r2_bucket/testdata/jurisdiction.tf
+++ b/internal/services/r2_bucket/testdata/jurisdiction.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_r2_bucket" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+	jurisdiction   = "eu"
+}


### PR DESCRIPTION
Manually updates the client to handle managing the jurisdiction while we incorporate HTTP header handling into the pipeline.