### PR TITLE
Fix import failures on old teams locations

### DIFF
--- a/.changelog/4859.txt
+++ b/.changelog/4859.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_teams_location: Fix import failures on teams locations
+```

--- a/internal/sdkv2provider/resource_cloudflare_teams_location.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_location.go
@@ -386,6 +386,9 @@ func flattenTeamsLocationNetworksIntoList(networks []cloudflare.TeamsLocationNet
 }
 
 func flattenTeamsEndpoints(endpoint *cloudflare.TeamsLocationEndpoints) []interface{} {
+	if endpoint == nil {
+		return nil
+	}
 	flattenedEndpoints := map[string]interface{}{
 		"ipv4": flattenTeamsEndpointIpv4Field(endpoint.IPv4Endpoint),
 		"ipv6": flattenTeamsEndpointIpv6Field(endpoint.IPv6Endpoint),


### PR DESCRIPTION
Recently a change was made to teams locations
which adds the "endpoints" field. However, old
locations still don't have that field.

The provider was failing to read these old
locations because it was assuming the field was
there. This was fixed by excluding this field
when not available.

It is not possible to have an integration test for
this now because accounts are not created like
this anymore.

Tested using one of these old accounts: b0b145b6eff5790e74510592c26492cd/6543045645ad4591a4dd9ce3f7cea626

```
{"id":"6543045645ad4591a4dd9ce3f7cea626","name":"Home","networks":[{"network":"86.20.102.184/32"}],"ip":"2a06:98c1:54::1:d9bb","doh_subdomain":"jjezp4o172","anonymized_logs_enabled":false,"ipv4_destination":"172.64.36.1","ipv4_destination_backup":"172.64.36.2","dns_destination_ips_id":"0e4a32c6-6fb8-4858-9296-98f51631e8e6","client_default":true,"ecs_support":false,"dns_destination_ipv6_block_id":null,"created_at":"2022-04-06T13:23:52Z","updated_at":"2024-03-27T10:13:16Z"}
```

Closes #4846