### PR TITLE
Fix typo in Workers example

### DIFF
--- a/docs/resources/worker_script.md
+++ b/docs/resources/worker_script.md
@@ -18,7 +18,7 @@ resource "cloudflare_workers_kv_namespace" "my_namespace" {
 }
 
 # Sets the script with the name "script_1"
-resource "cloudflare_worker_script" "my_script" {
+resource "cloudflare_workers_script" "my_script" {
   account_id = "f037e56e89293a057740de681ac9abbe"
   name       = "script_1"
   content    = file("script.js")


### PR DESCRIPTION
Seems like examples here aren't autogen