### PR TITLE
Update worker_script.md

### DIFF
--- a/docs/resources/worker_script.md
+++ b/docs/resources/worker_script.md
@@ -20,7 +20,7 @@ resource "cloudflare_workers_kv_namespace" "my_namespace" {
 # Sets the script with the name "script_1"
 resource "cloudflare_worker_script" "my_script" {
   account_id = "f037e56e89293a057740de681ac9abbe"
-  name       = "script_1"
+  script_name       = "script_1"
   content    = file("script.js")
 
   kv_namespace_binding {


### PR DESCRIPTION
Without this I get:

```
➜  terraform-test git:(main) ✗ terraform plan
╷
│ Error: Unsupported argument
│
│   on cloudflare.tf line 20, in resource "cloudflare_workers_script" "terraform-test":
│   20:   name       = "terraform-test"
│
│ An argument named "name" is not expected here.
```