### PR TITLE
fix validate function for s2s posture integrations

### DIFF
--- a/.changelog/4933.txt
+++ b/.changelog/4933.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_device_posture_integration: fix bug where `custom_s2s` and `tanium_s2s` was not included in the type validation for s2s posture integrations.
+```

--- a/internal/sdkv2provider/schema_cloudflare_device_posture_integration.go
+++ b/internal/sdkv2provider/schema_cloudflare_device_posture_integration.go
@@ -23,7 +23,7 @@ func resourceCloudflareDevicePostureIntegrationSchema() map[string]*schema.Schem
 		"type": {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: validation.StringInSlice([]string{ws1, uptycs, crowdstrike, intune, kolide, sentinelone}, false),
+			ValidateFunc: validation.StringInSlice([]string{ws1, uptycs, crowdstrike, intune, kolide, sentinelone, tanium, customs2s}, false),
 			Description:  fmt.Sprintf("The device posture integration type. %s", renderAvailableDocumentationValuesStringSlice([]string{ws1, uptycs, crowdstrike, intune, kolide, sentinelone, tanium, customs2s})),
 		},
 		"identifier": {


### PR DESCRIPTION
The validate function for s2s posture integrations did not include custom_s2s or tanium_s2s. They have been added as a part of this PR.