### PR TITLE
Wrap static route model into an array for the POST request

### DIFF
--- a/internal/services/magic_wan_static_route/model.go
+++ b/internal/services/magic_wan_static_route/model.go
@@ -24,8 +24,8 @@ type MagicWANStaticRouteModel struct {
 	Scope         customfield.NestedObject[MagicWANStaticRouteScopeModel]         `tfsdk:"scope" json:"scope,computed_optional"`
 	Modified      types.Bool                                                      `tfsdk:"modified" json:"modified,computed"`
 	ModifiedRoute customfield.NestedObject[MagicWANStaticRouteModifiedRouteModel] `tfsdk:"modified_route" json:"modified_route,computed"`
-	Route         customfield.NestedObject[MagicWANStaticRouteRouteModel]         `tfsdk:"route" json:"route,computed"`
-	Routes        customfield.NestedObjectList[MagicWANStaticRouteRoutesModel]    `tfsdk:"routes" json:"routes,computed"`
+	Route         customfield.NestedObject[MagicWANStaticRouteRouteModel]         `tfsdk:"route" json:"route,computed_optional"`
+	Routes        customfield.NestedObjectList[MagicWANStaticRouteRoutesModel]    `tfsdk:"routes" json:"routes,computed_optional"`
 }
 
 func (m MagicWANStaticRouteModel) MarshalJSON() (data []byte, err error) {
@@ -59,35 +59,35 @@ type MagicWANStaticRouteModifiedRouteScopeModel struct {
 }
 
 type MagicWANStaticRouteRouteModel struct {
-	Nexthop     types.String                                                 `tfsdk:"nexthop" json:"nexthop,computed"`
-	Prefix      types.String                                                 `tfsdk:"prefix" json:"prefix,computed"`
-	Priority    types.Int64                                                  `tfsdk:"priority" json:"priority,computed"`
+	Nexthop     types.String                                                 `tfsdk:"nexthop" json:"nexthop,computed_optional"`
+	Prefix      types.String                                                 `tfsdk:"prefix" json:"prefix,computed_optional"`
+	Priority    types.Int64                                                  `tfsdk:"priority" json:"priority,computed_optional"`
 	ID          types.String                                                 `tfsdk:"id" json:"id,computed"`
 	CreatedOn   timetypes.RFC3339                                            `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
-	Description types.String                                                 `tfsdk:"description" json:"description,computed"`
+	Description types.String                                                 `tfsdk:"description" json:"description,computed_optional"`
 	ModifiedOn  timetypes.RFC3339                                            `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
-	Scope       customfield.NestedObject[MagicWANStaticRouteRouteScopeModel] `tfsdk:"scope" json:"scope,computed"`
-	Weight      types.Int64                                                  `tfsdk:"weight" json:"weight,computed"`
+	Scope       customfield.NestedObject[MagicWANStaticRouteRouteScopeModel] `tfsdk:"scope" json:"scope,computed_optional"`
+	Weight      types.Int64                                                  `tfsdk:"weight" json:"weight,computed_optional"`
 }
 
 type MagicWANStaticRouteRouteScopeModel struct {
-	ColoNames   customfield.List[types.String] `tfsdk:"colo_names" json:"colo_names,computed"`
-	ColoRegions customfield.List[types.String] `tfsdk:"colo_regions" json:"colo_regions,computed"`
+	ColoNames   customfield.List[types.String] `tfsdk:"colo_names" json:"colo_names,computed_optional"`
+	ColoRegions customfield.List[types.String] `tfsdk:"colo_regions" json:"colo_regions,computed_optional"`
 }
 
 type MagicWANStaticRouteRoutesModel struct {
-	Nexthop     types.String                                                  `tfsdk:"nexthop" json:"nexthop,computed"`
-	Prefix      types.String                                                  `tfsdk:"prefix" json:"prefix,computed"`
-	Priority    types.Int64                                                   `tfsdk:"priority" json:"priority,computed"`
+	Nexthop     types.String                                                  `tfsdk:"nexthop" json:"nexthop,computed_optional"`
+	Prefix      types.String                                                  `tfsdk:"prefix" json:"prefix,computed_optional"`
+	Priority    types.Int64                                                   `tfsdk:"priority" json:"priority,computed_optional"`
 	ID          types.String                                                  `tfsdk:"id" json:"id,computed"`
 	CreatedOn   timetypes.RFC3339                                             `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
-	Description types.String                                                  `tfsdk:"description" json:"description,computed"`
+	Description types.String                                                  `tfsdk:"description" json:"description,computed_optional"`
 	ModifiedOn  timetypes.RFC3339                                             `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
-	Scope       customfield.NestedObject[MagicWANStaticRouteRoutesScopeModel] `tfsdk:"scope" json:"scope,computed"`
-	Weight      types.Int64                                                   `tfsdk:"weight" json:"weight,computed"`
+	Scope       customfield.NestedObject[MagicWANStaticRouteRoutesScopeModel] `tfsdk:"scope" json:"scope,computed_optional"`
+	Weight      types.Int64                                                   `tfsdk:"weight" json:"weight,computed_optional"`
 }
 
 type MagicWANStaticRouteRoutesScopeModel struct {
-	ColoNames   customfield.List[types.String] `tfsdk:"colo_names" json:"colo_names,computed"`
-	ColoRegions customfield.List[types.String] `tfsdk:"colo_regions" json:"colo_regions,computed"`
+	ColoNames   customfield.List[types.String] `tfsdk:"colo_names" json:"colo_names,computed_optional"`
+	ColoRegions customfield.List[types.String] `tfsdk:"colo_regions" json:"colo_regions,computed_optional"`
 }

--- a/internal/services/magic_wan_static_route/resource.go
+++ b/internal/services/magic_wan_static_route/resource.go
@@ -62,6 +62,11 @@ func (r *MagicWANStaticRouteResource) Create(ctx context.Context, req resource.C
 	}
 
 	dataBytes, err := data.MarshalJSON()
+
+	// Workaround to wrap the route into an array, which is what the API expects.
+	dataBytes = append([]byte("["), dataBytes...)
+	dataBytes = append(dataBytes, byte(']'))
+
 	if err != nil {
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
 		return

--- a/internal/services/magic_wan_static_route/schema.go
+++ b/internal/services/magic_wan_static_route/schema.go
@@ -131,19 +131,23 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"route": schema.SingleNestedAttribute{
 				Computed:   true,
+				Optional:   true,
 				CustomType: customfield.NewNestedObjectType[MagicWANStaticRouteRouteModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"nexthop": schema.StringAttribute{
 						Description: "The next-hop IP Address for the static route.",
 						Computed:    true,
+						Optional:    true,
 					},
 					"prefix": schema.StringAttribute{
 						Description: "IP Prefix in Classless Inter-Domain Routing format.",
 						Computed:    true,
+						Optional:    true,
 					},
 					"priority": schema.Int64Attribute{
 						Description: "Priority of the static route.",
 						Computed:    true,
+						Optional:    true,
 					},
 					"id": schema.StringAttribute{
 						Description: "Identifier",
@@ -157,6 +161,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"description": schema.StringAttribute{
 						Description: "An optional human provided description of the static route.",
 						Computed:    true,
+						Optional:    true,
 					},
 					"modified_on": schema.StringAttribute{
 						Description: "When the route was last modified.",
@@ -166,17 +171,20 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"scope": schema.SingleNestedAttribute{
 						Description: "Used only for ECMP routes.",
 						Computed:    true,
+						Optional:    true,
 						CustomType:  customfield.NewNestedObjectType[MagicWANStaticRouteRouteScopeModel](ctx),
 						Attributes: map[string]schema.Attribute{
 							"colo_names": schema.ListAttribute{
 								Description: "List of colo names for the ECMP scope.",
 								Computed:    true,
+								Optional:    true,
 								CustomType:  customfield.NewListType[types.String](ctx),
 								ElementType: types.StringType,
 							},
 							"colo_regions": schema.ListAttribute{
 								Description: "List of colo regions for the ECMP scope.",
 								Computed:    true,
+								Optional:    true,
 								CustomType:  customfield.NewListType[types.String](ctx),
 								ElementType: types.StringType,
 							},
@@ -185,25 +193,30 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"weight": schema.Int64Attribute{
 						Description: "Optional weight of the ECMP scope - if provided.",
 						Computed:    true,
+						Optional:    true,
 					},
 				},
 			},
 			"routes": schema.ListNestedAttribute{
 				Computed:   true,
+				Optional:   true,
 				CustomType: customfield.NewNestedObjectListType[MagicWANStaticRouteRoutesModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"nexthop": schema.StringAttribute{
 							Description: "The next-hop IP Address for the static route.",
 							Computed:    true,
+							Optional:    true,
 						},
 						"prefix": schema.StringAttribute{
 							Description: "IP Prefix in Classless Inter-Domain Routing format.",
 							Computed:    true,
+							Optional:    true,
 						},
 						"priority": schema.Int64Attribute{
 							Description: "Priority of the static route.",
 							Computed:    true,
+							Optional:    true,
 						},
 						"id": schema.StringAttribute{
 							Description: "Identifier",
@@ -217,6 +230,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"description": schema.StringAttribute{
 							Description: "An optional human provided description of the static route.",
 							Computed:    true,
+							Optional:    true,
 						},
 						"modified_on": schema.StringAttribute{
 							Description: "When the route was last modified.",
@@ -226,17 +240,20 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"scope": schema.SingleNestedAttribute{
 							Description: "Used only for ECMP routes.",
 							Computed:    true,
+							Optional:    true,
 							CustomType:  customfield.NewNestedObjectType[MagicWANStaticRouteRoutesScopeModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"colo_names": schema.ListAttribute{
 									Description: "List of colo names for the ECMP scope.",
 									Computed:    true,
+									Optional:    true,
 									CustomType:  customfield.NewListType[types.String](ctx),
 									ElementType: types.StringType,
 								},
 								"colo_regions": schema.ListAttribute{
 									Description: "List of colo regions for the ECMP scope.",
 									Computed:    true,
+									Optional:    true,
 									CustomType:  customfield.NewListType[types.String](ctx),
 									ElementType: types.StringType,
 								},
@@ -245,6 +262,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"weight": schema.Int64Attribute{
 							Description: "Optional weight of the ECMP scope - if provided.",
 							Computed:    true,
+							Optional:    true,
 						},
 					},
 				},


### PR DESCRIPTION
The `computed_optional` changes are needed because the `static_route` model and schema is currently a mashup of the bulk and single resource management endpoints.