### PR TITLE
Update version upgrade guide to use required_providers

### DIFF
--- a/docs/guides/version-5-upgrade.md
+++ b/docs/guides/version-5-upgrade.md
@@ -19,9 +19,13 @@ If you are not ready to make a move to version 5 of the Cloudflare provider,
 you may keep the 4.x branch active for your Terraform project by specifying:
 
 ```hcl
-provider "cloudflare" {
-  version = "~> 4"
-  # ... any other configuration
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
 }
 ```
 
@@ -36,9 +40,13 @@ existing configuration.
 Once ready, make the following change to use the latest 5.x release:
 
 ```hcl
-provider "cloudflare" {
-  version = "~> 5"
-  # ... any other configuration
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
* Changed examples from the provider block to `terraform { required_providers }` because Terraform 0.13+ recommends explicit provider blocks for clarity and future compatibility.

* Changed `~> 4 to ~> 4.0`. Terraform implicitly interprets `~> 4` as `~> 4.0`, but the explicit `~> 4.0` improves readability and maintains consistency with other versioning practices.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
