### PR TITLE
Add acceptance tests for dns-settings and dns-settings-view resources

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -188,6 +188,13 @@ func TestAccPreCheck_HyperdriveWithAccess(t *testing.T) {
 	}
 }
 
+// Test helper method checking `CLOUDFLARE_INTERNAL_ZONE_ID` is present.
+func TestAccPreCheck_InternalZoneID(t *testing.T) {
+	if v := os.Getenv("CLOUDFLARE_INTERNAL_ZONE_ID"); v == "" {
+		t.Skip("Skipping acceptance test as CLOUDFLARE_INTERNAL_ZONE_ID is not set")
+	}
+}
+
 // TestAccSkipForDefaultZone is used for skipping over tests that are not run by
 // default on usual acceptance test suite account.
 func TestAccSkipForDefaultZone(t *testing.T, reason string) {

--- a/internal/services/dns_settings/resource_test.go
+++ b/internal/services/dns_settings/resource_test.go
@@ -1,0 +1,84 @@
+package dns_settings_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDNSSettings_UpdateAccount(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_dns_settings." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDNSSettingsConfigAccount(rnd, accountID, false, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "account_id", accountID),
+					resource.TestCheckResourceAttr(name, "zone_defaults.flatten_all_cnames", "false"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.foundation_dns", "false"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.multi_provider", "false"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.nameservers.type", "cloudflare.standard"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.ns_ttl", "86400"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.secondary_overrides", "false"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.expire", "604800"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.min_ttl", "1800"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.mname", "kristina.ns.cloudflare.com"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.refresh", "10000"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.retry", "2400"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.rname", "admin.example.com"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.ttl", "3600"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.zone_mode", "standard"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDNSSettings_UpdateZone(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_dns_settings." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDNSSettingsConfigZone(rnd, zoneID, false, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
+					resource.TestCheckResourceAttr(name, "zone_defaults.flatten_all_cnames", "false"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.foundation_dns", "false"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.multi_provider", "false"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.nameservers.type", "cloudflare.standard"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.ns_ttl", "86400"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.secondary_overrides", "false"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.expire", "604800"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.min_ttl", "1800"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.mname", "kristina.ns.cloudflare.com"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.refresh", "10000"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.retry", "2400"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.rname", "admin.example.com"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.soa.ttl", "3600"),
+					resource.TestCheckResourceAttr(name, "zone_defaults.zone_mode", "standard"),
+				),
+			},
+		},
+	})
+}
+
+func testDNSSettingsConfigAccount(resourceID, ID string, flattenCnames, foundationDNS, multiProvider bool) string {
+	return acctest.LoadTestCase("account_setting.tf", resourceID, ID, flattenCnames, foundationDNS, multiProvider)
+}
+
+func testDNSSettingsConfigZone(resourceID, ID string, flattenCnames, foundationDNS, multiProvider bool) string {
+	return acctest.LoadTestCase("zone_setting.tf", resourceID, ID, flattenCnames, foundationDNS, multiProvider)
+}

--- a/internal/services/dns_settings/testdata/account_setting.tf
+++ b/internal/services/dns_settings/testdata/account_setting.tf
@@ -1,0 +1,24 @@
+resource "cloudflare_dns_settings" "%[1]s" {
+  account_id = "%[2]s"
+
+  zone_defaults = {
+    flatten_all_cnames = "%[3]t"
+    foundation_dns     = "%[4]t"
+    multi_provider     = "%[5]t"
+    nameservers = {
+      type = "cloudflare.standard"
+    }
+    ns_ttl = 86400
+    secondary_overrides = false
+    soa = {
+      expire  = 604800
+      min_ttl = 1800
+      mname   = "kristina.ns.cloudflare.com"
+      refresh = 10000
+      retry   = 2400
+      rname   = "admin.example.com"
+      ttl     = 3600
+    }
+    zone_mode = "standard"
+  }
+}

--- a/internal/services/dns_settings/testdata/zone_setting.tf
+++ b/internal/services/dns_settings/testdata/zone_setting.tf
@@ -1,0 +1,24 @@
+resource "cloudflare_dns_settings" "%[1]s" {
+  zone_id = "%[2]s"
+
+  zone_defaults = {
+    flatten_all_cnames = "%[3]t"
+    foundation_dns     = "%[4]t"
+    multi_provider     = "%[5]t"
+    nameservers = {
+      type = "cloudflare.standard"
+    }
+    ns_ttl = 86400
+    secondary_overrides = false
+    soa = {
+      expire  = 604800
+      min_ttl = 1800
+      mname   = "kristina.ns.cloudflare.com"
+      refresh = 10000
+      retry   = 2400
+      rname   = "admin.example.com"
+      ttl     = 3600
+    }
+    zone_mode = "standard"
+  }
+}

--- a/internal/services/dns_settings_internal_view/resource_test.go
+++ b/internal/services/dns_settings_internal_view/resource_test.go
@@ -1,0 +1,106 @@
+package dns_settings_internal_view_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v4"
+	"github.com/cloudflare/cloudflare-go/v4/dns"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("cloudflare_dns_settings_internal_view", &resource.Sweeper{
+		Name: "cloudflare_dns_settings_internal_view",
+		F:    testSweepCloudflareDNSSettingsInternalView,
+	})
+}
+
+func testSweepCloudflareDNSSettingsInternalView(r string) error {
+	ctx := context.Background()
+	client := acctest.SharedClient()
+
+	// Clean up the account level views
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		return errors.New("CLOUDFLARE_ACCOUNT_ID must be set")
+	}
+
+	views, err := client.DNS.Settings.Views.List(context.Background(), dns.SettingViewListParams{AccountID: cloudflare.F(accountID)})
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to fetch Cloudflare DNS internal views: %s", err))
+	}
+
+	if len(views.Result) == 0 {
+		log.Print("[DEBUG] No Cloudflare views to sweep")
+		return nil
+	}
+
+	for _, view := range views.Result {
+		tflog.Info(ctx, fmt.Sprintf("Deleting Cloudflare View ID: %s", view.ID))
+		//nolint:errcheck
+		client.DNS.Settings.Views.Delete(context.TODO(), view.ID, dns.SettingViewDeleteParams{AccountID: cloudflare.F(accountID)})
+	}
+
+	return nil
+}
+
+func TestAccCloudflareDNSInternalView_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_dns_settings_internal_view." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDNSInternalViewConfig(rnd, accountID, rnd, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "zones.0", zoneID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareDNSInternalView_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_dns_settings_internal_view." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDNSInternalViewConfig(rnd, accountID, rnd, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "zones.0", zoneID),
+				),
+			},
+			{
+				Config: testDNSInternalViewConfig(rnd, accountID, rnd+"-update", zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd+"-update"),
+					resource.TestCheckResourceAttr(name, "zones.0", zoneID),
+				),
+			},
+		},
+	})
+}
+
+func testDNSInternalViewConfig(resourceID, accountID, name, zone string) string {
+	return acctest.LoadTestCase("view.tf", resourceID, accountID, name, zone)
+}

--- a/internal/services/dns_settings_internal_view/resource_test.go
+++ b/internal/services/dns_settings_internal_view/resource_test.go
@@ -53,20 +53,22 @@ func testSweepCloudflareDNSSettingsInternalView(r string) error {
 }
 
 func TestAccCloudflareDNSInternalView_Basic(t *testing.T) {
+	acctest.TestAccPreCheck_InternalZoneID(t)
+
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_dns_settings_internal_view." + rnd
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	internalZoneID := os.Getenv("CLOUDFLARE_INTERNAL_ZONE_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDNSInternalViewConfig(rnd, accountID, rnd, zoneID),
+				Config: testDNSInternalViewConfig(rnd, accountID, rnd, internalZoneID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", rnd),
-					resource.TestCheckResourceAttr(name, "zones.0", zoneID),
+					resource.TestCheckResourceAttr(name, "zones.0", internalZoneID),
 				),
 			},
 		},
@@ -74,27 +76,29 @@ func TestAccCloudflareDNSInternalView_Basic(t *testing.T) {
 }
 
 func TestAccCloudflareDNSInternalView_Update(t *testing.T) {
+	acctest.TestAccPreCheck_InternalZoneID(t)
+
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_dns_settings_internal_view." + rnd
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	internalZoneID := os.Getenv("CLOUDFLARE_INTERNAL_ZONE_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDNSInternalViewConfig(rnd, accountID, rnd, zoneID),
+				Config: testDNSInternalViewConfig(rnd, accountID, rnd, internalZoneID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", rnd),
-					resource.TestCheckResourceAttr(name, "zones.0", zoneID),
+					resource.TestCheckResourceAttr(name, "zones.0", internalZoneID),
 				),
 			},
 			{
-				Config: testDNSInternalViewConfig(rnd, accountID, rnd+"-update", zoneID),
+				Config: testDNSInternalViewConfig(rnd, accountID, rnd+"-update", internalZoneID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", rnd+"-update"),
-					resource.TestCheckResourceAttr(name, "zones.0", zoneID),
+					resource.TestCheckResourceAttr(name, "zones.0", internalZoneID),
 				),
 			},
 		},

--- a/internal/services/dns_settings_internal_view/testdata/view.tf
+++ b/internal/services/dns_settings_internal_view/testdata/view.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_dns_settings_internal_view" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[3]s"
+  zones = ["%[4]s"]
+}


### PR DESCRIPTION
Tests passing:

=== RUN   TestAccCloudflareDNSInternalView_Basic
--- PASS: TestAccCloudflareDNSInternalView_Basic (3.54s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/dns_settings_internal_view        4.974s

=== RUN   TestAccCloudflareDNSInternalView_Update
--- PASS: TestAccCloudflareDNSInternalView_Update (6.51s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/dns_settings_internal_view        8.149s

=== RUN   TestAccDNSSettings_UpdateAccount
--- PASS: TestAccDNSSettings_UpdateAccount (2.94s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/dns_settings      4.377s

=== RUN   TestAccDNSSettings_UpdateZone
--- PASS: TestAccDNSSettings_UpdateZone (2.98s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/dns_settings      4.438s