### PR TITLE
docs: Pin squiggly 4 to 4.x and squiggly 5 to 5.x

### DIFF
--- a/docs/guides/version-5-upgrade.md
+++ b/docs/guides/version-5-upgrade.md
@@ -20,7 +20,7 @@ you may keep the 4.x branch active for your Terraform project by specifying:
 
 ```hcl
 provider "cloudflare" {
-  version = "~> 4"
+  version = "~> 4.0"
   # ... any other configuration
 }
 ```
@@ -37,7 +37,7 @@ Once ready, make the following change to use the latest 5.x release:
 
 ```hcl
 provider "cloudflare" {
-  version = "~> 5"
+  version = "~> 5.0"
   # ... any other configuration
 }
 ```


### PR DESCRIPTION
In the 4-to-5 upgrade guide, "~> 4" includes 5, which is not the intention of the text. This suggested change parallels the squiggly version recommendations in the prior major upgrade docs, such as https://github.com/cloudflare/terraform-provider-cloudflare/blob/main/docs/guides/version-4-upgrade.md

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
