### PR TITLE
fix(r2_bucket_event_notification): dedupe `bucket_name` parameters

### DIFF
--- a/internal/services/r2_bucket_event_notification/data_source_model.go
+++ b/internal/services/r2_bucket_event_notification/data_source_model.go
@@ -18,8 +18,7 @@ type R2BucketEventNotificationResultDataSourceEnvelope struct {
 
 type R2BucketEventNotificationDataSourceModel struct {
 	AccountID  types.String                                                                 `tfsdk:"account_id" path:"account_id,required"`
-	BucketName types.String                                                                 `tfsdk:"bucket_name" path:"bucket_name,required"`
-	BucketName types.String                                                                 `tfsdk:"bucket_name" json:"bucketName,computed"`
+	BucketName types.String                                                                 `tfsdk:"bucket_name" path:"bucket_name,required" json:"bucketName"`
 	Queues     customfield.NestedObjectList[R2BucketEventNotificationQueuesDataSourceModel] `tfsdk:"queues" json:"queues,computed"`
 }
 

--- a/internal/services/r2_bucket_event_notification/data_source_schema.go
+++ b/internal/services/r2_bucket_event_notification/data_source_schema.go
@@ -27,10 +27,6 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				Description: "Name of the bucket",
 				Required:    true,
 			},
-			"bucket_name": schema.StringAttribute{
-				Description: "Name of the bucket.",
-				Computed:    true,
-			},
 			"queues": schema.ListNestedAttribute{
 				Description: "List of queues associated with the bucket.",
 				Computed:    true,


### PR DESCRIPTION
Updates the handling to put the values into the one tfsdk attribute instead of two, conflicting ones.