### PR TITLE
[Examples] Fix cloudflare_dns_record example: changed ttl to 1 when record is marked as proxied

### DIFF
--- a/examples/resources/cloudflare_dns_record/resource.tf
+++ b/examples/resources/cloudflare_dns_record/resource.tf
@@ -9,6 +9,6 @@ resource "cloudflare_dns_record" "example_dns_record" {
     ipv6_only = true
   }
   tags = ["owner:dns-team"]
-  ttl = 3600
+  ttl = 1
   type = "A"
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

According to the provider: when a DNS record is marked as `proxied` the TTL must be 1 as Cloudflare will control the TTL internally.

## Additional context & links
