### PR TITLE
Scope cloudflare_terraform_v5_attribute_renames_state to only cloudflare resources

### DIFF
--- a/.grit/patterns/cloudflare_terraform_v5_attribute_renames_state.grit
+++ b/.grit/patterns/cloudflare_terraform_v5_attribute_renames_state.grit
@@ -3,7 +3,9 @@ language json
 pattern cloudflare_terraform_v5_attribute_renames_state() {
   any {
     // clear out any previously defined schema bumps
-    `"schema_version": $version`=> `"schema_version": 0`,
+    `"schema_version": $version`=> `"schema_version": 0` where {
+        $resource_type <: contains `cloudflare_`,
+    },
 
     // cloudflare_api_token
     `{ "mode": "managed", "type": "$resource_type", $..., "instances":[$instances] }` where {


### PR DESCRIPTION
Resolves #5190. (I think!)

Creating a PR here because while the code is auto-generated, I don't think the GritQL is. Feel free to close if you need to incorporate this in some other way.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

I'm newer to GritQL, but based on the other syntax, this should ensure that the schema_version changes performed by `cloudflare_terraform_v5_attribute_renames_state` only apply to resource types containing `cloudflare_`.

## Additional context & links
