### PR TITLE
Fix `match` example expression

### DIFF
--- a/examples/resources/cloudflare_zero_trust_device_custom_profile/resource.tf
+++ b/examples/resources/cloudflare_zero_trust_device_custom_profile/resource.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zero_trust_device_custom_profile" "example_zero_trust_device_custom_profile" {
   account_id = "699d98642c564d2e855e9661899b7252"
-  match = "user.identity == \"test@cloudflare.com\""
+  match = "identity.email == \"test@cloudflare.com\""
   name = "Allow Developers"
   precedence = 100
   allow_mode_switch = true


### PR DESCRIPTION
This PR replaces the invalid example expression with the correct equivalent so users copying example and replacing the dummy email address with their own will no longer receive errors when running an `apply`.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Merge my docs fix

## Additional context & links

Fixes #5201

```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # module.cfzt.cloudflare_zero_trust_device_custom_profile.example_zero_trust_device_custom_profile will be created
  + resource "cloudflare_zero_trust_device_custom_profile" "example_zero_trust_device_custom_profile" {
      + account_id        = "[REDACTED_ACCOUNT_ID]"
      + default           = (known after apply)
      + exclude           = (known after apply)
      + fallback_domains  = (known after apply)
      + gateway_unique_id = (known after apply)
      + id                = (known after apply)
      + include           = (known after apply)
      + match             = "identity.email == \"test@cloudflare.com\""
      + name              = "Allow Developers"
      + policy_id         = (known after apply)
      + precedence        = 100
      + service_mode_v2   = (known after apply)
      + target_tests      = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with the -target option, which means that the result of this plan may not represent all of the changes requested by the current configuration.
│ 
│ The -target option is not for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when OpenTofu specifically suggests to use it as part of an error message.
╵

Do you want to perform these actions?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.cfzt.cloudflare_zero_trust_device_custom_profile.example_zero_trust_device_custom_profile: Creating...
module.cfzt.cloudflare_zero_trust_device_custom_profile.example_zero_trust_device_custom_profile: Creation complete after 1s [id=[REDACTED_ID]]
╷
│ Warning: Applied changes may be incomplete
│ 
│ The plan was created with the -target option in effect, so some changes requested in the configuration may have been ignored and the output values may not be fully updated. Run the following command to verify that no other
│ changes are pending:
│     tofu plan
│       
│ Note that the -target option is not suitable for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when OpenTofu specifically suggests to use it as part of an error
│ message.
╵

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```