### PR TITLE
fix(authenticated_origin_pulls_certificate): handle schema behaviours more concretely

### DIFF
--- a/internal/services/authenticated_origin_pulls_certificate/resource.go
+++ b/internal/services/authenticated_origin_pulls_certificate/resource.go
@@ -88,6 +88,7 @@ func (r *AuthenticatedOriginPullsCertificateResource) Create(ctx context.Context
 		return
 	}
 	data = &env.Result
+	data.CertificateID = data.ID
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -136,6 +137,7 @@ func (r *AuthenticatedOriginPullsCertificateResource) Update(ctx context.Context
 		return
 	}
 	data = &env.Result
+	data.CertificateID = data.ID
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -176,6 +178,7 @@ func (r *AuthenticatedOriginPullsCertificateResource) Read(ctx context.Context, 
 		return
 	}
 	data = &env.Result
+	data.CertificateID = data.ID
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/authenticated_origin_pulls_certificate/resource.go
+++ b/internal/services/authenticated_origin_pulls_certificate/resource.go
@@ -61,6 +61,7 @@ func (r *AuthenticatedOriginPullsCertificateResource) Create(ctx context.Context
 		return
 	}
 
+	privateKey := data.PrivateKey
 	dataBytes, err := data.MarshalJSON()
 	if err != nil {
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
@@ -89,6 +90,7 @@ func (r *AuthenticatedOriginPullsCertificateResource) Create(ctx context.Context
 	}
 	data = &env.Result
 	data.CertificateID = data.ID
+	data.PrivateKey = privateKey
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -138,6 +140,7 @@ func (r *AuthenticatedOriginPullsCertificateResource) Update(ctx context.Context
 	}
 	data = &env.Result
 	data.CertificateID = data.ID
+	data.PrivateKey = state.PrivateKey
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -150,7 +153,7 @@ func (r *AuthenticatedOriginPullsCertificateResource) Read(ctx context.Context, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
+	privateKey := data.PrivateKey
 	res := new(http.Response)
 	env := AuthenticatedOriginPullsCertificateResultEnvelope{*data}
 	_, err := r.client.OriginTLSClientAuth.Get(
@@ -179,6 +182,7 @@ func (r *AuthenticatedOriginPullsCertificateResource) Read(ctx context.Context, 
 	}
 	data = &env.Result
 	data.CertificateID = data.ID
+	data.PrivateKey = privateKey
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/authenticated_origin_pulls_certificate/schema.go
+++ b/internal/services/authenticated_origin_pulls_certificate/schema.go
@@ -37,7 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"private_key": schema.StringAttribute{
 				Description:   "The zone's private key.",
 				Required:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"enabled": schema.BoolAttribute{
 				Description: "Indicates whether zone-level authenticated origin pulls is enabled.",

--- a/internal/services/authenticated_origin_pulls_certificate/schema.go
+++ b/internal/services/authenticated_origin_pulls_certificate/schema.go
@@ -26,8 +26,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"certificate_id": schema.StringAttribute{
 				Description:   "Identifier",
-				Optional:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"certificate": schema.StringAttribute{
 				Description:   "The zone's leaf certificate.",


### PR DESCRIPTION
`certificate_id` is used in the URL without it, API calls will fail. To address this, we alias the fields together and mark it as computed for good measure.

`private_key` is a write only attribute which requires some manual mapping to ensure we persist it across state and plan runs.

Closes #5055