### PR TITLE
fix(account_token): handle value write only field 

### DIFF
--- a/internal/services/account_token/resource.go
+++ b/internal/services/account_token/resource.go
@@ -111,6 +111,7 @@ func (r *AccountTokenResource) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	tokenValue := state.Value
 
 	dataBytes, err := data.MarshalJSONForUpdate(*state)
 	if err != nil {
@@ -140,6 +141,7 @@ func (r *AccountTokenResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 	data = &env.Result
+	data.Value = tokenValue
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -153,6 +155,7 @@ func (r *AccountTokenResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	tokenValue := data.Value
 	res := new(http.Response)
 	env := AccountTokenResultEnvelope{*data}
 	_, err := r.client.Accounts.Tokens.Get(
@@ -180,6 +183,7 @@ func (r *AccountTokenResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 	data = &env.Result
+	data.Value = tokenValue
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/account_token/schema.go
+++ b/internal/services/account_token/schema.go
@@ -63,6 +63,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"meta": schema.SingleNestedAttribute{
 										Description: "Attributes associated to the permission group.",
 										Optional:    true,
+										Computed:    true,
 										Attributes: map[string]schema.Attribute{
 											"key": schema.StringAttribute{
 												Optional: true,

--- a/internal/services/account_token/schema.go
+++ b/internal/services/account_token/schema.go
@@ -149,9 +149,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				CustomType:  timetypes.RFC3339Type{},
 			},
 			"value": schema.StringAttribute{
-				Description: "The token value.",
-				Computed:    true,
-				Sensitive:   true,
+				Description:   "The token value.",
+				Computed:      true,
+				Sensitive:     true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 	}


### PR DESCRIPTION
`value` is a write only attribute which requires some manual mapping to ensure we persist it across state and plan runs.

Closes #5232