### PR TITLE
fix(dns_record): relax constraint for overlapping unions

### DIFF
--- a/internal/services/dns_record/schema.go
+++ b/internal/services/dns_record/schema.go
@@ -124,9 +124,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"flags": schema.Float64Attribute{
 						Description: "Flags for the CAA record.",
 						Optional:    true,
-						Validators: []validator.Float64{
-							float64validator.Between(0, 255),
-						},
 					},
 					"tag": schema.StringAttribute{
 						Description: "Name of the property controlled by this record (e.g.: issue, issuewild, iodef).",


### PR DESCRIPTION
When the field is a part of a union that overlaps with other configurations, we currently take the first instance and apply the constraints from that to the field. This kinda works but gets difficult to automatically resolve so instead, let's remove this and instead rely on the remote to do the stricter validation.