### PR TITLE
removed provider support for API deprecated zone setting - sha1_support

### DIFF
--- a/internal/services/zone_setting/data_source_schema.go
+++ b/internal/services/zone_setting/data_source_schema.go
@@ -84,7 +84,6 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 						"security_header",
 						"security_level",
 						"server_side_exclude",
-						"sha1_support",
 						"sort_query_string_for_cache",
 						"ssl",
 						"ssl_recommender",

--- a/internal/services/zone_setting/schema.go
+++ b/internal/services/zone_setting/schema.go
@@ -81,7 +81,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"security_header",
 						"security_level",
 						"server_side_exclude",
-						"sha1_support",
 						"sort_query_string_for_cache",
 						"ssl",
 						"ssl_recommender",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Remove support for deprecated zone setting `sha1_support`

## Additional context & links

The cloudflare API has deprecated the zone setting `sha1_support` but the provider still considers this a valid `setting_id` which results in a successful `plan` and a failed `apply`.

### Sample terraform

```
terraform {
  required_providers {
    cloudflare = {
      source  = "cloudflare/cloudflare"
      version = "= 5.1.0"
    }
  }
  required_version = "= 1.11.1"
}

resource "cloudflare_zone_setting" "sha1_support" {
  id         = "sha1_support"
  setting_id = "sha1_support"
  value      = "off"
  zone_id    = "<REDACTED_ZONE_ID>"
}
```

### With provider v5.1.0: plan ✅ , apply ❌

```
sjwood@setecastronomy:~/test$ terraform plan 

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # cloudflare_zone_setting.sha1_support will be created
  + resource "cloudflare_zone_setting" "sha1_support" {
      + editable       = true
      + id             = "sha1_support"
      + modified_on    = (known after apply)
      + setting_id     = "sha1_support"
      + time_remaining = (known after apply)
      + value          = "off"
      + zone_id        = "<REDACTED_ZONE_ID>"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Warning: Resource Destruction Considerations
│ 
│   with cloudflare_zone_setting.sha1_support,
│   on main.tf line 11, in resource "cloudflare_zone_setting" "sha1_support":
│   11: resource "cloudflare_zone_setting" "sha1_support" {
│ 
│ This resource cannot be destroyed from Terraform. If you create this resource, it will be present in the API until manually deleted.
╵

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

```
sjwood@setecastronomy:~/test$ terraform apply -auto-approve 

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # cloudflare_zone_setting.sha1_support will be created
  + resource "cloudflare_zone_setting" "sha1_support" {
      + editable       = true
      + id             = "sha1_support"
      + modified_on    = (known after apply)
      + setting_id     = "sha1_support"
      + time_remaining = (known after apply)
      + value          = "off"
      + zone_id        = "<REDACTED_ZONE_ID>"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
cloudflare_zone_setting.sha1_support: Creating...
╷
│ Warning: Resource Destruction Considerations
│ 
│   with cloudflare_zone_setting.sha1_support,
│   on main.tf line 11, in resource "cloudflare_zone_setting" "sha1_support":
│   11: resource "cloudflare_zone_setting" "sha1_support" {
│ 
│ This resource cannot be destroyed from Terraform. If you create this resource, it will be present in the API until manually deleted.
│ 
│ (and one more similar warning elsewhere)
╵
╷
│ Error: failed to make http request
│ 
│   with cloudflare_zone_setting.sha1_support,
│   on main.tf line 11, in resource "cloudflare_zone_setting" "sha1_support":
│   11: resource "cloudflare_zone_setting" "sha1_support" {
│ 
│ PATCH "https://api.cloudflare.com/client/v4/zones/<REDACTED_ZONE_ID>/settings/sha1_support": 400 Bad Request {"success":false,"errors":[{"code":1006,"message":"Unrecognized zone setting name:
│ sha1_support"}],"messages":[],"result":null}
╵
```

### With provider vDev: plan ❌ , apply ❌

```
sjwood@setecastronomy:~/test$ TF_CLI_CONFIG_FILE=~/.terraform.rc terraform plan 
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - cloudflare/cloudflare in /home/sjwood/src/terraform-provider-cloudflare
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
╷
│ Error: Invalid Attribute Value Match
│ 
│   with cloudflare_zone_setting.sha1_support,
│   on main.tf line 12, in resource "cloudflare_zone_setting" "sha1_support":
│   12:   id         = "sha1_support"
│ 
│ Attribute id value must be one of: ["0rtt" "advanced_ddos" "aegis" "always_online" "always_use_https" "automatic_https_rewrites" "brotli" "browser_cache_ttl" "browser_check" "cache_level" "challenge_ttl" "ciphers"
│ "cname_flattening" "development_mode" "early_hints" "edge_cache_ttl" "email_obfuscation" "h2_prioritization" "hotlink_protection" "http2" "http3" "image_resizing" "ip_geolocation" "ipv6" "max_upload"
│ "min_tls_version" "mirage" "nel" "opportunistic_encryption" "opportunistic_onion" "orange_to_orange" "origin_error_page_pass_thru" "origin_h2_max_streams" "origin_max_http_version" "polish" "prefetch_preload"
│ "privacy_pass" "proxy_read_timeout" "pseudo_ipv4" "replace_insecure_js" "response_buffering" "rocket_loader" "automatic_platform_optimization" "security_header" "security_level" "server_side_exclude"
│ "sort_query_string_for_cache" "ssl" "ssl_recommender" "tls_1_2_only" "tls_1_3" "tls_client_auth" "true_client_ip_header" "waf" "webp" "websockets"], got: "sha1_support"
╵
```

```
sjwood@setecastronomy:~/test$ TF_CLI_CONFIG_FILE=~/.terraform.rc terraform apply -auto-approve 
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - cloudflare/cloudflare in /home/sjwood/src/terraform-provider-cloudflare
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
╷
│ Error: Invalid Attribute Value Match
│ 
│   with cloudflare_zone_setting.sha1_support,
│   on main.tf line 12, in resource "cloudflare_zone_setting" "sha1_support":
│   12:   id         = "sha1_support"
│ 
│ Attribute id value must be one of: ["0rtt" "advanced_ddos" "aegis" "always_online" "always_use_https" "automatic_https_rewrites" "brotli" "browser_cache_ttl" "browser_check" "cache_level" "challenge_ttl" "ciphers"
│ "cname_flattening" "development_mode" "early_hints" "edge_cache_ttl" "email_obfuscation" "h2_prioritization" "hotlink_protection" "http2" "http3" "image_resizing" "ip_geolocation" "ipv6" "max_upload"
│ "min_tls_version" "mirage" "nel" "opportunistic_encryption" "opportunistic_onion" "orange_to_orange" "origin_error_page_pass_thru" "origin_h2_max_streams" "origin_max_http_version" "polish" "prefetch_preload"
│ "privacy_pass" "proxy_read_timeout" "pseudo_ipv4" "replace_insecure_js" "response_buffering" "rocket_loader" "automatic_platform_optimization" "security_header" "security_level" "server_side_exclude"
│ "sort_query_string_for_cache" "ssl" "ssl_recommender" "tls_1_2_only" "tls_1_3" "tls_client_auth" "true_client_ip_header" "waf" "webp" "websockets"], got: "sha1_support"
╵
```
