### PR TITLE
feat(workers_kv): add value and metadata outputs to data source

### DIFF
--- a/docs/data-sources/workers_kv.md
+++ b/docs/data-sources/workers_kv.md
@@ -28,4 +28,9 @@ data "cloudflare_workers_kv" "example_workers_kv" {
 - `key_name` (String) A key's name. The name may be at most 512 bytes. All printable, non-whitespace characters are valid. Use percent-encoding to define key names as part of a URL.
 - `namespace_id` (String) Namespace identifier tag.
 
+### Read-Only
+
+- `value` (String) A byte sequence that was stored, up to 25 MiB in length.
+- `metadata` (String) Arbitrary JSON associated with the key/value pair.
+
 

--- a/internal/services/workers_kv/data_source_model.go
+++ b/internal/services/workers_kv/data_source_model.go
@@ -15,6 +15,8 @@ type WorkersKVDataSourceModel struct {
 	AccountID   types.String `tfsdk:"account_id" path:"account_id,required"`
 	KeyName     types.String `tfsdk:"key_name" path:"key_name,required"`
 	NamespaceID types.String `tfsdk:"namespace_id" path:"namespace_id,required"`
+	Value       types.String `tfsdk:"value" json:"value,computed"`
+	Metadata    types.String `tfsdk:"metadata" json:"metadata,computed"`
 }
 
 func (m *WorkersKVDataSourceModel) toReadParams(_ context.Context) (params kv.NamespaceValueGetParams, diags diag.Diagnostics) {

--- a/internal/services/workers_kv/data_source_schema.go
+++ b/internal/services/workers_kv/data_source_schema.go
@@ -26,6 +26,14 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				Description: "Namespace identifier tag.",
 				Required:    true,
 			},
+			"value": schema.StringAttribute{
+				Description: "A byte sequence that was stored, up to 25 MiB in length.",
+				Computed:    true,
+			},
+			"metadata": schema.StringAttribute{
+				Description: "Arbitrary JSON associated with the key/value pair.",
+				Computed:    true,
+			},
 		},
 	}
 }


### PR DESCRIPTION
Added value and metadata as computed outputs to the Workers KV data source schema and model, allowing users to access these values in their Terraform configurations.

fixes #5327