### PR TITLE
fix: correct logpush output_options field name

### DIFF
--- a/internal/services/logpush_dataset_job/data_source_model.go
+++ b/internal/services/logpush_dataset_job/data_source_model.go
@@ -53,7 +53,7 @@ func (m *LogpushDatasetJobDataSourceModel) toReadParams(_ context.Context) (para
 type LogpushDatasetJobOutputOptionsDataSourceModel struct {
 	BatchPrefix     types.String                   `tfsdk:"batch_prefix" json:"batch_prefix,computed"`
 	BatchSuffix     types.String                   `tfsdk:"batch_suffix" json:"batch_suffix,computed"`
-	Cve2021_4428    types.Bool                     `tfsdk:"cve_2021_4428" json:"CVE-2021-4428,computed"`
+	Cve2021_44228   types.Bool                     `tfsdk:"cve_2021_44228" json:"CVE-2021-44228,computed"`
 	FieldDelimiter  types.String                   `tfsdk:"field_delimiter" json:"field_delimiter,computed"`
 	FieldNames      customfield.List[types.String] `tfsdk:"field_names" json:"field_names,computed"`
 	OutputType      types.String                   `tfsdk:"output_type" json:"output_type,computed"`

--- a/internal/services/logpush_job/data_source_model.go
+++ b/internal/services/logpush_job/data_source_model.go
@@ -65,7 +65,7 @@ func (m *LogpushJobDataSourceModel) toListParams(_ context.Context) (params logp
 type LogpushJobOutputOptionsDataSourceModel struct {
 	BatchPrefix     types.String                   `tfsdk:"batch_prefix" json:"batch_prefix,computed"`
 	BatchSuffix     types.String                   `tfsdk:"batch_suffix" json:"batch_suffix,computed"`
-	Cve2021_4428    types.Bool                     `tfsdk:"cve_2021_4428" json:"CVE-2021-4428,computed"`
+	Cve2021_44228   types.Bool                     `tfsdk:"cve_2021_44228" json:"CVE-2021-44228,computed"`
 	FieldDelimiter  types.String                   `tfsdk:"field_delimiter" json:"field_delimiter,computed"`
 	FieldNames      customfield.List[types.String] `tfsdk:"field_names" json:"field_names,computed"`
 	OutputType      types.String                   `tfsdk:"output_type" json:"output_type,computed"`

--- a/internal/services/logpush_job/list_data_source_model.go
+++ b/internal/services/logpush_job/list_data_source_model.go
@@ -57,7 +57,7 @@ type LogpushJobsResultDataSourceModel struct {
 type LogpushJobsOutputOptionsDataSourceModel struct {
 	BatchPrefix     types.String                   `tfsdk:"batch_prefix" json:"batch_prefix,computed"`
 	BatchSuffix     types.String                   `tfsdk:"batch_suffix" json:"batch_suffix,computed"`
-	Cve2021_4428    types.Bool                     `tfsdk:"cve_2021_4428" json:"CVE-2021-4428,computed"`
+	Cve2021_44228   types.Bool                     `tfsdk:"cve_2021_44228" json:"CVE-2021-44228,computed"`
 	FieldDelimiter  types.String                   `tfsdk:"field_delimiter" json:"field_delimiter,computed"`
 	FieldNames      customfield.List[types.String] `tfsdk:"field_names" json:"field_names,computed"`
 	OutputType      types.String                   `tfsdk:"output_type" json:"output_type,computed"`

--- a/internal/services/logpush_job/model.go
+++ b/internal/services/logpush_job/model.go
@@ -45,7 +45,7 @@ func (m LogpushJobModel) MarshalJSONForUpdate(state LogpushJobModel) (data []byt
 type LogpushJobOutputOptionsModel struct {
 	BatchPrefix     types.String    `tfsdk:"batch_prefix" json:"batch_prefix,computed_optional"`
 	BatchSuffix     types.String    `tfsdk:"batch_suffix" json:"batch_suffix,computed_optional"`
-	Cve2021_4428    types.Bool      `tfsdk:"cve_2021_4428" json:"CVE-2021-4428,computed_optional"`
+	Cve2021_44228   types.Bool      `tfsdk:"cve_2021_44228" json:"CVE-2021-44228,computed_optional"`
 	FieldDelimiter  types.String    `tfsdk:"field_delimiter" json:"field_delimiter,computed_optional"`
 	FieldNames      *[]types.String `tfsdk:"field_names" json:"field_names,optional"`
 	OutputType      types.String    `tfsdk:"output_type" json:"output_type,computed_optional"`

--- a/internal/services/logpush_job/resource_test.go
+++ b/internal/services/logpush_job/resource_test.go
@@ -19,7 +19,7 @@ package logpush_job_test
 // 	resourceDataMap := map[string]interface{}{
 // 		"output_options": []interface{}{
 // 			map[string]interface{}{
-// 				"cve20214428":      *testData.CVE202144228,
+// 				"cve202144228":      *testData.CVE202144228,
 // 				"batch_prefix":     testData.BatchPrefix,
 // 				"batch_suffix":     testData.BatchSuffix,
 // 				"field_delimiter":  testData.FieldDelimiter,


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

I'm not sure where the gap came in from generation other than possibly resource_test.go where there was a mismatch.

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Corrects the CVE-2021-44228 field name to match Cloudflare API docs

## Additional context & links
* https://developers.cloudflare.com/api/resources/logpush/subresources/jobs/models/output_options/#(schema)