### PR TITLE
Add Support for Configurable Max Retries in terraform-provider-cloudflare

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -59,4 +59,10 @@ const (
 
 	// Environment variable key for the client base URL.
 	BaseURLEnvVarKey = "CLOUDFLARE_BASE_URL"
+
+	// Key for the max_retries attribute in the schema
+	MaxRetriesSchemaKey = "max_retries"
+
+	// Environment variable for max_retries
+    	MaxRetriesEnvVarKey = "CLOUDFLARE_MAX_RETRIES"
 )


### PR DESCRIPTION
## Description
This PR introduces support for configuring the maximum number of retries for API requests in the terraform-provider-cloudflare using the WithMaxRetries option from the cloudflare-go SDK.

We have more than 1500 IP Access Rules in our cloudflare domains, When we run terraform plan or apply getting `429 Too Many Requests` error sometimes due to huge api calls. 
Cloudflare-go SDK has internal retries already ([ref](https://github.com/cloudflare/cloudflare-go/tree/main?tab=readme-ov-file#retries)) it correctly considers the  rate limits([ref](https://github.com/cloudflare/cloudflare-go/blob/v4.0.0/internal/requestconfig/requestconfig.go#L203-L228)) so we would like to configure [WithMaxRetries](https://github.com/cloudflare/cloudflare-go/blob/v4.0.0/option/requestoption.go#L64-L77) on the terraform cloudflare provider.


## How to Use
Users can now configure max_retries in their Terraform provider block as follows:
```
provider "cloudflare" {
  api_token   = "<YOUR_API_TOKEN>"
  account_id  = "<YOUR_ACCOUNT_ID>"
  max_retries = 5
}
```

## Additional Notes
- The implementation leverages the built-in WithMaxRetries() from the cloudflare-go SDK, ensuring clean and efficient retry management.
- Users are encouraged to fine-tune max_retries based on their API usage patterns.


### Key changes include:

* Added `MaxRetries` field to `CloudflareProviderModel` to allow specifying the maximum number of retries for API requests. (`internal/provider.go`)
* Updated the `ProviderSchema` to include the `MaxRetries` attribute, allowing it to be set via configuration or environment variable. (`internal/provider.go`)
* Modified the `Configure` function to read the `MaxRetries` value from the configuration or environment variable and apply it to the Cloudflare client options. (`internal/provider.go`)