### PR TITLE
fix: increase list per page item limit to reduce number of calls

### DIFF
--- a/internal/sdkv2provider/resource_cloudflare_teams_list.go
+++ b/internal/sdkv2provider/resource_cloudflare_teams_list.go
@@ -110,6 +110,9 @@ func resourceCloudflareTeamsListRead(ctx context.Context, d *schema.ResourceData
 
 	listItems, _, err := client.ListTeamsListItems(ctx, identifier, cloudflare.ListTeamsListItemsParams{
 		ListID: d.Id(),
+		ResultInfo: cloudflare.ResultInfo{
+			PerPage: 1000,
+		},
 	})
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error finding Teams List %q: %w", d.Id(), err))


### PR DESCRIPTION
This will help to reduce list items call which can go up to like 100 calls right now and increases the chances of error.
v5 does not have this problem.
