### PR TITLE
Additional values for period in ratelimit rules

### DIFF
--- a/docs/data-sources/ruleset.md
+++ b/docs/data-sources/ruleset.md
@@ -497,7 +497,7 @@ Read-Only:
 - `counting_expression` (String) Defines when the ratelimit counter should be incremented. It is optional and defaults to the same as the rule's expression.
 - `mitigation_timeout` (Number) Period of time in seconds after which the action will be disabled following its first execution.
 - `period` (Number) Period in seconds over which the counter is being incremented.
-Available values: 10, 60, 600, 3600.
+Available values: 10, 60, 120, 300, 600, 3600.
 - `requests_per_period` (Number) The threshold of requests per period after which the action will be executed for the first time.
 - `requests_to_origin` (Boolean) Defines if ratelimit counting is only done when an origin is reached.
 - `score_per_period` (Number) The score threshold per period for which the action will be executed the first time.

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -560,7 +560,7 @@ Required:
 
 - `characteristics` (List of String) Characteristics of the request on which the ratelimiter counter will be incremented.
 - `period` (Number) Period in seconds over which the counter is being incremented.
-Available values: 10, 60, 600, 3600.
+Available values: 10, 60, 120, 300, 600, 3600.
 
 Optional:
 

--- a/internal/services/ruleset/data_source_schema.go
+++ b/internal/services/ruleset/data_source_schema.go
@@ -1069,12 +1069,14 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 									ElementType: types.StringType,
 								},
 								"period": schema.Int64Attribute{
-									Description: "Period in seconds over which the counter is being incremented.\nAvailable values: 10, 60, 600, 3600.",
+									Description: "Period in seconds over which the counter is being incremented.\nAvailable values: 10, 60, 120, 300, 600, 3600.",
 									Computed:    true,
 									Validators: []validator.Int64{
 										int64validator.OneOf(
 											10,
 											60,
+											120,
+											300,
 											600,
 											3600,
 										),

--- a/internal/services/ruleset/schema.go
+++ b/internal/services/ruleset/schema.go
@@ -1090,12 +1090,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									ElementType: types.StringType,
 								},
 								"period": schema.Int64Attribute{
-									Description: "Period in seconds over which the counter is being incremented.\nAvailable values: 10, 60, 600, 3600.",
+									Description: "Period in seconds over which the counter is being incremented.\nAvailable values: 10, 60, 120, 300, 600, 3600.",
 									Required:    true,
 									Validators: []validator.Int64{
 										int64validator.OneOf(
 											10,
 											60,
+											120,
+											300,
 											600,
 											3600,
 										),


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Regarding rate limit rules in rulesets, the attribute `period` now accepts the following additional values: 120, 300.

## Additional context & links
Updated documentation:
https://developers.cloudflare.com/waf/rate-limiting-rules/parameters/#when-rate-exceeds--period