### PR TITLE
fix(dns_record): don't include defaults for `data`

### DIFF
--- a/internal/services/dns_record/model.go
+++ b/internal/services/dns_record/model.go
@@ -60,15 +60,15 @@ type DNSRecordDataModel struct {
 	Altitude      types.Float64 `tfsdk:"altitude" json:"altitude,optional"`
 	LatDegrees    types.Float64 `tfsdk:"lat_degrees" json:"lat_degrees,optional"`
 	LatDirection  types.String  `tfsdk:"lat_direction" json:"lat_direction,optional"`
-	LatMinutes    types.Float64 `tfsdk:"lat_minutes" json:"lat_minutes,computed_optional"`
-	LatSeconds    types.Float64 `tfsdk:"lat_seconds" json:"lat_seconds,computed_optional"`
+	LatMinutes    types.Float64 `tfsdk:"lat_minutes" json:"lat_minutes,optional"`
+	LatSeconds    types.Float64 `tfsdk:"lat_seconds" json:"lat_seconds,optional"`
 	LongDegrees   types.Float64 `tfsdk:"long_degrees" json:"long_degrees,optional"`
 	LongDirection types.String  `tfsdk:"long_direction" json:"long_direction,optional"`
-	LongMinutes   types.Float64 `tfsdk:"long_minutes" json:"long_minutes,computed_optional"`
-	LongSeconds   types.Float64 `tfsdk:"long_seconds" json:"long_seconds,computed_optional"`
-	PrecisionHorz types.Float64 `tfsdk:"precision_horz" json:"precision_horz,computed_optional"`
-	PrecisionVert types.Float64 `tfsdk:"precision_vert" json:"precision_vert,computed_optional"`
-	Size          types.Float64 `tfsdk:"size" json:"size,computed_optional"`
+	LongMinutes   types.Float64 `tfsdk:"long_minutes" json:"long_minutes,optional"`
+	LongSeconds   types.Float64 `tfsdk:"long_seconds" json:"long_seconds,optional"`
+	PrecisionHorz types.Float64 `tfsdk:"precision_horz" json:"precision_horz,optional"`
+	PrecisionVert types.Float64 `tfsdk:"precision_vert" json:"precision_vert,optional"`
+	Size          types.Float64 `tfsdk:"size" json:"size,optional"`
 	Order         types.Float64 `tfsdk:"order" json:"order,optional"`
 	Preference    types.Float64 `tfsdk:"preference" json:"preference,optional"`
 	Regex         types.String  `tfsdk:"regex" json:"regex,optional"`

--- a/internal/services/dns_record/schema.go
+++ b/internal/services/dns_record/schema.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -214,21 +213,17 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 					"lat_minutes": schema.Float64Attribute{
 						Description: "Minutes of latitude.",
-						Computed:    true,
 						Optional:    true,
 						Validators: []validator.Float64{
 							float64validator.Between(0, 59),
 						},
-						Default: float64default.StaticFloat64(0),
 					},
 					"lat_seconds": schema.Float64Attribute{
 						Description: "Seconds of latitude.",
-						Computed:    true,
 						Optional:    true,
 						Validators: []validator.Float64{
 							float64validator.Between(0, 59.999),
 						},
-						Default: float64default.StaticFloat64(0),
 					},
 					"long_degrees": schema.Float64Attribute{
 						Description: "Degrees of longitude.",
@@ -246,48 +241,38 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 					"long_minutes": schema.Float64Attribute{
 						Description: "Minutes of longitude.",
-						Computed:    true,
 						Optional:    true,
 						Validators: []validator.Float64{
 							float64validator.Between(0, 59),
 						},
-						Default: float64default.StaticFloat64(0),
 					},
 					"long_seconds": schema.Float64Attribute{
 						Description: "Seconds of longitude.",
-						Computed:    true,
 						Optional:    true,
 						Validators: []validator.Float64{
 							float64validator.Between(0, 59.999),
 						},
-						Default: float64default.StaticFloat64(0),
 					},
 					"precision_horz": schema.Float64Attribute{
 						Description: "Horizontal precision of location.",
-						Computed:    true,
 						Optional:    true,
 						Validators: []validator.Float64{
 							float64validator.Between(0, 90000000),
 						},
-						Default: float64default.StaticFloat64(0),
 					},
 					"precision_vert": schema.Float64Attribute{
 						Description: "Vertical precision of location.",
-						Computed:    true,
 						Optional:    true,
 						Validators: []validator.Float64{
 							float64validator.Between(0, 90000000),
 						},
-						Default: float64default.StaticFloat64(0),
 					},
 					"size": schema.Float64Attribute{
 						Description: "Size of location in meters.",
-						Computed:    true,
 						Optional:    true,
 						Validators: []validator.Float64{
 							float64validator.Between(0, 90000000),
 						},
-						Default: float64default.StaticFloat64(0),
 					},
 					"order": schema.Float64Attribute{
 						Description: "Order.",


### PR DESCRIPTION
The `data` attributes are defining defaults which is being compared as part of the lifecycle despite them not being defined or returned by the service.

Closes #5405
