### PR TITLE
fix(workers_kv): fix state refresh

### DIFF
--- a/internal/services/workers_kv/resource.go
+++ b/internal/services/workers_kv/resource.go
@@ -172,6 +172,12 @@ func (r *WorkersKVResource) Read(ctx context.Context, req resource.ReadRequest, 
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
+	bytes, _ := io.ReadAll(res.Body)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read response body", err.Error())
+		return
+	}
+	data.Value = types.StringValue(string(bytes))
 	data.ID = data.KeyName
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
`GET /client/v4/accounts/:accountId/storage/kv/namespaces/:namespaceId/values/:key` returns the raw value, but the `cloudflare_workers_kv` resource's `Read()` method is not handling this appropriately. This results in terraform always planning to update this value even when it hasn't been modified.

Previously, this resource was attempting to unmarshal the response as JSON. In  febe04ec7f9341f665280be89bcb5ffea2ee4886, we dropped reading the response body entirely. This PR updates the resource to read the response body into the `WorkersKVModel.Value` field to allow state refreshes to work as expected.

## Additional context & links
Refs internal ticket IAC-108