### PR TITLE
fix(r2_bucket): fix handling of `cloudflare_r2_bucket` params

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -61,4 +61,6 @@ const (
 	BaseURLEnvVarKey = "CLOUDFLARE_BASE_URL"
 
 	R2JurisdictionHTTPHeaderName = "cf-r2-jurisdiction"
+
+	R2StorageClassHTTPHeaderName = "cf-r2-storage-class"
 )

--- a/internal/services/r2_bucket/model.go
+++ b/internal/services/r2_bucket/model.go
@@ -15,16 +15,22 @@ type R2BucketModel struct {
 	ID           types.String `tfsdk:"id" json:"-,computed"`
 	Name         types.String `tfsdk:"name" json:"name,required"`
 	AccountID    types.String `tfsdk:"account_id" path:"account_id,required"`
-	Location     types.String `tfsdk:"location" json:"locationHint,optional"`
+	Location     types.String `tfsdk:"location" json:"location,computed_optional"`
 	Jurisdiction types.String `tfsdk:"jurisdiction" json:"-,computed_optional"`
-	StorageClass types.String `tfsdk:"storage_class" json:"storageClass,computed_optional,no_refresh"`
+	StorageClass types.String `tfsdk:"storage_class" json:"storage_class,computed_optional"`
 	CreationDate types.String `tfsdk:"creation_date" json:"creation_date,computed"`
 }
 
-func (m R2BucketModel) MarshalJSON() (data []byte, err error) {
-	return apijson.MarshalRoot(m)
+type CreateR2BucketModel struct {
+	ID           types.String `tfsdk:"id" json:"-,computed"`
+	Name         types.String `tfsdk:"name" json:"name,required"`
+	AccountID    types.String `tfsdk:"account_id" path:"account_id,required"`
+	Location     types.String `tfsdk:"location" json:"locationHint,computed_optional"`
+	Jurisdiction types.String `tfsdk:"jurisdiction" json:"-,computed_optional"`
+	StorageClass types.String `tfsdk:"storage_class" json:"storageClass,computed_optional"`
+	CreationDate types.String `tfsdk:"creation_date" json:"-,computed"`
 }
 
-func (m R2BucketModel) MarshalJSONForUpdate(state R2BucketModel) (data []byte, err error) {
-	return apijson.MarshalForPatch(m, state)
+func (m CreateR2BucketModel) MarshalJSON() (data []byte, err error) {
+	return apijson.MarshalRoot(m)
 }

--- a/internal/services/r2_bucket/resource_test.go
+++ b/internal/services/r2_bucket/resource_test.go
@@ -120,6 +120,18 @@ func TestAccCloudflareR2Bucket_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rnd),
 					resource.TestCheckResourceAttr(resourceName, "id", rnd),
 					resource.TestCheckResourceAttr(resourceName, "location", "ENAM"),
+					resource.TestCheckResourceAttr(resourceName, "storage_class", "Standard"),
+					resource.TestCheckResourceAttr(resourceName, "jurisdiction", "default"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareR2BucketUpdate(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rnd),
+					resource.TestCheckResourceAttr(resourceName, "id", rnd),
+					resource.TestCheckResourceAttr(resourceName, "location", "ENAM"),
+					resource.TestCheckResourceAttr(resourceName, "storage_class", "InfrequentAccess"),
+					resource.TestCheckResourceAttr(resourceName, "jurisdiction", "default"),
 				),
 			},
 			{
@@ -127,9 +139,8 @@ func TestAccCloudflareR2Bucket_Basic(t *testing.T) {
 				ImportStateIdFunc: func(*terraform.State) (string, error) {
 					return strings.Join([]string{accountID, rnd, "default"}, "/"), nil
 				},
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "storage_class"},
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -182,9 +193,8 @@ func TestAccCloudflareR2Bucket_Jurisdiction(t *testing.T) {
 				ImportStateIdFunc: func(*terraform.State) (string, error) {
 					return strings.Join([]string{accountID, rnd, "eu"}, "/"), nil
 				},
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"storage_class"},
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -196,6 +206,10 @@ func testAccCheckCloudflareR2BucketMinimum(rnd, accountID string) string {
 
 func testAccCheckCloudflareR2BucketBasic(rnd, accountID string) string {
 	return acctest.LoadTestCase("r2bucketbasic.tf", rnd, accountID)
+}
+
+func testAccCheckCloudflareR2BucketUpdate(rnd, accountID string) string {
+	return acctest.LoadTestCase("r2bucketupdate.tf", rnd, accountID)
 }
 
 func testAccCheckCloudflareR2BucketJurisdiction(rnd, accountID string) string {

--- a/internal/services/r2_bucket/schema.go
+++ b/internal/services/r2_bucket/schema.go
@@ -36,6 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"location": schema.StringAttribute{
 				Description: "Location of the bucket.\nAvailable values: \"apac\", \"eeur\", \"enam\", \"weur\", \"wnam\", \"oc\".",
+				Computed:    true,
 				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive(
@@ -69,8 +70,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive("Standard", "InfrequentAccess"),
 				},
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-				Default:       stringdefault.StaticString("Standard"),
+				Default: stringdefault.StaticString("Standard"),
 			},
 			"creation_date": schema.StringAttribute{
 				Description: "Creation timestamp.",

--- a/internal/services/r2_bucket/testdata/basic.tf
+++ b/internal/services/r2_bucket/testdata/basic.tf
@@ -1,5 +1,0 @@
-resource "cloudflare_r2_bucket" "%[1]s" {
-  account_id = "%[2]s"
-  name       = "%[1]s"
-	location   = "ENAM"
-}

--- a/internal/services/r2_bucket/testdata/minimum.tf
+++ b/internal/services/r2_bucket/testdata/minimum.tf
@@ -1,4 +1,0 @@
-resource "cloudflare_r2_bucket" "%[1]s" {
-  account_id = "%[2]s"
-  name       = "%[1]s"
-}

--- a/internal/services/r2_bucket/testdata/r2bucketupdate.tf
+++ b/internal/services/r2_bucket/testdata/r2bucketupdate.tf
@@ -3,5 +3,5 @@
     account_id    = "%[2]s"
     name          = "%[1]s"
     location      = "ENAM"
-    storage_class = "Standard"
+    storage_class = "InfrequentAccess"
   }


### PR DESCRIPTION
## Changes being requested
This PR fixes the implementation of the `cloudflare_r2_bucket` resource.

Previously, the bucket params weren't being serialized/deserialized correctly in the various resource lifecycle methods. The `R2BucketModel` json field tags were based on the request body params of the Create Bucket endpoint rather than the property names used in responses. Now the model appropriately reflects the response shape so all of the API calls made during the resource lifecycle have their responses deserialized as expected. The lifecycle methods have also been updated to let the `cloudflare-go` SDK handle param serialization instead of trying to marshal JSON from the model struct.

`r2_bucket.location` has been updated to be `computed_optional`, and a corresponding update has also been made to the OpenAPI schema to add `x-stainless-terraform-configurability: computed_optional`.

Lastly, the acceptance tests have been updated. A test step has been added to test resource update behavior. We also no longer ignore fields in `ImportState` checks since they're now being returned by the API.

## Additional context & links

Fixes #5373
Fixes #5492
Fixes #5518