### PR TITLE
fix(dns_record): align flags data type for datasource to resource and api response

### DIFF
--- a/docs/data-sources/dns_record.md
+++ b/docs/data-sources/dns_record.md
@@ -133,7 +133,7 @@ Read-Only:
 - `digest` (String) Digest.
 - `digest_type` (Number) Digest Type.
 - `fingerprint` (String) fingerprint.
-- `flags` (Dynamic) Flags for the CAA record.
+- `flags` (Number) Flags for the CAA record.
 - `key_tag` (Number) Key Tag.
 - `lat_degrees` (Number) Degrees of latitude.
 - `lat_direction` (String) Latitude direction.

--- a/docs/data-sources/dns_records.md
+++ b/docs/data-sources/dns_records.md
@@ -161,7 +161,7 @@ Read-Only:
 - `digest` (String) Digest.
 - `digest_type` (Number) Digest Type.
 - `fingerprint` (String) fingerprint.
-- `flags` (Dynamic) Flags for the CAA record.
+- `flags` (Number) Flags for the CAA record.
 - `key_tag` (Number) Key Tag.
 - `lat_degrees` (Number) Degrees of latitude.
 - `lat_direction` (String) Latitude direction.

--- a/internal/services/dns_record/data_source_model.go
+++ b/internal/services/dns_record/data_source_model.go
@@ -157,7 +157,7 @@ func (m *DNSRecordDataSourceModel) toListParams(_ context.Context) (params dns.R
 }
 
 type DNSRecordDataDataSourceModel struct {
-	Flags         types.Dynamic `tfsdk:"flags" json:"flags,computed"`
+	Flags         types.Float64 `tfsdk:"flags" json:"flags,computed"`
 	Tag           types.String  `tfsdk:"tag" json:"tag,computed"`
 	Value         types.String  `tfsdk:"value" json:"value,computed"`
 	Algorithm     types.Float64 `tfsdk:"algorithm" json:"algorithm,computed"`

--- a/internal/services/dns_record/data_source_schema.go
+++ b/internal/services/dns_record/data_source_schema.go
@@ -6,7 +6,6 @@ import (
 	"context"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/customvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
@@ -17,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 var _ datasource.DataSourceWithConfigValidators = (*DNSRecordDataSource)(nil)
@@ -128,11 +126,11 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				Computed:    true,
 				CustomType:  customfield.NewNestedObjectType[DNSRecordDataDataSourceModel](ctx),
 				Attributes: map[string]schema.Attribute{
-					"flags": schema.DynamicAttribute{
+					"flags": schema.Float64Attribute{
 						Description: "Flags for the CAA record.",
 						Computed:    true,
-						Validators: []validator.Dynamic{
-							customvalidator.AllowedSubtypes(basetypes.Float64Type{}, basetypes.StringType{}),
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
 						},
 					},
 					"tag": schema.StringAttribute{

--- a/internal/services/dns_record/list_data_source_model.go
+++ b/internal/services/dns_record/list_data_source_model.go
@@ -201,7 +201,7 @@ type DNSRecordsSettingsDataSourceModel struct {
 }
 
 type DNSRecordsDataDataSourceModel struct {
-	Flags         types.Dynamic `tfsdk:"flags" json:"flags,computed"`
+	Flags         types.Float64 `tfsdk:"flags" json:"flags,computed"`
 	Tag           types.String  `tfsdk:"tag" json:"tag,computed"`
 	Value         types.String  `tfsdk:"value" json:"value,computed"`
 	Algorithm     types.Float64 `tfsdk:"algorithm" json:"algorithm,computed"`

--- a/internal/services/dns_record/list_data_source_schema.go
+++ b/internal/services/dns_record/list_data_source_schema.go
@@ -6,7 +6,6 @@ import (
 	"context"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/customvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
@@ -16,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 var _ datasource.DataSourceWithConfigValidators = (*DNSRecordsDataSource)(nil)
@@ -329,11 +327,11 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 							Computed:    true,
 							CustomType:  customfield.NewNestedObjectType[DNSRecordsDataDataSourceModel](ctx),
 							Attributes: map[string]schema.Attribute{
-								"flags": schema.DynamicAttribute{
+								"flags": schema.Float64Attribute{
 									Description: "Flags for the CAA record.",
 									Computed:    true,
-									Validators: []validator.Dynamic{
-										customvalidator.AllowedSubtypes(basetypes.Float64Type{}, basetypes.StringType{}),
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
 									},
 								},
 								"tag": schema.StringAttribute{

--- a/internal/services/dns_record/schema.go
+++ b/internal/services/dns_record/schema.go
@@ -95,6 +95,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"flags": schema.Float64Attribute{
 						Description: "Flags for the CAA record.",
 						Optional:    true,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"tag": schema.StringAttribute{
 						Description: "Name of the property controlled by this record (e.g.: issue, issuewild, iodef).",


### PR DESCRIPTION


<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Updating the `cloudflare_dns_record` and `cloudflare_dns_records` data_sources to align to the API response of a `Number` type (Instead of `Dynamic`) and also to the same that of the resource itself. 

This current difference prevents trying to compare any data sources to imports/resource definitions containing any CAA records with:

```
!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
...
panic: inconsistent list element types
```

Where source is is a `cty.Number` and the other is `cty.DynamicPseudoType` 

## Additional context & links

The underlying type in the go library is `float64` so this aligns to that too. 
https://github.com/cloudflare/cloudflare-go/blob/1219741028ab564f1307be5a2d463a136a0df815/dns/record.go#L1785

It looks like there was a similar issue with the actual resource earlier in the 5.x versions here https://github.com/cloudflare/terraform-provider-cloudflare/issues/5116 