### PR TITLE
TUN-9333: Fix cloudflared tunnel secret rotate

### DIFF
--- a/internal/services/zero_trust_tunnel_cloudflared/resource.go
+++ b/internal/services/zero_trust_tunnel_cloudflared/resource.go
@@ -112,8 +112,8 @@ func (r *ZeroTrustTunnelCloudflaredResource) Update(ctx context.Context, req res
 		return
 	}
 
-	configurationSource := state.ConfigSrc
-	tunnelSecret := state.TunnelSecret
+	configurationSource := data.ConfigSrc
+	tunnelSecret := data.TunnelSecret
 
 	dataBytes, err := data.MarshalJSONForUpdate(*state)
 	if err != nil {

--- a/internal/services/zero_trust_tunnel_cloudflared/testdata/tunnelsecret.tf
+++ b/internal/services/zero_trust_tunnel_cloudflared/testdata/tunnelsecret.tf
@@ -1,0 +1,6 @@
+
+	resource "cloudflare_zero_trust_tunnel_cloudflared" "%[2]s" {
+		account_id    = "%[1]s"
+		name          = "%[2]s"
+		tunnel_secret = "%[3]s"
+	}


### PR DESCRIPTION
## Summary
The tunnel secret is never returned by the API response, therefore, we need to store the tunnel secret and configuration source, sent in the request to update it in the state after the patch is successful.

Closes https://github.com/cloudflare/terraform-provider-cloudflare/issues/5561
