### PR TITLE
TUN-9171: Fix vnet resource by mapping IsDefaultNetwork to IsDefault

### DIFF
--- a/internal/services/zero_trust_tunnel_cloudflared_virtual_network/model.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_virtual_network/model.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 type ZeroTrustTunnelCloudflaredVirtualNetworkResultEnvelope struct {
@@ -15,16 +16,26 @@ type ZeroTrustTunnelCloudflaredVirtualNetworkResultEnvelope struct {
 type ZeroTrustTunnelCloudflaredVirtualNetworkModel struct {
 	ID               types.String      `tfsdk:"id" json:"id,computed"`
 	AccountID        types.String      `tfsdk:"account_id" path:"account_id,required"`
-	IsDefault        types.Bool        `tfsdk:"is_default" json:"is_default,optional,no_refresh"`
 	Name             types.String      `tfsdk:"name" json:"name,required"`
 	Comment          types.String      `tfsdk:"comment" json:"comment,optional"`
-	IsDefaultNetwork types.Bool        `tfsdk:"is_default_network" json:"is_default_network,optional"`
+	IsDefaultNetwork types.Bool        `tfsdk:"is_default_network" json:"is_default_network,computed_optional"`
 	CreatedAt        timetypes.RFC3339 `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
 	DeletedAt        timetypes.RFC3339 `tfsdk:"deleted_at" json:"deleted_at,computed" format:"date-time"`
 }
 
+type newZeroTrustTunnelCloudflaredVirtualNetworkModel struct {
+	Name      types.String `json:"name,required"`
+	Comment   types.String `json:"comment,optional"`
+	IsDefault types.Bool   `json:"is_default,required"`
+}
+
 func (m ZeroTrustTunnelCloudflaredVirtualNetworkModel) MarshalJSON() (data []byte, err error) {
-	return apijson.MarshalRoot(m)
+	body := &newZeroTrustTunnelCloudflaredVirtualNetworkModel{
+		Name:      m.Name,
+		Comment:   m.Comment,
+		IsDefault: basetypes.NewBoolValue(m.IsDefaultNetwork.ValueBool()),
+	}
+	return apijson.MarshalRoot(body)
 }
 
 func (m ZeroTrustTunnelCloudflaredVirtualNetworkModel) MarshalJSONForUpdate(state ZeroTrustTunnelCloudflaredVirtualNetworkModel) (data []byte, err error) {

--- a/internal/services/zero_trust_tunnel_cloudflared_virtual_network/resource.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_virtual_network/resource.go
@@ -112,8 +112,6 @@ func (r *ZeroTrustTunnelCloudflaredVirtualNetworkResource) Update(ctx context.Co
 		return
 	}
 
-	isDefault := state.IsDefault
-
 	dataBytes, err := data.MarshalJSONForUpdate(*state)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
@@ -142,7 +140,6 @@ func (r *ZeroTrustTunnelCloudflaredVirtualNetworkResource) Update(ctx context.Co
 		return
 	}
 	data = &env.Result
-	data.IsDefault = isDefault
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -155,8 +152,6 @@ func (r *ZeroTrustTunnelCloudflaredVirtualNetworkResource) Read(ctx context.Cont
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	isDefault := data.IsDefault
 
 	res := new(http.Response)
 	env := ZeroTrustTunnelCloudflaredVirtualNetworkResultEnvelope{*data}
@@ -185,7 +180,6 @@ func (r *ZeroTrustTunnelCloudflaredVirtualNetworkResource) Read(ctx context.Cont
 		return
 	}
 	data = &env.Result
-	data.IsDefault = isDefault
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/zero_trust_tunnel_cloudflared_virtual_network/resource_test.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_virtual_network/resource_test.go
@@ -70,13 +70,13 @@ func TestAccCloudflareTunnelVirtualNetwork_Exists(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudflareTunnelVirtualNetworkSimple(rnd, rnd, accountID, rnd, false),
+				Config: testAccCloudflareTunnelVirtualNetworkSimple(rnd, rnd, accountID, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareTunnelVirtualNetworkExists(name, &TunnelVirtualNetwork),
 					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
 					resource.TestCheckResourceAttr(name, "name", rnd),
 					resource.TestCheckResourceAttr(name, "comment", rnd),
-					resource.TestCheckResourceAttr(name, "is_default", "false"),
+					resource.TestCheckResourceAttr(name, "is_default_network", "false"),
 				),
 			},
 		},
@@ -128,14 +128,14 @@ func TestAccCloudflareTunnelVirtualNetwork_UpdateComment(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudflareTunnelVirtualNetworkSimple(rnd, rnd, accountID, rnd, false),
+				Config: testAccCloudflareTunnelVirtualNetworkSimple(rnd, rnd, accountID, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareTunnelVirtualNetworkExists(name, &TunnelVirtualNetwork),
 					resource.TestCheckResourceAttr(name, "comment", rnd),
 				),
 			},
 			{
-				Config: testAccCloudflareTunnelVirtualNetworkSimple(rnd, rnd+"-updated", accountID, rnd, false),
+				Config: testAccCloudflareTunnelVirtualNetworkSimple(rnd, rnd+"-updated", accountID, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflareTunnelVirtualNetworkExists(name, &TunnelVirtualNetwork),
 					resource.TestCheckResourceAttr(name, "comment", rnd+"-updated"),
@@ -145,6 +145,44 @@ func TestAccCloudflareTunnelVirtualNetwork_UpdateComment(t *testing.T) {
 	})
 }
 
-func testAccCloudflareTunnelVirtualNetworkSimple(ID, comment, accountID, name string, isDefault bool) string {
-	return acctest.LoadTestCase("tunnelvirtualnetworksimple.tf", ID, comment, accountID, name, isDefault)
+func TestAccCloudflareTunnelVirtualNetwork_WithIsDefault(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_zero_trust_tunnel_cloudflared_virtual_network.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	var TunnelVirtualNetwork cloudflare.TunnelVirtualNetwork
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareTunnelVirtualNetworkDefault(rnd, rnd, accountID, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareTunnelVirtualNetworkExists(name, &TunnelVirtualNetwork),
+					resource.TestCheckResourceAttr(name, "comment", rnd),
+					resource.TestCheckResourceAttr(name, "is_default_network", "false"),
+				),
+			},
+			{
+				Config: testAccCloudflareTunnelVirtualNetworkDefault(rnd, rnd, accountID, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareTunnelVirtualNetworkExists(name, &TunnelVirtualNetwork),
+					resource.TestCheckResourceAttr(name, "comment", rnd),
+					resource.TestCheckResourceAttr(name, "is_default_network", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareTunnelVirtualNetworkSimple(ID, comment, accountID, name string) string {
+	return acctest.LoadTestCase("tunnelvirtualnetworksimple.tf", ID, comment, accountID, name)
+}
+
+func testAccCloudflareTunnelVirtualNetworkDefault(ID, comment, accountID, name string) string {
+	return acctest.LoadTestCase("tunnelvirtualnetworkdefault.tf", ID, comment, accountID, name)
 }

--- a/internal/services/zero_trust_tunnel_cloudflared_virtual_network/schema.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_virtual_network/schema.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
@@ -28,11 +27,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
-			"is_default": schema.BoolAttribute{
-				Description:   "If `true`, this virtual network is the default for the account.",
-				Optional:      true,
-				PlanModifiers: []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
-			},
 			"name": schema.StringAttribute{
 				Description: "A user-friendly name for the virtual network.",
 				Required:    true,
@@ -43,6 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"is_default_network": schema.BoolAttribute{
 				Description: "If `true`, this virtual network is the default for the account.",
+				Computed:    true,
 				Optional:    true,
 			},
 			"created_at": schema.StringAttribute{

--- a/internal/services/zero_trust_tunnel_cloudflared_virtual_network/testdata/tunnelvirtualnetworkdefault.tf
+++ b/internal/services/zero_trust_tunnel_cloudflared_virtual_network/testdata/tunnelvirtualnetworkdefault.tf
@@ -2,4 +2,5 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "%[1]s" {
 	account_id         = "%[3]s"
 	name               = "%[4]s"
 	comment            = "%[2]s"
+	is_default_network = "false"
 }


### PR DESCRIPTION
## Summary
The virtual network resource uses a different field  to set and to read the same value. Therefore, to have the resource properly working on terraform v5, we need to map the value read to the value set. For this case the value used to write is `isDefault` and the value read, is `isDefaultNetwork`.
