### PR TITLE
TUN-9253: Fix list cloudflared tunnels optional fields

### DIFF
--- a/internal/services/zero_trust_tunnel_cloudflared/data_source_model.go
+++ b/internal/services/zero_trust_tunnel_cloudflared/data_source_model.go
@@ -45,11 +45,6 @@ func (m *ZeroTrustTunnelCloudflaredDataSourceModel) toReadParams(_ context.Conte
 }
 
 func (m *ZeroTrustTunnelCloudflaredDataSourceModel) toListParams(_ context.Context) (params zero_trust.TunnelCloudflaredListParams, diags diag.Diagnostics) {
-	mFilterWasActiveAt, errs := m.Filter.WasActiveAt.ValueRFC3339Time()
-	diags.Append(errs...)
-	mFilterWasInactiveAt, errs := m.Filter.WasInactiveAt.ValueRFC3339Time()
-	diags.Append(errs...)
-
 	params = zero_trust.TunnelCloudflaredListParams{
 		AccountID: cloudflare.F(m.AccountID.ValueString()),
 	}
@@ -76,10 +71,18 @@ func (m *ZeroTrustTunnelCloudflaredDataSourceModel) toListParams(_ context.Conte
 		params.UUID = cloudflare.F(m.Filter.UUID.ValueString())
 	}
 	if !m.Filter.WasActiveAt.IsNull() {
-		params.WasActiveAt = cloudflare.F(mFilterWasActiveAt)
+		mFilterWasActiveAt, errs := m.Filter.WasActiveAt.ValueRFC3339Time()
+		diags.Append(errs...)
+		if errs == nil {
+			params.WasActiveAt = cloudflare.F(mFilterWasActiveAt)
+		}
 	}
 	if !m.Filter.WasInactiveAt.IsNull() {
-		params.WasInactiveAt = cloudflare.F(mFilterWasInactiveAt)
+		mFilterWasInactiveAt, errs := m.Filter.WasInactiveAt.ValueRFC3339Time()
+		diags.Append(errs...)
+		if errs == nil {
+			params.WasInactiveAt = cloudflare.F(mFilterWasInactiveAt)
+		}
 	}
 
 	return

--- a/internal/services/zero_trust_tunnel_cloudflared/data_source_test.go
+++ b/internal/services/zero_trust_tunnel_cloudflared/data_source_test.go
@@ -1,0 +1,40 @@
+package zero_trust_tunnel_cloudflared_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccCloudflareTunnelDatasource_Basic(t *testing.T) {
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	accID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("data.cloudflare_zero_trust_tunnel_cloudflared.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareTunnelDatasourceBasic(accID, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(name, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareTunnelDatasourceBasic(accID, name string) string {
+	return acctest.LoadTestCase("datasource_basic.tf", accID, name)
+}

--- a/internal/services/zero_trust_tunnel_cloudflared/list_data_source_model.go
+++ b/internal/services/zero_trust_tunnel_cloudflared/list_data_source_model.go
@@ -34,10 +34,6 @@ type ZeroTrustTunnelCloudflaredsDataSourceModel struct {
 }
 
 func (m *ZeroTrustTunnelCloudflaredsDataSourceModel) toListParams(_ context.Context) (params zero_trust.TunnelCloudflaredListParams, diags diag.Diagnostics) {
-	mWasActiveAt, errs := m.WasActiveAt.ValueRFC3339Time()
-	diags.Append(errs...)
-	mWasInactiveAt, errs := m.WasInactiveAt.ValueRFC3339Time()
-	diags.Append(errs...)
 
 	params = zero_trust.TunnelCloudflaredListParams{
 		AccountID: cloudflare.F(m.AccountID.ValueString()),
@@ -65,10 +61,18 @@ func (m *ZeroTrustTunnelCloudflaredsDataSourceModel) toListParams(_ context.Cont
 		params.UUID = cloudflare.F(m.UUID.ValueString())
 	}
 	if !m.WasActiveAt.IsNull() {
-		params.WasActiveAt = cloudflare.F(mWasActiveAt)
+		mWasActiveAt, errs := m.WasActiveAt.ValueRFC3339Time()
+		diags.Append(errs...)
+		if errs == nil {
+			params.WasActiveAt = cloudflare.F(mWasActiveAt)
+		}
 	}
 	if !m.WasInactiveAt.IsNull() {
-		params.WasInactiveAt = cloudflare.F(mWasInactiveAt)
+		mWasInactiveAt, errs := m.WasInactiveAt.ValueRFC3339Time()
+		diags.Append(errs...)
+		if errs == nil {
+			params.WasInactiveAt = cloudflare.F(mWasInactiveAt)
+		}
 	}
 
 	return

--- a/internal/services/zero_trust_tunnel_cloudflared/list_data_source_test.go
+++ b/internal/services/zero_trust_tunnel_cloudflared/list_data_source_test.go
@@ -1,0 +1,38 @@
+package zero_trust_tunnel_cloudflared_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccCloudflareTunnelDatasource_List(t *testing.T) {
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	accID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("data.cloudflare_zero_trust_tunnel_cloudflareds.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareTunnelDatasourceList(accID, rnd),
+				Check:  resource.TestCheckResourceAttr(name, "result.0.name", rnd),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareTunnelDatasourceList(accID, name string) string {
+	return acctest.LoadTestCase("datasource_list.tf", accID, name)
+}

--- a/internal/services/zero_trust_tunnel_cloudflared/testdata/datasource_basic.tf
+++ b/internal/services/zero_trust_tunnel_cloudflared/testdata/datasource_basic.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_zero_trust_tunnel_cloudflared" "%[2]s" {
+	account_id = "%[1]s"
+	name       = "%[2]s"
+	tunnel_secret     = "AQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIAQIDBAUGBwg="
+}
+
+data "cloudflare_zero_trust_tunnel_cloudflared" "%[2]s" {
+	account_id = "%[1]s"
+	tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.%[2]s.id
+}

--- a/internal/services/zero_trust_tunnel_cloudflared/testdata/datasource_list.tf
+++ b/internal/services/zero_trust_tunnel_cloudflared/testdata/datasource_list.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_zero_trust_tunnel_cloudflared" "%[2]s" {
+	account_id = "%[1]s"
+	name       = "%[2]s"
+	tunnel_secret     = "AQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIAQIDBAUGBwg="
+}
+
+data "cloudflare_zero_trust_tunnel_cloudflareds" "%[2]s" {
+	account_id = "%[1]s"
+	uuid = cloudflare_zero_trust_tunnel_cloudflared.%[2]s.id
+}


### PR DESCRIPTION
## Summary
Previously, fields were parsed before checking if they were set, which could lead to empty value parsing. This change moves parsing after validation to ensure the fields are present.

Closes https://github.com/cloudflare/terraform-provider-cloudflare/issues/5524
