### PR TITLE
fix(r2_bucket): correctly handle optional `location`

### DIFF
--- a/internal/services/r2_bucket/schema.go
+++ b/internal/services/r2_bucket/schema.go
@@ -48,7 +48,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"oc",
 					),
 				},
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIfConfigured()},
 			},
 			"jurisdiction": schema.StringAttribute{
 				Description: "Jurisdiction where objects in this bucket are guaranteed to be stored.\nAvailable values: \"default\", \"eu\", \"fedramp\".",


### PR DESCRIPTION
Updates the schema behaviours to use `RequiresReplaceIfConfigured` for the computed and optional `location` value since the value _may_ be null at plan time causing incorrect full replacement instead of inline updates.
