### PR TITLE
Remove "Computed" primitive from user configurable properties.

### DIFF
--- a/internal/sdkv2provider/schema_cloudflare_load_balancer.go
+++ b/internal/sdkv2provider/schema_cloudflare_load_balancer.go
@@ -361,7 +361,6 @@ var (
 			"priority": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Computed:    true,
 				Description: "Priority used when determining the order of rule execution. Lower values are executed first. If not provided, the list order will be used.",
 			},
 
@@ -380,7 +379,6 @@ var (
 			"terminates": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Computed:    true,
 				Description: "Terminates indicates that if this rule is true no further rules should be executed. Note: setting a [`fixed_response`](#fixed_response) forces this field to `true`.",
 			},
 
@@ -464,7 +462,6 @@ var (
 						"pop_pools": {
 							Type:        schema.TypeSet,
 							Optional:    true,
-							Computed:    true,
 							Elem:        loadBalancerOverridesPopPoolElem,
 							Description: "A set containing mappings of Cloudflare Point-of-Presence (PoP) identifiers to a list of pool IDs (ordered by their failover priority) for the PoP (datacenter). This feature is only available to enterprise customers.",
 						},
@@ -472,7 +469,6 @@ var (
 						"country_pools": {
 							Type:        schema.TypeSet,
 							Optional:    true,
-							Computed:    true,
 							Elem:        loadBalancerOverridesCountryPoolElem,
 							Description: "A set containing mappings of country codes to a list of pool IDs (ordered by their failover priority) for the given country.",
 						},
@@ -480,7 +476,6 @@ var (
 						"region_pools": {
 							Type:        schema.TypeSet,
 							Optional:    true,
-							Computed:    true,
 							Elem:        loadBalancerOverridesRegionPoolElem,
 							Description: "A set containing mappings of region codes to a list of pool IDs (ordered by their failover priority) for the given region.",
 						},
@@ -587,7 +582,6 @@ func resourceCloudflareLoadBalancerSchema() map[string]*schema.Schema {
 		"ttl": {
 			Type:          schema.TypeInt,
 			Optional:      true,
-			Computed:      true,
 			ConflictsWith: []string{"proxied"}, // this is set to zero regardless of config when proxied=true
 			Description:   "Time to live (TTL) of the DNS entry for the IP address returned by this load balancer. This cannot be set for proxied load balancers. Defaults to `30`.",
 		},
@@ -602,7 +596,6 @@ func resourceCloudflareLoadBalancerSchema() map[string]*schema.Schema {
 		"steering_policy": {
 			Type:         schema.TypeString,
 			Optional:     true,
-			Computed:     true,
 			ValidateFunc: validation.StringInSlice([]string{"off", "geo", "dynamic_latency", "random", "proximity", "least_outstanding_requests", "least_connections", ""}, false),
 			Description:  fmt.Sprintf("The method the load balancer uses to determine the route to your origin. Value `off` uses [`default_pool_ids`](#default_pool_ids). Value `geo` uses [`pop_pools`](#pop_pools)/[`country_pools`](#country_pools)/[`region_pools`](#region_pools). For non-proxied requests, the [`country`](#country) for [`country_pools`](#country_pools) is determined by [`location_strategy`](#location_strategy). Value `random` selects a pool randomly. Value `dynamic_latency` uses round trip time to select the closest pool in [`default_pool_ids`](#default_pool_ids) (requires pool health checks). Value `proximity` uses the pools' latitude and longitude to select the closest pool using the Cloudflare PoP location for proxied requests or the location determined by [`location_strategy`](#location_strategy) for non-proxied requests. Value `least_outstanding_requests` selects a pool by taking into consideration [`random_steering`](#random_steering) weights, as well as each pool's number of outstanding requests. Pools with more pending requests are weighted proportionately less relative to others. Value `least_connections` selects a pool by taking into consideration [`random_steering`](#random_steering) weights, as well as each pool's number of open connections. Pools with more open connections are weighted proportionately less relative to others. Supported for HTTP/1 and HTTP/2 connections. Value `\"\"` maps to `geo` if you use [`pop_pools`](#pop_pools)/[`country_pools`](#country_pools)/[`region_pools`](#region_pools) otherwise `off`. %s Defaults to `\"\"`.", renderAvailableDocumentationValuesStringSlice([]string{"off", "geo", "dynamic_latency", "random", "proximity", "least_outstanding_requests", "least_connections", `""`})),
 		},


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Some load balancer properties such as `priority`, `terminates`, and `region_pools` are marked as "Computed" in the Cloudflare Terraform provider v4. However, these properties are user-configurable and therefore should not have been marked with `Computed: true`. This incorrect designation has introduced bugs that led to service outages (explained below in the additional context). This PR removes Computed: true from those user-configurable properties.

## Additional context & links

User-configurable properties marked with `Computed: true` can introduce unintended behavior in the configuration. For example, they may cause load balancer rules that are not explicitly marked with `terminates: true` to be incorrectly treated as terminated.

Consider the following scenario with three configured rules:

```
resource "cloudflare_load_balancer" "test-lb" {
  default_pool_ids     = [cloudflare_load_balancer_pool.test-default-pool.id]
  fallback_pool_id     = cloudflare_load_balancer_pool.test-fallback-pool.id
  name                 = "example.com"
  proxied              = true
  steering_policy      = "off"
  zone_id              = cloudflare_zone.example-com.id

  rules {
    condition = "(starts_with(http.request.uri.path, \"/hello1\"))"
    name      = "test-rule-1"
    overrides {
      default_pools = [cloudflare_load_balancer_pool.test-pool-1.id]
    }
    priority = 10
  }

  rules {
    condition = "(starts_with(http.request.uri.path, \"/hello2\"))"
    name      = "test-rule-2"
    overrides {
      default_pools = [cloudflare_load_balancer_pool.test-pool-2.id]
    }
    terminates = true
    priority = 20
  }

  rules {
    condition = "(starts_with(http.request.uri.path, \"/hello3\"))"
    name      = "test-rule-3"
    overrides {
      default_pools = [cloudflare_load_balancer_pool.test-pool-3.id]
    }
    priority = 30
  }
}
```

Only the second "teest-rule-2" has terminates=true. After creating three rules in the LB using this configuration, remove the first rule.

```
resource "cloudflare_load_balancer" "test-lb" {
  default_pool_ids     = [cloudflare_load_balancer_pool.test-default-pool.id]
  fallback_pool_id     = cloudflare_load_balancer_pool.test-fallback-pool.id
  name                 = "example.com"
  proxied              = true
  steering_policy      = "off"
  zone_id              = cloudflare_zone.example-com.id

  rules {
    condition = "(starts_with(http.request.uri.path, \"/hello2\"))"
    name      = "test-rule-2"
    overrides {
      default_pools = [cloudflare_load_balancer_pool.test-pool-2.id]
    }
    terminates = true
    priority = 20
  }

  rules {
    condition = "(starts_with(http.request.uri.path, \"/hello3\"))"
    name      = "test-rule-3"
    overrides {
      default_pools = [cloudflare_load_balancer_pool.test-pool-3.id]
    }
    priority = 30
  }
}
```
The expected behavior is, obviously, that "test-rule-1" is removed while "test-rule-2" and "test-rule-3" remain intact. However, this actually causes "test-rule-3" to have terminates = true.

Here's the Terraform plan output:
```
# cloudflare_load_balancer.test-lb will be updated in-place
  ~ resource "cloudflare_load_balancer" "test-lb" {
        id                   = "f47ed51a631e74e8acf116a555f5a74a"
        name                 = "example.com"
        # (12 unchanged attributes hidden)

      ~ rules {
          ~ condition  = "(starts_with(http.request.uri.path, \"/hello1\"))" -> "(starts_with(http.request.uri.path, \"/hello2\"))"
          ~ name       = "test-rule-1" -> "test-rule-2"
          ~ priority   = 10 -> 20
          ~ terminates = false -> true
            # (1 unchanged attribute hidden)

          ~ overrides {
              ~ default_pools        = [
                  ~ "af9d5c3f13972338781d6f4609f457c2" -> "141b37d26330a7c80598b865a6c39c6b",
                ]
                # (5 unchanged attributes hidden)
            }
        }
      ~ rules {
          ~ condition  = "(starts_with(http.request.uri.path, \"/hello2\"))" -> "(starts_with(http.request.uri.path, \"/hello3\"))"
          ~ name       = "test-rule-2" -> "test-rule-3"
          ~ priority   = 20 -> 30
            # (2 unchanged attributes hidden)

          ~ overrides {
              ~ default_pools        = [
                  ~ "141b37d26330a7c80598b865a6c39c6b" -> "29630a9ad557ff6c1c2e7f23d8abc522",
                ]
                # (5 unchanged attributes hidden)
            }
        }
      - rules {
          - condition  = "(starts_with(http.request.uri.path, \"/hello3\"))" -> null
          - name       = "test-rule-3" -> null
          - priority   = 30 -> null
          - terminates = false -> null

          - overrides {
              - default_pools        = [
                  - "29630a9ad557ff6c1c2e7f23d8abc522",
                ] -> null
                # (3 unchanged attributes hidden)
            }
        }
    }
```

As you can see in the plan output, the diff for the second rule doesn't properly capture that the "test-rule-3" definition does not have terminates set, unlike "test-rule-2", which previously occupied that index. This happens because the terminates property is marked as Computed:, so Terraform considers it unchanged (even though it isn't) resulting in "test-rule-3" being incorrectly marked with terminates = true.

I tested this fix locally and confirmed that it now behaves as expected. I have no idea why these user-configurable properties were marked as Computed in the first place, but they certainly should not be.