### PR TITLE
fix(static_route): API can accept single routes now

### DIFF
--- a/internal/services/magic_wan_static_route/resource.go
+++ b/internal/services/magic_wan_static_route/resource.go
@@ -65,11 +65,6 @@ func (r *MagicWANStaticRouteResource) Create(ctx context.Context, req resource.C
 	}
 
 	dataBytes, err := data.MarshalJSON()
-
-	// Workaround to wrap the route into an array, which is what the API expects.
-	dataBytes = append([]byte("["), dataBytes...)
-	dataBytes = append(dataBytes, byte(']'))
-
 	if err != nil {
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
 		return


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Gets rid of custom code that is no longer needed, since the underlying API now accepts single static routes. The old code wrapped the single route in an array.

## Additional context & links
