### PR TITLE
workers_script: Add `workflow_name` to resource schema

### DIFF
--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -291,6 +291,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Sensitive:   true,
 							CustomType:  jsontypes.NormalizedType{},
 						},
+						"workflow_name": schema.StringAttribute{
+							Description: "Name of the Workflow to bind to.",
+							Optional:    true,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
This PR adds `workflow_name` to the `cloudflare_workers_script` resource schema. It had already been added to the model, but perhaps got accidentally dropped from the schema during a merge conflict resolution.

## Additional context & links
Added to the model here: https://github.com/cloudflare/terraform-provider-cloudflare/commit/79649c8ba974f224895979b8f2d4ee42ae8d297c