### PR TITLE
The attribute for the schedule must be schedules, not body

### DIFF
--- a/examples/resources/cloudflare_workers_cron_trigger/resource.tf
+++ b/examples/resources/cloudflare_workers_cron_trigger/resource.tf
@@ -1,7 +1,7 @@
 resource "cloudflare_workers_cron_trigger" "example_workers_cron_trigger" {
   account_id = "023e105f4ecef8ad9ca31a8372d0c353"
   script_name = "this-is_my_script-01"
-  body = [{
+  schedules = [{
     cron = "*/30 * * * *"
   }]
 }


### PR DESCRIPTION


<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
The attribute for the schedule must be schedules, not body

## Additional context & links
│ Error: Missing required argument
│
│   on workers.tf line 55, in resource "cloudflare_workers_cron_trigger" "trigger":
│   55: resource "cloudflare_workers_cron_trigger" "trigger" {
│
│ The argument "schedules" is required, but no definition was found.
╵
╷
│ Error: Unsupported argument
│
│   on workers.tf line 58, in resource "cloudflare_workers_cron_trigger" "trigger":
│   58:   body = [{
│
│ An argument named "body" is not expected here.