### PR TITLE
workers_script: support `content_file` and `content_sha256` attribute pair as alternative to `content`

### DIFF
--- a/docs/resources/workers_script.md
+++ b/docs/resources/workers_script.md
@@ -28,10 +28,10 @@ resource "cloudflare_workers_script" "example_workers_script" {
     name = "MY_ENV_VAR"
     type = "plain_text"
   }]
-  body_part = "worker.js"
   compatibility_date = "2021-01-01"
   compatibility_flags = ["nodejs_compat"]
-  content = file("worker.js")
+  content_file = "worker.js"
+  content_sha256 = filesha256("worker.js")
   keep_assets = false
   keep_bindings = ["string"]
   logpush = false

--- a/examples/resources/cloudflare_workers_script/resource.tf
+++ b/examples/resources/cloudflare_workers_script/resource.tf
@@ -14,10 +14,10 @@ resource "cloudflare_workers_script" "example_workers_script" {
     name = "MY_ENV_VAR"
     type = "plain_text"
   }]
-  body_part = "worker.js"
   compatibility_date = "2021-01-01"
   compatibility_flags = ["nodejs_compat"]
-  content = file("worker.js")
+  content_file = "worker.js"
+  content_sha256 = filesha256("worker.js")
   keep_assets = false
   keep_bindings = ["string"]
   logpush = false

--- a/internal/services/workers_script/custom.go
+++ b/internal/services/workers_script/custom.go
@@ -1,11 +1,18 @@
 package workers_script
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"net/textproto"
+	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 func writeFileBytes(partName string, filename string, contentType string, content io.Reader, writer *multipart.Writer) error {
@@ -34,4 +41,135 @@ var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 
 func escapeQuotes(s string) string {
 	return quoteEscaper.Replace(s)
+}
+
+func readFile(path string) (string, error) {
+	if strings.HasPrefix(path, "~/") {
+		dirname, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("could not expand home directory in path %s: %w", path, err)
+		}
+		path = filepath.Join(dirname, path[2:])
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("could not read file %s: %w", path, err)
+	}
+
+	return string(content), nil
+}
+
+func calculateFileHash(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func calculateStringHash(content string) (string, error) {
+	hash := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(hash[:]), nil
+}
+
+var _ validator.String = &contentSHA256Validator{}
+
+type contentSHA256Validator struct {
+	ContentPath     string
+	ContentFilePath string
+}
+
+func (v contentSHA256Validator) Description(_ context.Context) string {
+	return fmt.Sprintf("Validates that the provided value matches the SHA-256 hash of content in either `content` or `content_file`.")
+}
+
+func (v contentSHA256Validator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v contentSHA256Validator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	providedHash := req.ConfigValue.ValueString()
+
+	var config WorkersScriptModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var hasContent, hasContentFile bool
+
+	if !config.Content.IsNull() {
+		hasContent = true
+	}
+
+	if !config.ContentFile.IsNull() {
+		hasContentFile = true
+	}
+
+	if !hasContent && !hasContentFile {
+		resp.Diagnostics.AddError("Missing required attributes", "One of `content` or `content_file` is required")
+		return
+	}
+
+	var actualHash string
+	var err error
+
+	if hasContent {
+		actualHash, err = calculateStringHash(config.Content.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Hash Calculation Error",
+				fmt.Sprintf("Failed to calculate SHA-256 hash of content: %s", err.Error()),
+			)
+			return
+		}
+	} else if hasContentFile {
+		actualHash, err = calculateFileHash(config.ContentFile.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Hash Calculation Error",
+				fmt.Sprintf("Failed to calculate SHA-256 hash of file '%s': %s", config.ContentFile.ValueString(), err.Error()),
+			)
+			return
+		}
+	}
+
+	if providedHash != actualHash {
+		var source string
+		if hasContent {
+			source = "content"
+		} else if hasContentFile {
+			source = fmt.Sprintf("content_file (%s)", config.ContentFile.ValueString())
+		}
+
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"SHA-256 Hash Mismatch",
+			fmt.Sprintf("The provided SHA-256 hash '%s' does not match the actual hash '%s' of %s",
+				providedHash, actualHash, source),
+		)
+	}
+}
+
+func ValidateContentSHA256() validator.String {
+	return contentSHA256Validator{
+		ContentPath:     "content",
+		ContentFilePath: "content_file",
+	}
 }

--- a/internal/services/workers_script/model.go
+++ b/internal/services/workers_script/model.go
@@ -38,7 +38,9 @@ type WorkersScriptModel struct {
 	ID            types.String      `tfsdk:"id" json:"-,computed"`
 	ScriptName    types.String      `tfsdk:"script_name" path:"script_name,required"`
 	AccountID     types.String      `tfsdk:"account_id" path:"account_id,required"`
-	Content       types.String      `tfsdk:"content" json:"content,required"`
+	Content       types.String      `tfsdk:"content" json:"-"`
+	ContentFile   types.String      `tfsdk:"content_file" json:"-"`
+	ContentSHA256 types.String      `tfsdk:"content_sha256" json:"-"`
 	CreatedOn     timetypes.RFC3339 `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
 	Etag          types.String      `tfsdk:"etag" json:"etag,computed"`
 	HasAssets     types.Bool        `tfsdk:"has_assets" json:"has_assets,computed"`

--- a/internal/services/workers_script/testdata/module_with_content_file.tf
+++ b/internal/services/workers_script/testdata/module_with_content_file.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_workers_script" "%[1]s" {
+  account_id = "%[2]s"
+  script_name = "%[1]s"
+  content_file = "%[3]s"
+  content_sha256 = filesha256("%[3]s")
+  main_module = "worker.mjs"
+}

--- a/internal/services/workers_script/testdata/module_with_invalid_content_sha256.tf
+++ b/internal/services/workers_script/testdata/module_with_invalid_content_sha256.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_workers_script" "%[1]s" {
+  account_id = "%[2]s"
+  script_name = "%[1]s"
+  content_file = "%[3]s"
+  content_sha256 = filesha1("%[3]s")
+  main_module = "worker.mjs"
+}


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

We received feedback that using the `content` attribute in the `cloudflare_workers_script` resource was resulting in cases where the Terraform state file grew unfavorably large due to the entire contents of a Workers script being persisted within it. As an alternative, you can now use a pair of attributes `content_file` and `content_sha256` to reference script content without persisting it to your state file.

e.g.
```tf
# Before
resource "cloudflare_workers_script" "example_before" {
  content = file("my-worker.js")
}

# After
resource "cloudflare_workers_script" "example_after" {
  content_file = "my-worker.js"
  content_sha256 = filesha256("my-worker.js")
}
```

## Additional context & links
