### PR TITLE
AUTH-7265 Fix zero_trust_access_applications

### DIFF
--- a/internal/customvalidator/required_when_other_attribute_is_one_of_validator.go
+++ b/internal/customvalidator/required_when_other_attribute_is_one_of_validator.go
@@ -1,0 +1,86 @@
+package customvalidator
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"strings"
+)
+
+func RequiredWhenOtherStringIsOneOf(pathExpr path.Expression, wantStrValues ...string) requiredWhenOtherAttributeIsOneOfValidator {
+	var wantValues []attr.Value
+	for _, v := range wantStrValues {
+		wantValues = append(wantValues, types.StringValue(v))
+	}
+	return requiredWhenOtherAttributeIsOneOfValidator{
+		pathExpr,
+		wantValues,
+	}
+}
+
+type requiredWhenOtherAttributeIsOneOfValidator struct {
+	pathExpr   path.Expression
+	wantValues []attr.Value
+}
+
+func (i requiredWhenOtherAttributeIsOneOfValidator) Description(ctx context.Context) string {
+	var wantValuesAsStrings []string
+	for _, v := range i.wantValues {
+		wantValuesAsStrings = append(wantValuesAsStrings, v.String())
+	}
+	return fmt.Sprintf("has to be set if %q is one of: %s", i.pathExpr, strings.Join(wantValuesAsStrings, ", "))
+}
+
+func (i requiredWhenOtherAttributeIsOneOfValidator) MarkdownDescription(ctx context.Context) string {
+	return i.Description(ctx)
+}
+
+func (i requiredWhenOtherAttributeIsOneOfValidator) validateAny(ctx context.Context, cfg *tfsdk.Config, attrPath path.Path, value attr.Value, resDiagnostics *diag.Diagnostics) {
+	if !value.IsNull() || value.IsUnknown() {
+		return
+	}
+
+	matchedPaths, diags := cfg.PathMatches(ctx, i.pathExpr)
+	resDiagnostics.Append(diags...)
+
+	for _, mp := range matchedPaths {
+		// If the user specifies the same attribute this validator is applied to,
+		// also as part of the input, skip it
+		if mp.Equal(attrPath) {
+			continue
+		}
+
+		var mpVal attr.Value
+		resDiagnostics.Append(cfg.GetAttribute(ctx, mp, &mpVal)...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		// Delay validation until all involved attribute have a known value
+		if mpVal.IsUnknown() {
+			return
+		}
+
+		for _, wantValue := range i.wantValues {
+			if mpVal.Equal(wantValue) {
+				description := fmt.Sprintf("%q %s", attrPath, i.Description(ctx))
+				resDiagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
+					attrPath,
+					description,
+				))
+			}
+		}
+	}
+}
+
+func (i requiredWhenOtherAttributeIsOneOfValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, res *validator.ObjectResponse) {
+	i.validateAny(ctx, &req.Config, req.Path, req.ConfigValue, &res.Diagnostics)
+}

--- a/internal/customvalidator/requires_other_attribute_to_be_one_of_validator.go
+++ b/internal/customvalidator/requires_other_attribute_to_be_one_of_validator.go
@@ -1,0 +1,110 @@
+package customvalidator
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"strings"
+)
+
+func RequiresOtherStringAttributeToBeOneOf(pathExpr path.Expression, wantStrValues ...string) requiresOtherAttributeToBeOneOfValidator {
+	var wantValues []attr.Value
+	for _, v := range wantStrValues {
+		wantValues = append(wantValues, types.StringValue(v))
+	}
+	return requiresOtherAttributeToBeOneOfValidator{
+		pathExpr,
+		wantValues,
+	}
+}
+
+func RequiresOtherStringAttributeToNullOrBeOneOf(pathExpr path.Expression, wantStrValues ...string) requiresOtherAttributeToBeOneOfValidator {
+	v := RequiresOtherStringAttributeToBeOneOf(pathExpr, wantStrValues...)
+	v.wantValues = append(v.wantValues, types.StringNull())
+	return v
+}
+
+type requiresOtherAttributeToBeOneOfValidator struct {
+	pathExpr   path.Expression
+	wantValues []attr.Value
+}
+
+func (i requiresOtherAttributeToBeOneOfValidator) Description(ctx context.Context) string {
+	var wantValuesAsStrings []string
+	for _, v := range i.wantValues {
+		wantValuesAsStrings = append(wantValuesAsStrings, v.String())
+	}
+	return fmt.Sprintf("can only be set if %q is one of: %s", i.pathExpr, strings.Join(wantValuesAsStrings, ", "))
+}
+
+func (i requiresOtherAttributeToBeOneOfValidator) MarkdownDescription(ctx context.Context) string {
+	return i.Description(ctx)
+}
+
+func (i requiresOtherAttributeToBeOneOfValidator) validateAny(ctx context.Context, cfg *tfsdk.Config, attrPath path.Path, value attr.Value, resDiagnostics *diag.Diagnostics) {
+	if value.IsNull() || value.IsUnknown() {
+		return
+	}
+
+	matchedPaths, diags := cfg.PathMatches(ctx, i.pathExpr)
+	resDiagnostics.Append(diags...)
+
+	for _, mp := range matchedPaths {
+		// If the user specifies the same attribute this validator is applied to,
+		// also as part of the input, skip it
+		if mp.Equal(attrPath) {
+			continue
+		}
+
+		var mpVal attr.Value
+		resDiagnostics.Append(cfg.GetAttribute(ctx, mp, &mpVal)...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		// Delay validation until all involved attribute have a known value
+		if mpVal.IsUnknown() {
+			return
+		}
+
+		foundMatch := false
+		for _, wantValue := range i.wantValues {
+			if mpVal.Equal(wantValue) {
+				foundMatch = true
+				break
+			}
+		}
+
+		if !foundMatch {
+			description := fmt.Sprintf("%q %s", attrPath, i.Description(ctx))
+			resDiagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
+				attrPath,
+				description,
+			))
+		}
+	}
+}
+
+func (i requiresOtherAttributeToBeOneOfValidator) ValidateBool(ctx context.Context, req validator.BoolRequest, res *validator.BoolResponse) {
+	i.validateAny(ctx, &req.Config, req.Path, req.ConfigValue, &res.Diagnostics)
+}
+
+func (i requiresOtherAttributeToBeOneOfValidator) ValidateString(ctx context.Context, req validator.StringRequest, res *validator.StringResponse) {
+	i.validateAny(ctx, &req.Config, req.Path, req.ConfigValue, &res.Diagnostics)
+}
+
+func (i requiresOtherAttributeToBeOneOfValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, res *validator.ObjectResponse) {
+	i.validateAny(ctx, &req.Config, req.Path, req.ConfigValue, &res.Diagnostics)
+}
+
+func (i requiresOtherAttributeToBeOneOfValidator) ValidateList(ctx context.Context, req validator.ListRequest, res *validator.ListResponse) {
+	i.validateAny(ctx, &req.Config, req.Path, req.ConfigValue, &res.Diagnostics)
+}

--- a/internal/services/zero_trust_access_application/model.go
+++ b/internal/services/zero_trust_access_application/model.go
@@ -24,10 +24,10 @@ type ZeroTrustAccessApplicationModel struct {
 	CustomDenyMessage           types.String                                                               `tfsdk:"custom_deny_message" json:"custom_deny_message,optional"`
 	CustomDenyURL               types.String                                                               `tfsdk:"custom_deny_url" json:"custom_deny_url,optional"`
 	CustomNonIdentityDenyURL    types.String                                                               `tfsdk:"custom_non_identity_deny_url" json:"custom_non_identity_deny_url,optional"`
-	Domain                      types.String                                                               `tfsdk:"domain" json:"domain,optional"`
+	Domain                      types.String                                                               `tfsdk:"domain" json:"domain,computed_optional"`
 	HeaderBgColor               types.String                                                               `tfsdk:"header_bg_color" json:"header_bg_color,optional"`
 	LogoURL                     types.String                                                               `tfsdk:"logo_url" json:"logo_url,optional"`
-	Name                        types.String                                                               `tfsdk:"name" json:"name,optional"`
+	Name                        types.String                                                               `tfsdk:"name" json:"name,computed_optional"`
 	OptionsPreflightBypass      types.Bool                                                                 `tfsdk:"options_preflight_bypass" json:"options_preflight_bypass,optional"`
 	ReadServiceTokensFromHeader types.String                                                               `tfsdk:"read_service_tokens_from_header" json:"read_service_tokens_from_header,optional"`
 	SameSiteCookieAttribute     types.String                                                               `tfsdk:"same_site_cookie_attribute" json:"same_site_cookie_attribute,optional"`
@@ -41,21 +41,19 @@ type ZeroTrustAccessApplicationModel struct {
 	SCIMConfig                  *ZeroTrustAccessApplicationSCIMConfigModel                                 `tfsdk:"scim_config" json:"scim_config,optional"`
 	TargetCriteria              *[]*ZeroTrustAccessApplicationTargetCriteriaModel                          `tfsdk:"target_criteria" json:"target_criteria,optional"`
 	AppLauncherVisible          types.Bool                                                                 `tfsdk:"app_launcher_visible" json:"app_launcher_visible,computed_optional"`
-	AutoRedirectToIdentity      types.Bool                                                                 `tfsdk:"auto_redirect_to_identity" json:"auto_redirect_to_identity,computed_optional"`
-	EnableBindingCookie         types.Bool                                                                 `tfsdk:"enable_binding_cookie" json:"enable_binding_cookie,computed_optional"`
+	AutoRedirectToIdentity      types.Bool                                                                 `tfsdk:"auto_redirect_to_identity" json:"auto_redirect_to_identity,optional"`
+	EnableBindingCookie         types.Bool                                                                 `tfsdk:"enable_binding_cookie" json:"enable_binding_cookie,optional"`
 	HTTPOnlyCookieAttribute     types.Bool                                                                 `tfsdk:"http_only_cookie_attribute" json:"http_only_cookie_attribute,computed_optional"`
-	PathCookieAttribute         types.Bool                                                                 `tfsdk:"path_cookie_attribute" json:"path_cookie_attribute,computed_optional"`
+	PathCookieAttribute         types.Bool                                                                 `tfsdk:"path_cookie_attribute" json:"path_cookie_attribute,optional"`
 	SessionDuration             types.String                                                               `tfsdk:"session_duration" json:"session_duration,computed_optional"`
 	SkipAppLauncherLoginPage    types.Bool                                                                 `tfsdk:"skip_app_launcher_login_page" json:"skip_app_launcher_login_page,computed_optional"`
 	SelfHostedDomains           customfield.List[types.String]                                             `tfsdk:"self_hosted_domains" json:"self_hosted_domains,computed_optional"`
-	Tags                        customfield.List[types.String]                                             `tfsdk:"tags" json:"tags,computed_optional"`
+	Tags                        customfield.List[types.String]                                             `tfsdk:"tags" json:"tags,optional"`
 	Destinations                customfield.NestedObjectList[ZeroTrustAccessApplicationDestinationsModel]  `tfsdk:"destinations" json:"destinations,computed_optional"`
-	LandingPageDesign           customfield.NestedObject[ZeroTrustAccessApplicationLandingPageDesignModel] `tfsdk:"landing_page_design" json:"landing_page_design,computed_optional"`
-	Policies                    customfield.NestedObjectList[ZeroTrustAccessApplicationPoliciesModel]      `tfsdk:"policies" json:"policies,computed_optional"`
-	SaaSApp                     customfield.NestedObject[ZeroTrustAccessApplicationSaaSAppModel]           `tfsdk:"saas_app" json:"saas_app,computed_optional"`
+	LandingPageDesign           customfield.NestedObject[ZeroTrustAccessApplicationLandingPageDesignModel] `tfsdk:"landing_page_design" json:"landing_page_design,optional"`
+	Policies                    *[]ZeroTrustAccessApplicationPoliciesModel                                 `tfsdk:"policies" json:"policies,optional"`
+	SaaSApp                     customfield.NestedObject[ZeroTrustAccessApplicationSaaSAppModel]           `tfsdk:"saas_app" json:"saas_app,optional"`
 	AUD                         types.String                                                               `tfsdk:"aud" json:"aud,computed"`
-	CreatedAt                   timetypes.RFC3339                                                          `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
-	UpdatedAt                   timetypes.RFC3339                                                          `tfsdk:"updated_at" json:"updated_at,computed" format:"date-time"`
 }
 
 func (m ZeroTrustAccessApplicationModel) MarshalJSON() (data []byte, err error) {
@@ -144,13 +142,13 @@ type ZeroTrustAccessApplicationLandingPageDesignModel struct {
 
 type ZeroTrustAccessApplicationPoliciesModel struct {
 	ID              types.String                                                                 `tfsdk:"id" json:"id,optional"`
-	Precedence      types.Int64                                                                  `tfsdk:"precedence" json:"precedence,optional"`
+	Precedence      types.Int64                                                                  `tfsdk:"precedence" json:"precedence,computed_optional"`
 	Decision        types.String                                                                 `tfsdk:"decision" json:"decision,optional"`
-	Include         customfield.NestedObjectList[ZeroTrustAccessApplicationPoliciesIncludeModel] `tfsdk:"include" json:"include,computed_optional"`
+	Include         customfield.NestedObjectList[ZeroTrustAccessApplicationPoliciesIncludeModel] `tfsdk:"include" json:"include,optional"`
 	Name            types.String                                                                 `tfsdk:"name" json:"name,optional"`
 	ConnectionRules *ZeroTrustAccessApplicationPoliciesConnectionRulesModel                      `tfsdk:"connection_rules" json:"connection_rules,optional"`
-	Exclude         customfield.NestedObjectList[ZeroTrustAccessApplicationPoliciesExcludeModel] `tfsdk:"exclude" json:"exclude,computed_optional"`
-	Require         customfield.NestedObjectList[ZeroTrustAccessApplicationPoliciesRequireModel] `tfsdk:"require" json:"require,computed_optional"`
+	Exclude         customfield.NestedObjectList[ZeroTrustAccessApplicationPoliciesExcludeModel] `tfsdk:"exclude" json:"exclude,optional"`
+	Require         customfield.NestedObjectList[ZeroTrustAccessApplicationPoliciesRequireModel] `tfsdk:"require" json:"require,optional"`
 }
 
 type ZeroTrustAccessApplicationPoliciesIncludeModel struct {
@@ -529,18 +527,18 @@ type ZeroTrustAccessApplicationSaaSAppModel struct {
 	CustomAttributes              *[]*ZeroTrustAccessApplicationSaaSAppCustomAttributesModel      `tfsdk:"custom_attributes" json:"custom_attributes,optional"`
 	DefaultRelayState             types.String                                                    `tfsdk:"default_relay_state" json:"default_relay_state,optional"`
 	IdPEntityID                   types.String                                                    `tfsdk:"idp_entity_id" json:"idp_entity_id,computed_optional"`
-	NameIDFormat                  types.String                                                    `tfsdk:"name_id_format" json:"name_id_format,optional"`
+	NameIDFormat                  types.String                                                    `tfsdk:"name_id_format" json:"name_id_format,computed_optional"`
 	NameIDTransformJsonata        types.String                                                    `tfsdk:"name_id_transform_jsonata" json:"name_id_transform_jsonata,optional"`
-	PublicKey                     types.String                                                    `tfsdk:"public_key" json:"public_key,computed_optional"`
+	PublicKey                     types.String                                                    `tfsdk:"public_key" json:"public_key,computed"`
 	SAMLAttributeTransformJsonata types.String                                                    `tfsdk:"saml_attribute_transform_jsonata" json:"saml_attribute_transform_jsonata,optional"`
 	SPEntityID                    types.String                                                    `tfsdk:"sp_entity_id" json:"sp_entity_id,optional"`
 	SSOEndpoint                   types.String                                                    `tfsdk:"sso_endpoint" json:"sso_endpoint,computed_optional"`
 	UpdatedAt                     timetypes.RFC3339                                               `tfsdk:"updated_at" json:"updated_at,computed" format:"date-time"`
-	AccessTokenLifetime           types.String                                                    `tfsdk:"access_token_lifetime" json:"access_token_lifetime,optional"`
+	AccessTokenLifetime           types.String                                                    `tfsdk:"access_token_lifetime" json:"access_token_lifetime,computed_optional"`
 	AllowPKCEWithoutClientSecret  types.Bool                                                      `tfsdk:"allow_pkce_without_client_secret" json:"allow_pkce_without_client_secret,optional"`
 	AppLauncherURL                types.String                                                    `tfsdk:"app_launcher_url" json:"app_launcher_url,optional"`
-	ClientID                      types.String                                                    `tfsdk:"client_id" json:"client_id,computed_optional"`
-	ClientSecret                  types.String                                                    `tfsdk:"client_secret" json:"client_secret,computed_optional"`
+	ClientID                      types.String                                                    `tfsdk:"client_id" json:"client_id,computed"`
+	ClientSecret                  types.String                                                    `tfsdk:"client_secret" json:"client_secret,computed"`
 	CustomClaims                  *[]*ZeroTrustAccessApplicationSaaSAppCustomClaimsModel          `tfsdk:"custom_claims" json:"custom_claims,optional"`
 	GrantTypes                    *[]types.String                                                 `tfsdk:"grant_types" json:"grant_types,optional"`
 	GroupFilterRegex              types.String                                                    `tfsdk:"group_filter_regex" json:"group_filter_regex,optional"`

--- a/internal/services/zero_trust_access_application/normalizations.go
+++ b/internal/services/zero_trust_access_application/normalizations.go
@@ -1,0 +1,178 @@
+package zero_trust_access_application
+
+import (
+	"context"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"slices"
+)
+
+func normalizeEmptyAndNullString(data *basetypes.StringValue, stateData basetypes.StringValue) {
+	if data.ValueString() != "" || stateData.ValueString() != "" {
+		return
+	}
+	*data = stateData
+}
+
+func normalizeFalseAndNullBool(data *basetypes.BoolValue, stateData basetypes.BoolValue) {
+	if data.ValueBool() || stateData.ValueBool() {
+		return
+	}
+	*data = stateData
+}
+
+func normalizeTrueAndNullBool(data *basetypes.BoolValue, stateData basetypes.BoolValue) {
+	if (!data.IsNull() && !data.ValueBool()) || (!stateData.IsNull() && !stateData.ValueBool()) {
+		return
+	}
+	if stateData.IsUnknown() {
+		return
+	}
+	*data = stateData
+}
+
+type ListField interface {
+	Elements() []attr.Value
+}
+
+func normalizeEmptyAndNullList[T ListField](data *T, stateData T) {
+	if len((*data).Elements()) != 0 || len(stateData.Elements()) != 0 {
+		return
+	}
+	*data = stateData
+}
+
+func normalizeEmptyAndNullSlice[T any](data **[]T, stateData *[]T) {
+	if (*data != nil && len(**data) != 0) || (stateData != nil && len(*stateData) != 0) {
+		return
+	}
+	*data = stateData
+}
+
+type IsNull interface {
+	IsNull() bool
+}
+
+func persistNullFromState[T IsNull](data *T, stateData T) {
+	if stateData.IsNull() {
+		*data = stateData
+	}
+}
+
+func normalizeReadZeroTrustApplicationSamlAppData(data *ZeroTrustAccessApplicationSaaSAppModel, stateData ZeroTrustAccessApplicationSaaSAppModel) {
+	normalizeEmptyAndNullString(&data.SPEntityID, stateData.SPEntityID)
+	normalizeEmptyAndNullString(&data.ConsumerServiceURL, stateData.ConsumerServiceURL)
+}
+
+func normalizeReadZeroTrustApplicationOidcAppData(data *ZeroTrustAccessApplicationSaaSAppModel, stateData ZeroTrustAccessApplicationSaaSAppModel) {
+	// Prevent diffs on the default access_token_lifetime
+	if data.AccessTokenLifetime.ValueString() == "5m" && stateData.AccessTokenLifetime == types.StringNull() {
+		data.AccessTokenLifetime = stateData.AccessTokenLifetime
+	}
+
+	// client_secret is only returned when the app is first created, assigning here from the state
+	// to prevent a diff when the app is updated
+	if !stateData.ClientSecret.IsUnknown() && !stateData.ClientSecret.IsNull() {
+		data.ClientSecret = stateData.ClientSecret
+	}
+
+	normalizeFalseAndNullBool(&data.AllowPKCEWithoutClientSecret, stateData.AllowPKCEWithoutClientSecret)
+}
+
+// Normalizing function to ensure consistency between the state and the meaning of the API response.
+// Alters the API response before applying it to the state by laxing equalities between null & zero-value
+// for some attributes, and nullifies fields that terraform should not be saving in the state.
+func normalizeReadZeroTrustApplicationAPIData(ctx context.Context, data, stateData *ZeroTrustAccessApplicationModel) diag.Diagnostics {
+	diags := make(diag.Diagnostics, 0)
+
+	// Empty `allowed_idps` is the same as a null value. The API might return an empty array, so we need to normalize it
+	// here  to avoid a diff
+	normalizeEmptyAndNullSlice(&data.AllowedIdPs, stateData.AllowedIdPs)
+	// `policies` might not be in the configuration, so we need to normalize it here to avoid a diff
+	normalizeEmptyAndNullSlice(&data.Policies, stateData.Policies)
+	// `tags` might not be in the configuration, so we need to normalize it here to avoid a diff
+	normalizeEmptyAndNullList(&data.Tags, stateData.Tags)
+
+	normalizeFalseAndNullBool(&data.EnableBindingCookie, stateData.EnableBindingCookie)
+	normalizeFalseAndNullBool(&data.OptionsPreflightBypass, stateData.OptionsPreflightBypass)
+	normalizeFalseAndNullBool(&data.AutoRedirectToIdentity, stateData.AutoRedirectToIdentity)
+	if slices.Contains(selfHostedAppTypes, data.Type.String()) {
+		normalizeTrueAndNullBool(&data.HTTPOnlyCookieAttribute, stateData.HTTPOnlyCookieAttribute)
+	}
+
+	if !data.SaaSApp.IsNull() && !stateData.SaaSApp.IsNull() {
+		var dataSaasApp, stateDataSaasApp ZeroTrustAccessApplicationSaaSAppModel
+		diags.Append(data.SaaSApp.As(ctx, &dataSaasApp, basetypes.ObjectAsOptions{})...)
+		diags.Append(stateData.SaaSApp.As(ctx, &stateDataSaasApp, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return diags
+		}
+
+		switch dataSaasApp.AuthType.ValueString() {
+		case "saml":
+			normalizeReadZeroTrustApplicationSamlAppData(&dataSaasApp, stateDataSaasApp)
+		case "oidc":
+			normalizeReadZeroTrustApplicationOidcAppData(&dataSaasApp, stateDataSaasApp)
+		}
+
+		var saasDiags diag.Diagnostics
+		data.SaaSApp, saasDiags = customfield.NewObject[ZeroTrustAccessApplicationSaaSAppModel](ctx, &dataSaasApp)
+		diags.Append(saasDiags...)
+		if diags.HasError() {
+			return diags
+		}
+	}
+
+	if data.Policies != nil && stateData.Policies != nil {
+		for i := range *data.Policies {
+			// Preserve null values from the Terraform state, even if the API response returns actual values.
+			// This is important because the API may populate these fields when it expands the attached reusable policy
+			// from its given ID.
+			//
+			// However, we intentionally avoid storing the full expanded policy inside the application resource's
+			// nested block, as its source of truth is the reusable policy resource itself.
+			// Only the policy ID should be persisted in state for reusable policies.
+			// For legacy policies, the ID should be ignored as they are not a standalone resource, but rather
+			// live as a nested object owned by the application.
+			persistNullFromState(&(*data.Policies)[i].ID, (*stateData.Policies)[i].ID)
+			persistNullFromState(&(*data.Policies)[i].Decision, (*stateData.Policies)[i].Decision)
+			persistNullFromState(&(*data.Policies)[i].Name, (*stateData.Policies)[i].Name)
+			persistNullFromState(&(*data.Policies)[i].Include, (*stateData.Policies)[i].Include)
+			persistNullFromState(&(*data.Policies)[i].Require, (*stateData.Policies)[i].Require)
+			persistNullFromState(&(*data.Policies)[i].Exclude, (*stateData.Policies)[i].Exclude)
+		}
+	}
+
+	if data.SCIMConfig != nil && stateData.SCIMConfig != nil {
+		if data.SCIMConfig.Authentication != nil && stateData.SCIMConfig.Authentication != nil {
+			data.SCIMConfig.Authentication.Password = stateData.SCIMConfig.Authentication.Password
+			data.SCIMConfig.Authentication.Token = stateData.SCIMConfig.Authentication.Token
+			data.SCIMConfig.Authentication.ClientSecret = stateData.SCIMConfig.Authentication.ClientSecret
+		}
+	}
+
+	return diags
+}
+
+// Some fields are write-only sensitive and should not be stored in the state.
+// Usually these secrets are injected in the config from a secret store.
+func loadConfigSensitiveValuesForWriting(ctx context.Context, data *ZeroTrustAccessApplicationModel, cfg *tfsdk.Config) diag.Diagnostics {
+	var (
+		diags   = make(diag.Diagnostics, 0)
+		cfgData *ZeroTrustAccessApplicationModel
+	)
+	diags.Append(cfg.Get(ctx, &cfgData)...)
+
+	if data.SCIMConfig != nil && cfgData.SCIMConfig != nil {
+		if data.SCIMConfig.Authentication != nil && cfgData.SCIMConfig.Authentication != nil {
+			data.SCIMConfig.Authentication.Password = cfgData.SCIMConfig.Authentication.Password
+			data.SCIMConfig.Authentication.Token = cfgData.SCIMConfig.Authentication.Token
+			data.SCIMConfig.Authentication.ClientSecret = cfgData.SCIMConfig.Authentication.ClientSecret
+		}
+	}
+	return diags
+}

--- a/internal/services/zero_trust_access_application/plan_modifiers.go
+++ b/internal/services/zero_trust_access_application/plan_modifiers.go
@@ -1,0 +1,137 @@
+package zero_trust_access_application
+
+import (
+	"context"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"regexp"
+	"slices"
+)
+
+var (
+	selfHostedAppTypes         = []string{"self_hosted", "ssh", "vnc", "rdp"}
+	saasAppTypes               = []string{"saas", "dash_sso"}
+	appLauncherVisibleAppTypes = []string{"self_hosted", "ssh", "vnc", "rdp", "saas", "bookmark", "infrastructure"}
+	targetCompatibleAppTypes   = []string{"rdp", "infrastructure"}
+	durationRegex              = regexp.MustCompile(`^(?:0|[-+]?(\d+(?:\.\d*)?|\.\d+)(?:ns|us|µs|ms|s|m|h)(?:(\d+(?:\.\d*)?|\.\d+)(?:ns|us|µs|ms|s|m|h))*)$`)
+)
+
+// Sets a specific default value for a computed attribute specific to a set of app types, in case the attribute is unknown.
+// If the app type is not in the list, it sets the second default value.
+func setDefaultAccordingToAppTypes[T attr.Value](wantAppTypes []string, gotAppType string, planAttribute *T, default1, default2 T) {
+	if planAttribute == nil || !(*planAttribute).IsUnknown() {
+		return
+	}
+	if slices.Contains(wantAppTypes, gotAppType) {
+		*planAttribute = default1
+	} else {
+		*planAttribute = default2
+	}
+}
+
+// Sets a specific default value for a computed attribute specific to a given app type, in case the attribute is unknown.
+// If the app type does not match, it sets the second default value.
+func setDefaultAccordingToAppType[T attr.Value](wantAppType string, gotAppType string, planAttribute *T, default1, default2 T) {
+	setDefaultAccordingToAppTypes([]string{wantAppType}, gotAppType, planAttribute, default1, default2)
+}
+
+func modifyPlanForDomains(ctx context.Context, planApp, stateApp *ZeroTrustAccessApplicationModel) {
+	appType := planApp.Type.ValueString()
+
+	setDefaultAccordingToAppTypes(selfHostedAppTypes, appType, &planApp.SelfHostedDomains, customfield.UnknownList[types.String](ctx), customfield.NullList[types.String](ctx))
+	setDefaultAccordingToAppTypes(selfHostedAppTypes, appType, &planApp.Destinations, customfield.UnknownObjectList[ZeroTrustAccessApplicationDestinationsModel](ctx), customfield.NullObjectList[ZeroTrustAccessApplicationDestinationsModel](ctx))
+	setDefaultAccordingToAppTypes(selfHostedAppTypes, appType, &planApp.HTTPOnlyCookieAttribute, types.BoolUnknown(), types.BoolNull())
+
+	// A self_hosted_app's 'domain', 'self_hosted_domains', and 'destinations' are all tied together in the API.
+	// changing one, causes the others to change. So we need to tell TF to set the other two to unknown if any of them
+	// changes from the previous state.
+	if stateApp == nil ||
+		(!planApp.Domain.IsUnknown() && !planApp.Domain.Equal(stateApp.Domain)) ||
+		(!planApp.SelfHostedDomains.IsUnknown() && !planApp.SelfHostedDomains.Equal(stateApp.SelfHostedDomains)) ||
+		(!planApp.Destinations.IsUnknown() && !planApp.Destinations.Equal(stateApp.Destinations)) {
+
+		if planApp.Domain.IsNull() {
+			planApp.Domain = types.StringUnknown()
+		}
+		if planApp.SelfHostedDomains.IsNull() {
+			planApp.SelfHostedDomains = customfield.UnknownList[types.String](ctx)
+		}
+		if planApp.Destinations.IsNull() {
+			planApp.Destinations = customfield.UnknownObjectList[ZeroTrustAccessApplicationDestinationsModel](ctx)
+		}
+	} else {
+		// If the domain, self_hosted_domains, and destinations have not changed, we can copy all of them from the state.
+		planApp.Domain = stateApp.Domain
+		planApp.SelfHostedDomains = stateApp.SelfHostedDomains
+		planApp.Destinations = stateApp.Destinations
+	}
+}
+
+func modifySaasAppNestedObjectPlan(ctx context.Context, planApp *ZeroTrustAccessApplicationModel) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+	if planApp.SaaSApp.IsNull() {
+		return diags
+	}
+	var planSaasApp ZeroTrustAccessApplicationSaaSAppModel
+	diags.Append(planApp.SaaSApp.As(ctx, &planSaasApp, basetypes.ObjectAsOptions{})...)
+
+	oidcType, samlType, currentType := "oidc", "saml", planSaasApp.AuthType.ValueString()
+
+	// These fields are non-existent for non-oidc saas_apps. So we can set them to null and avoid the recurring
+	// diffs due to unknown computed values.
+	setDefaultAccordingToAppType(oidcType, currentType, &planSaasApp.ClientID, types.StringUnknown(), types.StringNull())
+	setDefaultAccordingToAppType(oidcType, currentType, &planSaasApp.ClientSecret, types.StringUnknown(), types.StringNull())
+	setDefaultAccordingToAppType(oidcType, currentType, &planSaasApp.AllowPKCEWithoutClientSecret, types.BoolValue(false), types.BoolNull())
+	setDefaultAccordingToAppType(oidcType, currentType, &planSaasApp.AccessTokenLifetime, types.StringValue("5m"), types.StringNull())
+
+	// These fields are non-existent for non-saml saas_apps. So we can set them to null and avoid the recurring
+	// diffs due to unknown computed values.
+	setDefaultAccordingToAppType(samlType, currentType, &planSaasApp.IdPEntityID, types.StringUnknown(), types.StringNull())
+	setDefaultAccordingToAppType(samlType, currentType, &planSaasApp.NameIDFormat, types.StringUnknown(), types.StringNull())
+	setDefaultAccordingToAppType(samlType, currentType, &planSaasApp.SSOEndpoint, types.StringUnknown(), types.StringNull())
+
+	planApp.SaaSApp, _ = customfield.NewObject[ZeroTrustAccessApplicationSaaSAppModel](ctx, &planSaasApp)
+	return diags
+}
+
+func modifyNestedPoliciesPlan(_ context.Context, planApp *ZeroTrustAccessApplicationModel) {
+	lastKnownPrecedence := 0
+	for i := range *planApp.Policies {
+		if (*planApp.Policies)[i].Precedence.IsUnknown() {
+			(*planApp.Policies)[i].Precedence = types.Int64Value(int64(lastKnownPrecedence + 1))
+		}
+		lastKnownPrecedence = int((*planApp.Policies)[i].Precedence.ValueInt64())
+	}
+}
+
+func modifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
+	var planApp, stateApp *ZeroTrustAccessApplicationModel
+	res.Diagnostics.Append(req.Plan.Get(ctx, &planApp)...)
+	res.Diagnostics.Append(req.State.Get(ctx, &stateApp)...)
+	if res.Diagnostics.HasError() || planApp == nil {
+		return
+	}
+
+	modifyPlanForDomains(ctx, planApp, stateApp)
+
+	appType := planApp.Type.ValueString()
+
+	// Add default values for some app type specific attributes
+	setDefaultAccordingToAppTypes(selfHostedAppTypes, appType, &planApp.HTTPOnlyCookieAttribute, types.BoolValue(true), types.BoolNull())
+	setDefaultAccordingToAppTypes(appLauncherVisibleAppTypes, appType, &planApp.AppLauncherVisible, types.BoolValue(true), types.BoolNull())
+	setDefaultAccordingToAppType("app_launcher", appType, &planApp.SkipAppLauncherLoginPage, types.BoolValue(false), types.BoolNull())
+
+	if appType == "saas" {
+		res.Diagnostics.Append(modifySaasAppNestedObjectPlan(ctx, planApp)...)
+	}
+
+	if planApp.Policies != nil {
+		modifyNestedPoliciesPlan(ctx, planApp)
+	}
+
+	res.Plan.Set(ctx, &planApp)
+}

--- a/internal/services/zero_trust_access_application/resource_test.go
+++ b/internal/services/zero_trust_access_application/resource_test.go
@@ -102,6 +102,11 @@ func TestAccCloudflareAccessApplication_BasicZone(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "auto_redirect_to_identity", "false"),
 				),
 			},
+			{
+				// Ensures no diff on second plan
+				Config:   testAccCloudflareAccessApplicationConfigBasic(rnd, domain, cloudflare.ZoneIdentifier(zoneID)),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -130,6 +135,11 @@ func TestAccCloudflareAccessApplication_BasicAccount(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "sass_app.#", "0"),
 					resource.TestCheckResourceAttr(name, "auto_redirect_to_identity", "false"),
 				),
+			},
+			{
+				// Ensures no diff on second plan
+				Config:   testAccCloudflareAccessApplicationConfigBasic(rnd, domain, cloudflare.AccountIdentifier(accountID)),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -170,6 +180,11 @@ func TestAccCloudflareAccessApplication_WithSCIMConfigHttpBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "scim_config.mappings.0.operations.update", "true"),
 					resource.TestCheckResourceAttr(name, "scim_config.mappings.0.operations.delete", "true"),
 				),
+			},
+			{
+				// Ensures no diff on second plan
+				Config:   testAccCloudflareAccessApplicationSCIMConfigValidHttpBasic(rnd, accountID, domain),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -212,6 +227,11 @@ func TestAccCloudflareAccessApplication_UpdateSCIMConfig(t *testing.T) {
 				),
 			},
 			{
+				// Ensures no diff on second plan
+				Config:   testAccCloudflareAccessApplicationSCIMConfigValidHttpBasic(rnd, accountID, domain),
+				PlanOnly: true,
+			},
+			{
 				Config: testAccCloudflareAccessApplicationSCIMConfigValidOAuthBearerTokenNoMappings(rnd, accountID, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
@@ -227,6 +247,11 @@ func TestAccCloudflareAccessApplication_UpdateSCIMConfig(t *testing.T) {
 					resource.TestCheckResourceAttrSet(name, "scim_config.authentication.token"),
 					resource.TestCheckResourceAttr(name, "scim_config.mappings.#", "0"),
 				),
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationSCIMConfigValidOAuthBearerTokenNoMappings(rnd, accountID, domain),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -303,6 +328,11 @@ func TestAccCloudflareAccessApplication_WithSCIMConfigOAuthBearerToken(t *testin
 					resource.TestCheckResourceAttr(name, "scim_config.mappings.0.operations.delete", "true"),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationSCIMConfigValidOAuthBearerToken(rnd, accountID, domain),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -346,6 +376,11 @@ func TestAccCloudflareAccessApplication_WithSCIMConfigOAuth2(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "scim_config.mappings.0.operations.update", "true"),
 					resource.TestCheckResourceAttr(name, "scim_config.mappings.0.operations.delete", "true"),
 				),
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationSCIMConfigValidOAuth2(rnd, accountID, domain),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -394,6 +429,11 @@ func TestAccCloudflareAccessApplication_WithCORS(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "auto_redirect_to_identity", "false"),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithCORS(rnd, zoneID, domain),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -438,6 +478,11 @@ func TestAccCloudflareAccessApplication_WithSAMLSaas(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "saas_app.custom_attributes.1.required", "true"),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithSAMLSaas(rnd, accountID),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -481,13 +526,18 @@ func TestAccCloudflareAccessApplication_WithSAMLSaas_Import(t *testing.T) {
 				Config: testAccCloudflareAccessApplicationConfigWithSAMLSaas(rnd, accountID),
 				Check:  checkFn,
 			},
-			// {
-			// 	ImportState:         true,
-			// 	ImportStateVerify:   true,
-			// 	ResourceName:        name,
-			// 	ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
-			// 	Check:               checkFn,
-			// },
+			{
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ResourceName:        name,
+				ImportStateIdPrefix: fmt.Sprintf("accounts/%s/", accountID),
+				Check:               checkFn,
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithSAMLSaas(rnd, accountID),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -535,6 +585,11 @@ func TestAccCloudflareAccessApplication_WithOIDCSaas(t *testing.T) {
 					resource.TestCheckResourceAttrSet(name, "saas_app.client_secret"),
 					resource.TestCheckResourceAttrSet(name, "saas_app.public_key"),
 				),
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithOIDCSaas(rnd, accountID),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -585,14 +640,19 @@ func TestAccCloudflareAccessApplication_WithOIDCSaas_Import(t *testing.T) {
 				Config: testAccCloudflareAccessApplicationConfigWithOIDCSaas(rnd, accountID),
 				Check:  checkFn,
 			},
-			// {
-			// 	ImportState:             true,
-			// 	ImportStateVerify:       true,
-			// 	ImportStateVerifyIgnore: []string{"saas_app.client_secret"},
-			// 	ResourceName:            name,
-			// 	ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-			// 	Check:                   checkFn,
-			// },
+			{
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"saas_app.client_secret", "saas_app.allow_pkce_without_client_secret"},
+				ResourceName:            name,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				Check:                   checkFn,
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithOIDCSaas(rnd, accountID),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -620,6 +680,11 @@ func TestAccCloudflareAccessApplication_WithAutoRedirectToIdentity(t *testing.T)
 					resource.TestCheckResourceAttr(name, "allowed_idps.#", "1"),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithAutoRedirectToIdentity(rnd, zoneID, domain),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -645,6 +710,11 @@ func TestAccCloudflareAccessApplication_WithEnableBindingCookie(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
 					resource.TestCheckResourceAttr(name, "enable_binding_cookie", "true"),
 				),
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithEnableBindingCookie(rnd, zoneID, domain),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -674,11 +744,16 @@ func TestAccCloudflareAccessApplication_WithCustomDenyFields(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "custom_non_identity_deny_url", "https://www.blocked.com"),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithCustomDenyFields(rnd, zoneID, domain),
+				PlanOnly: true,
+			},
 		},
 	})
 }
 
-func TestAccCloudflareAccessApplication_WithADefinedIdps(t *testing.T) {
+func TestAccCloudflareAccessApplication_WithADefinedIdp(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_zero_trust_access_application.%s", rnd)
 
@@ -701,6 +776,11 @@ func TestAccCloudflareAccessApplication_WithADefinedIdps(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "allowed_idps.#", "1"),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithADefinedIdp(rnd, zoneID, domain, accountID),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -722,6 +802,11 @@ func TestAccCloudflareAccessApplication_WithMultipleIdpsReordered(t *testing.T) 
 			},
 			{
 				Config: testAccCloudflareAccessApplicationConfigWithMultipleIdps(rnd, zoneID, domain, accountID, idp2, idp1),
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithMultipleIdps(rnd, zoneID, domain, accountID, idp2, idp1),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -749,6 +834,11 @@ func TestAccCloudflareAccessApplication_WithHttpOnlyCookieAttribute(t *testing.T
 					resource.TestCheckResourceAttr(name, "http_only_cookie_attribute", "true"),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithHTTPOnlyCookieAttribute(rnd, zoneID, domain),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -774,6 +864,11 @@ func TestAccCloudflareAccessApplication_WithHTTPOnlyCookieAttributeSetToFalse(t 
 					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
 					resource.TestCheckResourceAttr(name, "http_only_cookie_attribute", "false"),
 				),
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithHTTPOnlyCookieAttributeSetToFalse(rnd, zoneID, domain),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -801,6 +896,11 @@ func TestAccCloudflareAccessApplication_WithSameSiteCookieAttribute(t *testing.T
 					resource.TestCheckResourceAttr(name, "same_site_cookie_attribute", "strict"),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigSameSiteCookieAttribute(rnd, zoneID, domain),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -826,6 +926,11 @@ func TestAccCloudflareAccessApplication_WithLogoURL(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
 					resource.TestCheckResourceAttr(name, "logo_url", "https://www.cloudflare.com/img/logo-web-badges/cf-logo-on-white-bg.svg"),
 				),
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigLogoURL(rnd, zoneID, domain),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -853,6 +958,11 @@ func TestAccCloudflareAccessApplication_WithSkipInterstitial(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "skip_interstitial", "true"),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigSkipInterstitial(rnd, zoneID, domain),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -878,6 +988,11 @@ func TestAccCloudflareAccessApplication_WithAppLauncherVisible(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
 					resource.TestCheckResourceAttr(name, "app_launcher_visible", "true"),
 				),
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithAppLauncherVisible(rnd, zoneID, domain),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -908,6 +1023,11 @@ func TestAccCloudflareAccessApplication_WithSelfHostedDomains(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "auto_redirect_to_identity", "false"),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationWithSelfHostedDomains(rnd, domain, cloudflare.AccountIdentifier(accountID)),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -935,6 +1055,41 @@ func TestAccCloudflareAccessApplication_WithDefinedTags(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "tags.#", "1"),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithADefinedTag(rnd, zoneID, domain, accountID),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareAccessApplication_WithLegacyPolicies(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_zero_trust_access_application.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareAccessApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareAccessApplicationConfigWithLegacyPolicies(rnd, domain, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "domain", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(name, "type", "self_hosted"),
+					resource.TestCheckResourceAttr(name, "policies.#", "3"),
+				),
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithLegacyPolicies(rnd, domain, accountID),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -960,6 +1115,11 @@ func TestAccCloudflareAccessApplication_WithReusablePolicies(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "policies.#", "2"),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCloudflareAccessApplicationConfigWithReusablePolicies(rnd, domain, accountID),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -976,7 +1136,8 @@ func TestAccCloudflareAccessApplication_WithAppLauncherCustomization(t *testing.
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckCloudflareAccessApplicationDestroy,
 		Steps: []resource.TestStep{
-			{Config: testAccessApplicationWithAppLauncherCustomizationFields(rnd, accountID),
+			{
+				Config: testAccessApplicationWithAppLauncherCustomizationFields(rnd, accountID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
 					resource.TestCheckResourceAttr(name, "type", "app_launcher"),
@@ -992,6 +1153,11 @@ func TestAccCloudflareAccessApplication_WithAppLauncherCustomization(t *testing.
 					resource.TestCheckResourceAttr(name, "footer_links.0.name", "footer link"),
 					resource.TestCheckResourceAttr(name, "footer_links.0.url", "https://www.cloudflare.com"),
 				),
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccessApplicationWithAppLauncherCustomizationFields(rnd, accountID),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -1068,7 +1234,8 @@ func testAccCloudflareAccessApplicationWithSelfHostedDomains(rnd string, domain 
 func testAccCheckCloudflareAccessApplicationDestroy(s *terraform.State) error {
 	client, clientErr := acctest.SharedV1Client() // TODO(terraform): replace with SharedV2Clent
 	if clientErr != nil {
-		tflog.Error(context.TODO(), fmt.Sprintf("failed to create Cloudflare client: %s", clientErr))
+		tflog.Error(context.TODO(), fmt.Sprintf("failed to create Cloudflare client for destroy check: %s", clientErr))
+		return clientErr
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -1124,111 +1291,113 @@ func TestAccCloudflareAccessApplicationWithZoneID(t *testing.T) {
 					resource.TestCheckResourceAttr(name, consts.ZoneIDSchemaKey, zoneID),
 				),
 			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccessApplicationWithZoneIDUpdated(rnd, zone, zoneID),
+				PlanOnly: true,
+			},
 		},
 	})
 }
 
-// TODO: tighten up validation here and re-enable.
-//
-// func TestAccCloudflareAccessApplicationWithMissingCORSMethods(t *testing.T) {
-// 	rnd := utils.GenerateRandomResourceName()
-// 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
-// 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+func TestAccCloudflareAccessApplicationWithMissingCORSMethods(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck: func() {
-// 			acctest.TestAccPreCheck(t)
-// 			acctest.TestAccPreCheck_AccountID(t)
-// 		},
-// 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config:      testAccessApplicationWithMissingCORSMethods(rnd, zone, zoneID),
-// 				ExpectError: regexp.MustCompile("must set allowed_methods or allow_all_methods"),
-// 			},
-// 		},
-// 	})
-// }
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccessApplicationWithMissingCORSMethods(rnd, zone, zoneID),
+				ExpectError: regexp.MustCompile(`No attribute specified when one \(and only one\) of\s+\[cors_headers\.allow_all_methods\.<\.allowed_methods\] is required`),
+			},
+		},
+	})
+}
 
-// func TestAccCloudflareAccessApplicationWithMissingCORSOrigins(t *testing.T) {
-// 	rnd := utils.GenerateRandomResourceName()
-// 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
-// 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+func TestAccCloudflareAccessApplicationWithMissingCORSOrigins(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck: func() {
-// 			acctest.TestAccPreCheck(t)
-// 			acctest.TestAccPreCheck_AccountID(t)
-// 		},
-// 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config:      testAccessApplicationWithMissingCORSOrigins(rnd, zone, zoneID),
-// 				ExpectError: regexp.MustCompile("must set allowed_origins or allow_all_origins"),
-// 			},
-// 		},
-// 	})
-// }
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccessApplicationWithMissingCORSOrigins(rnd, zone, zoneID),
+				ExpectError: regexp.MustCompile(`No attribute specified when one \(and only one\) of\s+\[cors_headers\.allow_all_origins\.<\.allowed_origins\] is required`),
+			},
+		},
+	})
+}
 
-// func TestAccCloudflareAccessApplicationWithInvalidSessionDuration(t *testing.T) {
-// 	rnd := utils.GenerateRandomResourceName()
-// 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
-// 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+func TestAccCloudflareAccessApplicationWithInvalidSessionDuration(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck: func() {
-// 			acctest.TestAccPreCheck(t)
-// 			acctest.TestAccPreCheck_AccountID(t)
-// 		},
-// 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config:      testAccessApplicationWithInvalidSessionDuration(rnd, zone, zoneID),
-// 				ExpectError: regexp.MustCompile(regexp.QuoteMeta(`"session_duration" only supports "ns", "us" (or "µs"), "ms", "s", "m", or "h" as valid units`)),
-// 			},
-// 		},
-// 	})
-// }
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccessApplicationWithInvalidSessionDuration(rnd, zone, zoneID),
+				ExpectError: regexp.MustCompile(`"session_duration" only supports .*`),
+			},
+		},
+	})
+}
 
-// func TestAccCloudflareAccessApplicationMisconfiguredCORSCredentialsAllowingAllOrigins(t *testing.T) {
-// 	rnd := utils.GenerateRandomResourceName()
-// 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
-// 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+func TestAccCloudflareAccessApplicationMisconfiguredCORSCredentialsAllowingAllOrigins(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck: func() {
-// 			acctest.TestAccPreCheck(t)
-// 			acctest.TestAccPreCheck_AccountID(t)
-// 		},
-// 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config:      testAccessApplicationMisconfiguredCORSAllowAllOriginsWithCredentials(rnd, zone, zoneID),
-// 				ExpectError: regexp.MustCompile(regexp.QuoteMeta(`CORS credentials are not permitted when all origins are allowed`)),
-// 			},
-// 		},
-// 	})
-// }
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccessApplicationMisconfiguredCORSAllowAllOriginsWithCredentials(rnd, zone, zoneID),
+				ExpectError: regexp.MustCompile(`Attribute "cors_headers.allow_all_origins" cannot be specified when\s+"cors_headers.allow_credentials" is specified`),
+			},
+		},
+	})
+}
 
-// func TestAccCloudflareAccessApplicationMisconfiguredCORSCredentialsAllowingWildcardOrigins(t *testing.T) {
-// 	rnd := utils.GenerateRandomResourceName()
-// 	zone := os.Getenv("CLOUDFLARE_DOMAIN")
-// 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+func TestAccCloudflareAccessApplicationWithInvalidSaas(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accoundID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck: func() {
-// 			acctest.TestAccPreCheck(t)
-// 			acctest.TestAccPreCheck_AccountID(t)
-// 		},
-// 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config:      testAccessApplicationMisconfiguredCORSAllowWildcardOriginWithCredentials(rnd, zone, zoneID),
-// 				ExpectError: regexp.MustCompile(regexp.QuoteMeta(`CORS credentials are not permitted when all origins are allowed`)),
-// 			},
-// 		},
-// 	})
-// }
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccessApplicationWithInvalidSaas(rnd, accoundID),
+				ExpectError: regexp.MustCompile("\"saas_app\" has to be set if \"type\" is one of: \"saas\", \"dash_sso\""),
+			},
+		},
+	})
+}
 
 func testAccessApplicationWithZoneID(resourceID, zone, zoneID string) string {
 	return acctest.LoadTestCase("accessapplicationwithzoneid.tf", resourceID, zone, zoneID)
@@ -1252,10 +1421,6 @@ func testAccessApplicationWithInvalidSessionDuration(resourceID, zone, zoneID st
 
 func testAccessApplicationMisconfiguredCORSAllowAllOriginsWithCredentials(resourceID, zone, zoneID string) string {
 	return acctest.LoadTestCase("accessapplicationmisconfiguredcorsallowalloriginswithcredentials.tf", resourceID, zone, zoneID)
-}
-
-func testAccessApplicationMisconfiguredCORSAllowWildcardOriginWithCredentials(resourceID, zone, zoneID string) string {
-	return acctest.LoadTestCase("accessapplicationmisconfiguredcorsallowwildcardoriginwithcredentials.tf", resourceID, zone, zoneID)
 }
 
 func testAccCloudflareAccessApplicationConfigWithADefinedTag(rnd, zoneID, domain string, accountID string) string {
@@ -1282,10 +1447,6 @@ func testAccCloudflareAccessApplicationSCIMConfigOAuth2MissingRequired(rnd, acco
 	return acctest.LoadTestCase("accessapplicationscimconfigoauth2missingrequired.tf", rnd, accountID, domain)
 }
 
-func testAccCloudflareAccessApplicationSCIMConfigAuthenticationInvalid(rnd, accountID, domain string) string {
-	return acctest.LoadTestCase("accessapplicationscimconfigauthenticationinvalid.tf", rnd, accountID, domain)
-}
-
 func testAccCloudflareAccessApplicationSCIMConfigHttpBasicMissingRequired(rnd, accountID, domain string) string {
 	return acctest.LoadTestCase("accessapplicationscimconfighttpbasicmissingrequired.tf", rnd, accountID, domain)
 }
@@ -1294,6 +1455,14 @@ func testAccCloudflareAccessApplicationSCIMConfigInvalidMappingSchema(rnd, accou
 	return acctest.LoadTestCase("accessapplicationscimconfiginvalidmappingschema.tf", rnd, accountID, domain)
 }
 
+func testAccCloudflareAccessApplicationConfigWithLegacyPolicies(rnd, domain string, accountID string) string {
+	return acctest.LoadTestCase("accessapplicationconfigwithlegacypolicies.tf", rnd, domain, accountID)
+}
+
 func testAccCloudflareAccessApplicationConfigWithReusablePolicies(rnd, domain string, accountID string) string {
 	return acctest.LoadTestCase("accessapplicationconfigwithreusablepolicies.tf", rnd, domain, accountID)
+}
+
+func testAccessApplicationWithInvalidSaas(resourceID, accountID string) string {
+	return acctest.LoadTestCase("accessapplicationconfigwithinvalidsaas.tf", resourceID, accountID)
 }

--- a/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwithadefinedidp.tf
+++ b/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwithadefinedidp.tf
@@ -1,12 +1,10 @@
 resource "cloudflare_zero_trust_access_identity_provider" "%[1]s" {
   account_id = "%[4]s"
-  name = "%[1]s"
-  type = "onetimepin"
-  config = {
-    client_id = "test"
-    client_secret = "test"
-  }
+  name       = "%[1]s"
+  type       = "onetimepin"
+  config = {}
 }
+
 resource "cloudflare_zero_trust_access_application" "%[1]s" {
   zone_id                   = "%[2]s"
   name                      = "%[1]s"
@@ -14,5 +12,5 @@ resource "cloudflare_zero_trust_access_application" "%[1]s" {
   type                      = "self_hosted"
   session_duration          = "24h"
   auto_redirect_to_identity = true
-  allowed_idps              = [cloudflare_zero_trust_access_identity_provider.%[1]s.id]
+  allowed_idps = [cloudflare_zero_trust_access_identity_provider.%[1]s.id]
 }

--- a/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwithinvalidsaas.tf
+++ b/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwithinvalidsaas.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_zero_trust_access_application" "%[1]s" {
+  account_id                = "%[2]s"
+  name                      = "%[1]s"
+  type                      = "saas"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+}

--- a/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwithlegacypolicies.tf
+++ b/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwithlegacypolicies.tf
@@ -1,0 +1,42 @@
+resource "cloudflare_zero_trust_access_policy" "%[1]s_reusable_p1" {
+  account_id = "%[3]s"
+  name       = "%[1]s"
+  decision   = "non_identity"
+  include = [
+    {
+      ip = { ip = "127.0.0.1/32" }
+    }
+  ]
+}
+
+resource "cloudflare_zero_trust_access_application" "%[1]s" {
+  account_id = "%[3]s"
+  name       = "%[1]s"
+  domain     = "%[1]s.%[2]s"
+  type       = "self_hosted"
+  policies = [
+    {
+      name     = "%[1]s.legacy_p1"
+      decision = "allow"
+      include = [
+        {
+          email = { email = "a@example.com" }
+        }
+      ]
+      precedence = 2
+    },
+    {
+      id         = cloudflare_zero_trust_access_policy.%[1]s_reusable_p1.id
+      precedence = 4
+    },
+    {
+      name     = "%[1]s.legacy_p2"
+      decision = "non_identity"
+      include = [
+        {
+          ip = { ip = "127.0.0.1/32" }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwithreusablepolicies.tf
+++ b/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwithreusablepolicies.tf
@@ -1,42 +1,37 @@
 resource "cloudflare_zero_trust_access_policy" "%[1]s_p1" {
-  account_id 	= "%[3]s"
-  name          = "%[1]s"
-  decision	= "allow"
-  include = [{
-    email = { email = "a@example.com" }
-  }]
+  account_id = "%[3]s"
+  name       = "%[1]s"
+  decision   = "allow"
+  include = [
+    {
+      email = { email = "a@example.com" }
+    }
+  ]
 }
 
 resource "cloudflare_zero_trust_access_policy" "%[1]s_p2" {
-  account_id	= "%[3]s"
-  name          = "%[1]s"
-  decision	= "non_identity"
-  include = [{
-    ip = { ip = "127.0.0.1/32" }
-  }]
+  account_id = "%[3]s"
+  name       = "%[1]s"
+  decision   = "non_identity"
+  include = [
+    {
+      ip = { ip = "127.0.0.1/32" }
+    }
+  ]
 }
 
 resource "cloudflare_zero_trust_access_application" "%[1]s" {
-  account_id   = "%[3]s"
-  name         = "%[1]s"
-  domain       = "%[1]s.%[2]s"
-  type         = "self_hosted"
-  policies     = [
-    { 
-      id = cloudflare_zero_trust_access_policy.%[1]s_p1.id
-      decision = cloudflare_zero_trust_access_policy.%[1]s_p1.decision
-      name = cloudflare_zero_trust_access_policy.%[1]s_p1.name
-      include = [{
-	email = { email = cloudflare_zero_trust_access_policy.%[1]s_p1.include.0.email.email }
-      }]
+  account_id = "%[3]s"
+  name       = "%[1]s"
+  domain     = "%[1]s.%[2]s"
+  type       = "self_hosted"
+  policies = [
+    {
+      id         = cloudflare_zero_trust_access_policy.%[1]s_p1.id
+      precedence = 4
     },
     {
       id = cloudflare_zero_trust_access_policy.%[1]s_p2.id
-      decision = cloudflare_zero_trust_access_policy.%[1]s_p2.decision
-      name = cloudflare_zero_trust_access_policy.%[1]s_p2.name
-      include = [{
-	ip = { ip = cloudflare_zero_trust_access_policy.%[1]s_p2.include.0.ip.ip }
-      }]
     }
   ]
 }

--- a/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwithsamlsaas.tf
+++ b/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwithsamlsaas.tf
@@ -4,23 +4,23 @@ resource "cloudflare_zero_trust_access_application" "%[1]s" {
   type             = "saas"
   session_duration = "24h"
   saas_app = {
-    consumer_service_url = "https://saas-app.example/sso/saml/consume"
-    sp_entity_id  = "saas-app.example"
-    name_id_format =  "email"
-    default_relay_state = "https://saas-app.example"
-    name_id_transform_jsonata = "$substringBefore(email, '@') & '+sandbox@' & $substringAfter(email, '@')"
+    consumer_service_url             = "https://saas-app.example/sso/saml/consume"
+    sp_entity_id                     = "saas-app.example"
+    name_id_format                   = "email"
+    default_relay_state              = "https://saas-app.example"
+    name_id_transform_jsonata        = "$substringBefore(email, '@') & '+sandbox@' & $substringAfter(email, '@')"
     saml_attribute_transform_jsonata = "$ ~>| groups | {'group_name': name} |"
     custom_attributes = [
       {
-	name = "email"
-	name_format = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
-	source = { name = "user_email" }
+        name        = "email"
+        name_format = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
+        source = { name = "user_email" }
       },
       {
-	name = "rank"
-	required = true
-	friendly_name = "Rank"
-	source = { name = "rank" }
+        name          = "rank"
+        required      = true
+        friendly_name = "Rank"
+        source = { name = "rank" }
       }
     ]
   }

--- a/internal/services/zero_trust_access_application/testdata/accessapplicationwithapplaunchercustomizationfields.tf
+++ b/internal/services/zero_trust_access_application/testdata/accessapplicationwithapplaunchercustomizationfields.tf
@@ -1,22 +1,23 @@
 resource "cloudflare_zero_trust_access_application" "%[1]s" {
-	account_id       = "%[2]s"
-	type             = "app_launcher"
-	session_duration = "24h"
-	app_launcher_visible = false
-	app_launcher_logo_url = "https://www.cloudflare.com/img/logo-web-badges/cf-logo-on-white-bg.svg"
-	bg_color = "#000000"
-	header_bg_color = "#000000"
+  account_id            = "%[2]s"
+  type                  = "app_launcher"
+  session_duration      = "24h"
+  app_launcher_logo_url = "https://www.cloudflare.com/img/logo-web-badges/cf-logo-on-white-bg.svg"
+  bg_color              = "#000000"
+  header_bg_color       = "#000000"
 
-	footer_links = [{
-		name = "footer link"
-		url = "https://www.cloudflare.com"
-	}]
+  footer_links = [
+    {
+      name = "footer link"
+      url  = "https://www.cloudflare.com"
+    }
+  ]
 
-	landing_page_design = {
-		title = "title"
-		message = "message"
-		button_color = "#000000"
-		image_url = "https://www.cloudflare.com/img/logo-web-badges/cf-logo-on-white-bg.svg"
-		button_text_color = "#000000"
-	}
+  landing_page_design = {
+    title             = "title"
+    message           = "message"
+    button_color      = "#000000"
+    image_url         = "https://www.cloudflare.com/img/logo-web-badges/cf-logo-on-white-bg.svg"
+    button_text_color = "#000000"
+  }
 }

--- a/internal/services/zero_trust_access_identity_provider/normalizations.go
+++ b/internal/services/zero_trust_access_identity_provider/normalizations.go
@@ -1,0 +1,18 @@
+package zero_trust_access_identity_provider
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+func normalizeReadZeroTrustIDPData(ctx context.Context, apiValue *ZeroTrustAccessIdentityProviderModel, state *tfsdk.State) diag.Diagnostics {
+	var stateValue ZeroTrustAccessIdentityProviderModel
+	d := state.Get(ctx, &stateValue)
+	if apiValue.Type.ValueString() == "azureAD" &&
+		(apiValue.Config != nil && !apiValue.Config.ConditionalAccessEnabled.ValueBool()) &&
+		(stateValue.Config != nil && !stateValue.Config.ConditionalAccessEnabled.ValueBool()) {
+		apiValue.Config.ConditionalAccessEnabled = stateValue.Config.ConditionalAccessEnabled
+	}
+	return d
+}

--- a/internal/services/zero_trust_access_identity_provider/resource.go
+++ b/internal/services/zero_trust_access_identity_provider/resource.go
@@ -213,6 +213,8 @@ func (r *ZeroTrustAccessIdentityProviderResource) Read(ctx context.Context, req 
 	}
 	data = &env.Result
 
+	normalizeReadZeroTrustIDPData(ctx, data, &req.State)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("scim_config").AtName("secret"), secret)...)
 }
@@ -302,6 +304,6 @@ func (r *ZeroTrustAccessIdentityProviderResource) ImportState(ctx context.Contex
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *ZeroTrustAccessIdentityProviderResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, _ *resource.ModifyPlanResponse) {
+func (r *ZeroTrustAccessIdentityProviderResource) ModifyPlan(context.Context, resource.ModifyPlanRequest, *resource.ModifyPlanResponse) {
 
 }

--- a/internal/services/zero_trust_access_identity_provider/schema.go
+++ b/internal/services/zero_trust_access_identity_provider/schema.go
@@ -44,8 +44,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Required:    true,
 			},
 			"type": schema.StringAttribute{
-				Description: "The type of identity provider. To determine the value for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).\nAvailable values: \"onetimepin\", \"azureAD\", \"saml\", \"centrify\", \"facebook\", \"github\", \"google-apps\", \"google\", \"linkedin\", \"oidc\", \"okta\", \"onelogin\", \"pingone\", \"yandex\".",
-				Required:    true,
+				Description:   "The type of identity provider. To determine the value for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).\nAvailable values: \"onetimepin\", \"azureAD\", \"saml\", \"centrify\", \"facebook\", \"github\", \"google-apps\", \"google\", \"linkedin\", \"oidc\", \"okta\", \"onelogin\", \"pingone\", \"yandex\".",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive(
 						"onetimepin",

--- a/internal/services/zero_trust_access_policy/model.go
+++ b/internal/services/zero_trust_access_policy/model.go
@@ -27,9 +27,7 @@ type ZeroTrustAccessPolicyModel struct {
 	Exclude                      customfield.NestedObjectList[ZeroTrustAccessPolicyExcludeModel] `tfsdk:"exclude" json:"exclude,computed_optional"`
 	Include                      customfield.NestedObjectList[ZeroTrustAccessPolicyIncludeModel] `tfsdk:"include" json:"include,computed_optional"`
 	Require                      customfield.NestedObjectList[ZeroTrustAccessPolicyRequireModel] `tfsdk:"require" json:"require,computed_optional"`
-	AppCount                     types.Int64                                                     `tfsdk:"app_count" json:"app_count,computed"`
 	CreatedAt                    timetypes.RFC3339                                               `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
-	Reusable                     types.Bool                                                      `tfsdk:"reusable" json:"reusable,computed"`
 	UpdatedAt                    timetypes.RFC3339                                               `tfsdk:"updated_at" json:"updated_at,computed" format:"date-time"`
 }
 

--- a/internal/services/zero_trust_access_policy/schema.go
+++ b/internal/services/zero_trust_access_policy/schema.go
@@ -800,16 +800,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 			},
-			"app_count": schema.Int64Attribute{
-				Description: "Number of access applications currently using this policy.",
-				Computed:    true,
-			},
 			"created_at": schema.StringAttribute{
 				Computed:   true,
 				CustomType: timetypes.RFC3339Type{},
-			},
-			"reusable": schema.BoolAttribute{
-				Computed: true,
 			},
 			"updated_at": schema.StringAttribute{
 				Computed:   true,

--- a/scripts/run-ci-acceptance-tests
+++ b/scripts/run-ci-acceptance-tests
@@ -113,6 +113,7 @@ go test -run "^TestAcc" -count 1 \
     ./internal/services/workers_route \
     ./internal/services/workers_script \
     ./internal/services/workers_script_subdomain \
+    ./internal/services/zero_trust_access_application \
     ./internal/services/zero_trust_access_infrastructure_target \
     ./internal/services/zero_trust_access_key_configuration \
     ./internal/services/zero_trust_access_mtls_hostname_settings \


### PR DESCRIPTION
- Fixes `zero_trust_access_applications` errors and warnings that completely break the resource in TF v5
- Adds API normalization, plan modifications, and new validators for `zero_trust_access_applications`
- Partially fixes  `zero_trust_access_policy` & `zero_trust_access_identity_provider` just enough to allow the `zero_trust_access_applications` to pass. A complete fix for this resources is still needed in future PRs
- Re-enables all  `zero_trust_access_applications` acceptance tests, and adds some more
- [X] I understand that this repository is auto-generated and my pull request may not be merged
- This will likely break auto-generation for Access, but that is ok. We need to fix the provider first to unblock users, we can keep working in the future to move whatever logic we can from here into the API docs, and make smooth it out with the generator.

## Changes being requested
- Resource `zero_trust_access_application`
- Resource `zero_trust_access_policy`
- Resource `zero_trust_access_identity_provider`

## Additional context & links
