### PR TITLE
Add acceptance test boilerplate for new DLP entry resources

### DIFF
--- a/internal/services/zero_trust_dlp_custom_entry/data_source_test.go
+++ b/internal/services/zero_trust_dlp_custom_entry/data_source_test.go
@@ -1,0 +1,36 @@
+package zero_trust_dlp_custom_entry_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccCloudflareZeroTrustDlpCustomEntryDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_zero_trust_dlp_custom_entry." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZeroTrustDlpCustomEntryDataSourceConfig(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						return errors.New("test not implemented")
+					},
+					resource.TestCheckResourceAttr(name, "some_string_attribute", "string_value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccZeroTrustDlpCustomEntryDataSourceConfig(rnd string) string {
+	return acctest.LoadTestCase("datasource_basic.tf", rnd)
+}

--- a/internal/services/zero_trust_dlp_custom_entry/resource_test.go
+++ b/internal/services/zero_trust_dlp_custom_entry/resource_test.go
@@ -1,0 +1,36 @@
+package zero_trust_dlp_custom_entry_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccCloudflareZeroTrustDlpCustomEntry_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_zero_trust_dlp_custom_entry." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZeroTrustDlpCustomEntryConfig(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						return errors.New("test not implemented")
+					},
+					resource.TestCheckResourceAttr(name, "some_string_attribute", "string_value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccZeroTrustDlpCustomEntryConfig(rnd string) string {
+	return acctest.LoadTestCase("basic.tf", rnd)
+}

--- a/internal/services/zero_trust_dlp_custom_entry/testdata/basic.tf
+++ b/internal/services/zero_trust_dlp_custom_entry/testdata/basic.tf
@@ -1,0 +1,1 @@
+resource "cloudflare_zero_trust_dlp_custom_entry" "%[1]s" {}

--- a/internal/services/zero_trust_dlp_custom_entry/testdata/datasource_basic.tf
+++ b/internal/services/zero_trust_dlp_custom_entry/testdata/datasource_basic.tf
@@ -1,0 +1,1 @@
+data "cloudflare_zero_trust_dlp_custom_entry" "%[1]s" {}

--- a/internal/services/zero_trust_dlp_integration_entry/data_source_test.go
+++ b/internal/services/zero_trust_dlp_integration_entry/data_source_test.go
@@ -1,0 +1,36 @@
+package zero_trust_dlp_integration_entry_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccCloudflareZeroTrustDlpIntegrationEntryDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_zero_trust_dlp_integration_entry." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZeroTrustDlpIntegrationEntryDataSourceConfig(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						return errors.New("test not implemented")
+					},
+					resource.TestCheckResourceAttr(name, "some_string_attribute", "string_value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccZeroTrustDlpIntegrationEntryDataSourceConfig(rnd string) string {
+	return acctest.LoadTestCase("datasource_basic.tf", rnd)
+}

--- a/internal/services/zero_trust_dlp_integration_entry/resource_test.go
+++ b/internal/services/zero_trust_dlp_integration_entry/resource_test.go
@@ -1,0 +1,36 @@
+package zero_trust_dlp_integration_entry_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccCloudflareZeroTrustDlpIntegrationEntry_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_zero_trust_dlp_integration_entry." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZeroTrustDlpIntegrationEntryConfig(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						return errors.New("test not implemented")
+					},
+					resource.TestCheckResourceAttr(name, "some_string_attribute", "string_value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccZeroTrustDlpIntegrationEntryConfig(rnd string) string {
+	return acctest.LoadTestCase("basic.tf", rnd)
+}

--- a/internal/services/zero_trust_dlp_integration_entry/testdata/basic.tf
+++ b/internal/services/zero_trust_dlp_integration_entry/testdata/basic.tf
@@ -1,0 +1,1 @@
+resource "cloudflare_zero_trust_dlp_integration_entry" "%[1]s" {}

--- a/internal/services/zero_trust_dlp_integration_entry/testdata/datasource_basic.tf
+++ b/internal/services/zero_trust_dlp_integration_entry/testdata/datasource_basic.tf
@@ -1,0 +1,1 @@
+data "cloudflare_zero_trust_dlp_integration_entry" "%[1]s" {}

--- a/internal/services/zero_trust_dlp_predefined_entry/data_source_test.go
+++ b/internal/services/zero_trust_dlp_predefined_entry/data_source_test.go
@@ -1,0 +1,36 @@
+package zero_trust_dlp_predefined_entry_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccCloudflareZeroTrustDlpPredefinedEntryDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_zero_trust_dlp_predefined_entry." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZeroTrustDlpPredefinedEntryDataSourceConfig(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						return errors.New("test not implemented")
+					},
+					resource.TestCheckResourceAttr(name, "some_string_attribute", "string_value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccZeroTrustDlpPredefinedEntryDataSourceConfig(rnd string) string {
+	return acctest.LoadTestCase("datasource_basic.tf", rnd)
+}

--- a/internal/services/zero_trust_dlp_predefined_entry/resource_test.go
+++ b/internal/services/zero_trust_dlp_predefined_entry/resource_test.go
@@ -1,0 +1,36 @@
+package zero_trust_dlp_predefined_entry_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccCloudflareZeroTrustDlpPredefinedEntry_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_zero_trust_dlp_predefined_entry." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZeroTrustDlpPredefinedEntryConfig(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						return errors.New("test not implemented")
+					},
+					resource.TestCheckResourceAttr(name, "some_string_attribute", "string_value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccZeroTrustDlpPredefinedEntryConfig(rnd string) string {
+	return acctest.LoadTestCase("basic.tf", rnd)
+}

--- a/internal/services/zero_trust_dlp_predefined_entry/testdata/basic.tf
+++ b/internal/services/zero_trust_dlp_predefined_entry/testdata/basic.tf
@@ -1,0 +1,1 @@
+resource "cloudflare_zero_trust_dlp_predefined_entry" "%[1]s" {}

--- a/internal/services/zero_trust_dlp_predefined_entry/testdata/datasource_basic.tf
+++ b/internal/services/zero_trust_dlp_predefined_entry/testdata/datasource_basic.tf
@@ -1,0 +1,1 @@
+data "cloudflare_zero_trust_dlp_predefined_entry" "%[1]s" {}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adds scaffolding for acceptance tests for the following resources:
  - `zero_trust_dlp_custom_entry`
  - `zero_trust_dlp_integration_entry`
  - `zero_trust_dlp_predefined_entry`

