### PR TITLE
set ssl attribute to optional

### DIFF
--- a/internal/services/custom_hostname/model.go
+++ b/internal/services/custom_hostname/model.go
@@ -17,7 +17,7 @@ type CustomHostnameModel struct {
 	ID                        types.String                                                           `tfsdk:"id" json:"id,computed"`
 	ZoneID                    types.String                                                           `tfsdk:"zone_id" path:"zone_id,required"`
 	Hostname                  types.String                                                           `tfsdk:"hostname" json:"hostname,required"`
-	SSL                       *CustomHostnameSSLModel                                                `tfsdk:"ssl" json:"ssl,required"`
+	SSL                       *CustomHostnameSSLModel                                                `tfsdk:"ssl" json:"ssl,optional"`
 	CustomOriginServer        types.String                                                           `tfsdk:"custom_origin_server" json:"custom_origin_server,optional"`
 	CustomOriginSNI           types.String                                                           `tfsdk:"custom_origin_sni" json:"custom_origin_sni,optional"`
 	CustomMetadata            *map[string]types.String                                               `tfsdk:"custom_metadata" json:"custom_metadata,optional"`

--- a/internal/services/custom_hostname/schema.go
+++ b/internal/services/custom_hostname/schema.go
@@ -39,7 +39,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"ssl": schema.SingleNestedAttribute{
 				Description: "SSL properties used when creating the custom hostname.",
-				Required:    true,
+				Optional:    true,
 				Attributes: map[string]schema.Attribute{
 					"bundle_method": schema.StringAttribute{
 						Description: "A ubiquitous bundle has the highest probability of being verified everywhere, even by clients using outdated or unusual trust stores. An optimal bundle uses the shortest chain and newest intermediates. And the force bundle verifies the chain, but does not otherwise modify it.\nAvailable values: \"ubiquitous\", \"optimal\", \"force\".",


### PR DESCRIPTION
Change the SSL attribute of `cloudflare_custom_hostname` to be optional to match the behavior of the API.

```
curl -v https://api.cloudflare.com/client/v4/zones/<zone_id>/custom_hostnames \
    -H 'Content-Type: application/json' \
    -H "Authorization: Bearer $API_TOKEN" \
    -d '{
      "hostname": "somedomain.example.com"
    }'
```