### PR TITLE
DS-15222: Add a Basic test for logpush_job resource

### DIFF
--- a/internal/services/logpush_job/testdata/basic.tf
+++ b/internal/services/logpush_job/testdata/basic.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_logpush_job" "%[1]s" {
+  enabled = false
+  account_id = "%[2]s"
+  destination_conf = "%[3]s"
+  dataset = "%[4]s"
+  name = "%[5]s"
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

This adds a Basic for `logpush_job` resource, following https://wiki.cfdata.org/display/API/Terraform+Acceptance+Tests

To run test:
```
export CLOUDFLARE_ACCOUNT_ID=a67e14daa5f8dceeb91fe5449ba496eb
export TF_ACC=2721447

export CLOUDFLARE_EMAIL=
export CLOUDFLARE_API_KEY=

go test ./internal/services/logpush_job -run "^TestAccCloudflareLogpushJob_" -v -count 1
```
