### PR TITLE
DS-15222: Fix Logpush job schema and model

### DIFF
--- a/internal/services/logpush_job/model.go
+++ b/internal/services/logpush_job/model.go
@@ -19,11 +19,11 @@ type LogpushJobModel struct {
 	Dataset                  types.String                  `tfsdk:"dataset" json:"dataset,computed_optional"`
 	DestinationConf          types.String                  `tfsdk:"destination_conf" json:"destination_conf,required"`
 	Filter                   types.String                  `tfsdk:"filter" json:"filter,optional,no_refresh"`
-	LogpullOptions           types.String                  `tfsdk:"logpull_options" json:"logpull_options,optional"`
-	MaxUploadBytes           types.Int64                   `tfsdk:"max_upload_bytes" json:"max_upload_bytes,optional"`
-	MaxUploadIntervalSeconds types.Int64                   `tfsdk:"max_upload_interval_seconds" json:"max_upload_interval_seconds,optional"`
-	MaxUploadRecords         types.Int64                   `tfsdk:"max_upload_records" json:"max_upload_records,optional"`
-	Name                     types.String                  `tfsdk:"name" json:"name,optional"`
+	LogpullOptions           types.String                  `tfsdk:"logpull_options" json:"logpull_options,optional,no_refresh"`
+	MaxUploadBytes           types.Int64                   `tfsdk:"max_upload_bytes" json:"max_upload_bytes,optional,no_refresh"`
+	MaxUploadIntervalSeconds types.Int64                   `tfsdk:"max_upload_interval_seconds" json:"max_upload_interval_seconds,optional,no_refresh"`
+	MaxUploadRecords         types.Int64                   `tfsdk:"max_upload_records" json:"max_upload_records,optional,no_refresh"`
+	Name                     types.String                  `tfsdk:"name" json:"name,optional,no_refresh"`
 	OwnershipChallenge       types.String                  `tfsdk:"ownership_challenge" json:"ownership_challenge,optional,no_refresh"`
 	OutputOptions            *LogpushJobOutputOptionsModel `tfsdk:"output_options" json:"output_options,optional"`
 	Enabled                  types.Bool                    `tfsdk:"enabled" json:"enabled,computed_optional"`
@@ -45,7 +45,7 @@ func (m LogpushJobModel) MarshalJSONForUpdate(state LogpushJobModel) (data []byt
 type LogpushJobOutputOptionsModel struct {
 	BatchPrefix     types.String    `tfsdk:"batch_prefix" json:"batch_prefix,optional"`
 	BatchSuffix     types.String    `tfsdk:"batch_suffix" json:"batch_suffix,optional"`
-	Cve2021_44228   types.Bool      `tfsdk:"cve_2021_44228" json:"CVE-2021-44228,optional"`
+	Cve2021_44228   types.Bool      `tfsdk:"cve_2021_44228" json:"CVE-2021-44228,optional,no_refresh"`
 	FieldDelimiter  types.String    `tfsdk:"field_delimiter" json:"field_delimiter,optional"`
 	FieldNames      *[]types.String `tfsdk:"field_names" json:"field_names,optional"`
 	OutputType      types.String    `tfsdk:"output_type" json:"output_type,optional"`

--- a/internal/services/logpush_job/schema.go
+++ b/internal/services/logpush_job/schema.go
@@ -94,14 +94,32 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"max_upload_bytes": schema.Int64Attribute{
 				Description: "The maximum uncompressed file size of a batch of logs. This setting value must be between `5 MB` and `1 GB`, or `0` to disable it. Note that you cannot set a minimum file size; this means that log files may be much smaller than this batch size.",
 				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.Any(
+						int64validator.OneOf(0),
+						int64validator.Between(5000000, 1000000000),
+					),
+				},
 			},
 			"max_upload_interval_seconds": schema.Int64Attribute{
 				Description: "The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds (5 minutes), or `0` to disable it. Note that you cannot specify a minimum interval for log batches; this means that log files may be sent in shorter intervals than this.",
 				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.Any(
+						int64validator.OneOf(0),
+						int64validator.Between(30, 300),
+					),
+				},
 			},
 			"max_upload_records": schema.Int64Attribute{
 				Description: "The maximum number of log lines per batch. This setting must be between 1000 and 1,000,000 lines, or `0` to disable it. Note that you cannot specify a minimum number of log lines per batch; this means that log files may contain many fewer lines than this.",
 				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.Any(
+						int64validator.OneOf(0),
+						int64validator.Between(1000, 1000000),
+					),
+				},
 			},
 			"name": schema.StringAttribute{
 				Description: "Optional human readable job name. Not unique. Cloudflare suggests that you set this to a meaningful string, like the domain name, to make it easier to identify your job.",


### PR DESCRIPTION
* DS-15222: Add no_refresh attribute for the fields that cause "drift" due to Logpush API json omitempty
    
    This adds `no_refresh` attribute for the fields that cause "drift" due to Logpush API json `omitempty`.

---
* DS-15222: Add validators to Logpush job max_upload_* fields, as SDK generator doesn't recognize multiple definitions by anyOf
    
    This adds validators to Logpush job `max_upload_*` fields, as SDK generator doesn't recognize multiple definitions by `anyOf`.
