### PR TITLE
Marks both logpull_options and output_options as computed

### DIFF
--- a/.changelog/5785.txt
+++ b/.changelog/5785.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_logpush_job: mark both logpull_options and output_options as computed
+```

--- a/docs/resources/logpush_job.md
+++ b/docs/resources/logpush_job.md
@@ -121,7 +121,7 @@ resource "cloudflare_logpush_job" "example_job" {
 - `filter` (String) Use filters to select the events to include and/or remove from your logs. For more information, refer to [Filters](https://developers.cloudflare.com/logs/reference/logpush-api-configuration/filters/).
 - `frequency` (String, Deprecated) A higher frequency will result in logs being pushed on faster with smaller files. `low` frequency will push logs less often with larger files. Available values: `high`, `low`. Defaults to `high`.
 - `kind` (String) The kind of logpush job to create. Available values: `edge`, `instant-logs`, `""`.
-- `logpull_options` (String) Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpush options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options).
+- `logpull_options` (String) Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpush options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options). For easier use, you should use "output_options".
 - `max_upload_bytes` (Number) The maximum uncompressed file size of a batch of logs. Value must be between 5MB and 1GB.
 - `max_upload_interval_seconds` (Number) The maximum interval in seconds for log batches. Value must be between 30 and 300.
 - `max_upload_records` (Number) The maximum number of log lines per batch. Value must be between 1000 and 1,000,000.

--- a/internal/sdkv2provider/resource_cloudflare_logpush_job.go
+++ b/internal/sdkv2provider/resource_cloudflare_logpush_job.go
@@ -216,10 +216,6 @@ func resourceCloudflareLogpushJobCreate(ctx context.Context, d *schema.ResourceD
 		job.Filter = &jobFilter
 	}
 
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error parsing logpush job from resource: %w", err))
-	}
-
 	tflog.Debug(ctx, fmt.Sprintf("Creating Cloudflare Logpush job for %s from struct: %+v", identifier, job))
 
 	j, err := client.CreateLogpushJob(ctx, identifier, job)
@@ -289,14 +285,6 @@ func resourceCloudflareLogpushJobUpdate(ctx context.Context, d *schema.ResourceD
 		job.Filter = &jobFilter
 	}
 
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error parsing logpush job from resource: %w", err))
-	}
-
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error parsing logpush job from resource: %w", err))
-	}
-
 	tflog.Info(ctx, fmt.Sprintf("Updating Cloudflare Logpush job for %s from struct: %+v", identifier, job))
 
 	err = client.UpdateLogpushJob(ctx, identifier, job)
@@ -334,7 +322,7 @@ func resourceCloudflareLogpushJobDelete(ctx context.Context, d *schema.ResourceD
 }
 
 func resourceCloudflareLogpushJobImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	// split the id so we can lookup
+	// split the id so we can look up
 	idAttr := strings.Split(d.Id(), "/")
 
 	if len(idAttr) != 3 || !contains([]string{"zone", "account"}, idAttr[0]) || idAttr[1] == "" || idAttr[2] == "" {

--- a/internal/sdkv2provider/schema_cloudflare_logpush_job.go
+++ b/internal/sdkv2provider/schema_cloudflare_logpush_job.go
@@ -76,7 +76,8 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 		"logpull_options": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: `Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpush options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options).`,
+			Computed:    true,
+			Description: `Configuration string for the Logshare API. It specifies things like requested fields and timestamp formats. See [Logpush options documentation](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/understanding-logpush-api/#options). For easier use, you should use "output_options".`,
 		},
 		"destination_conf": {
 			Type:        schema.TypeString,
@@ -123,6 +124,7 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			MaxItems:    1,
 			Optional:    true,
+			Computed:    true,
 			Description: "Structured replacement for logpull_options. When including this field, the logpull_option field will be ignored",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{


### PR DESCRIPTION
- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes an issue where the v4 provider has perma-drift due to the API setting both `logpull_options` and `output_options` but the current provider only expecting one to be set.

I also removed some err checks that weren't being used, as they were checking errors that would be already checked.

## Additional context & links
Similar to https://github.com/cloudflare/terraform-provider-cloudflare/issues/5578, but this fix is for the v4 provider.