### PR TITLE
Remove WriteOnly flag from zero_trust_access_identity_provider config.client_secret attribute

### DIFF
--- a/internal/services/zero_trust_access_identity_provider/normalizations.go
+++ b/internal/services/zero_trust_access_identity_provider/normalizations.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
@@ -37,7 +36,7 @@ func normalizeReadZeroTrustIDPScimConfigData(ctx context.Context, dataValue, sta
 	return diags
 }
 
-func normalizeReadZeroTrustIDPConfigData(ctx context.Context, dataValue *ZeroTrustAccessIdentityProviderModel, stateValue ZeroTrustAccessIdentityProviderModel) diag.Diagnostics {
+func normalizeReadZeroTrustIDPConfigData(_ context.Context, dataValue, stateValue *ZeroTrustAccessIdentityProviderModel) diag.Diagnostics {
 	diag := make(diag.Diagnostics, 0)
 	if dataValue.Config == nil || stateValue.Config == nil {
 		return diag
@@ -47,15 +46,17 @@ func normalizeReadZeroTrustIDPConfigData(ctx context.Context, dataValue *ZeroTru
 	normalizeFalseAndNullBool(&dataValue.Config.ConditionalAccessEnabled, stateValue.Config.ConditionalAccessEnabled)
 	normalizeFalseAndNullBool(&dataValue.Config.SupportGroups, stateValue.Config.SupportGroups)
 
+	if dataValue.Config != nil && stateValue.Config != nil && dataValue.Config.ClientSecret.IsNull() {
+		dataValue.Config.ClientSecret = stateValue.Config.ClientSecret
+	}
+
 	return diag
 }
 
-func normalizeReadZeroTrustIDPData(ctx context.Context, dataValue *ZeroTrustAccessIdentityProviderModel, state *tfsdk.State) diag.Diagnostics {
+func normalizeReadZeroTrustIDPData(ctx context.Context, dataValue, stateValue *ZeroTrustAccessIdentityProviderModel) diag.Diagnostics {
 	var (
-		diags      = make(diag.Diagnostics, 0)
-		stateValue ZeroTrustAccessIdentityProviderModel
+		diags = make(diag.Diagnostics, 0)
 	)
-	d := state.Get(ctx, &stateValue)
 
 	diags.Append(normalizeReadZeroTrustIDPConfigData(ctx, dataValue, stateValue)...)
 	if diags.HasError() {
@@ -69,22 +70,6 @@ func normalizeReadZeroTrustIDPData(ctx context.Context, dataValue *ZeroTrustAcce
 		if diags.HasError() {
 			return diags
 		}
-	}
-
-	return d
-}
-
-// Some fields are write-only sensitive and should not be stored in the state.
-// Usually these secrets are injected in the config from a secret store.
-func loadConfigSensitiveValuesForWriting(ctx context.Context, data *ZeroTrustAccessIdentityProviderModel, cfg *tfsdk.Config) diag.Diagnostics {
-	var (
-		diags   = make(diag.Diagnostics, 0)
-		cfgData *ZeroTrustAccessIdentityProviderModel
-	)
-	diags.Append(cfg.Get(ctx, &cfgData)...)
-
-	if data.Config != nil && cfgData.Config != nil {
-		data.Config.ClientSecret = cfgData.Config.ClientSecret
 	}
 
 	return diags

--- a/internal/services/zero_trust_access_identity_provider/resource_test.go
+++ b/internal/services/zero_trust_access_identity_provider/resource_test.go
@@ -144,7 +144,7 @@ func TestAccCloudflareAccessIdentityProvider_OAuth(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rnd),
 					resource.TestCheckResourceAttr(resourceName, "type", "github"),
 					resource.TestCheckResourceAttr(resourceName, "config.client_id", "test"),
-					resource.TestCheckNoResourceAttr(resourceName, "config.client_secret"),
+					resource.TestCheckResourceAttr(resourceName, "config.client_secret", "secret"),
 				),
 			},
 			{
@@ -175,7 +175,7 @@ func TestAccCloudflareAccessIdentityProvider_OAuthWithUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rnd),
 					resource.TestCheckResourceAttr(resourceName, "type", "github"),
 					resource.TestCheckResourceAttr(resourceName, "config.client_id", "test"),
-					resource.TestCheckNoResourceAttr(resourceName, "config.client_secret"),
+					resource.TestCheckResourceAttr(resourceName, "config.client_secret", "secret"),
 				),
 			},
 			{
@@ -190,7 +190,7 @@ func TestAccCloudflareAccessIdentityProvider_OAuthWithUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rnd+"-updated"),
 					resource.TestCheckResourceAttr(resourceName, "type", "github"),
 					resource.TestCheckResourceAttr(resourceName, "config.client_id", "test"),
-					resource.TestCheckNoResourceAttr(resourceName, "config.client_secret"),
+					resource.TestCheckResourceAttr(resourceName, "config.client_secret", "secret"),
 				),
 			},
 			{
@@ -284,7 +284,7 @@ func TestAccCloudflareAccessIdentityProvider_OAuth_Import(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "name", rnd),
 		resource.TestCheckResourceAttr(resourceName, "type", "github"),
 		resource.TestCheckResourceAttr(resourceName, "config.client_id", "test"),
-		resource.TestCheckNoResourceAttr(resourceName, "config.client_secret"),
+		resource.TestCheckResourceAttr(resourceName, "config.client_secret", "secret"),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -304,8 +304,12 @@ func TestAccCloudflareAccessIdentityProvider_OAuth_Import(t *testing.T) {
 				PlanOnly: true,
 			},
 			{
-				ImportState:         true,
-				ImportStateVerify:   true,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// cant import client_secret
+					"config.client_secret",
+				},
 				ResourceName:        resourceName,
 				ImportStateIdPrefix: fmt.Sprintf("accounts/%s/", accountID),
 				Check:               checkFn,

--- a/internal/services/zero_trust_access_identity_provider/schema.go
+++ b/internal/services/zero_trust_access_identity_provider/schema.go
@@ -85,7 +85,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Description: "Your OAuth Client Secret",
 						Optional:    true,
 						Sensitive:   true,
-						WriteOnly:   true,
 					},
 					"conditional_access_enabled": schema.BoolAttribute{
 						Description: "Should Cloudflare try to load authentication contexts from your account",


### PR DESCRIPTION
- Address this https://github.com/cloudflare/terraform-provider-cloudflare/issues/5748 by removing WriteOnly
- Normalizations for zero_trust_access_identity_provider after Update responses should be comparing  the response with the planned value and not the state, fixed that

