### PR TITLE
Fix zero_trust_access_application constant diffs for warp type apps

### DIFF
--- a/internal/services/zero_trust_access_application/normalizations.go
+++ b/internal/services/zero_trust_access_application/normalizations.go
@@ -158,6 +158,9 @@ func normalizeReadZeroTrustApplicationAPIData(ctx context.Context, data, stateDa
 
 	if data.Policies != nil && stateData.Policies != nil {
 		for i := range *data.Policies {
+			if len(*stateData.Policies) <= i {
+				break
+			}
 			normalizeZeroTrustApplicationPolicyAPIData(ctx, &(*data.Policies)[i], &(*stateData.Policies)[i])
 		}
 	}
@@ -173,9 +176,8 @@ func normalizeReadZeroTrustApplicationAPIData(ctx context.Context, data, stateDa
 	return diags
 }
 
-// Some fields are write-only sensitive and should not be stored in the state.
-// Usually these secrets are injected in the config from a secret store.
-func loadConfigSensitiveValuesForWriting(ctx context.Context, data *ZeroTrustAccessApplicationModel, cfg *tfsdk.Config) diag.Diagnostics {
+// Normalizes the API request before sending it to the API
+func normalizeWriteZeroTrustApplicationAPIData(ctx context.Context, data *ZeroTrustAccessApplicationModel, cfg *tfsdk.Config) diag.Diagnostics {
 	var (
 		diags   = make(diag.Diagnostics, 0)
 		cfgData *ZeroTrustAccessApplicationModel
@@ -183,11 +185,19 @@ func loadConfigSensitiveValuesForWriting(ctx context.Context, data *ZeroTrustAcc
 	diags.Append(cfg.Get(ctx, &cfgData)...)
 
 	if data.SCIMConfig != nil && cfgData.SCIMConfig != nil {
+		// load config sensitive write values directly from the config.
 		if data.SCIMConfig.Authentication != nil && cfgData.SCIMConfig.Authentication != nil {
 			data.SCIMConfig.Authentication.Password = cfgData.SCIMConfig.Authentication.Password
 			data.SCIMConfig.Authentication.Token = cfgData.SCIMConfig.Authentication.Token
 			data.SCIMConfig.Authentication.ClientSecret = cfgData.SCIMConfig.Authentication.ClientSecret
 		}
 	}
+
+	// If the API receives a null 'policies' array, it wont update the policies on the application, for historical reasons.
+	// To avoid a diff, we need to ensure that the array is not nil
+	if data.Policies == nil {
+		data.Policies = &[]ZeroTrustAccessApplicationPoliciesModel{}
+	}
+
 	return diags
 }

--- a/internal/services/zero_trust_access_application/plan_modifiers.go
+++ b/internal/services/zero_trust_access_application/plan_modifiers.go
@@ -13,12 +13,13 @@ import (
 )
 
 var (
-	selfHostedAppTypes                = []string{"self_hosted", "ssh", "vnc", "rdp"}
-	saasAppTypes                      = []string{"saas", "dash_sso"}
-	appLauncherVisibleAppTypes        = []string{"self_hosted", "ssh", "vnc", "rdp", "saas", "bookmark"}
-	targetCompatibleAppTypes          = []string{"rdp", "infrastructure"}
-	sessionDurationCompatibleAppTypes = []string{"saas", "dash_sso", "self_hosted", "ssh", "vnc", "rdp", "app_launcher"}
-	durationRegex                     = regexp.MustCompile(`^(?:0|[-+]?(\d+(?:\.\d*)?|\.\d+)(?:ns|us|µs|ms|s|m|h)(?:(\d+(?:\.\d*)?|\.\d+)(?:ns|us|µs|ms|s|m|h))*)$`)
+	selfHostedAppTypes                    = []string{"self_hosted", "ssh", "vnc", "rdp"}
+	saasAppTypes                          = []string{"saas", "dash_sso"}
+	appLauncherVisibleAppTypes            = []string{"self_hosted", "ssh", "vnc", "rdp", "saas", "bookmark"}
+	targetCompatibleAppTypes              = []string{"rdp", "infrastructure"}
+	sessionDurationCompatibleAppTypes     = []string{"saas", "dash_sso", "self_hosted", "ssh", "vnc", "rdp", "app_launcher", "warp"}
+	authenticateViaWarpCompatibleAppTypes = []string{"self_hosted", "ssh", "vnc", "rdp", "saas", "dash_sso"}
+	durationRegex                         = regexp.MustCompile(`^(?:0|[-+]?(\d+(?:\.\d*)?|\.\d+)(?:ns|us|µs|ms|s|m|h)(?:(\d+(?:\.\d*)?|\.\d+)(?:ns|us|µs|ms|s|m|h))*)$`)
 )
 
 // Sets a specific default value for a computed attribute specific to a set of app types, in case the attribute is unknown.

--- a/internal/services/zero_trust_access_application/resource.go
+++ b/internal/services/zero_trust_access_application/resource.go
@@ -63,7 +63,11 @@ func (r *ZeroTrustAccessApplicationResource) Create(ctx context.Context, req res
 		return
 	}
 
-	resp.Diagnostics.Append(loadConfigSensitiveValuesForWriting(ctx, data, &req.Config)...)
+	res := new(http.Response)
+	env := ZeroTrustAccessApplicationResultEnvelope{*data}
+	params := zero_trust.AccessApplicationNewParams{}
+
+	resp.Diagnostics.Append(normalizeWriteZeroTrustApplicationAPIData(ctx, data, &req.Config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -73,10 +77,6 @@ func (r *ZeroTrustAccessApplicationResource) Create(ctx context.Context, req res
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
 		return
 	}
-
-	res := new(http.Response)
-	env := ZeroTrustAccessApplicationResultEnvelope{*data}
-	params := zero_trust.AccessApplicationNewParams{}
 
 	if !data.AccountID.IsNull() {
 		params.AccountID = cloudflare.F(data.AccountID.ValueString())
@@ -123,7 +123,11 @@ func (r *ZeroTrustAccessApplicationResource) Update(ctx context.Context, req res
 		return
 	}
 
-	resp.Diagnostics.Append(loadConfigSensitiveValuesForWriting(ctx, data, &req.Config)...)
+	res := new(http.Response)
+	env := ZeroTrustAccessApplicationResultEnvelope{*data}
+	params := zero_trust.AccessApplicationUpdateParams{}
+
+	resp.Diagnostics.Append(normalizeWriteZeroTrustApplicationAPIData(ctx, data, &req.Config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -133,9 +137,6 @@ func (r *ZeroTrustAccessApplicationResource) Update(ctx context.Context, req res
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
 		return
 	}
-	res := new(http.Response)
-	env := ZeroTrustAccessApplicationResultEnvelope{*data}
-	params := zero_trust.AccessApplicationUpdateParams{}
 
 	if !data.AccountID.IsNull() {
 		params.AccountID = cloudflare.F(data.AccountID.ValueString())

--- a/internal/services/zero_trust_access_application/resource_test.go
+++ b/internal/services/zero_trust_access_application/resource_test.go
@@ -1557,6 +1557,25 @@ func TestAccCloudflareAccessApplicationWithInvalidSaas(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareAccessApplication_WarpInvalid(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accoundID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareAccessApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCloudflareAccessApplicationWarpInvalid(rnd, accoundID),
+				ExpectError: regexp.MustCompile(`"allow_authenticate_via_warp" can only be set if "type" is one of:\s"self_hosted", "ssh", "vnc", "rdp", "saas", "dash_sso"`),
+			},
+		},
+	})
+}
+
 func testAccessApplicationWithZoneID(resourceID, zone, zoneID string) string {
 	return acctest.LoadTestCase("accessapplicationwithzoneid.tf", resourceID, zone, zoneID)
 }
@@ -1635,4 +1654,8 @@ func testAccCloudflareAccessApplicationConfigWithReusablePoliciesInvalidPreceden
 
 func testAccessApplicationWithInvalidSaas(resourceID, accountID string) string {
 	return acctest.LoadTestCase("accessapplicationconfigwithinvalidsaas.tf", resourceID, accountID)
+}
+
+func testAccCloudflareAccessApplicationWarpInvalid(rnd, accountID string) string {
+	return acctest.LoadTestCase("accessapplicationconfigwarpinvalid.tf", rnd, accountID)
 }

--- a/internal/services/zero_trust_access_application/schema.go
+++ b/internal/services/zero_trust_access_application/schema.go
@@ -47,6 +47,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"allow_authenticate_via_warp": schema.BoolAttribute{
 				Description: "When set to true, users can authenticate to this application using their WARP session.  When set to false this application will always require direct IdP authentication. This setting always overrides the organization setting for WARP authentication.",
 				Optional:    true,
+				Validators: []validator.Bool{
+					customvalidator.RequiresOtherStringAttributeToBeOneOf(path.MatchRoot("type"), authenticateViaWarpCompatibleAppTypes...),
+				},
 			},
 			"allow_iframe": schema.BoolAttribute{
 				Description: "Enables loading application content in an iFrame.",

--- a/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwarpinvalid.tf
+++ b/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwarpinvalid.tf
@@ -1,0 +1,8 @@
+resource "cloudflare_zero_trust_access_application" "%[1]s" {
+  name                        = "Warp Login App"
+  account_id                  = "c91137350c00a28806157ec3918faff2"
+  type                        = "warp"
+  allow_authenticate_via_warp = false
+  session_duration            = "3h"
+  policies = []
+}


### PR DESCRIPTION
- warp type apps can not use allow_authenticate_via_warp
- Fixed an issue when setting policies to null would show constant drift as the API interprets null values for the policies array as a no-op

Addresses  https://github.com/cloudflare/terraform-provider-cloudflare/issues/5770

