### PR TITLE
DLS-314: Add dns in routing field for tests

### DIFF
--- a/internal/services/regional_hostname/resource_test.go
+++ b/internal/services/regional_hostname/resource_test.go
@@ -9,9 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-var (
-	zoneID = os.Getenv("CLOUDFLARE_ZONE_ID")
-)
+var zoneID = os.Getenv("CLOUDFLARE_ZONE_ID")
 
 func TestAccCloudflareRegionalHostname_Basic(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
@@ -23,14 +21,14 @@ func TestAccCloudflareRegionalHostname_Basic(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testRegionalHostnameConfig(rnd, zoneName, "ca"),
+				Config: testRegionalHostnameConfig(rnd, zoneName, "ca", "dns"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "hostname", zoneName),
 					resource.TestCheckResourceAttr(name, "region_key", "ca"),
 				),
 			},
 			{
-				Config: testRegionalHostnameConfig(rnd, zoneName, "eu"),
+				Config: testRegionalHostnameConfig(rnd, zoneName, "eu", "dns"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "hostname", zoneName),
 					resource.TestCheckResourceAttr(name, "region_key", "eu"),
@@ -40,6 +38,6 @@ func TestAccCloudflareRegionalHostname_Basic(t *testing.T) {
 	})
 }
 
-func testRegionalHostnameConfig(name string, zoneName, regionKey string) string {
-	return acctest.LoadTestCase("regionalhostnameconfig.tf", name, zoneID, zoneName, regionKey)
+func testRegionalHostnameConfig(name string, zoneName, regionKey, routing string) string {
+	return acctest.LoadTestCase("regionalhostnameconfig.tf", name, zoneID, zoneName, regionKey, routing)
 }

--- a/internal/services/regional_hostname/testdata/regionalhostnameconfig.tf
+++ b/internal/services/regional_hostname/testdata/regionalhostnameconfig.tf
@@ -3,4 +3,5 @@ resource "cloudflare_regional_hostname" "%[1]s" {
 	zone_id = "%[2]s"
 	hostname = "%[3]s"
 	region_key = "%[4]s"
+  routing = "%[5]s"
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Correcting tests

## Additional context & links
I have a corresponding test internally on the DLS-314 JIRA ticket to add default values for regional_hostnames
