### PR TITLE
fix(cloudflare_list_item) fix bulk operation polling and update

### DIFF
--- a/internal/services/list_item/resource.go
+++ b/internal/services/list_item/resource.go
@@ -85,6 +85,7 @@ func (r *ListItemResource) Create(ctx context.Context, req resource.CreateReques
 		option.WithRequestBody("application/json", wrappedBytes),
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
+		option.WithRequestTimeout(time.Second*3),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
@@ -115,6 +116,7 @@ func (r *ListItemResource) Create(ctx context.Context, req resource.CreateReques
 		},
 		option.WithResponseBodyInto(&findItemRes),
 		option.WithMiddleware(logging.Middleware(ctx)),
+		option.WithRequestTimeout(time.Second*3),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to fetch individual list item", err.Error())
@@ -135,6 +137,7 @@ func (r *ListItemResource) Create(ctx context.Context, req resource.CreateReques
 		},
 		option.WithResponseBodyInto(&listItemRes),
 		option.WithMiddleware(logging.Middleware(ctx)),
+		option.WithRequestTimeout(time.Second*3),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to fetch individual list item", err.Error())
@@ -188,6 +191,7 @@ func (r *ListItemResource) Update(ctx context.Context, req resource.UpdateReques
 		option.WithRequestBody("application/json", wrappedBytes),
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
+		option.WithRequestTimeout(time.Second*3),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
@@ -218,6 +222,7 @@ func (r *ListItemResource) Update(ctx context.Context, req resource.UpdateReques
 		},
 		option.WithResponseBodyInto(&findItemRes),
 		option.WithMiddleware(logging.Middleware(ctx)),
+		option.WithRequestTimeout(time.Second*3),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to fetch individual list item", err.Error())
@@ -238,6 +243,7 @@ func (r *ListItemResource) Update(ctx context.Context, req resource.UpdateReques
 		},
 		option.WithResponseBodyInto(&listItemRes),
 		option.WithMiddleware(logging.Middleware(ctx)),
+		option.WithRequestTimeout(time.Second*3),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to fetch individual list item", err.Error())
@@ -272,6 +278,7 @@ func (r *ListItemResource) Read(ctx context.Context, req resource.ReadRequest, r
 		rules.ListItemGetParams{AccountID: cloudflare.F(data.AccountID.ValueString())},
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
+		option.WithRequestTimeout(time.Second*3),
 	)
 	if res != nil && res.StatusCode == 404 {
 		resp.Diagnostics.AddWarning("Resource not found", "The resource was not found on the server and will be removed from state.")
@@ -317,6 +324,7 @@ func (r *ListItemResource) Delete(ctx context.Context, req resource.DeleteReques
 		},
 		option.WithMiddleware(logging.Middleware(ctx)),
 		option.WithRequestBody("application/json", deleteBody),
+		option.WithRequestTimeout(time.Second*3),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to make http request", err.Error())

--- a/internal/services/list_item/resource_test.go
+++ b/internal/services/list_item/resource_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestAccCloudflareListItem_Basic(t *testing.T) {
-	t.Skip("FIXME: Step 1/1 error: Error running apply: exit status 1. Getting rate limited, causing flaky tests.")
 	rnd := utils.GenerateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -34,7 +33,6 @@ func TestAccCloudflareListItem_Basic(t *testing.T) {
 }
 
 func TestAccCloudflareListItem_MultipleItems(t *testing.T) {
-	t.Skip("FIXME: Getting rate limited. Probably causing the cascading failures with the rest.")
 	rnd := utils.GenerateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -59,7 +57,6 @@ func TestAccCloudflareListItem_MultipleItems(t *testing.T) {
 }
 
 func TestAccCloudflareListItem_Update(t *testing.T) {
-	t.Skip("FIXME: Step 1/2 error: Error running apply: exit status 1. Getting rate limited, causing flaky tests.")
 	rnd := utils.GenerateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -86,8 +83,34 @@ func TestAccCloudflareListItem_Update(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareListItem_UpdateReplace(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareIPListItemNewIp(rnd, rnd, rnd, accountID, "192.0.2.0"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "ip", "192.0.2.0"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareIPListItemNewIp(rnd, rnd, rnd, accountID, "192.0.2.1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "ip", "192.0.2.1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudflareListItem_ASN(t *testing.T) {
-	t.Skip("FIXME: Step 1/1 error: Error running apply: exit status 1. Getting rate limited, causing flaky tests.")
 	rnd := utils.GenerateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -110,7 +133,6 @@ func TestAccCloudflareListItem_ASN(t *testing.T) {
 }
 
 func TestAccCloudflareListItem_Hostname(t *testing.T) {
-	t.Skip("FIXME: Getting rate limited, causing flaky tests.")
 	rnd := utils.GenerateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -132,7 +154,6 @@ func TestAccCloudflareListItem_Hostname(t *testing.T) {
 }
 
 func TestAccCloudflareListItem_Redirect(t *testing.T) {
-	t.Skip("FIXME: Step 1/1 error: Error running apply: exit status 1. Getting rate limited, causing flaky tests.")
 	rnd := utils.GenerateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_list_item.%s", rnd)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -159,6 +180,10 @@ func testAccCheckCloudflareIPListItem(ID, name, comment, accountID string) strin
 	return acctest.LoadTestCase("iplistitem.tf", ID, name, comment, accountID)
 }
 
+func testAccCheckCloudflareIPListItemNewIp(ID, name, comment, accountID, ip string) string {
+	return acctest.LoadTestCase("iplistitem_newip.tf", ID, name, comment, accountID, ip)
+}
+
 func testAccCheckCloudflareIPListItemMultipleEntries(ID, name, comment, accountID string) string {
 	return acctest.LoadTestCase("iplistitemmultipleentries.tf", ID, name, comment, accountID)
 }
@@ -180,7 +205,6 @@ func testAccCheckCloudflareHostnameRedirectItem(ID, name, comment, accountID str
 }
 
 func TestAccCloudflareListItem_RedirectWithOverlappingSourceURL(t *testing.T) {
-	t.Skip("Step 1/1 error: After applying this test step, the refresh plan was not empty. Getting rate limited, causing flaky tests.")
 	rnd := utils.GenerateRandomResourceName()
 	firstResource := fmt.Sprintf("cloudflare_list_item.%s_1", rnd)
 	secondResource := fmt.Sprintf("cloudflare_list_item.%s_2", rnd)

--- a/internal/services/list_item/schema.go
+++ b/internal/services/list_item/schema.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -34,11 +35,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"id": schema.StringAttribute{
 				Description:   "The unique ID of the item in the List.",
 				Computed:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"asn": schema.Int64Attribute{
 				Description: "A non-negative 32 bit integer",
 				Optional:    true,
+				PlanModifiers: []planmodifier.Int64{int64planmodifier.RequiresReplaceIf(func(ctx context.Context, req planmodifier.Int64Request, res *int64planmodifier.RequiresReplaceIfFuncResponse) {
+					res.RequiresReplace = req.PlanValue != req.StateValue
+				}, "List item must be replaced if asn has changed", "List item must be replaced if asn has changed")},
 			},
 			"comment": schema.StringAttribute{
 				Description: "An informative summary of the list item.",
@@ -63,6 +67,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Attributes: map[string]schema.Attribute{
 					"url_hostname": schema.StringAttribute{
 						Required: true,
+						PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIf(func(ctx context.Context, req planmodifier.StringRequest, res *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+							res.RequiresReplace = req.PlanValue != req.StateValue
+						}, "List item must be replaced if url_hostname has changed", "List item must be replaced if url_hostname has changed")},
 					},
 					"exclude_exact_hostname": schema.BoolAttribute{
 						Description: "Only applies to wildcard hostnames (e.g., *.example.com). When true (default), only subdomains are blocked. When false, both the root domain and subdomains are blocked.",
@@ -73,6 +80,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"ip": schema.StringAttribute{
 				Description: "An IPv4 address, an IPv4 CIDR, an IPv6 address, or an IPv6 CIDR.",
 				Optional:    true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIf(func(ctx context.Context, req planmodifier.StringRequest, res *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+					res.RequiresReplace = req.PlanValue != req.StateValue
+				}, "List item must be replaced if ip has changed", "List item must be replaced if ip has changed")},
 			},
 			"redirect": schema.SingleNestedAttribute{
 				Description: "The definition of the redirect.",
@@ -81,6 +91,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Attributes: map[string]schema.Attribute{
 					"source_url": schema.StringAttribute{
 						Required: true,
+						PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIf(func(ctx context.Context, req planmodifier.StringRequest, res *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+							res.RequiresReplace = req.PlanValue != req.StateValue
+						}, "List item must be replaced if source_url has changed", "List item must be replaced if source_url has changed")},
 					},
 					"target_url": schema.StringAttribute{
 						Required: true,

--- a/internal/services/list_item/testdata/iplistitem_newip.tf
+++ b/internal/services/list_item/testdata/iplistitem_newip.tf
@@ -1,0 +1,14 @@
+
+  resource "cloudflare_list" "%[2]s" {
+    account_id          = "%[4]s"
+    name                = "%[2]s"
+    description         = "list named %[2]s"
+    kind                = "ip"
+  }
+
+  resource "cloudflare_list_item" "%[1]s" {
+    account_id = "%[4]s"
+  	list_id    = cloudflare_list.%[2]s.id
+  	ip         = "%[5]s"
+  	comment    = "%[3]s"
+  }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Creating, updating, or deleting list items results in an asynchronous bulk job that must be polled to know when it has completed and the new list item is visible. 

It is not possible to update an existing list item by ID, so we must create a new list item and delete the old one.

If the "key" value is the same, they will be merged into the same list item. So we can optimize updates by only requiring replacement if the "key" value has changed.

## Additional context & links

Bulk operation status
https://developers.cloudflare.com/api/resources/rules/subresources/lists/subresources/bulk_operations/methods/get/