### PR TITLE
chore: modernize zero_trust_access_identity_provider tests

### DIFF
--- a/internal/services/zero_trust_access_identity_provider/resource_test.go
+++ b/internal/services/zero_trust_access_identity_provider/resource_test.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/cloudflare/cloudflare-go"
@@ -16,6 +15,10 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func init() {
@@ -73,20 +76,22 @@ func TestAccCloudflareAccessIdentityProvider_OneTimePin(t *testing.T) {
 			acctest.TestAccPreCheck_AccountID(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckCloudflareAccessIdentityProviderOneTimePin(rnd, cloudflare.AccountIdentifier(accountID)),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
-					resource.TestCheckResourceAttr(resourceName, "name", rnd),
-					resource.TestCheckResourceAttr(resourceName, "type", "onetimepin"),
-					resource.TestCheckResourceAttrWith(resourceName, "config.redirect_url", func(value string) error {
-						if !strings.HasSuffix(value, ".cloudflareaccess.com/cdn-cgi/access/callback") {
-							return fmt.Errorf("expected redirect_url to be a Cloudflare Access URL, got %s", value)
-						}
-						return nil
-					}),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("onetimepin")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("redirect_url"), knownvalue.StringRegexp(regexp.MustCompile(`\.cloudflareaccess\.com/cdn-cgi/access/callback$`))),
+				},
+			},
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("accounts/%s/", accountID),
 			},
 			{
 				// Ensures no diff on last plan
@@ -101,20 +106,22 @@ func TestAccCloudflareAccessIdentityProvider_OneTimePin(t *testing.T) {
 			acctest.TestAccPreCheck(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckCloudflareAccessIdentityProviderOneTimePin(rnd, cloudflare.ZoneIdentifier(zoneID)),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
-					resource.TestCheckResourceAttr(resourceName, "name", rnd),
-					resource.TestCheckResourceAttr(resourceName, "type", "onetimepin"),
-					resource.TestCheckResourceAttrWith(resourceName, "config.redirect_url", func(value string) error {
-						if !strings.HasSuffix(value, ".cloudflareaccess.com/cdn-cgi/access/callback") {
-							return fmt.Errorf("expected redirect_url to be a Cloudflare Access URL, got %s", value)
-						}
-						return nil
-					}),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("onetimepin")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("redirect_url"), knownvalue.StringRegexp(regexp.MustCompile(`\.cloudflareaccess\.com/cdn-cgi/access/callback$`))),
+				},
+			},
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("zones/%s/", zoneID),
 			},
 			{
 				// Ensures no diff on last plan
@@ -126,7 +133,6 @@ func TestAccCloudflareAccessIdentityProvider_OneTimePin(t *testing.T) {
 }
 
 func TestAccCloudflareAccessIdentityProvider_OAuth(t *testing.T) {
-	t.Parallel()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
@@ -136,16 +142,24 @@ func TestAccCloudflareAccessIdentityProvider_OAuth(t *testing.T) {
 			acctest.TestAccPreCheck_AccountID(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckCloudflareAccessIdentityProviderOAuth(accountID, rnd),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
-					resource.TestCheckResourceAttr(resourceName, "name", rnd),
-					resource.TestCheckResourceAttr(resourceName, "type", "github"),
-					resource.TestCheckResourceAttr(resourceName, "config.client_id", "test"),
-					resource.TestCheckResourceAttr(resourceName, "config.client_secret", "secret"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("github")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_secret"), knownvalue.StringExact("secret")),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				ImportStateVerifyIgnore: []string{"config.client_secret"},
 			},
 			{
 				// Ensures no diff on last plan
@@ -157,7 +171,6 @@ func TestAccCloudflareAccessIdentityProvider_OAuth(t *testing.T) {
 }
 
 func TestAccCloudflareAccessIdentityProvider_OAuthWithUpdate(t *testing.T) {
-	t.Parallel()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
@@ -167,16 +180,24 @@ func TestAccCloudflareAccessIdentityProvider_OAuthWithUpdate(t *testing.T) {
 			acctest.TestAccPreCheck_AccountID(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckCloudflareAccessIdentityProviderOAuth(accountID, rnd),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
-					resource.TestCheckResourceAttr(resourceName, "name", rnd),
-					resource.TestCheckResourceAttr(resourceName, "type", "github"),
-					resource.TestCheckResourceAttr(resourceName, "config.client_id", "test"),
-					resource.TestCheckResourceAttr(resourceName, "config.client_secret", "secret"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("github")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_secret"), knownvalue.StringExact("secret")),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				ImportStateVerifyIgnore: []string{"config.client_secret"},
 			},
 			{
 				// Ensures no diff on second plan
@@ -185,13 +206,13 @@ func TestAccCloudflareAccessIdentityProvider_OAuthWithUpdate(t *testing.T) {
 			},
 			{
 				Config: testAccCheckCloudflareAccessIdentityProviderOAuthUpdatedName(accountID, rnd),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
-					resource.TestCheckResourceAttr(resourceName, "name", rnd+"-updated"),
-					resource.TestCheckResourceAttr(resourceName, "type", "github"),
-					resource.TestCheckResourceAttr(resourceName, "config.client_id", "test"),
-					resource.TestCheckResourceAttr(resourceName, "config.client_secret", "secret"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("github")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_secret"), knownvalue.StringExact("secret")),
+				},
 			},
 			{
 				// Ensures no diff on last plan
@@ -203,7 +224,6 @@ func TestAccCloudflareAccessIdentityProvider_OAuthWithUpdate(t *testing.T) {
 }
 
 func TestAccCloudflareAccessIdentityProvider_SAML(t *testing.T) {
-	t.Parallel()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
@@ -213,20 +233,28 @@ func TestAccCloudflareAccessIdentityProvider_SAML(t *testing.T) {
 			acctest.TestAccPreCheck_AccountID(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckCloudflareAccessIdentityProviderSAML(accountID, rnd),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
-					resource.TestCheckResourceAttr(resourceName, "name", rnd),
-					resource.TestCheckResourceAttr(resourceName, "type", "saml"),
-					resource.TestCheckResourceAttr(resourceName, "config.issuer_url", "jumpcloud"),
-					resource.TestCheckResourceAttr(resourceName, "config.sso_target_url", "https://sso.myexample.jumpcloud.com/saml2/cloudflareaccess"),
-					resource.TestCheckResourceAttr(resourceName, "config.attributes.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "config.attributes.0", "email"),
-					resource.TestCheckResourceAttr(resourceName, "config.attributes.1", "username"),
-					resource.TestCheckResourceAttr(resourceName, "config.idp_public_certs.#", "1"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("saml")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("issuer_url"), knownvalue.StringExact("jumpcloud")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("sso_target_url"), knownvalue.StringExact("https://sso.myexample.jumpcloud.com/saml2/cloudflareaccess")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("attributes"), knownvalue.ListSizeExact(2)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("attributes").AtSliceIndex(0), knownvalue.StringExact("email")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("attributes").AtSliceIndex(1), knownvalue.StringExact("username")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("idp_public_certs"), knownvalue.ListSizeExact(1)),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				ImportStateVerifyIgnore: []string{"config.sign_request"},
 			},
 			{
 				// Ensures no diff on last plan
@@ -238,9 +266,6 @@ func TestAccCloudflareAccessIdentityProvider_SAML(t *testing.T) {
 }
 
 func TestAccCloudflareAccessIdentityProvider_AzureAD(t *testing.T) {
-	acctest.TestAccSkipForDefaultAccount(t, "Pending investigation into automating Azure IDP.")
-
-	t.Parallel()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
@@ -250,19 +275,27 @@ func TestAccCloudflareAccessIdentityProvider_AzureAD(t *testing.T) {
 			acctest.TestAccPreCheck_AccountID(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckCloudflareAccessIdentityProviderAzureAD(accountID, rnd),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
-					resource.TestCheckResourceAttr(resourceName, "name", rnd),
-					resource.TestCheckResourceAttr(resourceName, "type", "azureAD"),
-					resource.TestCheckResourceAttr(resourceName, "config.client_id", "test"),
-					resource.TestCheckResourceAttr(resourceName, "config.directory_id", "directory"),
-					resource.TestCheckResourceAttr(resourceName, "scim_config.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "scim_config.user_deprovision", "true"),
-					resource.TestCheckResourceAttr(resourceName, "scim_config.seat_deprovision", "true"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("azureAD")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("directory_id"), knownvalue.StringExact("directory")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("user_deprovision"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("seat_deprovision"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				ImportStateVerifyIgnore: []string{"config.client_secret", "config.conditional_access_enabled", "scim_config.secret"},
 			},
 			{
 				// Ensures no diff on last plan
@@ -274,18 +307,9 @@ func TestAccCloudflareAccessIdentityProvider_AzureAD(t *testing.T) {
 }
 
 func TestAccCloudflareAccessIdentityProvider_OAuth_Import(t *testing.T) {
-	t.Parallel()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
-
-	checkFn := resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
-		resource.TestCheckResourceAttr(resourceName, "name", rnd),
-		resource.TestCheckResourceAttr(resourceName, "type", "github"),
-		resource.TestCheckResourceAttr(resourceName, "config.client_id", "test"),
-		resource.TestCheckResourceAttr(resourceName, "config.client_secret", "secret"),
-	)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -296,7 +320,13 @@ func TestAccCloudflareAccessIdentityProvider_OAuth_Import(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckCloudflareAccessIdentityProviderOAuth(accountID, rnd),
-				Check:  checkFn,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("github")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_secret"), knownvalue.StringExact("secret")),
+				},
 			},
 			{
 				// Ensures no diff on second plan
@@ -312,14 +342,18 @@ func TestAccCloudflareAccessIdentityProvider_OAuth_Import(t *testing.T) {
 				},
 				ResourceName:        resourceName,
 				ImportStateIdPrefix: fmt.Sprintf("accounts/%s/", accountID),
-				Check:               checkFn,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("github")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+				},
 			},
 		},
 	})
 }
 
 func TestAccCloudflareAccessIdentityProvider_SCIM_Config_Secret(t *testing.T) {
-	t.Parallel()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
@@ -340,10 +374,29 @@ func TestAccCloudflareAccessIdentityProvider_SCIM_Config_Secret(t *testing.T) {
 			acctest.TestAccPreCheck_AccountID(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckCloudflareAccessIdentityProviderAzureAD(accountID, rnd),
 				Check:  checkFn,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("azureAD")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("directory_id"), knownvalue.StringExact("directory")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("user_deprovision"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("seat_deprovision"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("secret"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				ImportStateVerifyIgnore: []string{"config.client_secret", "scim_config.secret"},
 			},
 			{
 				// Ensures no diff on second plan
@@ -353,6 +406,17 @@ func TestAccCloudflareAccessIdentityProvider_SCIM_Config_Secret(t *testing.T) {
 			{
 				Config: testAccCheckCloudflareAccessIdentityProviderAzureADUpdated(accountID, rnd),
 				Check:  checkFn,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("azureAD")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("directory_id"), knownvalue.StringExact("directory")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("user_deprovision"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("seat_deprovision"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("secret"), knownvalue.NotNull()),
+				},
 			},
 			{
 				// Ensures no diff on last plan
@@ -364,7 +428,6 @@ func TestAccCloudflareAccessIdentityProvider_SCIM_Config_Secret(t *testing.T) {
 }
 
 func TestAccCloudflareAccessIdentityProvider_SCIM_Secret_Enabled_After_Resource_Creation(t *testing.T) {
-	t.Parallel()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
@@ -384,12 +447,20 @@ func TestAccCloudflareAccessIdentityProvider_SCIM_Secret_Enabled_After_Resource_
 			acctest.TestAccPreCheck_AccountID(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckCloudflareAccessIdentityProviderAzureADNoSCIM(accountID, rnd),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr(resourceName, "scim_config.secret"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("secret"), knownvalue.Null()),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				ImportStateVerifyIgnore: []string{"config.client_secret"},
 			},
 			{
 				Config:   testAccCheckCloudflareAccessIdentityProviderAzureADNoSCIM(accountID, rnd),
@@ -432,6 +503,7 @@ func TestAccCloudflareAccessIdentityProvider_OneTimePin_ConflictsWithSCIM(t *tes
 			acctest.TestAccPreCheck_AccountID(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckCloudflareAccessIdentityProviderOneTimePinWithScim(rnd, cloudflare.AccountIdentifier(accountID)),
@@ -439,6 +511,278 @@ func TestAccCloudflareAccessIdentityProvider_OneTimePin_ConflictsWithSCIM(t *tes
 			},
 		},
 	})
+}
+
+func TestAccCloudflareAccessIdentityProvider_OAuth_Comprehensive(t *testing.T) {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareAccessIdentityProviderOAuthMinimal(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("github")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_secret"), knownvalue.StringExact("secret")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("scopes"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("support_groups"), knownvalue.Null()),
+				},
+			},
+			{
+				Config: testAccCheckCloudflareAccessIdentityProviderOAuthComprehensive(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("github")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_secret"), knownvalue.StringExact("secret")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("scopes"), knownvalue.ListSizeExact(2)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("scopes").AtSliceIndex(0), knownvalue.StringExact("user:email")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("scopes").AtSliceIndex(1), knownvalue.StringExact("read:user")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("support_groups"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				ImportStateVerifyIgnore: []string{"config.client_secret"},
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCheckCloudflareAccessIdentityProviderOAuthComprehensive(accountID, rnd),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareAccessIdentityProvider_Okta(t *testing.T) {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareAccessIdentityProviderOkta(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("okta")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_secret"), knownvalue.StringExact("secret")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("okta_account"), knownvalue.StringExact("example.okta.com")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("authorization_server_id"), knownvalue.StringExact("default")),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				ImportStateVerifyIgnore: []string{"config.client_secret"},
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCheckCloudflareAccessIdentityProviderOkta(accountID, rnd),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareAccessIdentityProvider_GenericOAuth(t *testing.T) {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareAccessIdentityProviderGenericOAuth(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("oauth2")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_secret"), knownvalue.StringExact("secret")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("auth_url"), knownvalue.StringExact("https://example.com/auth")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("token_url"), knownvalue.StringExact("https://example.com/token")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("certs_url"), knownvalue.StringExact("https://example.com/certs")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("scopes"), knownvalue.ListSizeExact(3)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("scopes").AtSliceIndex(0), knownvalue.StringExact("openid")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("scopes").AtSliceIndex(1), knownvalue.StringExact("profile")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("scopes").AtSliceIndex(2), knownvalue.StringExact("email")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("pkce_enabled"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				ImportStateVerifyIgnore: []string{"config.client_secret"},
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCheckCloudflareAccessIdentityProviderGenericOAuth(accountID, rnd),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareAccessIdentityProvider_SAML_Comprehensive(t *testing.T) {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareAccessIdentityProviderSAMLComprehensive(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("saml")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("issuer_url"), knownvalue.StringExact("jumpcloud")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("sso_target_url"), knownvalue.StringExact("https://sso.myexample.jumpcloud.com/saml2/cloudflareaccess")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("attributes"), knownvalue.ListSizeExact(3)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("attributes").AtSliceIndex(0), knownvalue.StringExact("email")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("attributes").AtSliceIndex(1), knownvalue.StringExact("username")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("attributes").AtSliceIndex(2), knownvalue.StringExact("groups")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("email_attribute_name"), knownvalue.StringExact("email")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("sign_request"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("idp_public_certs"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("header_attributes"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("header_attributes").AtSliceIndex(0).AtMapKey("attribute_name"), knownvalue.StringExact("department")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("header_attributes").AtSliceIndex(0).AtMapKey("header_name"), knownvalue.StringExact("X-Department")),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				ImportStateVerifyIgnore: []string{"config.sign_request"},
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCheckCloudflareAccessIdentityProviderSAMLComprehensive(accountID, rnd),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareAccessIdentityProvider_AzureAD_Comprehensive(t *testing.T) {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareAccessIdentityProviderAzureADComprehensive(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("azureAD")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_id"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("client_secret"), knownvalue.StringExact("test")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("directory_id"), knownvalue.StringExact("directory")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("support_groups"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("conditional_access_enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("config").AtMapKey("prompt"), knownvalue.StringExact("select_account")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("seat_deprovision"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("user_deprovision"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("identity_update_behavior"), knownvalue.StringExact("automatic")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("scim_base_url"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("secret"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				ImportStateVerifyIgnore: []string{"config.client_secret", "config.conditional_access_enabled", "scim_config.secret"},
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccCheckCloudflareAccessIdentityProviderAzureADComprehensive(accountID, rnd),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareAccessIdentityProvider_SCIM_IdentityUpdateBehaviorValues(t *testing.T) {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_zero_trust_access_identity_provider." + rnd
+
+	testCases := []struct {
+		name     string
+		behavior string
+	}{
+		{name: "NoAction", behavior: "no_action"},
+		{name: "Reauth", behavior: "reauth"},
+		{name: "Automatic", behavior: "automatic"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				CheckDestroy:             testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccCheckCloudflareAccessIdentityProviderAzureADWithIdentityUpdateBehavior(accountID, rnd, tc.behavior),
+						ConfigStateChecks: []statecheck.StateCheck{
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scim_config").AtMapKey("identity_update_behavior"), knownvalue.StringExact(tc.behavior)),
+						},
+					},
+				},
+			})
+		})
+	}
 }
 
 func testAccCheckCloudflareAccessIdentityProviderOneTimePin(name string, identifier *cloudflare.ResourceContainer) string {
@@ -471,4 +815,75 @@ func testAccCheckCloudflareAccessIdentityProviderAzureADUpdated(accountID, name 
 
 func testAccCheckCloudflareAccessIdentityProviderAzureADNoSCIM(accountID, name string) string {
 	return acctest.LoadTestCase("accessidentityproviderazureadnoscim.tf", accountID, name)
+}
+
+func testAccCheckCloudflareAccessIdentityProviderOAuthMinimal(accountID, name string) string {
+	return acctest.LoadTestCase("accessidentityprovideroauthminimal.tf", accountID, name)
+}
+
+func testAccCheckCloudflareAccessIdentityProviderOAuthComprehensive(accountID, name string) string {
+	return acctest.LoadTestCase("accessidentityprovideroauthcomprehensive.tf", accountID, name)
+}
+
+func testAccCheckCloudflareAccessIdentityProviderOkta(accountID, name string) string {
+	return acctest.LoadTestCase("accessidentityproviderokta.tf", accountID, name)
+}
+
+func testAccCheckCloudflareAccessIdentityProviderGenericOAuth(accountID, name string) string {
+	return acctest.LoadTestCase("accessidentityprovidergenericoauth.tf", accountID, name)
+}
+
+func testAccCheckCloudflareAccessIdentityProviderSAMLComprehensive(accountID, name string) string {
+	return acctest.LoadTestCase("accessidentityprovidersamlcomprehensive.tf", accountID, name)
+}
+
+func testAccCheckCloudflareAccessIdentityProviderAzureADComprehensive(accountID, name string) string {
+	return acctest.LoadTestCase("accessidentityproviderazurecomprehensive.tf", accountID, name)
+}
+
+func testAccCheckCloudflareAccessIdentityProviderAzureADWithIdentityUpdateBehavior(accountID, name, behavior string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_zero_trust_access_identity_provider" "%[2]s" {
+  account_id = "%[1]s"
+  name       = "%[2]s"
+  type       = "azureAD"
+  config = {
+    client_id      = "test"
+    client_secret  = "test"
+    directory_id   = "directory"
+    support_groups = true
+  }
+  scim_config = {
+    enabled          = true
+    seat_deprovision = true
+    user_deprovision = true
+    identity_update_behavior = "%[3]s"
+  }
+}`, accountID, name, behavior)
+}
+
+func testAccCheckCloudflareZeroTrustAccessIdentityProviderDestroy(s *terraform.State) error {
+	client, _ := acctest.SharedV1Client()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_zero_trust_access_identity_provider" {
+			continue
+		}
+
+		accountID := rs.Primary.Attributes[consts.AccountIDSchemaKey]
+		zoneID := rs.Primary.Attributes[consts.ZoneIDSchemaKey]
+		
+		var err error
+		if accountID != "" {
+			_, err = client.GetAccessIdentityProvider(context.Background(), cloudflare.AccountIdentifier(accountID), rs.Primary.ID)
+		} else {
+			_, err = client.GetAccessIdentityProvider(context.Background(), cloudflare.ZoneIdentifier(zoneID), rs.Primary.ID)
+		}
+		
+		if err == nil {
+			return fmt.Errorf("zero trust access identity provider still exists")
+		}
+	}
+
+	return nil
 }

--- a/internal/services/zero_trust_access_identity_provider/testdata/accessidentityproviderazurecomprehensive.tf
+++ b/internal/services/zero_trust_access_identity_provider/testdata/accessidentityproviderazurecomprehensive.tf
@@ -1,0 +1,19 @@
+resource "cloudflare_zero_trust_access_identity_provider" "%[2]s" {
+  account_id = "%[1]s"
+  name       = "%[2]s"
+  type       = "azureAD"
+  config = {
+    client_id      = "test"
+    client_secret  = "test"
+    directory_id   = "directory"
+    support_groups = true
+    conditional_access_enabled = true
+    prompt = "select_account"
+  }
+  scim_config = {
+    enabled          = true
+    seat_deprovision = true
+    user_deprovision = true
+    identity_update_behavior = "automatic"
+  }
+}

--- a/internal/services/zero_trust_access_identity_provider/testdata/accessidentityprovidergenericoauth.tf
+++ b/internal/services/zero_trust_access_identity_provider/testdata/accessidentityprovidergenericoauth.tf
@@ -1,0 +1,14 @@
+resource "cloudflare_zero_trust_access_identity_provider" "%[2]s" {
+  account_id = "%[1]s"
+  name = "%[2]s"
+  type = "oauth2"
+  config = {
+    client_id = "test"
+    client_secret = "secret"
+    auth_url = "https://example.com/auth"
+    token_url = "https://example.com/token"
+    certs_url = "https://example.com/certs"
+    scopes = ["openid", "profile", "email"]
+    pkce_enabled = true
+  }
+}

--- a/internal/services/zero_trust_access_identity_provider/testdata/accessidentityprovideroauthcomprehensive.tf
+++ b/internal/services/zero_trust_access_identity_provider/testdata/accessidentityprovideroauthcomprehensive.tf
@@ -1,0 +1,11 @@
+resource "cloudflare_zero_trust_access_identity_provider" "%[2]s" {
+  account_id = "%[1]s"
+  name = "%[2]s"
+  type = "github"
+  config = {
+    client_id = "test"
+    client_secret = "secret"
+    scopes = ["user:email", "read:user"]
+    support_groups = true
+  }
+}

--- a/internal/services/zero_trust_access_identity_provider/testdata/accessidentityprovideroauthminimal.tf
+++ b/internal/services/zero_trust_access_identity_provider/testdata/accessidentityprovideroauthminimal.tf
@@ -1,0 +1,9 @@
+resource "cloudflare_zero_trust_access_identity_provider" "%[2]s" {
+  account_id = "%[1]s"
+  name = "%[2]s"
+  type = "github"
+  config = {
+    client_id = "test"
+    client_secret = "secret"
+  }
+}

--- a/internal/services/zero_trust_access_identity_provider/testdata/accessidentityproviderokta.tf
+++ b/internal/services/zero_trust_access_identity_provider/testdata/accessidentityproviderokta.tf
@@ -1,0 +1,11 @@
+resource "cloudflare_zero_trust_access_identity_provider" "%[2]s" {
+  account_id = "%[1]s"
+  name = "%[2]s"
+  type = "okta"
+  config = {
+    client_id = "test"
+    client_secret = "secret"
+    okta_account = "example.okta.com"
+    authorization_server_id = "default"
+  }
+}

--- a/internal/services/zero_trust_access_identity_provider/testdata/accessidentityprovidersamlcomprehensive.tf
+++ b/internal/services/zero_trust_access_identity_provider/testdata/accessidentityprovidersamlcomprehensive.tf
@@ -1,0 +1,21 @@
+resource "cloudflare_zero_trust_access_identity_provider" "%[2]s" {
+  account_id = "%[1]s"
+  name = "%[2]s"
+  type = "saml"
+  config = {
+    issuer_url = "jumpcloud"
+    sso_target_url = "https://sso.myexample.jumpcloud.com/saml2/cloudflareaccess"
+    attributes = ["email", "username", "groups"]
+    email_attribute_name = "email"
+    sign_request = true
+    idp_public_certs = [
+      "MIIDpDCCAoygAwIBAgIGAV2ka+55MA0GCSqGSIb3DQEBCwUAMIGSMQswCQYDVQQGEwJVUzETMBEG\nA1UEC…..GF/Q2/MHadws97cZg\nuTnQyuOqPuHbnN83d/2l1NSYKCbHt24o"
+    ]
+    header_attributes = [
+      {
+        attribute_name = "department"
+        header_name = "X-Department"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The MR modernizes tests from V4 to V5 syntax and increases testing coverage.

- [x] I understand that this repository is auto-generated and my pull request may not be merged
