### PR TITLE
magic_wan: support interface_address6 field for tunnels

### DIFF
--- a/internal/services/magic_wan_gre_tunnel/custom_model.go
+++ b/internal/services/magic_wan_gre_tunnel/custom_model.go
@@ -20,6 +20,7 @@ type CustomMagicWANGRETunnelModel struct {
 	InterfaceAddress      types.String                                                `tfsdk:"interface_address" json:"interface_address,required"`
 	Name                  types.String                                                `tfsdk:"name" json:"name,required"`
 	Description           types.String                                                `tfsdk:"description" json:"description,optional"`
+	InterfaceAddress6     types.String                                                `tfsdk:"interface_address6" json:"interface_address6,optional"`
 	Mtu                   types.Int64                                                 `tfsdk:"mtu" json:"mtu,computed_optional"`
 	TTL                   types.Int64                                                 `tfsdk:"ttl" json:"ttl,computed_optional"`
 	HealthCheck           customfield.NestedObject[MagicWANGRETunnelHealthCheckModel] `tfsdk:"health_check" json:"health_check,computed_optional"`

--- a/internal/services/magic_wan_gre_tunnel/custom_schema.go
+++ b/internal/services/magic_wan_gre_tunnel/custom_schema.go
@@ -51,6 +51,10 @@ func customResourceSchema(ctx context.Context) schema.Schema {
 				Description: "An optional description of the GRE tunnel.",
 				Optional:    true,
 			},
+			"interface_address6": schema.StringAttribute{
+				Description: "A 127 bit IPV6 prefix from within the virtual_subnet6 prefix space with the address being the first IP of the subnet and not same as the address of virtual_subnet6. Eg if virtual_subnet6 is 2606:54c1:7:0:a9fe:12d2::/127 , interface_address6 could be 2606:54c1:7:0:a9fe:12d2:1:200/127",
+				Optional:    true,
+			},
 			"mtu": schema.Int64Attribute{
 				Description: "Maximum Transmission Unit (MTU) in bytes for the GRE tunnel. The minimum value is 576.",
 				Computed:    true,

--- a/internal/services/magic_wan_ipsec_tunnel/custom_model.go
+++ b/internal/services/magic_wan_ipsec_tunnel/custom_model.go
@@ -20,6 +20,7 @@ type CustomMagicWANIPSECTunnelModel struct {
 	Name               types.String                                                  `tfsdk:"name" json:"name,required"`
 	CustomerEndpoint   types.String                                                  `tfsdk:"customer_endpoint" json:"customer_endpoint,optional"`
 	Description        types.String                                                  `tfsdk:"description" json:"description,optional"`
+	InterfaceAddress6  types.String                                                  `tfsdk:"interface_address6" json:"interface_address6,optional"`
 	PSK                types.String                                                  `tfsdk:"psk" json:"psk,optional,no_refresh"`
 	ReplayProtection   types.Bool                                                    `tfsdk:"replay_protection" json:"replay_protection,computed_optional"`
 	HealthCheck        customfield.NestedObject[MagicWANIPSECTunnelHealthCheckModel] `tfsdk:"health_check" json:"health_check,computed_optional"`

--- a/internal/services/magic_wan_ipsec_tunnel/custom_schema.go
+++ b/internal/services/magic_wan_ipsec_tunnel/custom_schema.go
@@ -48,6 +48,10 @@ func customResourceSchema(ctx context.Context) schema.Schema {
 				Description: "An optional description forthe IPsec tunnel.",
 				Optional:    true,
 			},
+			"interface_address6": schema.StringAttribute{
+				Description: "A 127 bit IPV6 prefix from within the virtual_subnet6 prefix space with the address being the first IP of the subnet and not same as the address of virtual_subnet6. Eg if virtual_subnet6 is 2606:54c1:7:0:a9fe:12d2::/127 , interface_address6 could be 2606:54c1:7:0:a9fe:12d2:1:200/127",
+				Optional:    true,
+			},
 			"psk": schema.StringAttribute{
 				Description: "A randomly generated or provided string for use in the IPsec tunnel.",
 				Optional:    true,


### PR DESCRIPTION
`magic_wan_gre_tunnel.interface_address6` and  `magic_wan_ipsec_tunnel.interface_address6` have been supported by backend service but weren't defined in API spec until a recent fix [here](https://github.com/cloudflare/cloudflare-go/commit/333b3645d7e0185484dee9d71a8f5951a43c95da)

this PR modified the corresponding custom models and schemas so that tf provider supports these two fields.

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
