### PR TITLE
Reduce drift for `cloudflare_resource` rule logging attribute

### DIFF
--- a/internal/services/ruleset/model.go
+++ b/internal/services/ruleset/model.go
@@ -35,12 +35,11 @@ type RulesetRulesModel struct {
 	ID                     types.String                                                      `tfsdk:"id" json:"id,computed"`
 	Action                 types.String                                                      `tfsdk:"action" json:"action,optional"`
 	ActionParameters       customfield.NestedObject[RulesetRulesActionParametersModel]       `tfsdk:"action_parameters" json:"action_parameters,optional"`
-	Categories             customfield.List[types.String]                                    `tfsdk:"categories" json:"categories,optional"`
 	Description            types.String                                                      `tfsdk:"description" json:"description,optional"`
 	Enabled                types.Bool                                                        `tfsdk:"enabled" json:"enabled,computed_optional"`
 	ExposedCredentialCheck customfield.NestedObject[RulesetRulesExposedCredentialCheckModel] `tfsdk:"exposed_credential_check" json:"exposed_credential_check,optional"`
 	Expression             types.String                                                      `tfsdk:"expression" json:"expression,optional"`
-	Logging                customfield.NestedObject[RulesetRulesLoggingModel]                `tfsdk:"logging" json:"logging,optional"`
+	Logging                customfield.NestedObject[RulesetRulesLoggingModel]                `tfsdk:"logging" json:"logging,computed_optional"`
 	Ratelimit              customfield.NestedObject[RulesetRulesRatelimitModel]              `tfsdk:"ratelimit" json:"ratelimit,optional"`
 	Ref                    types.String                                                      `tfsdk:"ref" json:"ref,computed_optional"`
 }
@@ -303,7 +302,7 @@ type RulesetRulesExposedCredentialCheckModel struct {
 }
 
 type RulesetRulesLoggingModel struct {
-	Enabled types.Bool `tfsdk:"enabled" json:"enabled,required"`
+	Enabled types.Bool `tfsdk:"enabled" json:"enabled,computed_optional"`
 }
 
 type RulesetRulesRatelimitModel struct {

--- a/internal/services/ruleset/schema.go
+++ b/internal/services/ruleset/schema.go
@@ -52,10 +52,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"zone",
 					),
 				},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{
-				Description: "The human-readable name of the ruleset.",
-				Required:    true,
+				Description:   "The human-readable name of the ruleset.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"phase": schema.StringAttribute{
 				Description: "The phase of the ruleset.\nAvailable values: \"ddos_l4\", \"ddos_l7\", \"http_config_settings\", \"http_custom_errors\", \"http_log_custom_fields\", \"http_ratelimit\", \"http_request_cache_settings\", \"http_request_dynamic_redirect\", \"http_request_firewall_custom\", \"http_request_firewall_managed\", \"http_request_late_transform\", \"http_request_origin\", \"http_request_redirect\", \"http_request_sanitize\", \"http_request_sbfm\", \"http_request_transform\", \"http_response_compression\", \"http_response_firewall_managed\", \"http_response_headers_transform\", \"magic_transit\", \"magic_transit_ids_managed\", \"magic_transit_managed\", \"magic_transit_ratelimit\".",
@@ -87,6 +89,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"magic_transit_ratelimit",
 					),
 				},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"description": schema.StringAttribute{
 				Description: "An informative description of the ruleset.",
@@ -1015,12 +1018,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								},
 							},
 						},
-						"categories": schema.ListAttribute{
-							Description: "The categories of the rule.",
-							Optional:    true,
-							CustomType:  customfield.NewListType[types.String](ctx),
-							ElementType: types.StringType,
-						},
 						"description": schema.StringAttribute{
 							Description: "An informative description of the rule.",
 							Optional:    true,
@@ -1052,12 +1049,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"logging": schema.SingleNestedAttribute{
 							Description: "An object configuring the rule's logging behavior.",
+							Computed:    true,
 							Optional:    true,
 							CustomType:  customfield.NewNestedObjectType[RulesetRulesLoggingModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"enabled": schema.BoolAttribute{
 									Description: "Whether to generate a log when the rule matches.",
-									Required:    true,
+									Computed:    true,
+									Optional:    true,
 								},
 							},
 						},
@@ -1107,8 +1106,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"ref": schema.StringAttribute{
 							Description: "The reference of the rule (the rule ID by default).",
-							Optional:    true,
 							Computed:    true,
+							Optional:    true,
 						},
 					},
 				},

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/disabled.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/disabled.tf
@@ -1,0 +1,20 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+  rules = [
+    {
+      expression = "ip.src eq 1.1.1.1"
+      action     = "skip"
+      action_parameters = {
+        ruleset = "current"
+      }
+      logging = {
+        enabled = false
+      }
+    }
+  ]
+}

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/enabled.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/enabled.tf
@@ -1,0 +1,20 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+  rules = [
+    {
+      expression = "ip.src eq 1.1.1.1"
+      action     = "skip"
+      action_parameters = {
+        ruleset = "current"
+      }
+      logging = {
+        enabled = true
+      }
+    }
+  ]
+}

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/modify/action/after.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/modify/action/after.tf
@@ -1,0 +1,15 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+  rules = [
+    {
+      expression = "ip.src eq 1.1.1.1"
+      action     = "block"
+      ref        = "one"
+    }
+  ]
+}

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/modify/action/before.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/modify/action/before.tf
@@ -1,0 +1,18 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+  rules = [
+    {
+      expression = "ip.src eq 1.1.1.1"
+      action     = "skip"
+      action_parameters = {
+        ruleset = "current"
+      }
+      ref = "one"
+    }
+  ]
+}

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/modify/expression/after.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/modify/expression/after.tf
@@ -1,0 +1,18 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+  rules = [
+    {
+      expression = "ip.src eq 2.2.2.2"
+      action     = "skip"
+      action_parameters = {
+        ruleset = "current"
+      }
+      ref = "one"
+    }
+  ]
+}

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/modify/expression/before.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/modify/expression/before.tf
@@ -1,0 +1,18 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+  rules = [
+    {
+      expression = "ip.src eq 1.1.1.1"
+      action     = "skip"
+      action_parameters = {
+        ruleset = "current"
+      }
+      ref = "one"
+    }
+  ]
+}

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/modify/id/after.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/modify/id/after.tf
@@ -1,0 +1,18 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+  rules = [
+    {
+      expression = "ip.src eq 1.1.1.1"
+      action     = "skip"
+      action_parameters = {
+        ruleset = "current"
+      }
+      ref = "two"
+    }
+  ]
+}

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/modify/id/before.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/modify/id/before.tf
@@ -1,0 +1,18 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+  rules = [
+    {
+      expression = "ip.src eq 1.1.1.1"
+      action     = "skip"
+      action_parameters = {
+        ruleset = "current"
+      }
+      ref = "one"
+    }
+  ]
+}

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/omitted.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_RuleLogging/omitted.tf
@@ -1,0 +1,17 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+  rules = [
+    {
+      expression = "ip.src eq 1.1.1.1"
+      action     = "skip"
+      action_parameters = {
+        ruleset = "current"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Also mark immutable attributes on rulesets as `RequiresReplace` and
remove the read-only rule categories attribute.