### PR TITLE
Add deprecation notice and clear errors for non-functional `snippets`

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -879,6 +879,8 @@ func (p *CloudflareProvider) DataSources(ctx context.Context) []func() datasourc
 		snippet.NewSnippetDataSource,
 		snippet.NewSnippetsDataSource,
 		snippet_rules.NewSnippetRulesListDataSource,
+		snippets.NewSnippetsDataSource,     // deprecated.
+		snippets.NewSnippetsListDataSource, // deprecated.
 		calls_sfu_app.NewCallsSFUAppDataSource,
 		calls_sfu_app.NewCallsSFUAppsDataSource,
 		calls_turn_app.NewCallsTURNAppDataSource,

--- a/internal/services/snippet/list_data_source.go
+++ b/internal/services/snippet/list_data_source.go
@@ -24,7 +24,7 @@ func NewSnippetsDataSource() datasource.DataSource {
 }
 
 func (d *SnippetsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_snippets"
+	resp.TypeName = req.ProviderTypeName + "_snippet_list"
 }
 
 func (d *SnippetsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {

--- a/internal/services/snippets/data_source_schema.go
+++ b/internal/services/snippets/data_source_schema.go
@@ -14,6 +14,7 @@ var _ datasource.DataSourceWithConfigValidators = (*SnippetsDataSource)(nil)
 
 func DataSourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		DeprecationMessage: "The `snippets` data source has been deprecated. Use `snippet` instead.",
 		Attributes: map[string]schema.Attribute{
 			"snippet_name": schema.StringAttribute{
 				Description: "The identifying name of the snippet.",

--- a/internal/services/snippets/list_data_source_schema.go
+++ b/internal/services/snippets/list_data_source_schema.go
@@ -17,6 +17,7 @@ var _ datasource.DataSourceWithConfigValidators = (*SnippetsListDataSource)(nil)
 
 func ListDataSourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		DeprecationMessage: "The `snippets_list` data source has been deprecated. Use `snippet_list` instead.",
 		Attributes: map[string]schema.Attribute{
 			"zone_id": schema.StringAttribute{
 				Description: "The unique ID of the zone.",

--- a/internal/services/snippets/resource.go
+++ b/internal/services/snippets/resource.go
@@ -5,14 +5,8 @@ package snippets
 import (
 	"context"
 	"fmt"
-	"io"
-	"net/http"
 
 	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/option"
-	"github.com/cloudflare/cloudflare-go/v5/snippets"
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
@@ -52,159 +46,22 @@ func (r *SnippetsResource) Configure(ctx context.Context, req resource.Configure
 	r.client = client
 }
 
+var ErrNonfunctionalResource = fmt.Errorf("use 'cloudflare_snippet' instead of 'cloudflare_snippets'")
+
 func (r *SnippetsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data *SnippetsModel
-
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	dataBytes, contentType, err := data.MarshalMultipart()
-	if err != nil {
-		resp.Diagnostics.AddError("failed to serialize multipart http request", err.Error())
-		return
-	}
-	res := new(http.Response)
-	env := SnippetsResultEnvelope{*data}
-	_, err = r.client.Snippets.Update(
-		ctx,
-		data.SnippetName.ValueString(),
-		snippets.SnippetUpdateParams{
-			ZoneID: cloudflare.F(data.ZoneID.ValueString()),
-		},
-		option.WithRequestBody(contentType, dataBytes),
-		option.WithResponseBodyInto(&res),
-		option.WithMiddleware(logging.Middleware(ctx)),
-	)
-	if err != nil {
-		resp.Diagnostics.AddError("failed to make http request", err.Error())
-		return
-	}
-	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.UnmarshalComputed(bytes, &env)
-	if err != nil {
-		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
-		return
-	}
-	data = &env.Result
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.AddError("resource is non-functional", ErrNonfunctionalResource.Error())
 }
 
 func (r *SnippetsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data *SnippetsModel
-
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	var state *SnippetsModel
-
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	dataBytes, contentType, err := data.MarshalMultipart()
-	if err != nil {
-		resp.Diagnostics.AddError("failed to serialize multipart http request", err.Error())
-		return
-	}
-	res := new(http.Response)
-	env := SnippetsResultEnvelope{*data}
-	_, err = r.client.Snippets.Update(
-		ctx,
-		data.SnippetName.ValueString(),
-		snippets.SnippetUpdateParams{
-			ZoneID: cloudflare.F(data.ZoneID.ValueString()),
-		},
-		option.WithRequestBody(contentType, dataBytes),
-		option.WithResponseBodyInto(&res),
-		option.WithMiddleware(logging.Middleware(ctx)),
-	)
-	if err != nil {
-		resp.Diagnostics.AddError("failed to make http request", err.Error())
-		return
-	}
-	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.UnmarshalComputed(bytes, &env)
-	if err != nil {
-		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
-		return
-	}
-	data = &env.Result
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.AddError("resource is non-functional", ErrNonfunctionalResource.Error())
 }
 
 func (r *SnippetsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data *SnippetsModel
-
-	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	res := new(http.Response)
-	env := SnippetsResultEnvelope{*data}
-	_, err := r.client.Snippets.Get(
-		ctx,
-		data.SnippetName.ValueString(),
-		snippets.SnippetGetParams{
-			ZoneID: cloudflare.F(data.ZoneID.ValueString()),
-		},
-		option.WithResponseBodyInto(&res),
-		option.WithMiddleware(logging.Middleware(ctx)),
-	)
-	if res != nil && res.StatusCode == 404 {
-		resp.Diagnostics.AddWarning("Resource not found", "The resource was not found on the server and will be removed from state.")
-		resp.State.RemoveResource(ctx)
-		return
-	}
-	if err != nil {
-		resp.Diagnostics.AddError("failed to make http request", err.Error())
-		return
-	}
-	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
-	if err != nil {
-		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
-		return
-	}
-	data = &env.Result
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.AddError("resource is non-functional", ErrNonfunctionalResource.Error())
 }
 
 func (r *SnippetsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data *SnippetsModel
-
-	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	_, err := r.client.Snippets.Delete(
-		ctx,
-		data.SnippetName.ValueString(),
-		snippets.SnippetDeleteParams{
-			ZoneID: cloudflare.F(data.ZoneID.ValueString()),
-		},
-		option.WithMiddleware(logging.Middleware(ctx)),
-	)
-	if err != nil {
-		resp.Diagnostics.AddError("failed to make http request", err.Error())
-		return
-	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.AddError("resource is non-functional", ErrNonfunctionalResource.Error())
 }
 
 func (r *SnippetsResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, _ *resource.ModifyPlanResponse) {

--- a/internal/services/snippets/schema.go
+++ b/internal/services/snippets/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*SnippetsResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		DeprecationMessage: "The `snippets` resource has been deprecated. Use `snippet` instead.",
 		Attributes: map[string]schema.Attribute{
 			"snippet_name": schema.StringAttribute{
 				Description:   "The identifying name of the snippet.",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Context

The current `cloudflare_snippets` resource does not currently function. Additionally, the name is confusing because the resource only manages a single snippet. The data sources do function in their current state.

This PR adds explicit deprecation notices to the resource and data sources that point users to use the newer (and functional) `cloudflare_snippet`. 

The hard errors in the resource prevent the user from seeing generic HTTP 400 errors when trying to use the resource. These errors have only been added to the **resource**, since the data sources technically work as-is.

## Changes
- Adds deprecations to `resource.cloudflare_snippets`, `data.cloudflare_snippets_list`, and `data.cloudflare_snippets`.
- Adds hard errors to `resource.cloudflare_snippets` to intercept Terraform operations and give more clear guidance. These operations currently fail in the API layer instead, yielding HTTP 400 errors.

## Example Output
Refreshing new and old data sources in a single config:
```
╰─❯ terraform refresh
data.cloudflare_snippets_list.sniplist: Reading...
data.cloudflare_snippet.example_snippets: Reading...
data.cloudflare_snippets.example_snippets: Reading...
data.cloudflare_snippet_list.sniplist: Reading...
data.cloudflare_snippets.example_snippets: Read complete after 0s
data.cloudflare_snippet.example_snippets: Read complete after 0s
data.cloudflare_snippets_list.sniplist: Read complete after 0s
data.cloudflare_snippet_list.sniplist: Read complete after 0s
╷
│ Warning: Empty or non-existent state
│
│ There are currently no remote objects tracked in the state, so there is nothing to refresh.
╵
╷
│ Warning: Deprecated
│
│   with cloudflare_snippets.my_snippets,
│   on base.tf line 10, in resource "cloudflare_snippets" "my_snippets":
│   10: resource "cloudflare_snippets" "my_snippets" {
│
│ The `snippets` resource has been deprecated. Use `snippet` instead.
│
│ (and 5 more similar warnings elsewhere)
```

Trying to apply the old resource:
```
│ Error: resource is non-functional
│
│   with cloudflare_snippets.my_snippets,
│   on base.tf line 10, in resource "cloudflare_snippets" "my_snippets":
│   10: resource "cloudflare_snippets" "my_snippets" {
│
│ use 'cloudflare_snippet' instead of 'cloudflare_snippets'
```