### PR TITLE
Fix list items polling during async creation and add acceptance tests 

### DIFF
--- a/internal/services/list_item/model.go
+++ b/internal/services/list_item/model.go
@@ -15,7 +15,7 @@ type ListItemResultEnvelope struct {
 type ListItemModel struct {
 	ListID      types.String                                    `tfsdk:"list_id" path:"list_id,required"`
 	AccountID   types.String                                    `tfsdk:"account_id" path:"account_id,required"`
-	ID          types.String                                    `tfsdk:"id" path:"item_id,computed"`
+	ID          types.String                                    `tfsdk:"id" json:"id,computed" path:"item_id,computed"`
 	ASN         types.Int64                                     `tfsdk:"asn" json:"asn,optional"`
 	Comment     types.String                                    `tfsdk:"comment" json:"comment,optional"`
 	IP          types.String                                    `tfsdk:"ip" json:"ip,optional"`

--- a/internal/services/list_item/schema.go
+++ b/internal/services/list_item/schema.go
@@ -10,7 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -34,15 +36,17 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"id": schema.StringAttribute{
 				Description:   "The unique ID of the item in the List.",
 				Computed:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"asn": schema.Int64Attribute{
-				Description: "A non-negative 32 bit integer",
-				Optional:    true,
+				Description:   "A non-negative 32 bit integer",
+				Optional:      true,
+				PlanModifiers: []planmodifier.Int64{int64planmodifier.RequiresReplace()},
 			},
 			"comment": schema.StringAttribute{
-				Description: "An informative summary of the list item.",
-				Optional:    true,
+				Description:   "An informative summary of the list item.",
+				Optional:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIfConfigured()},
 			},
 			"created_on": schema.StringAttribute{
 				Description: "The RFC 3339 timestamp of when the item was created.",
@@ -62,17 +66,20 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				CustomType:  customfield.NewNestedObjectType[ListItemHostnameModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"url_hostname": schema.StringAttribute{
-						Required: true,
+						Required:      true,
+						PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 					},
 					"exclude_exact_hostname": schema.BoolAttribute{
-						Description: "Only applies to wildcard hostnames (e.g., *.example.com). When true (default), only subdomains are blocked. When false, both the root domain and subdomains are blocked.",
-						Optional:    true,
+						Description:   "Only applies to wildcard hostnames (e.g., *.example.com). When true (default), only subdomains are blocked. When false, both the root domain and subdomains are blocked.",
+						Optional:      true,
+						PlanModifiers: []planmodifier.Bool{boolplanmodifier.RequiresReplaceIfConfigured()},
 					},
 				},
 			},
 			"ip": schema.StringAttribute{
-				Description: "An IPv4 address, an IPv4 CIDR, an IPv6 address, or an IPv6 CIDR.",
-				Optional:    true,
+				Description:   "An IPv4 address, an IPv4 CIDR, an IPv6 address, or an IPv6 CIDR.",
+				Optional:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"redirect": schema.SingleNestedAttribute{
 				Description: "The definition of the redirect.",
@@ -80,25 +87,30 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				CustomType:  customfield.NewNestedObjectType[ListItemRedirectModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"source_url": schema.StringAttribute{
-						Required: true,
+						Required:      true,
+						PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 					},
 					"target_url": schema.StringAttribute{
-						Required: true,
+						Required:      true,
+						PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 					},
 					"include_subdomains": schema.BoolAttribute{
-						Computed: true,
-						Optional: true,
-						Default:  booldefault.StaticBool(false),
+						Computed:      true,
+						Optional:      true,
+						Default:       booldefault.StaticBool(false),
+						PlanModifiers: []planmodifier.Bool{boolplanmodifier.RequiresReplaceIfConfigured()},
 					},
 					"preserve_path_suffix": schema.BoolAttribute{
-						Computed: true,
-						Optional: true,
-						Default:  booldefault.StaticBool(false),
+						Computed:      true,
+						Optional:      true,
+						Default:       booldefault.StaticBool(false),
+						PlanModifiers: []planmodifier.Bool{boolplanmodifier.RequiresReplaceIfConfigured()},
 					},
 					"preserve_query_string": schema.BoolAttribute{
-						Computed: true,
-						Optional: true,
-						Default:  booldefault.StaticBool(false),
+						Computed:      true,
+						Optional:      true,
+						Default:       booldefault.StaticBool(false),
+						PlanModifiers: []planmodifier.Bool{boolplanmodifier.RequiresReplaceIfConfigured()},
 					},
 					"status_code": schema.Int64Attribute{
 						Description: "Available values: 301, 302, 307, 308.",
@@ -112,12 +124,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								308,
 							),
 						},
-						Default: int64default.StaticInt64(301),
+						Default:       int64default.StaticInt64(301),
+						PlanModifiers: []planmodifier.Int64{int64planmodifier.RequiresReplaceIfConfigured()},
 					},
 					"subpath_matching": schema.BoolAttribute{
-						Computed: true,
-						Optional: true,
-						Default:  booldefault.StaticBool(false),
+						Computed:      true,
+						Optional:      true,
+						Default:       booldefault.StaticBool(false),
+						PlanModifiers: []planmodifier.Bool{boolplanmodifier.RequiresReplaceIfConfigured()},
 					},
 				},
 			},

--- a/internal/services/list_item/testdata/hostnamelistitemmultipleentries.tf
+++ b/internal/services/list_item/testdata/hostnamelistitemmultipleentries.tf
@@ -1,0 +1,25 @@
+
+  resource "cloudflare_list" "%[2]s" {
+    account_id          = "%[4]s"
+    name                = "%[2]s"
+    description         = "list named %[2]s"
+    kind                = "hostname"
+  }
+
+  resource "cloudflare_list_item" "%[1]s_1" {
+    account_id = "%[4]s"
+  	list_id    = cloudflare_list.%[2]s.id
+  	hostname         = {
+      url_hostname = "a.example.com"
+    }
+  	comment    = "%[3]s"
+  }
+
+  resource "cloudflare_list_item" "%[1]s_2" {
+    account_id = "%[4]s"
+  	list_id    = cloudflare_list.%[2]s.id
+  	hostname         = {
+      url_hostname = "example.com"
+    }
+  	comment    = "%[3]s"
+  }

--- a/internal/services/list_item/testdata/iplistitem_newip.tf
+++ b/internal/services/list_item/testdata/iplistitem_newip.tf
@@ -1,0 +1,14 @@
+
+  resource "cloudflare_list" "%[2]s" {
+    account_id          = "%[4]s"
+    name                = "%[2]s"
+    description         = "list named %[2]s"
+    kind                = "ip"
+  }
+
+  resource "cloudflare_list_item" "%[1]s" {
+    account_id = "%[4]s"
+  	list_id    = cloudflare_list.%[2]s.id
+  	ip         = "%[5]s"
+  	comment    = "%[3]s"
+  }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Implements polling the asynchronous operation that results from creating the list item. This also specifies that the list items cannot be updated, requiring recreation on changes. 

This implementation is limited in functionality for large lists, those with lots of items, due to the pagination implementation being broken at the moment. This should cover most uses for now until that is fixed.

## Additional context & links

https://developers.cloudflare.com/api/resources/rules/subresources/lists/subresources/items/methods/create/

Supersedes https://github.com/cloudflare/terraform-provider-cloudflare/pull/5854
