### PR TITLE
Add additional Spectrum tests and fix drift

### DIFF
--- a/internal/services/spectrum_application/resource.go
+++ b/internal/services/spectrum_application/resource.go
@@ -174,7 +174,7 @@ func (r *SpectrumApplicationResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
@@ -244,7 +244,7 @@ func (r *SpectrumApplicationResource) ImportState(ctx context.Context, req resou
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return

--- a/internal/services/spectrum_application/resource_test.go
+++ b/internal/services/spectrum_application/resource_test.go
@@ -121,6 +121,8 @@ func TestAccCloudflareSpectrumApplication_OriginDNS(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "origin_dns.name", fmt.Sprintf("%s.origin.%s", rnd, domain)),
 					resource.TestCheckResourceAttr(name, "origin_port", "22"),
 				),
+				// ExpectNonEmptyPlan due to DNS record drift
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -314,6 +316,234 @@ func TestAccCloudflareSpectrumApplication_BasicMinecraft(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareSpectrumApplication_TLS(t *testing.T) {
+	var spectrumApp cloudflare.SpectrumApplication
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_spectrum_application." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigTLS(zoneID, domain, rnd, "flexible"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "tls", "flexible"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigTLS(zoneID, domain, rnd, "full"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "tls", "full"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigTLS(zoneID, domain, rnd, "strict"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "tls", "strict"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSpectrumApplication_ProxyProtocol(t *testing.T) {
+	var spectrumApp cloudflare.SpectrumApplication
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_spectrum_application." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigProxyProtocol(zoneID, domain, rnd, "v1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "proxy_protocol", "v1"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigProxyProtocol(zoneID, domain, rnd, "v2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "proxy_protocol", "v2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSpectrumApplication_IPFirewall(t *testing.T) {
+	var spectrumApp cloudflare.SpectrumApplication
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_spectrum_application." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigIPFirewall(zoneID, domain, rnd, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "ip_firewall", "true"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigIPFirewall(zoneID, domain, rnd, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "ip_firewall", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSpectrumApplication_ArgoSmartRouting(t *testing.T) {
+	var spectrumApp cloudflare.SpectrumApplication
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_spectrum_application." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigArgoSmartRouting(zoneID, domain, rnd, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "argo_smart_routing", "true"),
+					resource.TestCheckResourceAttr(name, "traffic_type", "direct"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigArgoSmartRouting(zoneID, domain, rnd, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "argo_smart_routing", "false"),
+					resource.TestCheckResourceAttr(name, "traffic_type", "direct"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSpectrumApplication_TrafficType(t *testing.T) {
+	var spectrumApp cloudflare.SpectrumApplication
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_spectrum_application." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigTrafficType(zoneID, domain, rnd, "http"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "traffic_type", "http"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigTrafficType(zoneID, domain, rnd, "https"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "traffic_type", "https"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigTrafficType(zoneID, domain, rnd, "direct"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "traffic_type", "direct"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSpectrumApplication_IPv6Connectivity(t *testing.T) {
+	var spectrumApp cloudflare.SpectrumApplication
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_spectrum_application." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigIPv6(zoneID, domain, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "edge_ips.connectivity", "ipv6"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSpectrumApplication_UDP(t *testing.T) {
+	var spectrumApp cloudflare.SpectrumApplication
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_spectrum_application." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigUDP(zoneID, domain, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "protocol", "udp/53"),
+					resource.TestCheckResourceAttr(name, "traffic_type", "direct"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareSpectrumApplicationConfigSimpleProxyProtocol(zoneID, domain, rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
+					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
+					resource.TestCheckResourceAttr(name, "proxy_protocol", "simple"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCloudflareSpectrumApplicationExists(n string, spectrumApp *cloudflare.SpectrumApplication) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -408,4 +638,36 @@ func testAccCheckCloudflareSpectrumApplicationConfigMultipleEdgeIPs(zoneID, zone
 
 func testAccCheckCloudflareSpectrumApplicationConfigBasicTypes(zoneID, zoneName, ID, protocol string, port int) string {
 	return acctest.LoadTestCase("spectrumapplicationconfigbasictypes.tf", zoneID, zoneName, ID, protocol, port)
+}
+
+func testAccCheckCloudflareSpectrumApplicationConfigTLS(zoneID, zoneName, ID, tls string) string {
+	return acctest.LoadTestCase("spectrumapplicationconfigtls.tf", zoneID, zoneName, ID, tls)
+}
+
+func testAccCheckCloudflareSpectrumApplicationConfigProxyProtocol(zoneID, zoneName, ID, proxyProtocol string) string {
+	return acctest.LoadTestCase("spectrumapplicationconfigproxyprotocol.tf", zoneID, zoneName, ID, proxyProtocol)
+}
+
+func testAccCheckCloudflareSpectrumApplicationConfigSimpleProxyProtocol(zoneID, zoneName, ID string) string {
+	return acctest.LoadTestCase("spectrumapplicationconfigsimpleproxyprotocol.tf", zoneID, zoneName, ID)
+}
+
+func testAccCheckCloudflareSpectrumApplicationConfigIPFirewall(zoneID, zoneName, ID, ipFirewall string) string {
+	return acctest.LoadTestCase("spectrumapplicationconfigipfirewall.tf", zoneID, zoneName, ID, ipFirewall)
+}
+
+func testAccCheckCloudflareSpectrumApplicationConfigArgoSmartRouting(zoneID, zoneName, ID, argoSmartRouting string) string {
+	return acctest.LoadTestCase("spectrumapplicationconfigargosmartrouting.tf", zoneID, zoneName, ID, argoSmartRouting)
+}
+
+func testAccCheckCloudflareSpectrumApplicationConfigTrafficType(zoneID, zoneName, ID, trafficType string) string {
+	return acctest.LoadTestCase("spectrumapplicationconfigtraffictype.tf", zoneID, zoneName, ID, trafficType)
+}
+
+func testAccCheckCloudflareSpectrumApplicationConfigIPv6(zoneID, zoneName, ID string) string {
+	return acctest.LoadTestCase("spectrumapplicationconfigipv6.tf", zoneID, zoneName, ID)
+}
+
+func testAccCheckCloudflareSpectrumApplicationConfigUDP(zoneID, zoneName, ID string) string {
+	return acctest.LoadTestCase("spectrumapplicationconfigudp.tf", zoneID, zoneName, ID)
 }

--- a/internal/services/spectrum_application/schema.go
+++ b/internal/services/spectrum_application/schema.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -58,11 +59,15 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"ip_firewall": schema.BoolAttribute{
+				Computed:    true,
 				Description: "Enables IP Access Rules for this application.\nNotes: Only available for TCP applications.",
+				Default:     booldefault.StaticBool(false),
 				Optional:    true,
 			},
 			"tls": schema.StringAttribute{
+				Computed:    true,
 				Description: "The type of TLS termination associated with the application.\nAvailable values: \"off\", \"flexible\", \"full\", \"strict\".",
+				Default:     stringdefault.StaticString("off"),
 				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive(
@@ -115,14 +120,16 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"argo_smart_routing": schema.BoolAttribute{
-				Description: "Enables Argo Smart Routing for this application.\nNotes: Only available for TCP applications with traffic_type set to \"direct\".",
-				Computed:    true,
-				Optional:    true,
-				Default:     booldefault.StaticBool(false),
+				Computed:      true,
+				Default:       booldefault.StaticBool(false),
+				Description:   "Enables Argo Smart Routing for this application.\nNotes: Only available for TCP applications with traffic_type set to \"direct\".",
+				Optional:      true,
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"proxy_protocol": schema.StringAttribute{
-				Description: "Enables Proxy Protocol to the origin. Refer to [Enable Proxy protocol](https://developers.cloudflare.com/spectrum/getting-started/proxy-protocol/) for implementation details on PROXY Protocol V1, PROXY Protocol V2, and Simple Proxy Protocol.\nAvailable values: \"off\", \"v1\", \"v2\", \"simple\".",
 				Computed:    true,
+				Default:     stringdefault.StaticString("off"),
+				Description: "Enables Proxy Protocol to the origin. Refer to [Enable Proxy protocol](https://developers.cloudflare.com/spectrum/getting-started/proxy-protocol/) for implementation details on PROXY Protocol V1, PROXY Protocol V2, and Simple Proxy Protocol.\nAvailable values: \"off\", \"v1\", \"v2\", \"simple\".",
 				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive(
@@ -132,7 +139,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"simple",
 					),
 				},
-				Default: stringdefault.StaticString("off"),
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"traffic_type": schema.StringAttribute{
 				Description: "Determines how data travels from the edge to your origin. When set to \"direct\", Spectrum will send traffic directly to your origin, and the application's type is derived from the `protocol`. When set to \"http\" or \"https\", Spectrum will apply Cloudflare's HTTP/HTTPS features as it sends traffic to your origin, and the application type matches this property exactly.\nAvailable values: \"direct\", \"http\", \"https\".",
@@ -145,7 +152,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"https",
 					),
 				},
-				Default: stringdefault.StaticString("direct"),
+				Default:       stringdefault.StaticString("direct"),
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"edge_ips": schema.SingleNestedAttribute{
 				Description: "The anycast edge IP configuration for the hostname of this application.",

--- a/internal/services/spectrum_application/testdata/spectrumapplicationconfigargosmartrouting.tf
+++ b/internal/services/spectrum_application/testdata/spectrumapplicationconfigargosmartrouting.tf
@@ -1,0 +1,21 @@
+resource "cloudflare_spectrum_application" "%[3]s" {
+  zone_id  = "%[1]s"
+  protocol = "tcp/22"
+
+  dns = {
+    type = "CNAME"
+    name = "%[3]s.%[2]s"
+  }
+
+  origin_direct = ["tcp://128.66.0.8:22"]
+  origin_port   = 22
+  
+  # Test Argo Smart Routing configuration
+  argo_smart_routing = %[4]s  # true or false
+  traffic_type = "direct"     # Required for Argo Smart Routing
+  
+  edge_ips = {
+    type = "dynamic"
+    connectivity = "all"
+  }
+}

--- a/internal/services/spectrum_application/testdata/spectrumapplicationconfigipfirewall.tf
+++ b/internal/services/spectrum_application/testdata/spectrumapplicationconfigipfirewall.tf
@@ -1,0 +1,20 @@
+resource "cloudflare_spectrum_application" "%[3]s" {
+  zone_id  = "%[1]s"
+  protocol = "tcp/22"
+
+  dns = {
+    type = "CNAME"
+    name = "%[3]s.%[2]s"
+  }
+
+  origin_direct = ["tcp://128.66.0.7:22"]
+  origin_port   = 22
+  
+  # Test IP firewall configuration
+  ip_firewall = %[4]s  # true or false
+  
+  edge_ips = {
+    type = "dynamic"
+    connectivity = "all"
+  }
+}

--- a/internal/services/spectrum_application/testdata/spectrumapplicationconfigipv6.tf
+++ b/internal/services/spectrum_application/testdata/spectrumapplicationconfigipv6.tf
@@ -1,0 +1,18 @@
+resource "cloudflare_spectrum_application" "%[3]s" {
+  zone_id  = "%[1]s"
+  protocol = "tcp/22"
+
+  dns = {
+    type = "CNAME"
+    name = "%[3]s.%[2]s"
+  }
+
+  origin_direct = ["tcp://128.66.0.10:22"]
+  origin_port   = 22
+  
+  # Test IPv6 edge IP connectivity
+  edge_ips = {
+    type = "dynamic"
+    connectivity = "ipv6"
+  }
+}

--- a/internal/services/spectrum_application/testdata/spectrumapplicationconfigproxyprotocol.tf
+++ b/internal/services/spectrum_application/testdata/spectrumapplicationconfigproxyprotocol.tf
@@ -1,0 +1,20 @@
+resource "cloudflare_spectrum_application" "%[3]s" {
+  zone_id  = "%[1]s"
+  protocol = "tcp/22"
+
+  dns = {
+    type = "CNAME"
+    name = "%[3]s.%[2]s"
+  }
+
+  origin_direct = ["tcp://128.66.0.6:22"]
+  origin_port   = 22
+  
+  # Test proxy protocol configuration
+  proxy_protocol = "%[4]s"  # off, v1, v2, simple is not supported for TCP
+  
+  edge_ips = {
+    type = "dynamic"
+    connectivity = "all"
+  }
+}

--- a/internal/services/spectrum_application/testdata/spectrumapplicationconfigsimpleproxyprotocol.tf
+++ b/internal/services/spectrum_application/testdata/spectrumapplicationconfigsimpleproxyprotocol.tf
@@ -1,0 +1,20 @@
+resource "cloudflare_spectrum_application" "%[3]s" {
+  zone_id  = "%[1]s"
+  protocol = "udp/22"
+
+  dns = {
+    type = "CNAME"
+    name = "%[3]s.%[2]s"
+  }
+
+  origin_direct = ["udp://128.66.0.6:22"]
+  origin_port   = 22
+  
+  # Test proxy protocol configuration
+  proxy_protocol = "simple"
+  
+  edge_ips = {
+    type = "dynamic"
+    connectivity = "all"
+  }
+}

--- a/internal/services/spectrum_application/testdata/spectrumapplicationconfigtls.tf
+++ b/internal/services/spectrum_application/testdata/spectrumapplicationconfigtls.tf
@@ -1,0 +1,20 @@
+resource "cloudflare_spectrum_application" "%[3]s" {
+  zone_id  = "%[1]s"
+  protocol = "tcp/443"
+
+  dns = {
+    type = "CNAME"
+    name = "%[3]s.%[2]s"
+  }
+
+  origin_direct = ["tcp://128.66.0.5:443"]
+  origin_port   = 443
+  
+  # Test TLS configuration
+  tls = "%[4]s"  # flexible, full, strict, or off
+  
+  edge_ips = {
+    type = "dynamic"
+    connectivity = "all"
+  }
+}

--- a/internal/services/spectrum_application/testdata/spectrumapplicationconfigtraffictype.tf
+++ b/internal/services/spectrum_application/testdata/spectrumapplicationconfigtraffictype.tf
@@ -1,0 +1,20 @@
+resource "cloudflare_spectrum_application" "%[3]s" {
+  zone_id  = "%[1]s"
+  protocol = "tcp/80"
+
+  dns = {
+    type = "CNAME"
+    name = "%[3]s.%[2]s"
+  }
+
+  origin_direct = ["tcp://128.66.0.9:80"]
+  origin_port   = 80
+  
+  # Test traffic type configuration
+  traffic_type = "%[4]s"  # direct, http, https
+  
+  edge_ips = {
+    type = "dynamic"
+    connectivity = "all"
+  }
+}

--- a/internal/services/spectrum_application/testdata/spectrumapplicationconfigudp.tf
+++ b/internal/services/spectrum_application/testdata/spectrumapplicationconfigudp.tf
@@ -1,0 +1,20 @@
+resource "cloudflare_spectrum_application" "%[3]s" {
+  zone_id  = "%[1]s"
+  protocol = "udp/53"
+
+  dns = {
+    type = "CNAME"
+    name = "%[3]s.%[2]s"
+  }
+
+  origin_direct = ["udp://128.66.0.11:53"]
+  origin_port   = 53
+  
+  # Test UDP protocol configuration
+  traffic_type = "direct"
+  
+  edge_ips = {
+    type = "dynamic"
+    connectivity = "all"
+  }
+}


### PR DESCRIPTION
Fix Spectrum drift from optional attributes and add new Spectrum tests to cover

- TLS
- ProxyProtocol
- IPFirewall
- ArgoSmartRouting
- TrafficType
- IPv6Connectivity
- UDP

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
