### PR TITLE
Updates to `cloudflare_workers_script`

### DIFF
--- a/internal/services/workers_script/custom.go
+++ b/internal/services/workers_script/custom.go
@@ -184,9 +184,9 @@ func ValidateContentSHA256() validator.String {
 
 func UpdateSecretTextsFromState[T any](
 	ctx context.Context,
-	refreshed customfield.NestedObjectSet[T],
-	state customfield.NestedObjectSet[T],
-) (customfield.NestedObjectSet[T], diag.Diagnostics) {
+	refreshed customfield.NestedObjectList[T],
+	state customfield.NestedObjectList[T],
+) (customfield.NestedObjectList[T], diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	refreshedElems := refreshed.Elements()
@@ -252,11 +252,11 @@ func UpdateSecretTextsFromState[T any](
 		updatedElems[i] = refreshedObj
 	}
 
-	setValue, d := types.SetValue(refreshed.ElementType(ctx), updatedElems)
+	value, d := types.ListValue(refreshed.ElementType(ctx), updatedElems)
 	diags.Append(d...)
 
-	return customfield.NestedObjectSet[T]{
-		SetValue: setValue,
+	return customfield.NestedObjectList[T]{
+		ListValue: value,
 	}, diags
 }
 

--- a/internal/services/workers_script/custom.go
+++ b/internal/services/workers_script/custom.go
@@ -128,11 +128,6 @@ func (v contentSHA256Validator) ValidateString(ctx context.Context, req validato
 		hasContentFile = true
 	}
 
-	if !hasContent && !hasContentFile {
-		resp.Diagnostics.AddError("Missing required attributes", "One of `content` or `content_file` is required")
-		return
-	}
-
 	var actualHash string
 	var err error
 

--- a/internal/services/workers_script/model.go
+++ b/internal/services/workers_script/model.go
@@ -89,18 +89,18 @@ func (r WorkersScriptModel) MarshalMultipart() (data []byte, formDataContentType
 }
 
 type WorkersScriptMetadataModel struct {
-	Assets             *WorkersScriptMetadataAssetsModel                               `tfsdk:"assets" json:"assets,optional"`
-	Bindings           customfield.NestedObjectSet[WorkersScriptMetadataBindingsModel] `tfsdk:"bindings" json:"bindings,computed_optional"`
-	BodyPart           types.String                                                    `tfsdk:"body_part" json:"body_part,optional"`
-	CompatibilityDate  types.String                                                    `tfsdk:"compatibility_date" json:"compatibility_date,computed_optional"`
-	CompatibilityFlags customfield.Set[types.String]                                   `tfsdk:"compatibility_flags" json:"compatibility_flags,computed_optional"`
-	KeepAssets         types.Bool                                                      `tfsdk:"keep_assets" json:"keep_assets,optional"`
-	KeepBindings       *[]types.String                                                 `tfsdk:"keep_bindings" json:"keep_bindings,optional"`
-	Logpush            types.Bool                                                      `tfsdk:"logpush" json:"logpush,computed_optional"`
-	MainModule         types.String                                                    `tfsdk:"main_module" json:"main_module,optional"`
-	Migrations         customfield.NestedObject[WorkersScriptMetadataMigrationsModel]  `tfsdk:"migrations" json:"migrations,optional"`
-	Observability      *WorkersScriptMetadataObservabilityModel                        `tfsdk:"observability" json:"observability,optional"`
-	Placement          customfield.NestedObject[WorkersScriptMetadataPlacementModel]   `tfsdk:"placement" json:"placement,computed_optional"`
+	Assets             *WorkersScriptMetadataAssetsModel                                `tfsdk:"assets" json:"assets,optional"`
+	Bindings           customfield.NestedObjectList[WorkersScriptMetadataBindingsModel] `tfsdk:"bindings" json:"bindings,computed_optional"`
+	BodyPart           types.String                                                     `tfsdk:"body_part" json:"body_part,optional"`
+	CompatibilityDate  types.String                                                     `tfsdk:"compatibility_date" json:"compatibility_date,computed_optional"`
+	CompatibilityFlags customfield.Set[types.String]                                    `tfsdk:"compatibility_flags" json:"compatibility_flags,computed_optional"`
+	KeepAssets         types.Bool                                                       `tfsdk:"keep_assets" json:"keep_assets,optional"`
+	KeepBindings       *[]types.String                                                  `tfsdk:"keep_bindings" json:"keep_bindings,optional"`
+	Logpush            types.Bool                                                       `tfsdk:"logpush" json:"logpush,computed_optional"`
+	MainModule         types.String                                                     `tfsdk:"main_module" json:"main_module,optional"`
+	Migrations         customfield.NestedObject[WorkersScriptMetadataMigrationsModel]   `tfsdk:"migrations" json:"migrations,optional"`
+	Observability      *WorkersScriptMetadataObservabilityModel                         `tfsdk:"observability" json:"observability,optional"`
+	Placement          customfield.NestedObject[WorkersScriptMetadataPlacementModel]    `tfsdk:"placement" json:"placement,computed_optional"`
 	// Tags               *[]types.String                                                       `tfsdk:"tags" json:"tags,optional"`
 	TailConsumers customfield.NestedObjectSet[WorkersScriptMetadataTailConsumersModel] `tfsdk:"tail_consumers" json:"tail_consumers,computed_optional"`
 	UsageModel    types.String                                                         `tfsdk:"usage_model" json:"usage_model,computed_optional"`

--- a/internal/services/workers_script/resource.go
+++ b/internal/services/workers_script/resource.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jinzhu/copier"
@@ -65,6 +66,7 @@ func (r *WorkersScriptResource) Create(ctx context.Context, req resource.CreateR
 	var data *WorkersScriptModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("migrations"), &data.Migrations)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -126,6 +128,7 @@ func (r *WorkersScriptResource) Update(ctx context.Context, req resource.UpdateR
 	var data *WorkersScriptModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("migrations"), &data.Migrations)...)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/workers_script/resource_test.go
+++ b/internal/services/workers_script/resource_test.go
@@ -150,7 +150,7 @@ func TestAccCloudflareWorkerScript_ModuleUpload(t *testing.T) {
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"bindings.2.text", "main_module", "startup_time_ms"},
+				ImportStateVerifyIgnore: []string{"bindings.2", "bindings.#", "main_module", "startup_time_ms"},
 			},
 		},
 	})

--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -650,5 +651,10 @@ func (r *WorkersScriptResource) Schema(ctx context.Context, req resource.SchemaR
 }
 
 func (r *WorkersScriptResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
-	return []resource.ConfigValidator{}
+	return []resource.ConfigValidator{
+		resourcevalidator.ExactlyOneOf(
+			path.MatchRoot("content"),
+			path.MatchRoot("content_file"),
+		),
+	}
 }

--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -145,11 +145,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 			},
-			"bindings": schema.SetNestedAttribute{
+			"bindings": schema.ListNestedAttribute{
 				Description: "List of bindings attached to a Worker. You can find more about bindings on our docs: https://developers.cloudflare.com/workers/configuration/multipart-upload-metadata/#bindings.",
 				Computed:    true,
 				Optional:    true,
-				CustomType:  customfield.NewNestedObjectSetType[WorkersScriptMetadataBindingsModel](ctx),
+				CustomType:  customfield.NewNestedObjectListType[WorkersScriptMetadataBindingsModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{

--- a/internal/services/workers_script/testdata/module.tf
+++ b/internal/services/workers_script/testdata/module.tf
@@ -29,14 +29,14 @@ resource "cloudflare_workers_script" "%[1]s" {
       namespace_id = cloudflare_workers_kv_namespace.%[1]s.id
     },
     {
-      name = "SECRET"
-      type = "secret_text"
-      text = "shhh!!"
-    },
-    {
       name = "MY_QUEUE"
       type = "queue"
       queue_name = cloudflare_queue.%[1]s.queue_name
+    },
+    {
+      name = "SECRET"
+      type = "secret_text"
+      text = "shhh!!"
     }
   ]
   observability = {

--- a/internal/services/workers_script/testdata/module_with_durable_object.tf
+++ b/internal/services/workers_script/testdata/module_with_durable_object.tf
@@ -1,0 +1,21 @@
+resource "cloudflare_workers_script" "%[1]s" {
+  account_id = "%[2]s"
+  script_name = "%[1]s"
+  content = <<-EOT
+    import {DurableObject} from "cloudflare:workers"
+    export class MyDurableObject extends DurableObject {}
+    export default { fetch() {return new Response()} }
+  EOT
+  main_module = "worker.js"
+  migrations = {
+    new_tag = "v1"
+    new_sqlite_classes = ["MyDurableObject"]
+  }
+  bindings = [
+    {
+      name = "MY_DO"
+      type = "durable_object_namespace"
+      class_name = "MyDurableObject"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
This PR includes the following updates and fixes for the `cloudflare_workers_script` resource:

> **[fix(workers_script): Revert treating cloudflare_workers_script.bindings as a Set](https://github.com/cloudflare/terraform-provider-cloudflare/commit/17c8defb79d71e316b043d6e8b23ac7e0797a554)**
>
> This was originally intended to prevent diffs due to ordering inconsistency between API and Terraform config, but resulted in a loss of fidelity in diffs as the entire `bindings` attribute was now being shown in diffs as `(sensitive)` due to a nested attribute being as such.

> **[chore(workers_script): use resourcevalidator.ExactlyOneOf() to ensure `content` or `content_file` is provided](https://github.com/cloudflare/terraform-provider-cloudflare/commit/9b445632016eb7cac8c36304a37a0b1acb97d8a4)**

> **[fix(workers_script): ignore unmanaged secret_text bindings](https://github.com/cloudflare/terraform-provider-cloudflare/commit/7c80a3d91bc7c36f0b1f5d916af1a21944abf8ff)**
>
> Fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/5892

> **[fix(workers_script): Obtain migrations directly from config instead of plan](https://github.com/cloudflare/terraform-provider-cloudflare/commit/d48f08cea6f0a843b77e47cc318df3d3f8773085)**
>
> Fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/5898
## Additional context & links
