### PR TITLE
fix(cloudflare_ruleset): handle omitted `rules` in API responses

### DIFF
--- a/internal/services/ruleset/model.go
+++ b/internal/services/ruleset/model.go
@@ -20,7 +20,7 @@ type RulesetModel struct {
 	Name        types.String                                    `tfsdk:"name" json:"name,required"`
 	Phase       types.String                                    `tfsdk:"phase" json:"phase,required"`
 	Description types.String                                    `tfsdk:"description" json:"description,computed_optional"`
-	Rules       customfield.NestedObjectList[RulesetRulesModel] `tfsdk:"rules" json:"rules,optional"`
+	Rules       customfield.NestedObjectList[RulesetRulesModel] `tfsdk:"rules" json:"rules,computed_optional,decode_null_to_zero"`
 }
 
 func (m RulesetModel) MarshalJSON() (data []byte, err error) {

--- a/internal/services/ruleset/resource_test.go
+++ b/internal/services/ruleset/resource_test.go
@@ -222,6 +222,52 @@ func TestAccCloudflareRuleset_Description(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareRuleset_Rules(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigFile:      config.TestNameFile("1.tf"),
+				ConfigVariables: configVariables,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("cloudflare_ruleset.my_ruleset", plancheck.ResourceActionCreate),
+						plancheck.ExpectKnownValue(
+							"cloudflare_ruleset.my_ruleset",
+							tfjsonpath.New("rules"),
+							knownvalue.ListExact([]knownvalue.Check{}),
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"cloudflare_ruleset.my_ruleset",
+						tfjsonpath.New("rules"),
+						knownvalue.ListExact([]knownvalue.Check{}),
+					),
+				},
+			},
+			{
+				ConfigFile:      config.TestNameFile("2.tf"),
+				ConfigVariables: configVariables,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"cloudflare_ruleset.my_ruleset",
+						tfjsonpath.New("rules"),
+						knownvalue.ListExact([]knownvalue.Check{}),
+					),
+				},
+			},
+		},
+	})
+}
+
 func TestAccCloudflareRuleset_RulesLogging(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },

--- a/internal/services/ruleset/schema.go
+++ b/internal/services/ruleset/schema.go
@@ -12,10 +12,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -107,8 +109,13 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"rules": schema.ListNestedAttribute{
 				Description: "The list of rules in the ruleset.",
+				Computed:    true,
 				Optional:    true,
-				CustomType:  customfield.NewNestedObjectListType[RulesetRulesModel](ctx),
+				Default: listdefault.StaticValue(types.ListValueMust(
+					customfield.NewNestedObjectType[RulesetRulesModel](ctx),
+					[]attr.Value{},
+				)),
+				CustomType: customfield.NewNestedObjectListType[RulesetRulesModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_Rules/1.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_Rules/1.tf
@@ -1,0 +1,8 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+}

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_Rules/2.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_Rules/2.tf
@@ -1,0 +1,9 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+  rules   = []
+}


### PR DESCRIPTION
* Add `decode_null_to_zero` tag to `rules` attribute in `RulesetModel`.
* Set `rules` attribute as computed with empty list default in schema.
* Fix indentation in `RulesetRulesActionParametersModel`.
* Add test case for `rules` attribute behavior verification.