### PR TITLE
zt access: Clean up identity_provider and service_token plans

### DIFF
--- a/internal/services/zero_trust_access_identity_provider/normalizations.go
+++ b/internal/services/zero_trust_access_identity_provider/normalizations.go
@@ -2,6 +2,7 @@ package zero_trust_access_identity_provider
 
 import (
 	"context"
+
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -30,6 +31,11 @@ func normalizeReadZeroTrustIDPScimConfigData(ctx context.Context, dataValue, sta
 		// Scim secret is only generated and returned in the create request, and null on reads.
 		// so we need to load it from the state
 		dataScimConfig.Secret = stateScimConfig.Secret
+	}
+
+	// SCIMBaseURL is computed on create but doesn't change - preserve from state
+	if !stateScimConfig.SCIMBaseURL.IsUnknown() && !stateScimConfig.SCIMBaseURL.IsNull() {
+		dataScimConfig.SCIMBaseURL = stateScimConfig.SCIMBaseURL
 	}
 
 	*dataValue, diags = customfield.NewObject[ZeroTrustAccessIdentityProviderSCIMConfigModel](ctx, &dataScimConfig)

--- a/internal/services/zero_trust_access_identity_provider/plan_modifiers.go
+++ b/internal/services/zero_trust_access_identity_provider/plan_modifiers.go
@@ -1,0 +1,28 @@
+package zero_trust_access_identity_provider
+
+import (
+	"context"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func modifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
+	var planApp, stateApp *ZeroTrustAccessIdentityProviderModel
+	res.Diagnostics.Append(req.Plan.Get(ctx, &planApp)...)
+	res.Diagnostics.Append(req.State.Get(ctx, &stateApp)...)
+	if res.Diagnostics.HasError() || planApp == nil {
+		return
+	}
+
+	// Secret value is computed from create but does not change. Set to state value to not show changes in plan
+	if stateApp != nil && !stateApp.SCIMConfig.IsNull() && !planApp.SCIMConfig.IsNull() {
+		stateModel, _ := stateApp.SCIMConfig.Value(ctx)
+		planModel, _ := planApp.SCIMConfig.Value(ctx)
+
+		planModel.Secret = stateModel.Secret
+		planApp.SCIMConfig, _ = customfield.NewObject(ctx, planModel)
+	}
+
+	res.Plan.Set(ctx, &planApp)
+}

--- a/internal/services/zero_trust_access_identity_provider/resource.go
+++ b/internal/services/zero_trust_access_identity_provider/resource.go
@@ -311,4 +311,5 @@ func (r *ZeroTrustAccessIdentityProviderResource) ImportState(ctx context.Contex
 }
 
 func (r *ZeroTrustAccessIdentityProviderResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
+	modifyPlan(ctx, req, res)
 }

--- a/internal/services/zero_trust_access_identity_provider/schema.go
+++ b/internal/services/zero_trust_access_identity_provider/schema.go
@@ -4,6 +4,7 @@ package zero_trust_access_identity_provider
 
 import (
 	"context"
+
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
@@ -312,6 +313,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"scim_base_url": schema.StringAttribute{
 						Description: "The base URL of Cloudflare's SCIM V2.0 API endpoint.",
 						Computed:    true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"seat_deprovision": schema.BoolAttribute{
 						Description: "A flag to remove a user's seat in Zero Trust when they have been deprovisioned in the Identity Provider.  This cannot be enabled unless user_deprovision is also enabled.",

--- a/internal/services/zero_trust_access_service_token/plan_modifiers.go
+++ b/internal/services/zero_trust_access_service_token/plan_modifiers.go
@@ -1,0 +1,24 @@
+package zero_trust_access_service_token
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func modifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
+	var planApp, stateApp *ZeroTrustAccessServiceTokenModel
+	res.Diagnostics.Append(req.Plan.Get(ctx, &planApp)...)
+	res.Diagnostics.Append(req.State.Get(ctx, &stateApp)...)
+	if res.Diagnostics.HasError() || planApp == nil {
+		return
+	}
+
+	// Client secret can't ever be updated - it's only set when the token is first created.
+	// Tell TF to set the value to Null if it's unknown.
+	if stateApp != nil && stateApp.ClientSecret.IsNull() && planApp.ClientSecret.IsUnknown() {
+		planApp.ClientSecret = stateApp.ClientSecret
+	}
+
+	res.Plan.Set(ctx, &planApp)
+}

--- a/internal/services/zero_trust_access_service_token/resource.go
+++ b/internal/services/zero_trust_access_service_token/resource.go
@@ -297,6 +297,6 @@ func (r *ZeroTrustAccessServiceTokenResource) ImportState(ctx context.Context, r
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *ZeroTrustAccessServiceTokenResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, _ *resource.ModifyPlanResponse) {
-
+func (r *ZeroTrustAccessServiceTokenResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
+	modifyPlan(ctx, req, res)
 }


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Removes unnecessary changes from plans. 
- when changing SCIM settings of the Identity provider the SCIMBaseUrl and Secret would show as changing.
- when changing service token settings (such as duration) the ClientSecret would show as computed, even though it will never be shown


## Additional context & links
