### PR TITLE
ACCT-10019 custom code to make token creation/update support nested resources value

### DIFF
--- a/internal/services/account_token/custom.go
+++ b/internal/services/account_token/custom.go
@@ -1,0 +1,48 @@
+package account_token
+
+import (
+	"encoding/json"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func (m AccountTokenModel) marshalCustom() (data []byte, err error) {
+	if data, err = apijson.MarshalRoot(m); err != nil {
+		return
+	}
+	return m.marshalPolicies(data)
+}
+
+func (m AccountTokenModel) marshalCustomForUpdate(state AccountTokenModel) (data []byte, err error) {
+	if data, err = apijson.MarshalForUpdate(m, state); err != nil {
+		return
+	}
+	return m.marshalPolicies(data)
+}
+
+func (m AccountTokenModel) marshalPolicies(b []byte) ([]byte, error) {
+	var base map[string]json.RawMessage
+	if err := json.Unmarshal(b, &base); err != nil {
+		return nil, err
+	}
+	if _, ok := base["policies"]; !ok {
+		return b, nil
+	}
+
+	type onlyPolicies struct {
+		Policies types.Dynamic `json:"policies,required"`
+	}
+	pb, err := apijson.MarshalRoot(onlyPolicies{Policies: m.Policies})
+	if err != nil {
+		return nil, err
+	}
+	var pm map[string]json.RawMessage
+	if err := json.Unmarshal(pb, &pm); err != nil {
+		return nil, err
+	}
+	if raw, ok := pm["policies"]; ok {
+		base["policies"] = raw
+	}
+	return json.Marshal(base)
+}

--- a/internal/services/account_token/model.go
+++ b/internal/services/account_token/model.go
@@ -3,7 +3,6 @@
 package account_token
 
 import (
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -14,26 +13,26 @@ type AccountTokenResultEnvelope struct {
 }
 
 type AccountTokenModel struct {
-	ID         types.String                  `tfsdk:"id" json:"id,computed"`
-	AccountID  types.String                  `tfsdk:"account_id" path:"account_id,required"`
-	Name       types.String                  `tfsdk:"name" json:"name,required"`
-	Policies   *[]*AccountTokenPoliciesModel `tfsdk:"policies" json:"policies,required"`
-	ExpiresOn  timetypes.RFC3339             `tfsdk:"expires_on" json:"expires_on,optional" format:"date-time"`
-	NotBefore  timetypes.RFC3339             `tfsdk:"not_before" json:"not_before,optional" format:"date-time"`
-	Condition  *AccountTokenConditionModel   `tfsdk:"condition" json:"condition,optional"`
-	Status     types.String                  `tfsdk:"status" json:"status,computed_optional"`
-	IssuedOn   timetypes.RFC3339             `tfsdk:"issued_on" json:"issued_on,computed" format:"date-time"`
-	LastUsedOn timetypes.RFC3339             `tfsdk:"last_used_on" json:"last_used_on,computed" format:"date-time"`
-	ModifiedOn timetypes.RFC3339             `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
-	Value      types.String                  `tfsdk:"value" json:"value,computed,no_refresh"`
+	ID         types.String                `tfsdk:"id" json:"id,computed"`
+	AccountID  types.String                `tfsdk:"account_id" path:"account_id,required"`
+	Name       types.String                `tfsdk:"name" json:"name,required"`
+	Policies   types.Dynamic               `tfsdk:"policies" json:"policies,required"`
+	ExpiresOn  timetypes.RFC3339           `tfsdk:"expires_on" json:"expires_on,optional" format:"date-time"`
+	NotBefore  timetypes.RFC3339           `tfsdk:"not_before" json:"not_before,optional" format:"date-time"`
+	Condition  *AccountTokenConditionModel `tfsdk:"condition" json:"condition,optional"`
+	Status     types.String                `tfsdk:"status" json:"status,computed_optional"`
+	IssuedOn   timetypes.RFC3339           `tfsdk:"issued_on" json:"issued_on,computed" format:"date-time"`
+	LastUsedOn timetypes.RFC3339           `tfsdk:"last_used_on" json:"last_used_on,computed" format:"date-time"`
+	ModifiedOn timetypes.RFC3339           `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
+	Value      types.String                `tfsdk:"value" json:"value,computed,no_refresh"`
 }
 
 func (m AccountTokenModel) MarshalJSON() (data []byte, err error) {
-	return apijson.MarshalRoot(m)
+	return m.marshalCustom()
 }
 
 func (m AccountTokenModel) MarshalJSONForUpdate(state AccountTokenModel) (data []byte, err error) {
-	return apijson.MarshalForUpdate(m, state)
+	return m.marshalCustomForUpdate(state)
 }
 
 type AccountTokenPoliciesModel struct {

--- a/internal/services/account_token/resource.go
+++ b/internal/services/account_token/resource.go
@@ -64,6 +64,9 @@ func (r *AccountTokenResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	// Preserve planned policies to keep exact type/shape from config
+	planPolicies := data.Policies
+
 	dataBytes, err := data.MarshalJSON()
 	if err != nil {
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
@@ -91,6 +94,8 @@ func (r *AccountTokenResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 	data = &env.Result
+	// Restore planned policies to ensure type consistency with plan
+	data.Policies = planPolicies
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -112,6 +117,7 @@ func (r *AccountTokenResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 	tokenValue := state.Value
+	planPolicies := data.Policies
 
 	dataBytes, err := data.MarshalJSONForUpdate(*state)
 	if err != nil {
@@ -141,6 +147,8 @@ func (r *AccountTokenResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 	data = &env.Result
+	// Preserve planned policies to avoid server normalization causing drift
+	data.Policies = planPolicies
 	data.Value = tokenValue
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -156,6 +164,7 @@ func (r *AccountTokenResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	tokenValue := data.Value
+	prevPolicies := data.Policies
 	res := new(http.Response)
 	env := AccountTokenResultEnvelope{*data}
 	_, err := r.client.Accounts.Tokens.Get(
@@ -177,12 +186,14 @@ func (r *AccountTokenResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
 	}
 	data = &env.Result
+	// Preserve user-set policies to avoid server normalization causing drift
+	data.Policies = prevPolicies
 	data.Value = tokenValue
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/services/account_token/schema.go
+++ b/internal/services/account_token/schema.go
@@ -5,7 +5,6 @@ package account_token
 import (
 	"context"
 
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -35,62 +34,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description: "Token name.",
 				Required:    true,
 			},
-			"policies": schema.ListNestedAttribute{
+			"policies": schema.DynamicAttribute{
 				Description: "List of access policies assigned to the token.",
 				Required:    true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"id": schema.StringAttribute{
-							Description: "Policy identifier.",
-							Computed:    true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
-							},
-						},
-						"effect": schema.StringAttribute{
-							Description: "Allow or deny operations against the resources.\nAvailable values: \"allow\", \"deny\".",
-							Required:    true,
-							Validators: []validator.String{
-								stringvalidator.OneOfCaseInsensitive("allow", "deny"),
-							},
-						},
-						"permission_groups": schema.SetNestedAttribute{
-							Description: "A set of permission groups that are specified to the policy.",
-							Required:    true,
-							NestedObject: schema.NestedAttributeObject{
-								Attributes: map[string]schema.Attribute{
-									"id": schema.StringAttribute{
-										Description: "Identifier of the permission group.",
-										Required:    true,
-									},
-									"meta": schema.SingleNestedAttribute{
-										Description: "Attributes associated to the permission group.",
-										Optional:    true,
-										Computed:    true,
-										CustomType:  customfield.NewNestedObjectType[AccountTokenPoliciesPermissionGroupsMetaModel](ctx),
-										Attributes: map[string]schema.Attribute{
-											"key": schema.StringAttribute{
-												Optional: true,
-											},
-											"value": schema.StringAttribute{
-												Optional: true,
-											},
-										},
-									},
-									"name": schema.StringAttribute{
-										Description: "Name of the permission group.",
-										Computed:    true,
-									},
-								},
-							},
-						},
-						"resources": schema.MapAttribute{
-							Description: "A list of resource names that the policy applies to.",
-							Required:    true,
-							ElementType: types.StringType,
-						},
-					},
-				},
 			},
 			"expires_on": schema.StringAttribute{
 				Description: "The expiration time on or after which the JWT MUST NOT be accepted for processing.",

--- a/internal/services/api_token/custom.go
+++ b/internal/services/api_token/custom.go
@@ -1,0 +1,48 @@
+package api_token
+
+import (
+	"encoding/json"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func (m APITokenModel) marshalCustom() (data []byte, err error) {
+	if data, err = apijson.MarshalRoot(m); err != nil {
+		return
+	}
+	return m.marshalPolicies(data)
+}
+
+func (m APITokenModel) marshalCustomForUpdate(state APITokenModel) (data []byte, err error) {
+	if data, err = apijson.MarshalForUpdate(m, state); err != nil {
+		return
+	}
+	return m.marshalPolicies(data)
+}
+
+func (m APITokenModel) marshalPolicies(b []byte) ([]byte, error) {
+	var base map[string]json.RawMessage
+	if err := json.Unmarshal(b, &base); err != nil {
+		return nil, err
+	}
+	if _, ok := base["policies"]; !ok {
+		return b, nil
+	}
+
+	type onlyPolicies struct {
+		Policies types.Dynamic `json:"policies,required"`
+	}
+	pb, err := apijson.MarshalRoot(onlyPolicies{Policies: m.Policies})
+	if err != nil {
+		return nil, err
+	}
+	var pm map[string]json.RawMessage
+	if err := json.Unmarshal(pb, &pm); err != nil {
+		return nil, err
+	}
+	if raw, ok := pm["policies"]; ok {
+		base["policies"] = raw
+	}
+	return json.Marshal(base)
+}

--- a/internal/services/api_token/model.go
+++ b/internal/services/api_token/model.go
@@ -3,7 +3,6 @@
 package api_token
 
 import (
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -13,25 +12,25 @@ type APITokenResultEnvelope struct {
 }
 
 type APITokenModel struct {
-	ID         types.String              `tfsdk:"id" json:"id,computed"`
-	Name       types.String              `tfsdk:"name" json:"name,required"`
-	Policies   *[]*APITokenPoliciesModel `tfsdk:"policies" json:"policies,required"`
-	ExpiresOn  timetypes.RFC3339         `tfsdk:"expires_on" json:"expires_on,optional" format:"date-time"`
-	NotBefore  timetypes.RFC3339         `tfsdk:"not_before" json:"not_before,optional" format:"date-time"`
-	Condition  *APITokenConditionModel   `tfsdk:"condition" json:"condition,optional"`
-	Status     types.String              `tfsdk:"status" json:"status,computed_optional"`
-	IssuedOn   timetypes.RFC3339         `tfsdk:"issued_on" json:"issued_on,computed" format:"date-time"`
-	LastUsedOn timetypes.RFC3339         `tfsdk:"last_used_on" json:"last_used_on,computed" format:"date-time"`
-	ModifiedOn timetypes.RFC3339         `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
-	Value      types.String              `tfsdk:"value" json:"value,computed,no_refresh"`
+	ID         types.String            `tfsdk:"id" json:"id,computed"`
+	Name       types.String            `tfsdk:"name" json:"name,required"`
+	Policies   types.Dynamic           `tfsdk:"policies" json:"policies,required"`
+	ExpiresOn  timetypes.RFC3339       `tfsdk:"expires_on" json:"expires_on,optional" format:"date-time"`
+	NotBefore  timetypes.RFC3339       `tfsdk:"not_before" json:"not_before,optional" format:"date-time"`
+	Condition  *APITokenConditionModel `tfsdk:"condition" json:"condition,optional"`
+	Status     types.String            `tfsdk:"status" json:"status,computed_optional"`
+	IssuedOn   timetypes.RFC3339       `tfsdk:"issued_on" json:"issued_on,computed" format:"date-time"`
+	LastUsedOn timetypes.RFC3339       `tfsdk:"last_used_on" json:"last_used_on,computed" format:"date-time"`
+	ModifiedOn timetypes.RFC3339       `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
+	Value      types.String            `tfsdk:"value" json:"value,computed,no_refresh"`
 }
 
 func (m APITokenModel) MarshalJSON() (data []byte, err error) {
-	return apijson.MarshalRoot(m)
+	return m.marshalCustom()
 }
 
 func (m APITokenModel) MarshalJSONForUpdate(state APITokenModel) (data []byte, err error) {
-	return apijson.MarshalForUpdate(m, state)
+	return m.marshalCustomForUpdate(state)
 }
 
 type APITokenPoliciesModel struct {

--- a/internal/services/api_token/resource.go
+++ b/internal/services/api_token/resource.go
@@ -172,7 +172,7 @@ func (r *APITokenResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return

--- a/internal/services/api_token/schema.go
+++ b/internal/services/api_token/schema.go
@@ -29,60 +29,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description: "Token name.",
 				Required:    true,
 			},
-			"policies": schema.ListNestedAttribute{
+			"policies": schema.DynamicAttribute{
 				Description: "List of access policies assigned to the token.",
 				Required:    true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"id": schema.StringAttribute{
-							Description: "Policy identifier.",
-							Computed:    true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
-							},
-						},
-						"effect": schema.StringAttribute{
-							Description: "Allow or deny operations against the resources.\nAvailable values: \"allow\", \"deny\".",
-							Required:    true,
-							Validators: []validator.String{
-								stringvalidator.OneOfCaseInsensitive("allow", "deny"),
-							},
-						},
-						"permission_groups": schema.SetNestedAttribute{
-							Description: "A set of permission groups that are specified to the policy.",
-							Required:    true,
-							NestedObject: schema.NestedAttributeObject{
-								Attributes: map[string]schema.Attribute{
-									"id": schema.StringAttribute{
-										Description: "Identifier of the permission group.",
-										Required:    true,
-									},
-									"meta": schema.SingleNestedAttribute{
-										Description: "Attributes associated to the permission group.",
-										Optional:    true,
-										Attributes: map[string]schema.Attribute{
-											"key": schema.StringAttribute{
-												Optional: true,
-											},
-											"value": schema.StringAttribute{
-												Optional: true,
-											},
-										},
-									},
-									"name": schema.StringAttribute{
-										Description: "Name of the permission group.",
-										Computed:    true,
-									},
-								},
-							},
-						},
-						"resources": schema.MapAttribute{
-							Description: "A list of resource names that the policy applies to.",
-							Required:    true,
-							ElementType: types.StringType,
-						},
-					},
-				},
 			},
 			"expires_on": schema.StringAttribute{
 				Description: "The expiration time on or after which the JWT MUST NOT be accepted for processing.",


### PR DESCRIPTION


<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
token creation/update policies can be nested resources 
<img width="638" height="343" alt="image" src="https://github.com/user-attachments/assets/a4e4d37a-42a1-4e74-bea9-7c6dd2460d3e" />

API schema changes cannot trigger the correct auto generated code, have to create custom code for this.

In this PR: use Dynamic types for policies (cannot simply change resources to dynamic, terraform doesn't allow this)

Create custom marshal code for create and update.

## Testing

user API token creation/update

```
xuranwang  ~/cf-repos/xuran-terraform-testing/example-1 → terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - cloudflare/cloudflare in /Users/xuranwang/cf-repos/terraform-provider-cloudflare
│
│ The behavior may therefore not match any released version of the provider and applying changes may
│ cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # cloudflare_api_token.test_demo_1 will be created
  + resource "cloudflare_api_token" "test_demo_1" {
      + id           = (known after apply)
      + issued_on    = (known after apply)
      + last_used_on = (known after apply)
      + modified_on  = (known after apply)
      + name         = "ABC test token demo 2"
      + policies     = [
          + {
              + effect            = "allow"
              + permission_groups = [
                  + {
                      + id   = "c8fed203ed3043cba015a93ad1616f1f"
                      + meta = {
                          + key   = "key"
                          + value = "value"
                        }
                    },
                  + {
                      + id   = "82e64a83756745bbbb1c9c2701bf816b"
                      + meta = {
                          + key   = "key"
                          + value = "value"
                        }
                    },
                ]
              + resources         = {
                  + "com.cloudflare.api.account.472e41d66440f10635de39c7ffaf6080" = "*"
                }
            },
        ]
      + status       = (known after apply)
      + value        = (sensitive value)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

cloudflare_api_token.test_demo_1: Creating...
cloudflare_api_token.test_demo_1: Creation complete after 1s [id=6763dc6099d05133ea93863f9df6fa29]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
xuranwang  ~/cf-repos/xuran-terraform-testing/example-1 → terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - cloudflare/cloudflare in /Users/xuranwang/cf-repos/terraform-provider-cloudflare
│
│ The behavior may therefore not match any released version of the provider and applying changes may
│ cause the state to become incompatible with published releases.
╵
cloudflare_api_token.test_demo_1: Refreshing state... [id=6763dc6099d05133ea93863f9df6fa29]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # cloudflare_api_token.test_demo_1 will be updated in-place
  ~ resource "cloudflare_api_token" "test_demo_1" {
        id           = "6763dc6099d05133ea93863f9df6fa29"
      ~ issued_on    = "2025-08-13T22:16:48Z" -> (known after apply)
      + last_used_on = (known after apply)
      ~ modified_on  = "2025-08-13T22:16:48Z" -> (known after apply)
        name         = "ABC test token demo 2"
      ~ policies     = [
          ~ {
              ~ resources         = {
                  ~ "com.cloudflare.api.account.472e41d66440f10635de39c7ffaf6080" = "*" -> {
                      + "com.cloudflare.api.account.zone.*" = "*"
                    }
                }
                # (2 unchanged attributes hidden)
            },
        ]
      ~ status       = "active" -> (known after apply)
      ~ value        = (sensitive value)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

cloudflare_api_token.test_demo_1: Modifying... [id=6763dc6099d05133ea93863f9df6fa29]
cloudflare_api_token.test_demo_1: Modifications complete after 1s [id=6763dc6099d05133ea93863f9df6fa29]
```

account token create / update

```
xuranwang  ~/cf-repos/xuran-terraform-testing/example-1 → terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - cloudflare/cloudflare in /Users/xuranwang/cf-repos/terraform-provider-cloudflare
│
│ The behavior may therefore not match any released version of the provider and applying changes may
│ cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # cloudflare_account_token.test_demo_1 will be created
  + resource "cloudflare_account_token" "test_demo_1" {
      + account_id   = "472e41d66440f10635de39c7ffaf6080"
      + id           = (known after apply)
      + issued_on    = (known after apply)
      + last_used_on = (known after apply)
      + modified_on  = (known after apply)
      + name         = "ABC test token demo 2"
      + policies     = [
          + {
              + effect            = "allow"
              + permission_groups = [
                  + {
                      + id   = "c8fed203ed3043cba015a93ad1616f1f"
                      + meta = {
                          + key   = "key"
                          + value = "value"
                        }
                    },
                  + {
                      + id   = "82e64a83756745bbbb1c9c2701bf816b"
                      + meta = {
                          + key   = "key"
                          + value = "value"
                        }
                    },
                ]
              + resources         = {
                  + "com.cloudflare.api.account.472e41d66440f10635de39c7ffaf6080" = {
                      + "com.cloudflare.api.account.zone.*" = "*"
                    }
                }
            },
        ]
      + status       = (known after apply)
      + value        = (sensitive value)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

cloudflare_account_token.test_demo_1: Creating...
cloudflare_account_token.test_demo_1: Creation complete after 0s [id=572ce3b507eec8e3734db2dbe1c4de84]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
xuranwang  ~/cf-repos/xuran-terraform-testing/example-1 → terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - cloudflare/cloudflare in /Users/xuranwang/cf-repos/terraform-provider-cloudflare
│
│ The behavior may therefore not match any released version of the provider and applying changes may
│ cause the state to become incompatible with published releases.
╵
cloudflare_account_token.test_demo_1: Refreshing state... [id=572ce3b507eec8e3734db2dbe1c4de84]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # cloudflare_account_token.test_demo_1 will be updated in-place
  ~ resource "cloudflare_account_token" "test_demo_1" {
        id           = "572ce3b507eec8e3734db2dbe1c4de84"
      ~ issued_on    = "2025-08-13T22:15:57Z" -> (known after apply)
      + last_used_on = (known after apply)
      ~ modified_on  = "2025-08-13T22:15:57Z" -> (known after apply)
        name         = "ABC test token demo 2"
      ~ policies     = [
          ~ {
              ~ resources         = {
                  ~ "com.cloudflare.api.account.472e41d66440f10635de39c7ffaf6080" = {
                      - "com.cloudflare.api.account.zone.*" = "*"
                    } -> "*"
                }
                # (2 unchanged attributes hidden)
            },
        ]
      ~ status       = "active" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

cloudflare_account_token.test_demo_1: Modifying... [id=572ce3b507eec8e3734db2dbe1c4de84]
cloudflare_account_token.test_demo_1: Modifications complete after 0s [id=572ce3b507eec8e3734db2dbe1c4de84]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

Apply again without any change:
```
xuranwang  ~/cf-repos/xuran-terraform-testing/example-1 → terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - cloudflare/cloudflare in /Users/xuranwang/cf-repos/terraform-provider-cloudflare
│
│ The behavior may therefore not match any released version of the provider and applying changes may
│ cause the state to become incompatible with published releases.
╵
cloudflare_api_token.test_demo_1: Refreshing state... [id=6763dc6099d05133ea93863f9df6fa29]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so
no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

## Additional context & links
