### PR TITLE
fix: zone setting failing test

### DIFF
--- a/internal/services/zone_setting/schema.go
+++ b/internal/services/zone_setting/schema.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
@@ -45,7 +44,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"editable": schema.BoolAttribute{
 				Description: "Whether or not this setting can be modified for this zone (based on your Cloudflare plan level).",
 				Computed:    true,
-				Default:     booldefault.StaticBool(true),
+				//Default:     booldefault.StaticBool(true),
 			},
 			"modified_on": schema.StringAttribute{
 				Description: "last time this setting was modified.",

--- a/internal/services/zone_setting/schema.go
+++ b/internal/services/zone_setting/schema.go
@@ -44,7 +44,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"editable": schema.BoolAttribute{
 				Description: "Whether or not this setting can be modified for this zone (based on your Cloudflare plan level).",
 				Computed:    true,
-				//Default:     booldefault.StaticBool(true),
 			},
 			"modified_on": schema.StringAttribute{
 				Description: "last time this setting was modified.",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links

fixes 

`=== RUN   TestAccCloudflareZoneSetting_EditableInconsistency/advanced_ddos
    resource_test.go:287: Step 1/1 error: Error running apply: exit status 1

        Error: Provider produced inconsistent result after apply

        When applying changes to cloudflare_zone_setting.aehvrcinwt, provider
        "provider[\"registry.terraform.io/hashicorp/cloudflare\"]" produced an
        unexpected new value: .editable: was cty.True, but now cty.False.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.`
