### PR TITLE
WIP: Add zone migration tests

### DIFF
--- a/internal/services/zone/migrations_test.go
+++ b/internal/services/zone/migrations_test.go
@@ -1,0 +1,450 @@
+package zone_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareZone_Migration(t *testing.T) {
+
+	// Generate a unique zone name for this test
+	rnd := utils.GenerateRandomResourceName()
+	zoneName := fmt.Sprintf("%s.cfapi.net", rnd)
+	resourceName := fmt.Sprintf("cloudflare_zone.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	v4Config := testAccCloudflareZoneConfigV4(rnd, zoneName, accountID)
+	tmpDir := t.TempDir()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.TestAccPreCheck(t); acctest.TestAccPreCheck_AccountID(t) },
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create zone with v4 provider
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			{
+				// Step 2: Migrate to v5 provider
+				PreConfig: func() {
+					// Run the migration command to transform config and state
+					acctest.RunMigrationCommand(t, v4Config, tmpDir)
+				},
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory(tmpDir),
+				// Verify no changes needed after migration
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(zoneName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("paused"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("full")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("plan").AtMapKey("legacy_id"), knownvalue.StringExact("free")),
+
+					// Verify meta transformed correctly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("meta").AtMapKey("page_rule_quota"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("meta").AtMapKey("custom_certificate_quota"), knownvalue.NotNull()),
+				},
+			},
+			{
+				// Step 3 - make sure importing gives the same result as migrating
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ResourceName:             resourceName,
+				ImportState:              true,
+				ImportStateVerify:        true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZone_MigrationMinimalConfig(t *testing.T) {
+
+	// Generate a unique zone name for this test
+	rnd := utils.GenerateRandomResourceName()
+	zoneName := fmt.Sprintf("%s.cfapi.net", rnd)
+	resourceName := fmt.Sprintf("cloudflare_zone.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	v4Config := testAccCloudflareZoneConfigV4Minimal(rnd, zoneName, accountID)
+	tmpDir := t.TempDir()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.TestAccPreCheck(t); acctest.TestAccPreCheck_AccountID(t) },
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create zone with v4 provider with minimal config (only required fields)
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			{
+				// Step 2: Migrate to v5 provider
+				PreConfig: func() {
+					// Run the migration command to transform config and state
+					acctest.RunMigrationCommand(t, v4Config, tmpDir)
+				},
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory(tmpDir),
+				// Verify no changes needed after migration
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(zoneName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
+					// Verify default values migrated correctly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("paused"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("full")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("plan").AtMapKey("legacy_id"), knownvalue.StringExact("free")),
+					// Verify meta transformed correctly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("meta").AtMapKey("page_rule_quota"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("meta").AtMapKey("custom_certificate_quota"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ResourceName:             resourceName,
+				ImportState:              true,
+				ImportStateVerify:        true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZone_MigrationEnterpriseWithVanityNameServers(t *testing.T) {
+
+	// Generate a unique zone name for this test
+	rnd := utils.GenerateRandomResourceName()
+	zoneName := fmt.Sprintf("%s.cfapi.net", rnd)
+	resourceName := fmt.Sprintf("cloudflare_zone.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	v4Config := testAccCloudflareZoneConfigV4Enterprise(rnd, zoneName, accountID)
+	tmpDir := t.TempDir()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.TestAccPreCheck(t); acctest.TestAccPreCheck_AccountID(t) },
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create zone with v4 provider that has meta attributes
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			{
+				// Step 2: Migrate to v5 provider
+				PreConfig: func() {
+					// Run the migration command to transform config and state
+					acctest.RunMigrationCommand(t, v4Config, tmpDir)
+				},
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory(tmpDir),
+				// Verify no updates needed after migration
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(zoneName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("paused"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("full")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("plan").AtMapKey("legacy_id"), knownvalue.StringExact("enterprise")),
+					// Verify vanity name servers migrated correctly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("vanity_name_servers"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact(fmt.Sprintf("ns1.%s", zoneName)), knownvalue.StringExact(fmt.Sprintf("ns2.%s", zoneName))})),
+					// Verify meta transformed correctly
+					// Verify meta transformed correctly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("meta").AtMapKey("page_rule_quota"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("meta").AtMapKey("custom_certificate_quota"), knownvalue.NotNull()),
+				},
+			},
+			{
+				// Step 3 - make sure importing gives the same result as migrating
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ResourceName:             resourceName,
+				ImportState:              true,
+				ImportStateVerify:        true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZone_MigrationWithUnicode(t *testing.T) {
+
+	// Generate a unique zone name for this test with Unicode characters
+	rnd := utils.GenerateRandomResourceName()
+	zoneName := fmt.Sprintf("żółw-%s.cfapi.net", rnd)
+	resourceName := fmt.Sprintf("cloudflare_zone.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	v4Config := testAccCloudflareZoneConfigV4Minimal(rnd, zoneName, accountID)
+	tmpDir := t.TempDir()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.TestAccPreCheck(t); acctest.TestAccPreCheck_AccountID(t) },
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create zone with v4 provider with Unicode domain name
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			{
+				// Step 2: Migrate to v5 provider
+				PreConfig: func() {
+					// Run the migration command to transform config and state
+					acctest.RunMigrationCommand(t, v4Config, tmpDir)
+				},
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory(tmpDir),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(zoneName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
+				},
+			},
+			{
+				// Step 3 - make sure importing gives the same result as migrating
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ResourceName:             resourceName,
+				ImportState:              true,
+				ImportStateVerify:        true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZone_MigrationWithPunycode(t *testing.T) {
+
+	// TODO: Check with the service team about Punycode to Unicode conversion behavior
+	// and update the migration guide accordingly. The v5 provider may deliberately handle
+	// Punycode domains differently than v4.
+	t.Skip("Skipping Punycode test - need to verify expected behavior with service team")
+
+	// Generate a unique zone name for this test with Punycode
+	rnd := utils.GenerateRandomResourceName()
+	punycodeZoneName := fmt.Sprintf("xn--w-uga1v8h-%s.cfapi.net", rnd) // Punycode for żółw
+	unicodeZoneName := fmt.Sprintf("żółw-%s.cfapi.net", rnd)           // Expected Unicode result
+	resourceName := fmt.Sprintf("cloudflare_zone.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	v4Config := testAccCloudflareZoneConfigV4Minimal(rnd, punycodeZoneName, accountID)
+	tmpDir := t.TempDir()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.TestAccPreCheck(t); acctest.TestAccPreCheck_AccountID(t) },
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create zone with v4 provider with Punycode domain name
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			// NOTE: PlanOnly: true followed by refresh or import test seems to catch issues that make "terraform show" choke,
+			// but actually applying the plan does not catch those issues
+			{
+				// Step 2: Migrate to v5 provider
+				PreConfig: func() {
+					// Run the migration command to transform config and state
+					acctest.RunMigrationCommand(t, v4Config, tmpDir)
+				},
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory(tmpDir),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					// V5 provider should maintain Unicode representation
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(unicodeZoneName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
+					// Verify default values migrated correctly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("paused"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("full")),
+					// Plan should be set to its default
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("plan").AtMapKey("legacy_id"), knownvalue.StringExact("free")),
+					// Verify meta transformed correctly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("meta").AtMapKey("page_rule_quota"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ResourceName:             resourceName,
+				ImportState:              true,
+				ImportStateVerify:        true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZone_MigrationPartialType(t *testing.T) {
+
+	// Generate a unique zone name for this test
+	rnd := utils.GenerateRandomResourceName()
+	// Can't use whatever.cfapi.net for partial zones b/c base domain is already a full zone
+	zoneName := fmt.Sprintf("%s-partial.net", rnd)
+	resourceName := fmt.Sprintf("cloudflare_zone.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	v4Config := testAccCloudflareZoneConfigV4Type(rnd, zoneName, accountID, "partial")
+	tmpDir := t.TempDir()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.TestAccPreCheck(t); acctest.TestAccPreCheck_AccountID(t) },
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create zone with v4 provider with partial type
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			{
+				// Step 2: Migrate to v5 provider
+				PreConfig: func() {
+					// Run the migration command to transform config and state
+					acctest.RunMigrationCommand(t, v4Config, tmpDir)
+				},
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory(tmpDir),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(zoneName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("paused"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("partial")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("plan").AtMapKey("legacy_id"), knownvalue.StringExact("enterprise")),
+				},
+			},
+			{
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ResourceName:             resourceName,
+				ImportState:              true,
+				ImportStateVerify:        true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZone_MigrationSecondaryType(t *testing.T) {
+
+	// Generate a unique zone name for this test
+	rnd := utils.GenerateRandomResourceName()
+	zoneName := fmt.Sprintf("%s.cfapi.net", rnd)
+	resourceName := fmt.Sprintf("cloudflare_zone.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	v4Config := testAccCloudflareZoneConfigV4Type(rnd, zoneName, accountID, "secondary")
+	tmpDir := t.TempDir()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.TestAccPreCheck(t); acctest.TestAccPreCheck_AccountID(t) },
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create zone with v4 provider with secondary type
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			{
+				// Step 2: Migrate to v5 provider
+				PreConfig: func() {
+					// Run the migration command to transform config and state
+					acctest.RunMigrationCommand(t, v4Config, tmpDir)
+				},
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory(tmpDir),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(zoneName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("paused"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("secondary")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("plan").AtMapKey("legacy_id"), knownvalue.StringExact("enterprise")),
+					// Verify meta transformed correctly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("meta").AtMapKey("page_rule_quota"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				ResourceName:             resourceName,
+				ImportState:              true,
+				ImportStateVerify:        true,
+			},
+		},
+	})
+}
+
+func testAccCloudflareZoneConfigV4(rnd, zoneName, accountID string) string {
+	return acctest.LoadTestCase("zoneconfigv4.tf", rnd, zoneName, accountID)
+}
+
+func testAccCloudflareZoneConfigV4Minimal(rnd, zoneName, accountID string) string {
+	return acctest.LoadTestCase("zoneconfigv4minimal.tf", rnd, zoneName, accountID)
+}
+
+func testAccCloudflareZoneConfigV4Enterprise(rnd, zoneName, accountID string) string {
+	return acctest.LoadTestCase("zoneconfigv4enterprise.tf", rnd, zoneName, accountID)
+}
+
+func testAccCloudflareZoneConfigV4Type(rnd, zoneName, accountID, zoneType string) string {
+	return acctest.LoadTestCase("zoneconfigv4type.tf", rnd, zoneName, accountID, zoneType)
+}

--- a/internal/services/zone/testdata/zoneconfigv4.tf
+++ b/internal/services/zone/testdata/zoneconfigv4.tf
@@ -1,0 +1,8 @@
+resource "cloudflare_zone" "%[1]s" {
+  zone       = "%[2]s"
+  account_id = "%[3]s"
+  paused     = false
+  plan       = "free"
+  type       = "full"
+  jump_start = true
+}

--- a/internal/services/zone/testdata/zoneconfigv4enterprise.tf
+++ b/internal/services/zone/testdata/zoneconfigv4enterprise.tf
@@ -1,0 +1,9 @@
+resource "cloudflare_zone" "%[1]s" {
+  zone                = "%[2]s"
+  account_id          = "%[3]s"
+  paused              = true
+  plan                = "enterprise"
+  type                = "full"
+  jump_start          = false
+  vanity_name_servers = ["ns1.%[2]s", "ns2.%[2]s"]
+}

--- a/internal/services/zone/testdata/zoneconfigv4minimal.tf
+++ b/internal/services/zone/testdata/zoneconfigv4minimal.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_zone" "%[1]s" {
+  zone       = "%[2]s"
+  account_id = "%[3]s"
+}

--- a/internal/services/zone/testdata/zoneconfigv4type.tf
+++ b/internal/services/zone/testdata/zoneconfigv4type.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_zone" "%[1]s" {
+  zone       = "%[2]s"
+  account_id = "%[3]s"
+  type       = "%[4]s"
+  plan       = "enterprise"
+}


### PR DESCRIPTION
## Summary

This PR adds migration tests for the Zone resource as part of the v4 to v5 migration effort.

### Resources Updated
- `cloudflare_zone`

### Changes Made
- Added comprehensive migration tests covering:
  - Basic zone configuration with all attributes
  - Minimal zone configuration
  - Enterprise zones with vanity name servers
  - Zones with Unicode characters in the name
- Tests cover migration from v4 configurations to v5 format

## Test Results

### Migration Tests
❌ **Zone Migration Tests**: All failing with the same error pattern
- `TestAccCloudflareZone_Migration` - ❌ FAIL
- `TestAccCloudflareZone_MigrationMinimalConfig` - ❌ FAIL  
- `TestAccCloudflareZone_MigrationEnterpriseWithVanityNameServers` - ❌ FAIL
- `TestAccCloudflareZone_MigrationWithUnicode` - ❌ FAIL

**Error Details:**
1. All tests show successful Grit migration transformations:
   - `zone` → `name` attribute rename
   - `account_id` → `account.id` nested structure
   - `plan` and `jump_start` attributes removed

2. Tests fail at Step 2/3 with: `expected empty plan, but cloudflare_zone.<name> has planned action(s): [delete]`

3. State retrieval error: `Failed to marshal state to json: unsupported attribute "wildcard_proxiable"`

### Basic Acceptance Tests
✅ **Zone Basic Test**: Passing
- `TestAccCloudflareZone_Basic` - ✅ PASS (3.70s)

## TODO / Items Requiring Review

### Critical Issues
- [ ] **Fix "wildcard_proxiable" attribute error**: The state contains `meta.wildcard_proxiable` which appears to be unsupported in v5 schema
- [ ] **Investigate delete action**: After migration, Terraform plans to delete the zone instead of recognizing it as the same resource
- [ ] **State upgrade function needed**: May need a state upgrader to handle the `meta` block transformation

### Migration Issues
- [ ] The Grit migration successfully transforms the configuration files
- [ ] The state file is transformed but contains incompatible attributes
- [ ] Need to verify if `meta.wildcard_proxiable` should be removed or transformed differently
- [ ] Check if the zone resource needs a state upgrade function similar to other resources

### Testing Gaps
- [ ] Once migration is fixed, verify with real Cloudflare zones
- [ ] Test partial zones and secondary zones if supported
- [ ] Verify that zone settings are preserved during migration

## Dependencies
- Depends on #5910 (improved migration tooling)

## Related Issues
Part of the v4→v5 migration test suite improvements.

## Notes
The migration tool successfully transforms the configuration syntax but the resulting state is incompatible with the v5 provider schema. This appears to be a schema mismatch issue rather than a test problem.