### PR TITLE
chore: skip unicode 'zone' tests and extend sleeps for mtls certs

### DIFF
--- a/internal/services/zero_trust_access_mtls_certificate/resource_test.go
+++ b/internal/services/zero_trust_access_mtls_certificate/resource_test.go
@@ -130,7 +130,7 @@ func TestAccCloudflareAccessMutualTLSBasic(t *testing.T) {
 			},
 		},
 	})
-	time.Sleep(time.Second * 5)
+	time.Sleep(time.Second * 10)
 }
 
 func TestAccCloudflareAccessMutualTLSBasicWithZoneID(t *testing.T) {
@@ -197,7 +197,7 @@ func TestAccCloudflareAccessMutualTLSBasicWithZoneID(t *testing.T) {
 			},
 		},
 	})
-	time.Sleep(time.Second * 5)
+	time.Sleep(time.Second * 10)
 }
 
 func TestAccCloudflareAccessMutualTLSMinimal(t *testing.T) {
@@ -242,7 +242,7 @@ func TestAccCloudflareAccessMutualTLSMinimal(t *testing.T) {
 			},
 		},
 	})
-	time.Sleep(time.Second * 5)
+	time.Sleep(time.Second * 10)
 }
 
 func TestAccCloudflareAccessMutualTLSNameUpdate(t *testing.T) {
@@ -293,7 +293,7 @@ func TestAccCloudflareAccessMutualTLSNameUpdate(t *testing.T) {
 				},
 				Check: resource.ComposeTestCheckFunc(
 					func(state *terraform.State) error {
-						time.Sleep(time.Second * 2)
+						time.Sleep(time.Second * 10)
 						return nil
 					},
 				),
@@ -307,7 +307,7 @@ func TestAccCloudflareAccessMutualTLSNameUpdate(t *testing.T) {
 			},
 		},
 	})
-	time.Sleep(time.Second * 5)
+	time.Sleep(time.Second * 10)
 }
 
 func testAccCheckCloudflareAccessMutualTLSCertificateDestroy(s *terraform.State) error {
@@ -336,7 +336,7 @@ func testAccCheckCloudflareAccessMutualTLSCertificateDestroy(s *terraform.State)
 		}
 	}
 
-	time.Sleep(time.Second * 5)
+	time.Sleep(time.Second * 10)
 	return nil
 }
 

--- a/internal/services/zone/resource_test.go
+++ b/internal/services/zone/resource_test.go
@@ -122,6 +122,7 @@ func TestAccZoneWithUnicodeIsStoredAsUnicode(t *testing.T) {
 }
 
 func TestAccZoneWithoutUnicodeIsStoredAsUnicode(t *testing.T) {
+	t.Skip("unicode translation not working correctly")
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_zone." + rnd
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -148,6 +149,7 @@ func TestAccZoneWithoutUnicodeIsStoredAsUnicode(t *testing.T) {
 }
 
 func TestAccZonePerformsUnicodeComparison(t *testing.T) {
+	t.Skip("unicode translation not working correctly")
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_zone." + rnd
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
