### PR TITLE
fix(ruleset): update data sources and documentation

### DIFF
--- a/docs/data-sources/ruleset.md
+++ b/docs/data-sources/ruleset.md
@@ -13,9 +13,8 @@ description: |-
 
 ```terraform
 data "cloudflare_ruleset" "example_ruleset" {
-  ruleset_id = "2f2feab2026849078ba485f918791bdc"
-  account_id = "account_id"
-  zone_id = "zone_id"
+  zone_id = "9f1839b6152d298aca64c4e906b6d074"
+  id      = "2f2feab2026849078ba485f918791bdc"
 }
 ```
 
@@ -24,20 +23,22 @@ data "cloudflare_ruleset" "example_ruleset" {
 
 ### Optional
 
-- `account_id` (String) The Account ID to use for this endpoint. Mutually exclusive with the Zone ID.
-- `ruleset_id` (String) The unique ID of the ruleset.
-- `zone_id` (String) The Zone ID to use for this endpoint. Mutually exclusive with the Account ID.
+- `account_id` (String) The unique ID of the account.
+- `id` (String) The unique ID of the ruleset.
+- `ruleset_id` (String, Deprecated) The unique ID of the ruleset.
+- `zone_id` (String) The unique ID of the zone.
 
 ### Read-Only
 
 - `description` (String) An informative description of the ruleset.
-- `id` (String) The unique ID of the ruleset.
 - `kind` (String) The kind of the ruleset.
 Available values: "managed", "custom", "root", "zone".
+- `last_updated` (String) The timestamp of when the ruleset was last modified.
 - `name` (String) The human-readable name of the ruleset.
 - `phase` (String) The phase of the ruleset.
 Available values: "ddos_l4", "ddos_l7", "http_config_settings", "http_custom_errors", "http_log_custom_fields", "http_ratelimit", "http_request_cache_settings", "http_request_dynamic_redirect", "http_request_firewall_custom", "http_request_firewall_managed", "http_request_late_transform", "http_request_origin", "http_request_redirect", "http_request_sanitize", "http_request_sbfm", "http_request_transform", "http_response_compression", "http_response_firewall_managed", "http_response_headers_transform", "magic_transit", "magic_transit_ids_managed", "magic_transit_managed", "magic_transit_ratelimit".
 - `rules` (Attributes List) The list of rules in the ruleset. (see [below for nested schema](#nestedatt--rules))
+- `version` (String) The version of the ruleset.
 
 <a id="nestedatt--rules"></a>
 ### Nested Schema for `rules`
@@ -45,91 +46,91 @@ Available values: "ddos_l4", "ddos_l7", "http_config_settings", "http_custom_err
 Read-Only:
 
 - `action` (String) The action to perform when the rule matches.
-Available values: "block", "challenge", "compress_response", "execute", "js_challenge", "log", "managed_challenge", "redirect", "rewrite", "route", "score", "serve_error", "set_config", "skip", "set_cache_settings", "log_custom_field", "ddos_dynamic", "force_connection_close".
+Available values: "block", "challenge", "compress_response", "ddos_dynamic", "execute", "force_connection_close", "js_challenge", "log", "log_custom_field", "managed_challenge", "redirect", "rewrite", "route", "score", "serve_error", "set_cache_settings", "set_config", "skip".
 - `action_parameters` (Attributes) The parameters configuring the rule's action. (see [below for nested schema](#nestedatt--rules--action_parameters))
-- `categories` (List of String) The categories of the rule.
 - `description` (String) An informative description of the rule.
 - `enabled` (Boolean) Whether the rule should be executed.
-- `exposed_credential_check` (Attributes) Configure checks for exposed credentials. (see [below for nested schema](#nestedatt--rules--exposed_credential_check))
+- `exposed_credential_check` (Attributes) Configuration for exposed credential checking. (see [below for nested schema](#nestedatt--rules--exposed_credential_check))
 - `expression` (String) The expression defining which traffic will match the rule.
 - `id` (String) The unique ID of the rule.
 - `logging` (Attributes) An object configuring the rule's logging behavior. (see [below for nested schema](#nestedatt--rules--logging))
-- `ratelimit` (Attributes) An object configuring the rule's ratelimit behavior. (see [below for nested schema](#nestedatt--rules--ratelimit))
-- `ref` (String) The reference of the rule (the rule ID by default).
+- `ratelimit` (Attributes) An object configuring the rule's rate limit behavior. (see [below for nested schema](#nestedatt--rules--ratelimit))
+- `ref` (String) The reference of the rule (the rule's ID by default).
 
 <a id="nestedatt--rules--action_parameters"></a>
 ### Nested Schema for `rules.action_parameters`
 
 Read-Only:
 
-- `additional_cacheable_ports` (List of Number) List of additional ports that caching can be enabled on.
+- `additional_cacheable_ports` (List of Number) A list of additional ports that caching should be enabled on.
 - `algorithms` (Attributes List) Custom order for compression algorithms. (see [below for nested schema](#nestedatt--rules--action_parameters--algorithms))
-- `automatic_https_rewrites` (Boolean) Turn on or off Automatic HTTPS Rewrites.
-- `autominify` (Attributes) Select which file extensions to minify automatically. (see [below for nested schema](#nestedatt--rules--action_parameters--autominify))
-- `bic` (Boolean) Turn on or off Browser Integrity Check.
-- `browser_ttl` (Attributes) Specify how long client browsers should cache the response. Cloudflare cache purge will not purge content cached on client browsers, so high browser TTLs may lead to stale content. (see [below for nested schema](#nestedatt--rules--action_parameters--browser_ttl))
-- `cache` (Boolean) Mark whether the request’s response from origin is eligible for caching. Caching itself will still depend on the cache-control header and your other caching configurations.
-- `cache_key` (Attributes) Define which components of the request are included or excluded from the cache key Cloudflare uses to store the response in cache. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key))
-- `cache_reserve` (Attributes) Mark whether the request's response from origin is eligible for Cache Reserve (requires a Cache Reserve add-on plan). (see [below for nested schema](#nestedatt--rules--action_parameters--cache_reserve))
-- `content` (String) Error response content.
-- `content_type` (String) Content-type header to set with the response.
-Available values: "application/json", "text/xml", "text/plain", "text/html".
+- `asset_name` (String) The name of a custom asset to serve as the response.
+- `automatic_https_rewrites` (Boolean) Whether to enable Automatic HTTPS Rewrites.
+- `autominify` (Attributes) Which file extensions to minify automatically. (see [below for nested schema](#nestedatt--rules--action_parameters--autominify))
+- `bic` (Boolean) Whether to enable Browser Integrity Check (BIC).
+- `browser_ttl` (Attributes) How long client browsers should cache the response. Cloudflare cache purge will not purge content cached on client browsers, so high browser TTLs may lead to stale content. (see [below for nested schema](#nestedatt--rules--action_parameters--browser_ttl))
+- `cache` (Boolean) Whether the request's response from the origin is eligible for caching. Caching itself will still depend on the cache control header and your other caching configurations.
+- `cache_key` (Attributes) Which components of the request are included in or excluded from the cache key Cloudflare uses to store the response in cache. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key))
+- `cache_reserve` (Attributes) Settings to determine whether the request's response from origin is eligible for Cache Reserve (requires a Cache Reserve add-on plan). (see [below for nested schema](#nestedatt--rules--action_parameters--cache_reserve))
+- `content` (String) The response content.
+- `content_type` (String) The content type header to set with the error response.
+Available values: "application/json", "text/html", "text/plain", "text/xml".
 - `cookie_fields` (Attributes List) The cookie fields to log. (see [below for nested schema](#nestedatt--rules--action_parameters--cookie_fields))
-- `disable_apps` (Boolean) Turn off all active Cloudflare Apps.
-- `disable_rum` (Boolean) Turn off Real User Monitoring (RUM).
-- `disable_zaraz` (Boolean) Turn off Zaraz.
-- `edge_ttl` (Attributes) TTL (Time to Live) specifies the maximum time to cache a resource in the Cloudflare edge network. (see [below for nested schema](#nestedatt--rules--action_parameters--edge_ttl))
-- `email_obfuscation` (Boolean) Turn on or off Email Obfuscation.
-- `fonts` (Boolean) Turn on or off Cloudflare Fonts.
-- `from_list` (Attributes) Serve a redirect based on a bulk list lookup. (see [below for nested schema](#nestedatt--rules--action_parameters--from_list))
-- `from_value` (Attributes) Serve a redirect based on the request properties. (see [below for nested schema](#nestedatt--rules--action_parameters--from_value))
-- `headers` (Attributes Map) Map of request headers to modify. (see [below for nested schema](#nestedatt--rules--action_parameters--headers))
-- `host_header` (String) Rewrite the HTTP Host header.
-- `hotlink_protection` (Boolean) Turn on or off the Hotlink Protection.
+- `disable_apps` (Boolean) Whether to disable Cloudflare Apps.
+- `disable_rum` (Boolean) Whether to disable Real User Monitoring (RUM).
+- `disable_zaraz` (Boolean) Whether to disable Zaraz.
+- `edge_ttl` (Attributes) How long the Cloudflare edge network should cache the response. (see [below for nested schema](#nestedatt--rules--action_parameters--edge_ttl))
+- `email_obfuscation` (Boolean) Whether to enable Email Obfuscation.
+- `fonts` (Boolean) Whether to enable Cloudflare Fonts.
+- `from_list` (Attributes) A redirect based on a bulk list lookup. (see [below for nested schema](#nestedatt--rules--action_parameters--from_list))
+- `from_value` (Attributes) A redirect based on the request properties. (see [below for nested schema](#nestedatt--rules--action_parameters--from_value))
+- `headers` (Attributes Map) A map of headers to rewrite. (see [below for nested schema](#nestedatt--rules--action_parameters--headers))
+- `host_header` (String) A value to rewrite the HTTP host header to.
+- `hotlink_protection` (Boolean) Whether to enable Hotlink Protection.
 - `id` (String) The ID of the ruleset to execute.
-- `increment` (Number) Increment contains the delta to change the score and can be either positive or negative.
+- `increment` (Number) A delta to change the score by, which can be either positive or negative.
 - `matched_data` (Attributes) The configuration to use for matched data logging. (see [below for nested schema](#nestedatt--rules--action_parameters--matched_data))
-- `mirage` (Boolean) Turn on or off Mirage.
-- `opportunistic_encryption` (Boolean) Turn on or off Opportunistic Encryption.
-- `origin` (Attributes) Override the IP/TCP destination. (see [below for nested schema](#nestedatt--rules--action_parameters--origin))
-- `origin_cache_control` (Boolean) When enabled, Cloudflare will aim to strictly adhere to RFC 7234.
-- `origin_error_page_passthru` (Boolean) Generate Cloudflare error pages from issues sent from the origin server. When on, error pages will trigger for issues from the origin.
+- `mirage` (Boolean) Whether to enable Mirage.
+- `opportunistic_encryption` (Boolean) Whether to enable Opportunistic Encryption.
+- `origin` (Attributes) An origin to route to. (see [below for nested schema](#nestedatt--rules--action_parameters--origin))
+- `origin_cache_control` (Boolean) Whether Cloudflare will aim to strictly adhere to RFC 7234.
+- `origin_error_page_passthru` (Boolean) Whether to generate Cloudflare error pages for issues from the origin server.
 - `overrides` (Attributes) A set of overrides to apply to the target ruleset. (see [below for nested schema](#nestedatt--rules--action_parameters--overrides))
-- `phase` (String) A phase to skip the execution of. This property is only compatible with products.
-Available values: "current".
 - `phases` (List of String) A list of phases to skip the execution of. This option is incompatible with the rulesets option.
-- `polish` (String) Configure the Polish level.
+Available values: "ddos_l4", "ddos_l7", "http_config_settings", "http_custom_errors", "http_log_custom_fields", "http_ratelimit", "http_request_cache_settings", "http_request_dynamic_redirect", "http_request_firewall_custom", "http_request_firewall_managed", "http_request_late_transform", "http_request_origin", "http_request_redirect", "http_request_sanitize", "http_request_sbfm", "http_request_transform", "http_response_compression", "http_response_firewall_managed", "http_response_headers_transform", "magic_transit", "magic_transit_ids_managed", "magic_transit_managed", "magic_transit_ratelimit".
+- `polish` (String) The Polish level to configure.
 Available values: "off", "lossless", "lossy", "webp".
 - `products` (List of String) A list of legacy security products to skip the execution of.
+Available values: "bic", "hot", "rateLimit", "securityLevel", "uaBlock", "waf", "zoneLockdown".
 - `raw_response_fields` (Attributes List) The raw response fields to log. (see [below for nested schema](#nestedatt--rules--action_parameters--raw_response_fields))
-- `read_timeout` (Number) Define a timeout value between two successive read operations to your origin server. Historically, the timeout value between two read options from Cloudflare to an origin server is 100 seconds. If you are attempting to reduce HTTP 524 errors because of timeouts from an origin server, try increasing this timeout value.
+- `read_timeout` (Number) A timeout value between two successive read operations to use for your origin server. Historically, the timeout value between two read options from Cloudflare to an origin server is 100 seconds. If you are attempting to reduce HTTP 524 errors because of timeouts from an origin server, try increasing this timeout value.
 - `request_fields` (Attributes List) The raw request fields to log. (see [below for nested schema](#nestedatt--rules--action_parameters--request_fields))
-- `respect_strong_etags` (Boolean) Specify whether or not Cloudflare should respect strong ETag (entity tag) headers. When off, Cloudflare converts strong ETag headers to weak ETag headers.
+- `respect_strong_etags` (Boolean) Whether Cloudflare should respect strong ETag (entity tag) headers. If false, Cloudflare converts strong ETag headers to weak ETag headers.
 - `response` (Attributes) The response to show when the block is applied. (see [below for nested schema](#nestedatt--rules--action_parameters--response))
 - `response_fields` (Attributes List) The transformed response fields to log. (see [below for nested schema](#nestedatt--rules--action_parameters--response_fields))
-- `rocket_loader` (Boolean) Turn on or off Rocket Loader.
+- `rocket_loader` (Boolean) Whether to enable Rocket Loader.
 - `rules` (Map of List of String) A mapping of ruleset IDs to a list of rule IDs in that ruleset to skip the execution of. This option is incompatible with the ruleset option.
 - `ruleset` (String) A ruleset to skip the execution of. This option is incompatible with the rulesets option.
 Available values: "current".
 - `rulesets` (List of String) A list of ruleset IDs to skip the execution of. This option is incompatible with the ruleset and phases options.
-- `security_level` (String) Configure the Security Level.
+- `security_level` (String) The Security Level to configure.
 Available values: "off", "essentially_off", "low", "medium", "high", "under_attack".
-- `serve_stale` (Attributes) Define if Cloudflare should serve stale content while getting the latest content from the origin. If on, Cloudflare will not serve stale content while getting the latest content from the origin. (see [below for nested schema](#nestedatt--rules--action_parameters--serve_stale))
-- `server_side_excludes` (Boolean) Turn on or off Server Side Excludes.
-- `sni` (Attributes) Override the Server Name Indication (SNI). (see [below for nested schema](#nestedatt--rules--action_parameters--sni))
-- `ssl` (String) Configure the SSL level.
+- `serve_stale` (Attributes) When to serve stale content from cache. (see [below for nested schema](#nestedatt--rules--action_parameters--serve_stale))
+- `server_side_excludes` (Boolean) Whether to enable Server-Side Excludes.
+- `sni` (Attributes) A Server Name Indication (SNI) override. (see [below for nested schema](#nestedatt--rules--action_parameters--sni))
+- `ssl` (String) The SSL level to configure.
 Available values: "off", "flexible", "full", "strict", "origin_pull".
 - `status_code` (Number) The status code to use for the error.
-- `sxg` (Boolean) Turn on or off Signed Exchanges (SXG).
+- `sxg` (Boolean) Whether to enable Signed Exchanges (SXG).
 - `transformed_request_fields` (Attributes List) The transformed request fields to log. (see [below for nested schema](#nestedatt--rules--action_parameters--transformed_request_fields))
-- `uri` (Attributes) URI to rewrite the request to. (see [below for nested schema](#nestedatt--rules--action_parameters--uri))
+- `uri` (Attributes) A URI rewrite. (see [below for nested schema](#nestedatt--rules--action_parameters--uri))
 
 <a id="nestedatt--rules--action_parameters--algorithms"></a>
 ### Nested Schema for `rules.action_parameters.algorithms`
 
 Read-Only:
 
-- `name` (String) Name of compression algorithm to enable.
+- `name` (String) Name of the compression algorithm to enable.
 Available values: "none", "auto", "default", "gzip", "brotli", "zstd".
 
 
@@ -138,9 +139,9 @@ Available values: "none", "auto", "default", "gzip", "brotli", "zstd".
 
 Read-Only:
 
-- `css` (Boolean) Minify CSS files.
-- `html` (Boolean) Minify HTML files.
-- `js` (Boolean) Minify JS files.
+- `css` (Boolean) Whether to minify CSS files.
+- `html` (Boolean) Whether to minify HTML files.
+- `js` (Boolean) Whether to minify JavaScript files.
 
 
 <a id="nestedatt--rules--action_parameters--browser_ttl"></a>
@@ -148,8 +149,8 @@ Read-Only:
 
 Read-Only:
 
-- `default` (Number) The TTL (in seconds) if you choose override_origin mode.
-- `mode` (String) Determines which browser ttl mode to use.
+- `default` (Number) The browser TTL (in seconds) if you choose the "override_origin" mode.
+- `mode` (String) The browser TTL mode.
 Available values: "respect_origin", "bypass_by_default", "override_origin", "bypass".
 
 
@@ -158,29 +159,29 @@ Available values: "respect_origin", "bypass_by_default", "override_origin", "byp
 
 Read-Only:
 
-- `cache_by_device_type` (Boolean) Separate cached content based on the visitor’s device type.
-- `cache_deception_armor` (Boolean) Protect from web cache deception attacks while allowing static assets to be cached.
-- `custom_key` (Attributes) Customize which components of the request are included or excluded from the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key))
-- `ignore_query_strings_order` (Boolean) Treat requests with the same query parameters the same, regardless of the order those query parameters are in. A value of true ignores the query strings' order.
+- `cache_by_device_type` (Boolean) Whether to separate cached content based on the visitor's device type.
+- `cache_deception_armor` (Boolean) Whether to protect from web cache deception attacks, while allowing static assets to be cached.
+- `custom_key` (Attributes) Which components of the request are included or excluded from the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key))
+- `ignore_query_strings_order` (Boolean) Whether to treat requests with the same query parameters the same, regardless of the order those query parameters are in.
 
 <a id="nestedatt--rules--action_parameters--cache_key--custom_key"></a>
 ### Nested Schema for `rules.action_parameters.cache_key.custom_key`
 
 Read-Only:
 
-- `cookie` (Attributes) The cookies to include in building the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--cookie))
-- `header` (Attributes) The header names and values to include in building the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--header))
-- `host` (Attributes) Whether to use the original host or the resolved host in the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--host))
-- `query_string` (Attributes) Use the presence of parameters in the query string to build the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--query_string))
-- `user` (Attributes) Characteristics of the request user agent used in building the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--user))
+- `cookie` (Attributes) Which cookies to include in the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--cookie))
+- `header` (Attributes) Which headers to include in the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--header))
+- `host` (Attributes) How to use the host in the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--host))
+- `query_string` (Attributes) Which query string parameters to include in or exclude from the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--query_string))
+- `user` (Attributes) How to use characteristics of the request user agent in the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--user))
 
 <a id="nestedatt--rules--action_parameters--cache_key--custom_key--cookie"></a>
 ### Nested Schema for `rules.action_parameters.cache_key.custom_key.cookie`
 
 Read-Only:
 
-- `check_presence` (List of String) Checks for the presence of these cookie names. The presence of these cookies is used in building the cache key.
-- `include` (List of String) Include these cookies' names and their values.
+- `check_presence` (List of String) A list of cookies to check for the presence of. The presence of these cookies is included in the cache key.
+- `include` (List of String) A list of cookies to include in the cache key.
 
 
 <a id="nestedatt--rules--action_parameters--cache_key--custom_key--header"></a>
@@ -188,10 +189,10 @@ Read-Only:
 
 Read-Only:
 
-- `check_presence` (List of String) Checks for the presence of these header names. The presence of these headers is used in building the cache key.
-- `contains` (Map of List of String) For each header name and list of values combination, check if the request header contains any of the values provided. The presence of the request header and whether any of the values provided are contained in the request header value is used in building the cache key.
-- `exclude_origin` (Boolean) Whether or not to include the origin header. A value of true will exclude the origin header in the cache key.
-- `include` (List of String) Include these headers' names and their values.
+- `check_presence` (List of String) A list of headers to check for the presence of. The presence of these headers is included in the cache key.
+- `contains` (Map of List of String) A mapping of header names to a list of values. If a header is present in the request and contains any of the values provided, its value is included in the cache key.
+- `exclude_origin` (Boolean) Whether to exclude the origin header in the cache key.
+- `include` (List of String) A list of headers to include in the cache key.
 
 
 <a id="nestedatt--rules--action_parameters--cache_key--custom_key--host"></a>
@@ -199,7 +200,7 @@ Read-Only:
 
 Read-Only:
 
-- `resolved` (Boolean) Use the resolved host in the cache key. A value of true will use the resolved host, while a value or false will use the original host.
+- `resolved` (Boolean) Whether to use the resolved host in the cache key.
 
 
 <a id="nestedatt--rules--action_parameters--cache_key--custom_key--query_string"></a>
@@ -207,16 +208,16 @@ Read-Only:
 
 Read-Only:
 
-- `exclude` (Attributes) A list of query string parameters NOT used to build the cache key. All parameters present in the request but missing in this list will be used to build the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--query_string--exclude))
-- `include` (Attributes) A list of query string parameters used to build the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--query_string--include))
+- `exclude` (Attributes) Which query string parameters to exclude from the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--query_string--exclude))
+- `include` (Attributes) Which query string parameters to include in the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--cache_key--custom_key--query_string--include))
 
 <a id="nestedatt--rules--action_parameters--cache_key--custom_key--query_string--exclude"></a>
 ### Nested Schema for `rules.action_parameters.cache_key.custom_key.query_string.exclude`
 
 Read-Only:
 
-- `all` (Boolean) Determines whether to exclude all query string parameters from the cache key.
-- `list` (List of String)
+- `all` (Boolean) Whether to exclude all query string parameters from the cache key.
+- `list` (List of String) A list of query string parameters to exclude from the cache key.
 
 
 <a id="nestedatt--rules--action_parameters--cache_key--custom_key--query_string--include"></a>
@@ -224,8 +225,8 @@ Read-Only:
 
 Read-Only:
 
-- `all` (Boolean) Determines whether to include all query string parameters in the cache key.
-- `list` (List of String)
+- `all` (Boolean) Whether to include all query string parameters in the cache key.
+- `list` (List of String) A list of query string parameters to include in the cache key.
 
 
 
@@ -234,9 +235,9 @@ Read-Only:
 
 Read-Only:
 
-- `device_type` (Boolean) Use the user agent's device type in the cache key.
-- `geo` (Boolean) Use the user agents's country in the cache key.
-- `lang` (Boolean) Use the user agent's language in the cache key.
+- `device_type` (Boolean) Whether to use the user agent's device type in the cache key.
+- `geo` (Boolean) Whether to use the user agents's country in the cache key.
+- `lang` (Boolean) Whether to use the user agent's language in the cache key.
 
 
 
@@ -246,8 +247,8 @@ Read-Only:
 
 Read-Only:
 
-- `eligible` (Boolean) Determines whether cache reserve is enabled. If this is true and a request meets eligibility criteria, Cloudflare will write the resource to cache reserve.
-- `minimum_file_size` (Number) The minimum file size eligible for store in cache reserve.
+- `eligible` (Boolean) Whether Cache Reserve is enabled. If this is true and a request meets eligibility criteria, Cloudflare will write the resource to Cache Reserve.
+- `minimum_file_size` (Number) The minimum file size eligible for storage in Cache Reserve.
 
 
 <a id="nestedatt--rules--action_parameters--cookie_fields"></a>
@@ -255,7 +256,7 @@ Read-Only:
 
 Read-Only:
 
-- `name` (String) The name of the field.
+- `name` (String) The name of the cookie.
 
 
 <a id="nestedatt--rules--action_parameters--edge_ttl"></a>
@@ -263,27 +264,27 @@ Read-Only:
 
 Read-Only:
 
-- `default` (Number) The TTL (in seconds) if you choose override_origin mode.
-- `mode` (String) Edge TTL options.
+- `default` (Number) The edge TTL (in seconds) if you choose the "override_origin" mode.
+- `mode` (String) The edge TTL mode.
 Available values: "respect_origin", "bypass_by_default", "override_origin".
-- `status_code_ttl` (Attributes List) List of single status codes, or status code ranges to apply the selected mode. (see [below for nested schema](#nestedatt--rules--action_parameters--edge_ttl--status_code_ttl))
+- `status_code_ttl` (Attributes List) A list of TTLs to apply to specific status codes or status code ranges. (see [below for nested schema](#nestedatt--rules--action_parameters--edge_ttl--status_code_ttl))
 
 <a id="nestedatt--rules--action_parameters--edge_ttl--status_code_ttl"></a>
 ### Nested Schema for `rules.action_parameters.edge_ttl.status_code_ttl`
 
 Read-Only:
 
-- `status_code_range` (Attributes) The range of status codes used to apply the selected mode. (see [below for nested schema](#nestedatt--rules--action_parameters--edge_ttl--status_code_ttl--status_code_range))
-- `status_code_value` (Number) Set the TTL for responses with this specific status code.
-- `value` (Number) Time to cache a response (in seconds). A value of 0 is equivalent to setting the Cache-Control header with the value "no-cache". A value of -1 is equivalent to setting Cache-Control header with the value of "no-store".
+- `status_code` (Number) A single status code to apply the TTL to.
+- `status_code_range` (Attributes) A range of status codes to apply the TTL to. (see [below for nested schema](#nestedatt--rules--action_parameters--edge_ttl--status_code_ttl--status_code_range))
+- `value` (Number) The time to cache the response for (in seconds). A value of 0 is equivalent to setting the cache control header with the value "no-cache". A value of -1 is equivalent to setting the cache control header with the value of "no-store".
 
 <a id="nestedatt--rules--action_parameters--edge_ttl--status_code_ttl--status_code_range"></a>
 ### Nested Schema for `rules.action_parameters.edge_ttl.status_code_ttl.status_code_range`
 
 Read-Only:
 
-- `from` (Number) Response status code lower bound.
-- `to` (Number) Response status code upper bound.
+- `from` (Number) The lower bound of the range.
+- `to` (Number) The upper bound of the range.
 
 
 
@@ -293,7 +294,7 @@ Read-Only:
 
 Read-Only:
 
-- `key` (String) Expression that evaluates to the list lookup key.
+- `key` (String) An expression that evaluates to the list lookup key.
 - `name` (String) The name of the list to match against.
 
 
@@ -302,18 +303,17 @@ Read-Only:
 
 Read-Only:
 
-- `preserve_query_string` (Boolean) Keep the query string of the original request.
-- `status_code` (Number) The status code to be used for the redirect.
-Available values: 301, 302, 303, 307, 308.
-- `target_url` (Attributes) The URL to redirect the request to. (see [below for nested schema](#nestedatt--rules--action_parameters--from_value--target_url))
+- `preserve_query_string` (Boolean) Whether to keep the query string of the original request.
+- `status_code` (Number) The status code to use for the redirect.
+- `target_url` (Attributes) A URL to redirect the request to. (see [below for nested schema](#nestedatt--rules--action_parameters--from_value--target_url))
 
 <a id="nestedatt--rules--action_parameters--from_value--target_url"></a>
 ### Nested Schema for `rules.action_parameters.from_value.target_url`
 
 Read-Only:
 
-- `expression` (String) An expression to evaluate to get the URL to redirect the request to.
-- `value` (String) The URL to redirect the request to.
+- `expression` (String) An expression that evaluates to a URL to redirect the request to.
+- `value` (String) A URL to redirect the request to.
 
 
 
@@ -322,9 +322,10 @@ Read-Only:
 
 Read-Only:
 
-- `expression` (String) Expression for the header value.
-- `operation` (String) Available values: "remove", "add", "set".
-- `value` (String) Static value for the header.
+- `expression` (String) An expression that evaluates to a value for the header.
+- `operation` (String) The operation to perform on the header.
+Available values: "add", "set", "remove".
+- `value` (String) A static value for the header.
 
 
 <a id="nestedatt--rules--action_parameters--matched_data"></a>
@@ -340,8 +341,8 @@ Read-Only:
 
 Read-Only:
 
-- `host` (String) Override the resolved hostname.
-- `port` (Number) Override the destination port.
+- `host` (String) A resolved host to route to.
+- `port` (Number) A destination port to route to.
 
 
 <a id="nestedatt--rules--action_parameters--overrides"></a>
@@ -364,7 +365,7 @@ Read-Only:
 - `action` (String) The action to override rules in the category with.
 - `category` (String) The name of the category to override.
 - `enabled` (Boolean) Whether to enable execution of rules in the category.
-- `sensitivity_level` (String) The sensitivity level to use for rules in the category.
+- `sensitivity_level` (String) The sensitivity level to use for rules in the category. This option is only applicable for DDoS phases.
 Available values: "default", "medium", "low", "eoff".
 
 
@@ -377,7 +378,7 @@ Read-Only:
 - `enabled` (Boolean) Whether to enable execution of the rule.
 - `id` (String) The ID of the rule to override.
 - `score_threshold` (Number) The score threshold to use for the rule.
-- `sensitivity_level` (String) The sensitivity level to use for the rule.
+- `sensitivity_level` (String) The sensitivity level to use for the rule. This option is only applicable for DDoS phases.
 Available values: "default", "medium", "low", "eoff".
 
 
@@ -387,7 +388,7 @@ Available values: "default", "medium", "low", "eoff".
 
 Read-Only:
 
-- `name` (String) The name of the field.
+- `name` (String) The name of the response header.
 - `preserve_duplicates` (Boolean) Whether to log duplicate values of the same header.
 
 
@@ -396,7 +397,7 @@ Read-Only:
 
 Read-Only:
 
-- `name` (String) The name of the field.
+- `name` (String) The name of the header.
 
 
 <a id="nestedatt--rules--action_parameters--response"></a>
@@ -414,7 +415,7 @@ Read-Only:
 
 Read-Only:
 
-- `name` (String) The name of the field.
+- `name` (String) The name of the response header.
 - `preserve_duplicates` (Boolean) Whether to log duplicate values of the same header.
 
 
@@ -423,7 +424,7 @@ Read-Only:
 
 Read-Only:
 
-- `disable_stale_while_updating` (Boolean) Defines whether Cloudflare should serve stale content while updating. If true, Cloudflare will not serve stale content while getting the latest content from the origin.
+- `disable_stale_while_updating` (Boolean) Whether Cloudflare should disable serving stale content while getting the latest content from the origin.
 
 
 <a id="nestedatt--rules--action_parameters--sni"></a>
@@ -431,7 +432,7 @@ Read-Only:
 
 Read-Only:
 
-- `value` (String) The SNI override.
+- `value` (String) A value to override the SNI to.
 
 
 <a id="nestedatt--rules--action_parameters--transformed_request_fields"></a>
@@ -439,7 +440,7 @@ Read-Only:
 
 Read-Only:
 
-- `name` (String) The name of the field.
+- `name` (String) The name of the header.
 
 
 <a id="nestedatt--rules--action_parameters--uri"></a>
@@ -447,16 +448,16 @@ Read-Only:
 
 Read-Only:
 
-- `path` (Attributes) Path portion rewrite. (see [below for nested schema](#nestedatt--rules--action_parameters--uri--path))
-- `query` (Attributes) Query portion rewrite. (see [below for nested schema](#nestedatt--rules--action_parameters--uri--query))
+- `path` (Attributes) A URI path rewrite. (see [below for nested schema](#nestedatt--rules--action_parameters--uri--path))
+- `query` (Attributes) A URI query rewrite. (see [below for nested schema](#nestedatt--rules--action_parameters--uri--query))
 
 <a id="nestedatt--rules--action_parameters--uri--path"></a>
 ### Nested Schema for `rules.action_parameters.uri.path`
 
 Read-Only:
 
-- `expression` (String) Expression to evaluate for the replacement value.
-- `value` (String) Predefined replacement value.
+- `expression` (String) An expression that evaluates to a value to rewrite the URI path to.
+- `value` (String) A value to rewrite the URI path to.
 
 
 <a id="nestedatt--rules--action_parameters--uri--query"></a>
@@ -464,8 +465,8 @@ Read-Only:
 
 Read-Only:
 
-- `expression` (String) Expression to evaluate for the replacement value.
-- `value` (String) Predefined replacement value.
+- `expression` (String) An expression that evaluates to a value to rewrite the URI query to.
+- `value` (String) A value to rewrite the URI query to.
 
 
 
@@ -475,8 +476,8 @@ Read-Only:
 
 Read-Only:
 
-- `password_expression` (String) Expression that selects the password used in the credentials check.
-- `username_expression` (String) Expression that selects the user ID used in the credentials check.
+- `password_expression` (String) An expression that selects the password used in the credentials check.
+- `username_expression` (String) An expression that selects the user ID used in the credentials check.
 
 
 <a id="nestedatt--rules--logging"></a>
@@ -492,13 +493,13 @@ Read-Only:
 
 Read-Only:
 
-- `characteristics` (List of String) Characteristics of the request on which the ratelimiter counter will be incremented.
-- `counting_expression` (String) Defines when the ratelimit counter should be incremented. It is optional and defaults to the same as the rule's expression.
+- `characteristics` (List of String) Characteristics of the request on which the rate limit counter will be incremented.
+- `counting_expression` (String) An expression that defines when the rate limit counter should be incremented. It defaults to the same as the rule's expression.
 - `mitigation_timeout` (Number) Period of time in seconds after which the action will be disabled following its first execution.
 - `period` (Number) Period in seconds over which the counter is being incremented.
 - `requests_per_period` (Number) The threshold of requests per period after which the action will be executed for the first time.
-- `requests_to_origin` (Boolean) Defines if ratelimit counting is only done when an origin is reached.
+- `requests_to_origin` (Boolean) Whether counting is only performed when an origin is reached.
 - `score_per_period` (Number) The score threshold per period for which the action will be executed the first time.
-- `score_response_header_name` (String) The response header name provided by the origin which should contain the score to increment ratelimit counter on.
+- `score_response_header_name` (String) A response header name provided by the origin, which contains the score to increment rate limit counter with.
 
 

--- a/docs/data-sources/rulesets.md
+++ b/docs/data-sources/rulesets.md
@@ -13,8 +13,7 @@ description: |-
 
 ```terraform
 data "cloudflare_rulesets" "example_rulesets" {
-  account_id = "account_id"
-  zone_id = "zone_id"
+  zone_id = "9f1839b6152d298aca64c4e906b6d074"
 }
 ```
 
@@ -23,16 +22,31 @@ data "cloudflare_rulesets" "example_rulesets" {
 
 ### Optional
 
-- `account_id` (String) The Account ID to use for this endpoint. Mutually exclusive with the Zone ID.
-- `max_items` (Number) Max items to fetch, default: 1000
-- `zone_id` (String) The Zone ID to use for this endpoint. Mutually exclusive with the Account ID.
+- `account_id` (String) The unique ID of the account.
+- `max_items` (Number) Maximum number of rulesets to fetch (defaults to 1000).
+- `zone_id` (String) The unique ID of the zone.
 
 ### Read-Only
 
-- `result` (Attributes List) The items returned by the data source (see [below for nested schema](#nestedatt--result))
+- `result` (Attributes List, Deprecated) A list of rulesets. The returned information will not include the rules in each ruleset. (see [below for nested schema](#nestedatt--result))
+- `rulesets` (Attributes List) A list of rulesets. The returned information will not include the rules in each ruleset. (see [below for nested schema](#nestedatt--rulesets))
 
 <a id="nestedatt--result"></a>
 ### Nested Schema for `result`
+
+Read-Only:
+
+- `description` (String, Deprecated) An informative description of the ruleset.
+- `id` (String, Deprecated) The unique ID of the ruleset.
+- `kind` (String, Deprecated) The kind of the ruleset.
+Available values: "managed", "custom", "root", "zone".
+- `name` (String, Deprecated) The human-readable name of the ruleset.
+- `phase` (String, Deprecated) The phase of the ruleset.
+Available values: "ddos_l4", "ddos_l7", "http_config_settings", "http_custom_errors", "http_log_custom_fields", "http_ratelimit", "http_request_cache_settings", "http_request_dynamic_redirect", "http_request_firewall_custom", "http_request_firewall_managed", "http_request_late_transform", "http_request_origin", "http_request_redirect", "http_request_sanitize", "http_request_sbfm", "http_request_transform", "http_response_compression", "http_response_firewall_managed", "http_response_headers_transform", "magic_transit", "magic_transit_ids_managed", "magic_transit_managed", "magic_transit_ratelimit".
+
+
+<a id="nestedatt--rulesets"></a>
+### Nested Schema for `rulesets`
 
 Read-Only:
 

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -13,47 +13,19 @@ description: |-
 
 ```terraform
 resource "cloudflare_ruleset" "example_ruleset" {
-  kind = "root"
-  name = "My ruleset"
-  phase = "http_request_firewall_custom"
-  zone_id = "zone_id"
-  description = "My ruleset to execute managed rulesets"
-  rules = [{
-    action = "block"
-    action_parameters = {
-      response = {
-        content = <<EOT
-        {
-          "success": false,
-          "error": "you have been blocked"
-        }
-        EOT
-        content_type = "application/json"
-        status_code = 400
-      }
+  zone_id     = "9f1839b6152d298aca64c4e906b6d074"
+  name        = "My ruleset"
+  phase       = "http_request_firewall_custom"
+  kind        = "root"
+  description = "A description for my ruleset."
+  rules = [
+    {
+      description = "Block the request."
+      expression  = "ip.src ne 1.1.1.1"
+      action      = "block"
+      ref         = "my_rule"
     }
-    description = "Block when the IP address is not 1.1.1.1"
-    enabled = true
-    exposed_credential_check = {
-      password_expression = "url_decode(http.request.body.form[\\\"password\\\"][0])"
-      username_expression = "url_decode(http.request.body.form[\\\"username\\\"][0])"
-    }
-    expression = "ip.src ne 1.1.1.1"
-    logging = {
-      enabled = true
-    }
-    ratelimit = {
-      characteristics = ["ip.src"]
-      period = 60
-      counting_expression = "http.request.body.raw eq \"abcd\""
-      mitigation_timeout = 600
-      requests_per_period = 1000
-      requests_to_origin = true
-      score_per_period = 400
-      score_response_header_name = "my-score"
-    }
-    ref = "my_ref"
-  }]
+  ]
 }
 ```
 

--- a/examples/data-sources/cloudflare_ruleset/data-source.tf
+++ b/examples/data-sources/cloudflare_ruleset/data-source.tf
@@ -1,5 +1,4 @@
 data "cloudflare_ruleset" "example_ruleset" {
-  ruleset_id = "2f2feab2026849078ba485f918791bdc"
-  account_id = "account_id"
-  zone_id = "zone_id"
+  zone_id = "9f1839b6152d298aca64c4e906b6d074"
+  id      = "2f2feab2026849078ba485f918791bdc"
 }

--- a/examples/data-sources/cloudflare_rulesets/data-source.tf
+++ b/examples/data-sources/cloudflare_rulesets/data-source.tf
@@ -1,4 +1,3 @@
 data "cloudflare_rulesets" "example_rulesets" {
-  account_id = "account_id"
-  zone_id = "zone_id"
+  zone_id = "9f1839b6152d298aca64c4e906b6d074"
 }

--- a/examples/resources/cloudflare_ruleset/resource.tf
+++ b/examples/resources/cloudflare_ruleset/resource.tf
@@ -1,43 +1,15 @@
 resource "cloudflare_ruleset" "example_ruleset" {
-  kind = "root"
-  name = "My ruleset"
-  phase = "http_request_firewall_custom"
-  zone_id = "zone_id"
-  description = "My ruleset to execute managed rulesets"
-  rules = [{
-    action = "block"
-    action_parameters = {
-      response = {
-        content = <<EOT
-        {
-          "success": false,
-          "error": "you have been blocked"
-        }
-        EOT
-        content_type = "application/json"
-        status_code = 400
-      }
+  zone_id     = "9f1839b6152d298aca64c4e906b6d074"
+  name        = "My ruleset"
+  phase       = "http_request_firewall_custom"
+  kind        = "root"
+  description = "A description for my ruleset."
+  rules = [
+    {
+      description = "Block the request."
+      expression  = "ip.src ne 1.1.1.1"
+      action      = "block"
+      ref         = "my_rule"
     }
-    description = "Block when the IP address is not 1.1.1.1"
-    enabled = true
-    exposed_credential_check = {
-      password_expression = "url_decode(http.request.body.form[\\\"password\\\"][0])"
-      username_expression = "url_decode(http.request.body.form[\\\"username\\\"][0])"
-    }
-    expression = "ip.src ne 1.1.1.1"
-    logging = {
-      enabled = true
-    }
-    ratelimit = {
-      characteristics = ["ip.src"]
-      period = 60
-      counting_expression = "http.request.body.raw eq \"abcd\""
-      mitigation_timeout = 600
-      requests_per_period = 1000
-      requests_to_origin = true
-      score_per_period = 400
-      score_response_header_name = "my-score"
-    }
-    ref = "my_ref"
-  }]
+  ]
 }

--- a/internal/services/ruleset/data_source.go
+++ b/internal/services/ruleset/data_source.go
@@ -57,6 +57,10 @@ func (d *RulesetDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
+	if data.ID.IsNull() {
+		data.ID = data.RulesetID
+	}
+
 	params, diags := data.toReadParams(ctx)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -67,7 +71,7 @@ func (d *RulesetDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	env := RulesetResultDataSourceEnvelope{*data}
 	_, err := d.client.Rulesets.Get(
 		ctx,
-		data.RulesetID.ValueString(),
+		data.ID.ValueString(),
 		params,
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),

--- a/internal/services/ruleset/data_source_model.go
+++ b/internal/services/ruleset/data_source_model.go
@@ -8,24 +8,27 @@ import (
 	"github.com/cloudflare/cloudflare-go/v5"
 	"github.com/cloudflare/cloudflare-go/v5/rulesets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type RulesetResultDataSourceEnvelope struct {
-	Result RulesetDataSourceModel `json:"result,computed"`
+	Result RulesetDataSourceModel `json:"result"`
 }
 
 type RulesetDataSourceModel struct {
-	ID          types.String                                              `tfsdk:"id" path:"ruleset_id,computed"`
-	RulesetID   types.String                                              `tfsdk:"ruleset_id" path:"ruleset_id,optional"`
+	ID          types.String                                              `tfsdk:"id" path:"id,optional"`
+	RulesetID   types.String                                              `tfsdk:"ruleset_id"`
 	AccountID   types.String                                              `tfsdk:"account_id" path:"account_id,optional"`
 	ZoneID      types.String                                              `tfsdk:"zone_id" path:"zone_id,optional"`
 	Kind        types.String                                              `tfsdk:"kind" json:"kind,computed"`
 	Name        types.String                                              `tfsdk:"name" json:"name,computed"`
 	Phase       types.String                                              `tfsdk:"phase" json:"phase,computed"`
 	Description types.String                                              `tfsdk:"description" json:"description,computed"`
-	Rules       customfield.NestedObjectList[RulesetRulesDataSourceModel] `tfsdk:"rules" json:"rules,computed"`
+	Rules       customfield.NestedObjectList[RulesetRulesDataSourceModel] `tfsdk:"rules" json:"rules,computed,decode_null_to_zero"`
+	LastUpdated timetypes.RFC3339                                         `tfsdk:"last_updated" json:"last_updated,computed" format:"date-time"`
+	Version     types.String                                              `tfsdk:"version" json:"version,computed"`
 }
 
 func (m *RulesetDataSourceModel) toReadParams(_ context.Context) (params rulesets.RulesetGetParams, diags diag.Diagnostics) {
@@ -43,9 +46,8 @@ func (m *RulesetDataSourceModel) toReadParams(_ context.Context) (params ruleset
 type RulesetRulesDataSourceModel struct {
 	ID                     types.String                                                                `tfsdk:"id" json:"id,computed"`
 	Action                 types.String                                                                `tfsdk:"action" json:"action,computed"`
-	ActionParameters       customfield.NestedObject[RulesetRulesActionParametersDataSourceModel]       `tfsdk:"action_parameters" json:"action_parameters,computed"`
-	Categories             customfield.List[types.String]                                              `tfsdk:"categories" json:"categories,computed"`
-	Description            types.String                                                                `tfsdk:"description" json:"description,computed"`
+	ActionParameters       customfield.NestedObject[RulesetRulesActionParametersDataSourceModel]       `tfsdk:"action_parameters" json:"action_parameters,computed,decode_null_to_zero"`
+	Description            types.String                                                                `tfsdk:"description" json:"description,computed,decode_null_to_zero"`
 	Enabled                types.Bool                                                                  `tfsdk:"enabled" json:"enabled,computed"`
 	ExposedCredentialCheck customfield.NestedObject[RulesetRulesExposedCredentialCheckDataSourceModel] `tfsdk:"exposed_credential_check" json:"exposed_credential_check,computed"`
 	Expression             types.String                                                                `tfsdk:"expression" json:"expression,computed"`
@@ -55,40 +57,41 @@ type RulesetRulesDataSourceModel struct {
 }
 
 type RulesetRulesActionParametersDataSourceModel struct {
-	Response                 customfield.NestedObject[RulesetRulesActionParametersResponseDataSourceModel]                     `tfsdk:"response" json:"response,computed"`
-	Algorithms               customfield.NestedObjectList[RulesetRulesActionParametersAlgorithmsDataSourceModel]               `tfsdk:"algorithms" json:"algorithms,computed"`
-	ID                       types.String                                                                                      `tfsdk:"id" json:"id,computed"`
-	MatchedData              customfield.NestedObject[RulesetRulesActionParametersMatchedDataDataSourceModel]                  `tfsdk:"matched_data" json:"matched_data,computed"`
-	Overrides                customfield.NestedObject[RulesetRulesActionParametersOverridesDataSourceModel]                    `tfsdk:"overrides" json:"overrides,computed"`
-	FromList                 customfield.NestedObject[RulesetRulesActionParametersFromListDataSourceModel]                     `tfsdk:"from_list" json:"from_list,computed"`
-	FromValue                customfield.NestedObject[RulesetRulesActionParametersFromValueDataSourceModel]                    `tfsdk:"from_value" json:"from_value,computed"`
-	Headers                  customfield.NestedObjectMap[RulesetRulesActionParametersHeadersDataSourceModel]                   `tfsdk:"headers" json:"headers,computed"`
-	URI                      customfield.NestedObject[RulesetRulesActionParametersURIDataSourceModel]                          `tfsdk:"uri" json:"uri,computed"`
-	HostHeader               types.String                                                                                      `tfsdk:"host_header" json:"host_header,computed"`
-	Origin                   customfield.NestedObject[RulesetRulesActionParametersOriginDataSourceModel]                       `tfsdk:"origin" json:"origin,computed"`
-	SNI                      customfield.NestedObject[RulesetRulesActionParametersSNIDataSourceModel]                          `tfsdk:"sni" json:"sni,computed"`
-	Increment                types.Int64                                                                                       `tfsdk:"increment" json:"increment,computed"`
-	Content                  types.String                                                                                      `tfsdk:"content" json:"content,computed"`
-	ContentType              types.String                                                                                      `tfsdk:"content_type" json:"content_type,computed"`
-	StatusCode               types.Float64                                                                                     `tfsdk:"status_code" json:"status_code,computed"`
-	AutomaticHTTPSRewrites   types.Bool                                                                                        `tfsdk:"automatic_https_rewrites" json:"automatic_https_rewrites,computed"`
-	Autominify               customfield.NestedObject[RulesetRulesActionParametersAutominifyDataSourceModel]                   `tfsdk:"autominify" json:"autominify,computed"`
-	BIC                      types.Bool                                                                                        `tfsdk:"bic" json:"bic,computed"`
-	DisableApps              types.Bool                                                                                        `tfsdk:"disable_apps" json:"disable_apps,computed"`
-	DisableRUM               types.Bool                                                                                        `tfsdk:"disable_rum" json:"disable_rum,computed"`
-	DisableZaraz             types.Bool                                                                                        `tfsdk:"disable_zaraz" json:"disable_zaraz,computed"`
-	EmailObfuscation         types.Bool                                                                                        `tfsdk:"email_obfuscation" json:"email_obfuscation,computed"`
-	Fonts                    types.Bool                                                                                        `tfsdk:"fonts" json:"fonts,computed"`
-	HotlinkProtection        types.Bool                                                                                        `tfsdk:"hotlink_protection" json:"hotlink_protection,computed"`
-	Mirage                   types.Bool                                                                                        `tfsdk:"mirage" json:"mirage,computed"`
-	OpportunisticEncryption  types.Bool                                                                                        `tfsdk:"opportunistic_encryption" json:"opportunistic_encryption,computed"`
-	Polish                   types.String                                                                                      `tfsdk:"polish" json:"polish,computed"`
-	RocketLoader             types.Bool                                                                                        `tfsdk:"rocket_loader" json:"rocket_loader,computed"`
-	SecurityLevel            types.String                                                                                      `tfsdk:"security_level" json:"security_level,computed"`
-	ServerSideExcludes       types.Bool                                                                                        `tfsdk:"server_side_excludes" json:"server_side_excludes,computed"`
-	SSL                      types.String                                                                                      `tfsdk:"ssl" json:"ssl,computed"`
-	SXG                      types.Bool                                                                                        `tfsdk:"sxg" json:"sxg,computed"`
-	Phase                    types.String                                                                                      `tfsdk:"phase" json:"phase,computed"`
+	Response                customfield.NestedObject[RulesetRulesActionParametersResponseDataSourceModel]       `tfsdk:"response" json:"response,computed"`
+	Algorithms              customfield.NestedObjectList[RulesetRulesActionParametersAlgorithmsDataSourceModel] `tfsdk:"algorithms" json:"algorithms,computed"`
+	ID                      types.String                                                                        `tfsdk:"id" json:"id,computed"`
+	MatchedData             customfield.NestedObject[RulesetRulesActionParametersMatchedDataDataSourceModel]    `tfsdk:"matched_data" json:"matched_data,computed"`
+	Overrides               customfield.NestedObject[RulesetRulesActionParametersOverridesDataSourceModel]      `tfsdk:"overrides" json:"overrides,computed"`
+	FromList                customfield.NestedObject[RulesetRulesActionParametersFromListDataSourceModel]       `tfsdk:"from_list" json:"from_list,computed"`
+	FromValue               customfield.NestedObject[RulesetRulesActionParametersFromValueDataSourceModel]      `tfsdk:"from_value" json:"from_value,computed"`
+	Headers                 customfield.NestedObjectMap[RulesetRulesActionParametersHeadersDataSourceModel]     `tfsdk:"headers" json:"headers,computed"`
+	URI                     customfield.NestedObject[RulesetRulesActionParametersURIDataSourceModel]            `tfsdk:"uri" json:"uri,computed"`
+	HostHeader              types.String                                                                        `tfsdk:"host_header" json:"host_header,computed"`
+	Origin                  customfield.NestedObject[RulesetRulesActionParametersOriginDataSourceModel]         `tfsdk:"origin" json:"origin,computed"`
+	SNI                     customfield.NestedObject[RulesetRulesActionParametersSNIDataSourceModel]            `tfsdk:"sni" json:"sni,computed"`
+	Increment               types.Int64                                                                         `tfsdk:"increment" json:"increment,computed"`
+	AssetName               types.String                                                                        `tfsdk:"asset_name" json:"asset_name,computed"`
+	Content                 types.String                                                                        `tfsdk:"content" json:"content,computed"`
+	ContentType             types.String                                                                        `tfsdk:"content_type" json:"content_type,computed"`
+	StatusCode              types.Int64                                                                         `tfsdk:"status_code" json:"status_code,computed"`
+	AutomaticHTTPSRewrites  types.Bool                                                                          `tfsdk:"automatic_https_rewrites" json:"automatic_https_rewrites,computed"`
+	Autominify              customfield.NestedObject[RulesetRulesActionParametersAutominifyDataSourceModel]     `tfsdk:"autominify" json:"autominify,computed"`
+	BIC                     types.Bool                                                                          `tfsdk:"bic" json:"bic,computed"`
+	DisableApps             types.Bool                                                                          `tfsdk:"disable_apps" json:"disable_apps,computed"`
+	DisableRUM              types.Bool                                                                          `tfsdk:"disable_rum" json:"disable_rum,computed"`
+	DisableZaraz            types.Bool                                                                          `tfsdk:"disable_zaraz" json:"disable_zaraz,computed"`
+	EmailObfuscation        types.Bool                                                                          `tfsdk:"email_obfuscation" json:"email_obfuscation,computed"`
+	Fonts                   types.Bool                                                                          `tfsdk:"fonts" json:"fonts,computed"`
+	HotlinkProtection       types.Bool                                                                          `tfsdk:"hotlink_protection" json:"hotlink_protection,computed"`
+	Mirage                  types.Bool                                                                          `tfsdk:"mirage" json:"mirage,computed"`
+	OpportunisticEncryption types.Bool                                                                          `tfsdk:"opportunistic_encryption" json:"opportunistic_encryption,computed"`
+	Polish                  types.String                                                                        `tfsdk:"polish" json:"polish,computed"`
+	RocketLoader            types.Bool                                                                          `tfsdk:"rocket_loader" json:"rocket_loader,computed"`
+	SecurityLevel           types.String                                                                        `tfsdk:"security_level" json:"security_level,computed"`
+	ServerSideExcludes      types.Bool                                                                          `tfsdk:"server_side_excludes" json:"server_side_excludes,computed"`
+	SSL                     types.String                                                                        `tfsdk:"ssl" json:"ssl,computed"`
+	SXG                     types.Bool                                                                          `tfsdk:"sxg" json:"sxg,computed"`
+	// Phase                    types.String                                                                                      `tfsdk:"phase" json:"phase,computed"`
 	Phases                   customfield.List[types.String]                                                                    `tfsdk:"phases" json:"phases,computed"`
 	Products                 customfield.List[types.String]                                                                    `tfsdk:"products" json:"products,computed"`
 	Rules                    customfield.Map[customfield.List[types.String]]                                                   `tfsdk:"rules" json:"rules,computed"`
@@ -156,7 +159,7 @@ type RulesetRulesActionParametersFromListDataSourceModel struct {
 
 type RulesetRulesActionParametersFromValueDataSourceModel struct {
 	PreserveQueryString types.Bool                                                                              `tfsdk:"preserve_query_string" json:"preserve_query_string,computed"`
-	StatusCode          types.Float64                                                                           `tfsdk:"status_code" json:"status_code,computed"`
+	StatusCode          types.Int64                                                                             `tfsdk:"status_code" json:"status_code,computed"`
 	TargetURL           customfield.NestedObject[RulesetRulesActionParametersFromValueTargetURLDataSourceModel] `tfsdk:"target_url" json:"target_url,computed"`
 }
 
@@ -187,8 +190,8 @@ type RulesetRulesActionParametersURIQueryDataSourceModel struct {
 }
 
 type RulesetRulesActionParametersOriginDataSourceModel struct {
-	Host types.String  `tfsdk:"host" json:"host,computed"`
-	Port types.Float64 `tfsdk:"port" json:"port,computed"`
+	Host types.String `tfsdk:"host" json:"host,computed"`
+	Port types.Int64  `tfsdk:"port" json:"port,computed"`
 }
 
 type RulesetRulesActionParametersSNIDataSourceModel struct {
@@ -272,7 +275,7 @@ type RulesetRulesActionParametersEdgeTTLDataSourceModel struct {
 type RulesetRulesActionParametersEdgeTTLStatusCodeTTLDataSourceModel struct {
 	Value           types.Int64                                                                                              `tfsdk:"value" json:"value,computed"`
 	StatusCodeRange customfield.NestedObject[RulesetRulesActionParametersEdgeTTLStatusCodeTTLStatusCodeRangeDataSourceModel] `tfsdk:"status_code_range" json:"status_code_range,computed"`
-	StatusCodeValue types.Int64                                                                                              `tfsdk:"status_code_value" json:"status_code_value,computed"`
+	StatusCode      types.Int64                                                                                              `tfsdk:"status_code" json:"status_code,computed"`
 }
 
 type RulesetRulesActionParametersEdgeTTLStatusCodeTTLStatusCodeRangeDataSourceModel struct {
@@ -290,7 +293,7 @@ type RulesetRulesActionParametersCookieFieldsDataSourceModel struct {
 
 type RulesetRulesActionParametersRawResponseFieldsDataSourceModel struct {
 	Name               types.String `tfsdk:"name" json:"name,computed"`
-	PreserveDuplicates types.Bool   `tfsdk:"preserve_duplicates" json:"preserve_duplicates,computed"`
+	PreserveDuplicates types.Bool   `tfsdk:"preserve_duplicates" json:"preserve_duplicates,computed,decode_null_to_zero"`
 }
 
 type RulesetRulesActionParametersRequestFieldsDataSourceModel struct {
@@ -299,7 +302,7 @@ type RulesetRulesActionParametersRequestFieldsDataSourceModel struct {
 
 type RulesetRulesActionParametersResponseFieldsDataSourceModel struct {
 	Name               types.String `tfsdk:"name" json:"name,computed"`
-	PreserveDuplicates types.Bool   `tfsdk:"preserve_duplicates" json:"preserve_duplicates,computed"`
+	PreserveDuplicates types.Bool   `tfsdk:"preserve_duplicates" json:"preserve_duplicates,computed,decode_null_to_zero"`
 }
 
 type RulesetRulesActionParametersTransformedRequestFieldsDataSourceModel struct {
@@ -321,7 +324,7 @@ type RulesetRulesRatelimitDataSourceModel struct {
 	CountingExpression      types.String                   `tfsdk:"counting_expression" json:"counting_expression,computed"`
 	MitigationTimeout       types.Int64                    `tfsdk:"mitigation_timeout" json:"mitigation_timeout,computed"`
 	RequestsPerPeriod       types.Int64                    `tfsdk:"requests_per_period" json:"requests_per_period,computed"`
-	RequestsToOrigin        types.Bool                     `tfsdk:"requests_to_origin" json:"requests_to_origin,computed"`
+	RequestsToOrigin        types.Bool                     `tfsdk:"requests_to_origin" json:"requests_to_origin,computed,decode_null_to_zero"`
 	ScorePerPeriod          types.Int64                    `tfsdk:"score_per_period" json:"score_per_period,computed"`
 	ScoreResponseHeaderName types.String                   `tfsdk:"score_response_header_name" json:"score_response_header_name,computed"`
 }

--- a/internal/services/ruleset/data_source_schema.go
+++ b/internal/services/ruleset/data_source_schema.go
@@ -4,13 +4,15 @@ package ruleset
 
 import (
 	"context"
-	"math"
+	"regexp"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
-	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -26,19 +28,46 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The unique ID of the ruleset.",
-				Computed:    true,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(path.MatchRoot("ruleset_id")),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile("^[0-9a-f]{32}$"),
+						"value must be a 32-character hexadecimal string",
+					),
+				},
 			},
 			"ruleset_id": schema.StringAttribute{
-				Description: "The unique ID of the ruleset.",
-				Optional:    true,
+				Description:        "The unique ID of the ruleset.",
+				Optional:           true,
+				DeprecationMessage: "Configure id instead. This attribute will be removed in the next major version of the provider.",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile("^[0-9a-f]{32}$"),
+						"value must be a 32-character hexadecimal string",
+					),
+				},
 			},
 			"account_id": schema.StringAttribute{
-				Description: "The Account ID to use for this endpoint. Mutually exclusive with the Zone ID.",
+				Description: "The unique ID of the account.",
 				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(path.MatchRoot("zone_id")),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile("^[0-9a-f]{32}$"),
+						"value must be a 32-character hexadecimal string",
+					),
+				},
 			},
 			"zone_id": schema.StringAttribute{
-				Description: "The Zone ID to use for this endpoint. Mutually exclusive with the Account ID.",
+				Description: "The unique ID of the zone.",
 				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile("^[0-9a-f]{32}$"),
+						"value must be a 32-character hexadecimal string",
+					),
+				},
 			},
 			"kind": schema.StringAttribute{
 				Description: "The kind of the ruleset.\nAvailable values: \"managed\", \"custom\", \"root\", \"zone\".",
@@ -55,6 +84,9 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 			"name": schema.StringAttribute{
 				Description: "The human-readable name of the ruleset.",
 				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 			"phase": schema.StringAttribute{
 				Description: "The phase of the ruleset.\nAvailable values: \"ddos_l4\", \"ddos_l7\", \"http_config_settings\", \"http_custom_errors\", \"http_log_custom_fields\", \"http_ratelimit\", \"http_request_cache_settings\", \"http_request_dynamic_redirect\", \"http_request_firewall_custom\", \"http_request_firewall_managed\", \"http_request_late_transform\", \"http_request_origin\", \"http_request_redirect\", \"http_request_sanitize\", \"http_request_sbfm\", \"http_request_transform\", \"http_response_compression\", \"http_response_firewall_managed\", \"http_response_headers_transform\", \"magic_transit\", \"magic_transit_ids_managed\", \"magic_transit_managed\", \"magic_transit_ratelimit\".",
@@ -100,30 +132,40 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 						"id": schema.StringAttribute{
 							Description: "The unique ID of the rule.",
 							Computed:    true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(
+									regexp.MustCompile("^[0-9a-f]{32}$"),
+									"value must be a 32-character hexadecimal string",
+								),
+							},
 						},
 						"action": schema.StringAttribute{
-							Description: "The action to perform when the rule matches.\nAvailable values: \"block\", \"challenge\", \"compress_response\", \"execute\", \"js_challenge\", \"log\", \"managed_challenge\", \"redirect\", \"rewrite\", \"route\", \"score\", \"serve_error\", \"set_config\", \"skip\", \"set_cache_settings\", \"log_custom_field\", \"ddos_dynamic\", \"force_connection_close\".",
+							Description: "The action to perform when the rule matches.\nAvailable values: \"block\", \"challenge\", \"compress_response\", \"ddos_dynamic\", \"execute\", \"force_connection_close\", \"js_challenge\", \"log\", \"log_custom_field\", \"managed_challenge\", \"redirect\", \"rewrite\", \"route\", \"score\", \"serve_error\", \"set_cache_settings\", \"set_config\", \"skip\".",
 							Computed:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOfCaseInsensitive(
 									"block",
 									"challenge",
 									"compress_response",
+									"ddos_dynamic",
 									"execute",
+									"force_connection_close",
 									"js_challenge",
 									"log",
+									"log_custom_field",
 									"managed_challenge",
 									"redirect",
 									"rewrite",
 									"route",
 									"score",
 									"serve_error",
+									"set_cache_settings",
 									"set_config",
 									"skip",
-									"set_cache_settings",
-									"log_custom_field",
-									"ddos_dynamic",
-									"force_connection_close",
+								),
+								stringvalidator.RegexMatches(
+									regexp.MustCompile("^[a-z_]+$"),
+									"value must be a non-empty string containing only lowercase characters and underscores",
 								),
 							},
 						},
@@ -140,10 +182,16 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 										"content": schema.StringAttribute{
 											Description: "The content to return.",
 											Computed:    true,
+											Validators: []validator.String{
+												stringvalidator.LengthAtLeast(1),
+											},
 										},
 										"content_type": schema.StringAttribute{
 											Description: "The type of the content to return.",
 											Computed:    true,
+											Validators: []validator.String{
+												stringvalidator.LengthAtLeast(1),
+											},
 										},
 										"status_code": schema.Int64Attribute{
 											Description: "The status code to return.",
@@ -157,11 +205,14 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 								"algorithms": schema.ListNestedAttribute{
 									Description: "Custom order for compression algorithms.",
 									Computed:    true,
-									CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersAlgorithmsDataSourceModel](ctx),
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(1),
+									},
+									CustomType: customfield.NewNestedObjectListType[RulesetRulesActionParametersAlgorithmsDataSourceModel](ctx),
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"name": schema.StringAttribute{
-												Description: "Name of compression algorithm to enable.\nAvailable values: \"none\", \"auto\", \"default\", \"gzip\", \"brotli\", \"zstd\".",
+												Description: "Name of the compression algorithm to enable.\nAvailable values: \"none\", \"auto\", \"default\", \"gzip\", \"brotli\", \"zstd\".",
 												Computed:    true,
 												Validators: []validator.String{
 													stringvalidator.OneOfCaseInsensitive(
@@ -180,6 +231,12 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 								"id": schema.StringAttribute{
 									Description: "The ID of the ruleset to execute.",
 									Computed:    true,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(
+											regexp.MustCompile("^[0-9a-f]{32}$"),
+											"value must be a 32-character hexadecimal string",
+										),
+									},
 								},
 								"matched_data": schema.SingleNestedAttribute{
 									Description: "The configuration to use for matched data logging.",
@@ -189,6 +246,9 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 										"public_key": schema.StringAttribute{
 											Description: "The public key to encrypt matched data logs with.",
 											Computed:    true,
+											Validators: []validator.String{
+												stringvalidator.LengthAtLeast(1),
+											},
 										},
 									},
 								},
@@ -200,27 +260,55 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 										"action": schema.StringAttribute{
 											Description: "An action to override all rules with. This option has lower precedence than rule and category overrides.",
 											Computed:    true,
+											Validators: []validator.String{
+												stringvalidator.AtLeastOneOf(
+													path.MatchRelative().AtParent().AtName("categories"),
+													path.MatchRelative().AtParent().AtName("enabled"),
+													path.MatchRelative().AtParent().AtName("rules"),
+													path.MatchRelative().AtParent().AtName("sensitivity_level"),
+												),
+												stringvalidator.RegexMatches(
+													regexp.MustCompile("^[a-z_]+$"),
+													"value must be a non-empty string containing only lowercase characters and underscores",
+												),
+											},
 										},
 										"categories": schema.ListNestedAttribute{
 											Description: "A list of category-level overrides. This option has the second-highest precedence after rule-level overrides.",
 											Computed:    true,
-											CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersOverridesCategoriesDataSourceModel](ctx),
+											Validators: []validator.List{
+												listvalidator.SizeAtLeast(1),
+											},
+											CustomType: customfield.NewNestedObjectListType[RulesetRulesActionParametersOverridesCategoriesDataSourceModel](ctx),
 											NestedObject: schema.NestedAttributeObject{
 												Attributes: map[string]schema.Attribute{
 													"category": schema.StringAttribute{
 														Description: "The name of the category to override.",
 														Computed:    true,
+														Validators: []validator.String{
+															stringvalidator.LengthAtLeast(1),
+														},
 													},
 													"action": schema.StringAttribute{
 														Description: "The action to override rules in the category with.",
 														Computed:    true,
+														Validators: []validator.String{
+															stringvalidator.AtLeastOneOf(
+																path.MatchRelative().AtParent().AtName("enabled"),
+																path.MatchRelative().AtParent().AtName("sensitivity_level"),
+															),
+															stringvalidator.RegexMatches(
+																regexp.MustCompile("^[a-z_]+$"),
+																"value must be a non-empty string containing only lowercase characters and underscores",
+															),
+														},
 													},
 													"enabled": schema.BoolAttribute{
 														Description: "Whether to enable execution of rules in the category.",
 														Computed:    true,
 													},
 													"sensitivity_level": schema.StringAttribute{
-														Description: "The sensitivity level to use for rules in the category.\nAvailable values: \"default\", \"medium\", \"low\", \"eoff\".",
+														Description: "The sensitivity level to use for rules in the category. This option is only applicable for DDoS phases.\nAvailable values: \"default\", \"medium\", \"low\", \"eoff\".",
 														Computed:    true,
 														Validators: []validator.String{
 															stringvalidator.OneOfCaseInsensitive(
@@ -241,16 +329,36 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 										"rules": schema.ListNestedAttribute{
 											Description: "A list of rule-level overrides. This option has the highest precedence.",
 											Computed:    true,
-											CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersOverridesRulesDataSourceModel](ctx),
+											Validators: []validator.List{
+												listvalidator.SizeAtLeast(1),
+											},
+											CustomType: customfield.NewNestedObjectListType[RulesetRulesActionParametersOverridesRulesDataSourceModel](ctx),
 											NestedObject: schema.NestedAttributeObject{
 												Attributes: map[string]schema.Attribute{
 													"id": schema.StringAttribute{
 														Description: "The ID of the rule to override.",
 														Computed:    true,
+														Validators: []validator.String{
+															stringvalidator.RegexMatches(
+																regexp.MustCompile("^[0-9a-f]{32}$"),
+																"value must be a 32-character hexadecimal string",
+															),
+														},
 													},
 													"action": schema.StringAttribute{
 														Description: "The action to override the rule with.",
 														Computed:    true,
+														Validators: []validator.String{
+															stringvalidator.AtLeastOneOf(
+																path.MatchRelative().AtParent().AtName("enabled"),
+																path.MatchRelative().AtParent().AtName("score_threshold"),
+																path.MatchRelative().AtParent().AtName("sensitivity_level"),
+															),
+															stringvalidator.RegexMatches(
+																regexp.MustCompile("^[a-z_]+$"),
+																"value must be a non-empty string containing only lowercase characters and underscores",
+															),
+														},
 													},
 													"enabled": schema.BoolAttribute{
 														Description: "Whether to enable execution of the rule.",
@@ -261,7 +369,7 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 														Computed:    true,
 													},
 													"sensitivity_level": schema.StringAttribute{
-														Description: "The sensitivity level to use for the rule.\nAvailable values: \"default\", \"medium\", \"low\", \"eoff\".",
+														Description: "The sensitivity level to use for the rule. This option is only applicable for DDoS phases.\nAvailable values: \"default\", \"medium\", \"low\", \"eoff\".",
 														Computed:    true,
 														Validators: []validator.String{
 															stringvalidator.OneOfCaseInsensitive(
@@ -290,34 +398,49 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 									},
 								},
 								"from_list": schema.SingleNestedAttribute{
-									Description: "Serve a redirect based on a bulk list lookup.",
+									Description: "A redirect based on a bulk list lookup.",
 									Computed:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersFromListDataSourceModel](ctx),
+									Validators: []validator.Object{
+										objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("from_value")),
+									},
+									CustomType: customfield.NewNestedObjectType[RulesetRulesActionParametersFromListDataSourceModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"key": schema.StringAttribute{
-											Description: "Expression that evaluates to the list lookup key.",
+											Description: "An expression that evaluates to the list lookup key.",
 											Computed:    true,
+											Validators: []validator.String{
+												stringvalidator.LengthAtLeast(1),
+											},
 										},
 										"name": schema.StringAttribute{
 											Description: "The name of the list to match against.",
 											Computed:    true,
+											Validators: []validator.String{
+												stringvalidator.RegexMatches(
+													regexp.MustCompile("^[a-zA-Z0-9_]+$"),
+													"value must be a non-empty string containing only alphanumeric characters and underscores",
+												),
+											},
 										},
 									},
 								},
 								"from_value": schema.SingleNestedAttribute{
-									Description: "Serve a redirect based on the request properties.",
+									Description: "A redirect based on the request properties.",
 									Computed:    true,
-									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersFromValueDataSourceModel](ctx),
+									Validators: []validator.Object{
+										objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("from_list")),
+									},
+									CustomType: customfield.NewNestedObjectType[RulesetRulesActionParametersFromValueDataSourceModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"preserve_query_string": schema.BoolAttribute{
-											Description: "Keep the query string of the original request.",
+											Description: "Whether to keep the query string of the original request.",
 											Computed:    true,
 										},
-										"status_code": schema.Float64Attribute{
-											Description: "The status code to be used for the redirect.\nAvailable values: 301, 302, 303, 307, 308.",
+										"status_code": schema.Int64Attribute{
+											Description: "The status code to use for the redirect.",
 											Computed:    true,
-											Validators: []validator.Float64{
-												float64validator.OneOf(
+											Validators: []validator.Int64{
+												int64validator.OneOf(
 													301,
 													302,
 													303,
@@ -327,208 +450,274 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 											},
 										},
 										"target_url": schema.SingleNestedAttribute{
-											Description: "The URL to redirect the request to.",
+											Description: "A URL to redirect the request to.",
 											Computed:    true,
 											CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersFromValueTargetURLDataSourceModel](ctx),
 											Attributes: map[string]schema.Attribute{
 												"value": schema.StringAttribute{
-													Description: "The URL to redirect the request to.",
+													Description: "A URL to redirect the request to.",
 													Computed:    true,
+													Validators: []validator.String{
+														stringvalidator.ExactlyOneOf(path.MatchRelative().AtParent().AtName("expression")),
+														stringvalidator.LengthAtLeast(1),
+													},
 												},
 												"expression": schema.StringAttribute{
-													Description: "An expression to evaluate to get the URL to redirect the request to.",
+													Description: "An expression that evaluates to a URL to redirect the request to.",
 													Computed:    true,
+													Validators: []validator.String{
+														stringvalidator.LengthAtLeast(1),
+													},
 												},
 											},
 										},
 									},
 								},
 								"headers": schema.MapNestedAttribute{
-									Description: "Map of request headers to modify.",
+									Description: "A map of headers to rewrite.",
 									Computed:    true,
-									CustomType:  customfield.NewNestedObjectMapType[RulesetRulesActionParametersHeadersDataSourceModel](ctx),
+									Validators: []validator.Map{
+										mapvalidator.SizeAtLeast(1),
+									},
+									CustomType: customfield.NewNestedObjectMapType[RulesetRulesActionParametersHeadersDataSourceModel](ctx),
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"operation": schema.StringAttribute{
-												Description: `Available values: "remove", "add", "set".`,
+												Description: "The operation to perform on the header.\nAvailable values: \"add\", \"set\", \"remove\".",
 												Computed:    true,
 												Validators: []validator.String{
 													stringvalidator.OneOfCaseInsensitive(
-														"remove",
 														"add",
 														"set",
+														"remove",
 													),
 												},
 											},
 											"value": schema.StringAttribute{
-												Description: "Static value for the header.",
+												Description: "A static value for the header.",
 												Computed:    true,
+												Validators: []validator.String{
+													stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("expression")),
+													stringvalidator.LengthAtLeast(1),
+												},
 											},
 											"expression": schema.StringAttribute{
-												Description: "Expression for the header value.",
+												Description: "An expression that evaluates to a value for the header.",
 												Computed:    true,
+												Validators: []validator.String{
+													stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("value")),
+													stringvalidator.LengthAtLeast(1),
+												},
 											},
 										},
 									},
 								},
 								"uri": schema.SingleNestedAttribute{
-									Description: "URI to rewrite the request to.",
+									Description: "A URI rewrite.",
 									Computed:    true,
 									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersURIDataSourceModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"path": schema.SingleNestedAttribute{
-											Description: "Path portion rewrite.",
+											Description: "A URI path rewrite.",
 											Computed:    true,
-											CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersURIPathDataSourceModel](ctx),
+											Validators: []validator.Object{
+												objectvalidator.AtLeastOneOf(path.MatchRelative().AtParent().AtName("query")),
+											},
+											CustomType: customfield.NewNestedObjectType[RulesetRulesActionParametersURIPathDataSourceModel](ctx),
 											Attributes: map[string]schema.Attribute{
 												"value": schema.StringAttribute{
-													Description: "Predefined replacement value.",
+													Description: "A value to rewrite the URI path to.",
 													Computed:    true,
+													Validators: []validator.String{
+														stringvalidator.ExactlyOneOf(path.MatchRelative().AtParent().AtName("expression")),
+														stringvalidator.LengthAtLeast(1),
+													},
 												},
 												"expression": schema.StringAttribute{
-													Description: "Expression to evaluate for the replacement value.",
+													Description: "An expression that evaluates to a value to rewrite the URI path to.",
 													Computed:    true,
+													Validators: []validator.String{
+														stringvalidator.LengthAtLeast(1),
+													},
 												},
 											},
 										},
 										"query": schema.SingleNestedAttribute{
-											Description: "Query portion rewrite.",
+											Description: "A URI query rewrite.",
 											Computed:    true,
 											CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersURIQueryDataSourceModel](ctx),
 											Attributes: map[string]schema.Attribute{
 												"value": schema.StringAttribute{
-													Description: "Predefined replacement value.",
+													Description: "A value to rewrite the URI query to.",
 													Computed:    true,
+													Validators: []validator.String{
+														stringvalidator.ExactlyOneOf(path.MatchRelative().AtParent().AtName("expression")),
+														stringvalidator.LengthAtLeast(1),
+													},
 												},
 												"expression": schema.StringAttribute{
-													Description: "Expression to evaluate for the replacement value.",
+													Description: "An expression that evaluates to a value to rewrite the URI query to.",
 													Computed:    true,
+													Validators: []validator.String{
+														stringvalidator.LengthAtLeast(1),
+													},
 												},
 											},
 										},
 									},
 								},
 								"host_header": schema.StringAttribute{
-									Description: "Rewrite the HTTP Host header.",
+									Description: "A value to rewrite the HTTP host header to.",
 									Computed:    true,
+									Validators: []validator.String{
+										stringvalidator.LengthAtLeast(1),
+									},
 								},
 								"origin": schema.SingleNestedAttribute{
-									Description: "Override the IP/TCP destination.",
+									Description: "An origin to route to.",
 									Computed:    true,
 									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersOriginDataSourceModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"host": schema.StringAttribute{
-											Description: "Override the resolved hostname.",
+											Description: "A resolved host to route to.",
 											Computed:    true,
+											Validators: []validator.String{
+												stringvalidator.AtLeastOneOf(path.MatchRelative().AtParent().AtName("port")),
+												stringvalidator.LengthAtLeast(1),
+											},
 										},
-										"port": schema.Float64Attribute{
-											Description: "Override the destination port.",
+										"port": schema.Int64Attribute{
+											Description: "A destination port to route to.",
 											Computed:    true,
-											Validators: []validator.Float64{
-												float64validator.Between(1, 65535),
+											Validators: []validator.Int64{
+												int64validator.Between(1, 65535),
 											},
 										},
 									},
 								},
 								"sni": schema.SingleNestedAttribute{
-									Description: "Override the Server Name Indication (SNI).",
+									Description: "A Server Name Indication (SNI) override.",
 									Computed:    true,
 									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersSNIDataSourceModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"value": schema.StringAttribute{
-											Description: "The SNI override.",
+											Description: "A value to override the SNI to.",
 											Computed:    true,
+											Validators: []validator.String{
+												stringvalidator.LengthAtLeast(1),
+											},
 										},
 									},
 								},
 								"increment": schema.Int64Attribute{
-									Description: "Increment contains the delta to change the score and can be either positive or negative.",
+									Description: "A delta to change the score by, which can be either positive or negative.",
 									Computed:    true,
+								},
+								"asset_name": schema.StringAttribute{
+									Description: "The name of a custom asset to serve as the response.",
+									Computed:    true,
+									Validators: []validator.String{
+										stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("content")),
+										stringvalidator.LengthAtLeast(1),
+									},
 								},
 								"content": schema.StringAttribute{
-									Description: "Error response content.",
+									Description: "The response content.",
 									Computed:    true,
+									Validators: []validator.String{
+										stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("asset_name")),
+										stringvalidator.LengthAtLeast(1),
+									},
 								},
 								"content_type": schema.StringAttribute{
-									Description: "Content-type header to set with the response.\nAvailable values: \"application/json\", \"text/xml\", \"text/plain\", \"text/html\".",
+									Description: "The content type header to set with the error response.\nAvailable values: \"application/json\", \"text/html\", \"text/plain\", \"text/xml\".",
 									Computed:    true,
 									Validators: []validator.String{
 										stringvalidator.OneOfCaseInsensitive(
 											"application/json",
-											"text/xml",
-											"text/plain",
 											"text/html",
+											"text/plain",
+											"text/xml",
 										),
 									},
 								},
-								"status_code": schema.Float64Attribute{
+								"status_code": schema.Int64Attribute{
 									Description: "The status code to use for the error.",
 									Computed:    true,
-									Validators: []validator.Float64{
-										float64validator.Between(400, 999),
+									Validators: []validator.Int64{
+										int64validator.Between(400, 999),
 									},
 								},
 								"automatic_https_rewrites": schema.BoolAttribute{
-									Description: "Turn on or off Automatic HTTPS Rewrites.",
+									Description: "Whether to enable Automatic HTTPS Rewrites.",
 									Computed:    true,
 								},
 								"autominify": schema.SingleNestedAttribute{
-									Description: "Select which file extensions to minify automatically.",
+									Description: "Which file extensions to minify automatically.",
 									Computed:    true,
 									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersAutominifyDataSourceModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"css": schema.BoolAttribute{
-											Description: "Minify CSS files.",
+											Description: "Whether to minify CSS files.",
 											Computed:    true,
 										},
 										"html": schema.BoolAttribute{
-											Description: "Minify HTML files.",
+											Description: "Whether to minify HTML files.",
 											Computed:    true,
 										},
 										"js": schema.BoolAttribute{
-											Description: "Minify JS files.",
+											Description: "Whether to minify JavaScript files.",
 											Computed:    true,
 										},
 									},
 								},
 								"bic": schema.BoolAttribute{
-									Description: "Turn on or off Browser Integrity Check.",
+									Description: "Whether to enable Browser Integrity Check (BIC).",
 									Computed:    true,
 								},
 								"disable_apps": schema.BoolAttribute{
-									Description: "Turn off all active Cloudflare Apps.",
+									Description: "Whether to disable Cloudflare Apps.",
 									Computed:    true,
+									Validators: []validator.Bool{
+										boolvalidator.Equals(true),
+									},
 								},
 								"disable_rum": schema.BoolAttribute{
-									Description: "Turn off Real User Monitoring (RUM).",
+									Description: "Whether to disable Real User Monitoring (RUM).",
 									Computed:    true,
+									Validators: []validator.Bool{
+										boolvalidator.Equals(true),
+									},
 								},
 								"disable_zaraz": schema.BoolAttribute{
-									Description: "Turn off Zaraz.",
+									Description: "Whether to disable Zaraz.",
 									Computed:    true,
+									Validators: []validator.Bool{
+										boolvalidator.Equals(true),
+									},
 								},
 								"email_obfuscation": schema.BoolAttribute{
-									Description: "Turn on or off Email Obfuscation.",
+									Description: "Whether to enable Email Obfuscation.",
 									Computed:    true,
 								},
 								"fonts": schema.BoolAttribute{
-									Description: "Turn on or off Cloudflare Fonts.",
+									Description: "Whether to enable Cloudflare Fonts.",
 									Computed:    true,
 								},
 								"hotlink_protection": schema.BoolAttribute{
-									Description: "Turn on or off the Hotlink Protection.",
+									Description: "Whether to enable Hotlink Protection.",
 									Computed:    true,
 								},
 								"mirage": schema.BoolAttribute{
-									Description: "Turn on or off Mirage.",
+									Description: "Whether to enable Mirage.",
 									Computed:    true,
 								},
 								"opportunistic_encryption": schema.BoolAttribute{
-									Description: "Turn on or off Opportunistic Encryption.",
+									Description: "Whether to enable Opportunistic Encryption.",
 									Computed:    true,
 								},
 								"polish": schema.StringAttribute{
-									Description: "Configure the Polish level.\nAvailable values: \"off\", \"lossless\", \"lossy\", \"webp\".",
+									Description: "The Polish level to configure.\nAvailable values: \"off\", \"lossless\", \"lossy\", \"webp\".",
 									Computed:    true,
 									Validators: []validator.String{
 										stringvalidator.OneOfCaseInsensitive(
@@ -540,11 +729,11 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 									},
 								},
 								"rocket_loader": schema.BoolAttribute{
-									Description: "Turn on or off Rocket Loader.",
+									Description: "Whether to enable Rocket Loader.",
 									Computed:    true,
 								},
 								"security_level": schema.StringAttribute{
-									Description: "Configure the Security Level.\nAvailable values: \"off\", \"essentially_off\", \"low\", \"medium\", \"high\", \"under_attack\".",
+									Description: "The Security Level to configure.\nAvailable values: \"off\", \"essentially_off\", \"low\", \"medium\", \"high\", \"under_attack\".",
 									Computed:    true,
 									Validators: []validator.String{
 										stringvalidator.OneOfCaseInsensitive(
@@ -558,11 +747,11 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 									},
 								},
 								"server_side_excludes": schema.BoolAttribute{
-									Description: "Turn on or off Server Side Excludes.",
+									Description: "Whether to enable Server-Side Excludes.",
 									Computed:    true,
 								},
 								"ssl": schema.StringAttribute{
-									Description: "Configure the SSL level.\nAvailable values: \"off\", \"flexible\", \"full\", \"strict\", \"origin_pull\".",
+									Description: "The SSL level to configure.\nAvailable values: \"off\", \"flexible\", \"full\", \"strict\", \"origin_pull\".",
 									Computed:    true,
 									Validators: []validator.String{
 										stringvalidator.OneOfCaseInsensitive(
@@ -575,20 +764,21 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 									},
 								},
 								"sxg": schema.BoolAttribute{
-									Description: "Turn on or off Signed Exchanges (SXG).",
+									Description: "Whether to enable Signed Exchanges (SXG).",
 									Computed:    true,
 								},
-								"phase": schema.StringAttribute{
-									Description: "A phase to skip the execution of. This property is only compatible with products.\nAvailable values: \"current\".",
-									Computed:    true,
-									Validators: []validator.String{
-										stringvalidator.OneOfCaseInsensitive("current"),
-									},
-								},
+								// "phase": schema.StringAttribute{
+								// 	Description: "A phase to skip the execution of. This option is only compatible with the products option.\nAvailable values: \"current\".",
+								// 	Computed:    true,
+								// 	Validators: []validator.String{
+								// 		stringvalidator.OneOfCaseInsensitive("current"),
+								// 	},
+								// },
 								"phases": schema.ListAttribute{
-									Description: "A list of phases to skip the execution of. This option is incompatible with the rulesets option.",
+									Description: "A list of phases to skip the execution of. This option is incompatible with the rulesets option.\nAvailable values: \"ddos_l4\", \"ddos_l7\", \"http_config_settings\", \"http_custom_errors\", \"http_log_custom_fields\", \"http_ratelimit\", \"http_request_cache_settings\", \"http_request_dynamic_redirect\", \"http_request_firewall_custom\", \"http_request_firewall_managed\", \"http_request_late_transform\", \"http_request_origin\", \"http_request_redirect\", \"http_request_sanitize\", \"http_request_sbfm\", \"http_request_transform\", \"http_response_compression\", \"http_response_firewall_managed\", \"http_response_headers_transform\", \"magic_transit\", \"magic_transit_ids_managed\", \"magic_transit_managed\", \"magic_transit_ratelimit\".",
 									Computed:    true,
 									Validators: []validator.List{
+										listvalidator.SizeAtLeast(1),
 										listvalidator.ValueStringsAre(
 											stringvalidator.OneOfCaseInsensitive(
 												"ddos_l4",
@@ -621,9 +811,10 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 									ElementType: types.StringType,
 								},
 								"products": schema.ListAttribute{
-									Description: "A list of legacy security products to skip the execution of.",
+									Description: "A list of legacy security products to skip the execution of.\nAvailable values: \"bic\", \"hot\", \"rateLimit\", \"securityLevel\", \"uaBlock\", \"waf\", \"zoneLockdown\".",
 									Computed:    true,
 									Validators: []validator.List{
+										listvalidator.SizeAtLeast(1),
 										listvalidator.ValueStringsAre(
 											stringvalidator.OneOfCaseInsensitive(
 												"bic",
@@ -642,7 +833,19 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 								"rules": schema.MapAttribute{
 									Description: "A mapping of ruleset IDs to a list of rule IDs in that ruleset to skip the execution of. This option is incompatible with the ruleset option.",
 									Computed:    true,
-									CustomType:  customfield.NewMapType[customfield.List[types.String]](ctx),
+									Validators: []validator.Map{
+										mapvalidator.SizeAtLeast(1),
+										mapvalidator.ValueListsAre(
+											listvalidator.SizeAtLeast(1),
+											listvalidator.ValueStringsAre(
+												stringvalidator.RegexMatches(
+													regexp.MustCompile("^[0-9a-f]{32}$"),
+													"value must be a 32-character hexadecimal string",
+												),
+											),
+										),
+									},
+									CustomType: customfield.NewMapType[customfield.List[types.String]](ctx),
 									ElementType: types.ListType{
 										ElemType: types.StringType,
 									},
@@ -657,22 +860,35 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 								"rulesets": schema.ListAttribute{
 									Description: "A list of ruleset IDs to skip the execution of. This option is incompatible with the ruleset and phases options.",
 									Computed:    true,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(1),
+										listvalidator.ValueStringsAre(
+											stringvalidator.RegexMatches(
+												regexp.MustCompile("^[0-9a-f]{32}$"),
+												"value must be a 32-character hexadecimal string",
+											),
+										),
+									},
 									CustomType:  customfield.NewListType[types.String](ctx),
 									ElementType: types.StringType,
 								},
 								"additional_cacheable_ports": schema.ListAttribute{
-									Description: "List of additional ports that caching can be enabled on.",
+									Description: "A list of additional ports that caching should be enabled on.",
 									Computed:    true,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(1),
+										listvalidator.ValueInt64sAre(int64validator.Between(1, 65535)),
+									},
 									CustomType:  customfield.NewListType[types.Int64](ctx),
 									ElementType: types.Int64Type,
 								},
 								"browser_ttl": schema.SingleNestedAttribute{
-									Description: "Specify how long client browsers should cache the response. Cloudflare cache purge will not purge content cached on client browsers, so high browser TTLs may lead to stale content.",
+									Description: "How long client browsers should cache the response. Cloudflare cache purge will not purge content cached on client browsers, so high browser TTLs may lead to stale content.",
 									Computed:    true,
 									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersBrowserTTLDataSourceModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"mode": schema.StringAttribute{
-											Description: "Determines which browser ttl mode to use.\nAvailable values: \"respect_origin\", \"bypass_by_default\", \"override_origin\", \"bypass\".",
+											Description: "The browser TTL mode.\nAvailable values: \"respect_origin\", \"bypass_by_default\", \"override_origin\", \"bypass\".",
 											Computed:    true,
 											Validators: []validator.String{
 												stringvalidator.OneOfCaseInsensitive(
@@ -684,148 +900,189 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 											},
 										},
 										"default": schema.Int64Attribute{
-											Description: "The TTL (in seconds) if you choose override_origin mode.",
+											Description: "The browser TTL (in seconds) if you choose the \"override_origin\" mode.",
 											Computed:    true,
+											Validators: []validator.Int64{
+												int64validator.AtLeast(0),
+											},
 										},
 									},
 								},
 								"cache": schema.BoolAttribute{
-									Description: "Mark whether the request’s response from origin is eligible for caching. Caching itself will still depend on the cache-control header and your other caching configurations.",
+									Description: "Whether the request's response from the origin is eligible for caching. Caching itself will still depend on the cache control header and your other caching configurations.",
 									Computed:    true,
 								},
 								"cache_key": schema.SingleNestedAttribute{
-									Description: "Define which components of the request are included or excluded from the cache key Cloudflare uses to store the response in cache.",
+									Description: "Which components of the request are included in or excluded from the cache key Cloudflare uses to store the response in cache.",
 									Computed:    true,
 									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyDataSourceModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"cache_by_device_type": schema.BoolAttribute{
-											Description: "Separate cached content based on the visitor’s device type.",
+											Description: "Whether to separate cached content based on the visitor's device type.",
 											Computed:    true,
 										},
 										"cache_deception_armor": schema.BoolAttribute{
-											Description: "Protect from web cache deception attacks while allowing static assets to be cached.",
+											Description: "Whether to protect from web cache deception attacks, while allowing static assets to be cached.",
 											Computed:    true,
 										},
 										"custom_key": schema.SingleNestedAttribute{
-											Description: "Customize which components of the request are included or excluded from the cache key.",
+											Description: "Which components of the request are included or excluded from the cache key.",
 											Computed:    true,
 											CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyDataSourceModel](ctx),
 											Attributes: map[string]schema.Attribute{
 												"cookie": schema.SingleNestedAttribute{
-													Description: "The cookies to include in building the cache key.",
+													Description: "Which cookies to include in the cache key.",
 													Computed:    true,
 													CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyCookieDataSourceModel](ctx),
 													Attributes: map[string]schema.Attribute{
 														"check_presence": schema.ListAttribute{
-															Description: "Checks for the presence of these cookie names. The presence of these cookies is used in building the cache key.",
+															Description: "A list of cookies to check for the presence of. The presence of these cookies is included in the cache key.",
 															Computed:    true,
+															Validators: []validator.List{
+																listvalidator.SizeAtLeast(1),
+															},
 															CustomType:  customfield.NewListType[types.String](ctx),
 															ElementType: types.StringType,
 														},
 														"include": schema.ListAttribute{
-															Description: "Include these cookies' names and their values.",
+															Description: "A list of cookies to include in the cache key.",
 															Computed:    true,
+															Validators: []validator.List{
+																listvalidator.SizeAtLeast(1),
+															},
 															CustomType:  customfield.NewListType[types.String](ctx),
 															ElementType: types.StringType,
 														},
 													},
 												},
 												"header": schema.SingleNestedAttribute{
-													Description: "The header names and values to include in building the cache key.",
+													Description: "Which headers to include in the cache key.",
 													Computed:    true,
 													CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyHeaderDataSourceModel](ctx),
 													Attributes: map[string]schema.Attribute{
 														"check_presence": schema.ListAttribute{
-															Description: "Checks for the presence of these header names. The presence of these headers is used in building the cache key.",
+															Description: "A list of headers to check for the presence of. The presence of these headers is included in the cache key.",
 															Computed:    true,
+															Validators: []validator.List{
+																listvalidator.SizeAtLeast(1),
+															},
 															CustomType:  customfield.NewListType[types.String](ctx),
 															ElementType: types.StringType,
 														},
 														"contains": schema.MapAttribute{
-															Description: "For each header name and list of values combination, check if the request header contains any of the values provided. The presence of the request header and whether any of the values provided are contained in the request header value is used in building the cache key.",
+															Description: "A mapping of header names to a list of values. If a header is present in the request and contains any of the values provided, its value is included in the cache key.",
 															Computed:    true,
-															CustomType:  customfield.NewMapType[customfield.List[types.String]](ctx),
+															Validators: []validator.Map{
+																mapvalidator.SizeAtLeast(1),
+																mapvalidator.ValueListsAre(listvalidator.SizeAtLeast(1)),
+															},
+															CustomType: customfield.NewMapType[customfield.List[types.String]](ctx),
 															ElementType: types.ListType{
 																ElemType: types.StringType,
 															},
 														},
 														"exclude_origin": schema.BoolAttribute{
-															Description: "Whether or not to include the origin header. A value of true will exclude the origin header in the cache key.",
+															Description: "Whether to exclude the origin header in the cache key.",
 															Computed:    true,
 														},
 														"include": schema.ListAttribute{
-															Description: "Include these headers' names and their values.",
+															Description: "A list of headers to include in the cache key.",
 															Computed:    true,
+															Validators: []validator.List{
+																listvalidator.SizeAtLeast(1),
+															},
 															CustomType:  customfield.NewListType[types.String](ctx),
 															ElementType: types.StringType,
 														},
 													},
 												},
 												"host": schema.SingleNestedAttribute{
-													Description: "Whether to use the original host or the resolved host in the cache key.",
+													Description: "How to use the host in the cache key.",
 													Computed:    true,
 													CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyHostDataSourceModel](ctx),
 													Attributes: map[string]schema.Attribute{
 														"resolved": schema.BoolAttribute{
-															Description: "Use the resolved host in the cache key. A value of true will use the resolved host, while a value or false will use the original host.",
+															Description: "Whether to use the resolved host in the cache key.",
 															Computed:    true,
 														},
 													},
 												},
 												"query_string": schema.SingleNestedAttribute{
-													Description: "Use the presence of parameters in the query string to build the cache key.",
+													Description: "Which query string parameters to include in or exclude from the cache key.",
 													Computed:    true,
 													CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyQueryStringDataSourceModel](ctx),
 													Attributes: map[string]schema.Attribute{
 														"include": schema.SingleNestedAttribute{
-															Description: "A list of query string parameters used to build the cache key.",
+															Description: "Which query string parameters to include in the cache key.",
 															Computed:    true,
-															CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyQueryStringIncludeDataSourceModel](ctx),
+															Validators: []validator.Object{
+																objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("exclude")),
+															},
+															CustomType: customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyQueryStringIncludeDataSourceModel](ctx),
 															Attributes: map[string]schema.Attribute{
 																"list": schema.ListAttribute{
+																	Description: "A list of query string parameters to include in the cache key.",
 																	Computed:    true,
+																	Validators: []validator.List{
+																		listvalidator.ExactlyOneOf(path.MatchRelative().AtParent().AtName("all")),
+																		listvalidator.SizeAtLeast(1),
+																	},
 																	CustomType:  customfield.NewListType[types.String](ctx),
 																	ElementType: types.StringType,
 																},
 																"all": schema.BoolAttribute{
-																	Description: "Determines whether to include all query string parameters in the cache key.",
+																	Description: "Whether to include all query string parameters in the cache key.",
 																	Computed:    true,
+																	Validators: []validator.Bool{
+																		boolvalidator.Equals(true),
+																	},
 																},
 															},
 														},
 														"exclude": schema.SingleNestedAttribute{
-															Description: "A list of query string parameters NOT used to build the cache key. All parameters present in the request but missing in this list will be used to build the cache key.",
+															Description: "Which query string parameters to exclude from the cache key.",
 															Computed:    true,
-															CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyQueryStringExcludeDataSourceModel](ctx),
+															Validators: []validator.Object{
+																objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("include")),
+															},
+															CustomType: customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyQueryStringExcludeDataSourceModel](ctx),
 															Attributes: map[string]schema.Attribute{
 																"list": schema.ListAttribute{
+																	Description: "A list of query string parameters to exclude from the cache key.",
 																	Computed:    true,
+																	Validators: []validator.List{
+																		listvalidator.ExactlyOneOf(path.MatchRelative().AtParent().AtName("all")),
+																		listvalidator.SizeAtLeast(1),
+																	},
 																	CustomType:  customfield.NewListType[types.String](ctx),
 																	ElementType: types.StringType,
 																},
 																"all": schema.BoolAttribute{
-																	Description: "Determines whether to exclude all query string parameters from the cache key.",
+																	Description: "Whether to exclude all query string parameters from the cache key.",
 																	Computed:    true,
+																	Validators: []validator.Bool{
+																		boolvalidator.Equals(true),
+																	},
 																},
 															},
 														},
 													},
 												},
 												"user": schema.SingleNestedAttribute{
-													Description: "Characteristics of the request user agent used in building the cache key.",
+													Description: "How to use characteristics of the request user agent in the cache key.",
 													Computed:    true,
 													CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheKeyCustomKeyUserDataSourceModel](ctx),
 													Attributes: map[string]schema.Attribute{
 														"device_type": schema.BoolAttribute{
-															Description: "Use the user agent's device type in the cache key.",
+															Description: "Whether to use the user agent's device type in the cache key.",
 															Computed:    true,
 														},
 														"geo": schema.BoolAttribute{
-															Description: "Use the user agents's country in the cache key.",
+															Description: "Whether to use the user agents's country in the cache key.",
 															Computed:    true,
 														},
 														"lang": schema.BoolAttribute{
-															Description: "Use the user agent's language in the cache key.",
+															Description: "Whether to use the user agent's language in the cache key.",
 															Computed:    true,
 														},
 													},
@@ -833,40 +1090,43 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 											},
 										},
 										"ignore_query_strings_order": schema.BoolAttribute{
-											Description: "Treat requests with the same query parameters the same, regardless of the order those query parameters are in. A value of true ignores the query strings' order.",
+											Description: "Whether to treat requests with the same query parameters the same, regardless of the order those query parameters are in.",
 											Computed:    true,
 										},
 									},
 								},
 								"cache_reserve": schema.SingleNestedAttribute{
-									Description: "Mark whether the request's response from origin is eligible for Cache Reserve (requires a Cache Reserve add-on plan).",
+									Description: "Settings to determine whether the request's response from origin is eligible for Cache Reserve (requires a Cache Reserve add-on plan).",
 									Computed:    true,
 									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersCacheReserveDataSourceModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"eligible": schema.BoolAttribute{
-											Description: "Determines whether cache reserve is enabled. If this is true and a request meets eligibility criteria, Cloudflare will write the resource to cache reserve.",
+											Description: "Whether Cache Reserve is enabled. If this is true and a request meets eligibility criteria, Cloudflare will write the resource to Cache Reserve.",
 											Computed:    true,
 										},
 										"minimum_file_size": schema.Int64Attribute{
-											Description: "The minimum file size eligible for store in cache reserve.",
+											Description: "The minimum file size eligible for storage in Cache Reserve.",
 											Computed:    true,
+											Validators: []validator.Int64{
+												int64validator.AtLeast(0),
+											},
 										},
 									},
 								},
 								"edge_ttl": schema.SingleNestedAttribute{
-									Description: "TTL (Time to Live) specifies the maximum time to cache a resource in the Cloudflare edge network.",
+									Description: "How long the Cloudflare edge network should cache the response.",
 									Computed:    true,
 									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersEdgeTTLDataSourceModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"default": schema.Int64Attribute{
-											Description: "The TTL (in seconds) if you choose override_origin mode.",
+											Description: "The edge TTL (in seconds) if you choose the \"override_origin\" mode.",
 											Computed:    true,
 											Validators: []validator.Int64{
-												int64validator.Between(0, math.MaxInt64),
+												int64validator.AtLeast(0),
 											},
 										},
 										"mode": schema.StringAttribute{
-											Description: "Edge TTL options.\nAvailable values: \"respect_origin\", \"bypass_by_default\", \"override_origin\".",
+											Description: "The edge TTL mode.\nAvailable values: \"respect_origin\", \"bypass_by_default\", \"override_origin\".",
 											Computed:    true,
 											Validators: []validator.String{
 												stringvalidator.OneOfCaseInsensitive(
@@ -877,32 +1137,48 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 											},
 										},
 										"status_code_ttl": schema.ListNestedAttribute{
-											Description: "List of single status codes, or status code ranges to apply the selected mode.",
+											Description: "A list of TTLs to apply to specific status codes or status code ranges.",
 											Computed:    true,
-											CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersEdgeTTLStatusCodeTTLDataSourceModel](ctx),
+											Validators: []validator.List{
+												listvalidator.SizeAtLeast(1),
+											},
+											CustomType: customfield.NewNestedObjectListType[RulesetRulesActionParametersEdgeTTLStatusCodeTTLDataSourceModel](ctx),
 											NestedObject: schema.NestedAttributeObject{
 												Attributes: map[string]schema.Attribute{
-													"value": schema.Int64Attribute{
-														Description: `Time to cache a response (in seconds). A value of 0 is equivalent to setting the Cache-Control header with the value "no-cache". A value of -1 is equivalent to setting Cache-Control header with the value of "no-store".`,
-														Computed:    true,
-													},
 													"status_code_range": schema.SingleNestedAttribute{
-														Description: "The range of status codes used to apply the selected mode.",
+														Description: "A range of status codes to apply the TTL to.",
 														Computed:    true,
-														CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersEdgeTTLStatusCodeTTLStatusCodeRangeDataSourceModel](ctx),
+														Validators: []validator.Object{
+															objectvalidator.ExactlyOneOf(path.MatchRelative().AtParent().AtName("status_code")),
+														},
+														CustomType: customfield.NewNestedObjectType[RulesetRulesActionParametersEdgeTTLStatusCodeTTLStatusCodeRangeDataSourceModel](ctx),
 														Attributes: map[string]schema.Attribute{
 															"from": schema.Int64Attribute{
-																Description: "Response status code lower bound.",
+																Description: "The lower bound of the range.",
 																Computed:    true,
+																Validators: []validator.Int64{
+																	int64validator.AtLeastOneOf(path.MatchRelative().AtParent().AtName("to")),
+																	int64validator.Between(100, 999),
+																},
 															},
 															"to": schema.Int64Attribute{
-																Description: "Response status code upper bound.",
+																Description: "The upper bound of the range.",
 																Computed:    true,
+																Validators: []validator.Int64{
+																	int64validator.Between(100, 999),
+																},
 															},
 														},
 													},
-													"status_code_value": schema.Int64Attribute{
-														Description: "Set the TTL for responses with this specific status code.",
+													"status_code": schema.Int64Attribute{
+														Description: "A single status code to apply the TTL to.",
+														Computed:    true,
+														Validators: []validator.Int64{
+															int64validator.Between(100, 999),
+														},
+													},
+													"value": schema.Int64Attribute{
+														Description: "The time to cache the response for (in seconds). A value of 0 is equivalent to setting the cache control header with the value \"no-cache\". A value of -1 is equivalent to setting the cache control header with the value of \"no-store\".",
 														Computed:    true,
 													},
 												},
@@ -911,28 +1187,31 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 									},
 								},
 								"origin_cache_control": schema.BoolAttribute{
-									Description: "When enabled, Cloudflare will aim to strictly adhere to RFC 7234.",
+									Description: "Whether Cloudflare will aim to strictly adhere to RFC 7234.",
 									Computed:    true,
 								},
 								"origin_error_page_passthru": schema.BoolAttribute{
-									Description: "Generate Cloudflare error pages from issues sent from the origin server. When on, error pages will trigger for issues from the origin.",
+									Description: "Whether to generate Cloudflare error pages for issues from the origin server.",
 									Computed:    true,
 								},
 								"read_timeout": schema.Int64Attribute{
-									Description: "Define a timeout value between two successive read operations to your origin server. Historically, the timeout value between two read options from Cloudflare to an origin server is 100 seconds. If you are attempting to reduce HTTP 524 errors because of timeouts from an origin server, try increasing this timeout value.",
+									Description: "A timeout value between two successive read operations to use for your origin server. Historically, the timeout value between two read options from Cloudflare to an origin server is 100 seconds. If you are attempting to reduce HTTP 524 errors because of timeouts from an origin server, try increasing this timeout value.",
 									Computed:    true,
+									Validators: []validator.Int64{
+										int64validator.Between(100, 6000),
+									},
 								},
 								"respect_strong_etags": schema.BoolAttribute{
-									Description: "Specify whether or not Cloudflare should respect strong ETag (entity tag) headers. When off, Cloudflare converts strong ETag headers to weak ETag headers.",
+									Description: "Whether Cloudflare should respect strong ETag (entity tag) headers. If false, Cloudflare converts strong ETag headers to weak ETag headers.",
 									Computed:    true,
 								},
 								"serve_stale": schema.SingleNestedAttribute{
-									Description: "Define if Cloudflare should serve stale content while getting the latest content from the origin. If on, Cloudflare will not serve stale content while getting the latest content from the origin.",
+									Description: "When to serve stale content from cache.",
 									Computed:    true,
 									CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersServeStaleDataSourceModel](ctx),
 									Attributes: map[string]schema.Attribute{
 										"disable_stale_while_updating": schema.BoolAttribute{
-											Description: "Defines whether Cloudflare should serve stale content while updating. If true, Cloudflare will not serve stale content while getting the latest content from the origin.",
+											Description: "Whether Cloudflare should disable serving stale content while getting the latest content from the origin.",
 											Computed:    true,
 										},
 									},
@@ -940,12 +1219,18 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 								"cookie_fields": schema.ListNestedAttribute{
 									Description: "The cookie fields to log.",
 									Computed:    true,
-									CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersCookieFieldsDataSourceModel](ctx),
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(1),
+									},
+									CustomType: customfield.NewNestedObjectListType[RulesetRulesActionParametersCookieFieldsDataSourceModel](ctx),
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"name": schema.StringAttribute{
-												Description: "The name of the field.",
+												Description: "The name of the cookie.",
 												Computed:    true,
+												Validators: []validator.String{
+													stringvalidator.LengthAtLeast(1),
+												},
 											},
 										},
 									},
@@ -953,12 +1238,18 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 								"raw_response_fields": schema.ListNestedAttribute{
 									Description: "The raw response fields to log.",
 									Computed:    true,
-									CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersRawResponseFieldsDataSourceModel](ctx),
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(1),
+									},
+									CustomType: customfield.NewNestedObjectListType[RulesetRulesActionParametersRawResponseFieldsDataSourceModel](ctx),
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"name": schema.StringAttribute{
-												Description: "The name of the field.",
+												Description: "The name of the response header.",
 												Computed:    true,
+												Validators: []validator.String{
+													stringvalidator.LengthAtLeast(1),
+												},
 											},
 											"preserve_duplicates": schema.BoolAttribute{
 												Description: "Whether to log duplicate values of the same header.",
@@ -970,12 +1261,18 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 								"request_fields": schema.ListNestedAttribute{
 									Description: "The raw request fields to log.",
 									Computed:    true,
-									CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersRequestFieldsDataSourceModel](ctx),
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(1),
+									},
+									CustomType: customfield.NewNestedObjectListType[RulesetRulesActionParametersRequestFieldsDataSourceModel](ctx),
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"name": schema.StringAttribute{
-												Description: "The name of the field.",
+												Description: "The name of the header.",
 												Computed:    true,
+												Validators: []validator.String{
+													stringvalidator.LengthAtLeast(1),
+												},
 											},
 										},
 									},
@@ -983,12 +1280,18 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 								"response_fields": schema.ListNestedAttribute{
 									Description: "The transformed response fields to log.",
 									Computed:    true,
-									CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersResponseFieldsDataSourceModel](ctx),
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(1),
+									},
+									CustomType: customfield.NewNestedObjectListType[RulesetRulesActionParametersResponseFieldsDataSourceModel](ctx),
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"name": schema.StringAttribute{
-												Description: "The name of the field.",
+												Description: "The name of the response header.",
 												Computed:    true,
+												Validators: []validator.String{
+													stringvalidator.LengthAtLeast(1),
+												},
 											},
 											"preserve_duplicates": schema.BoolAttribute{
 												Description: "Whether to log duplicate values of the same header.",
@@ -1000,23 +1303,23 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 								"transformed_request_fields": schema.ListNestedAttribute{
 									Description: "The transformed request fields to log.",
 									Computed:    true,
-									CustomType:  customfield.NewNestedObjectListType[RulesetRulesActionParametersTransformedRequestFieldsDataSourceModel](ctx),
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(1),
+									},
+									CustomType: customfield.NewNestedObjectListType[RulesetRulesActionParametersTransformedRequestFieldsDataSourceModel](ctx),
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"name": schema.StringAttribute{
-												Description: "The name of the field.",
+												Description: "The name of the header.",
 												Computed:    true,
+												Validators: []validator.String{
+													stringvalidator.LengthAtLeast(1),
+												},
 											},
 										},
 									},
 								},
 							},
-						},
-						"categories": schema.ListAttribute{
-							Description: "The categories of the rule.",
-							Computed:    true,
-							CustomType:  customfield.NewListType[types.String](ctx),
-							ElementType: types.StringType,
 						},
 						"description": schema.StringAttribute{
 							Description: "An informative description of the rule.",
@@ -1027,28 +1330,40 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 							Computed:    true,
 						},
 						"exposed_credential_check": schema.SingleNestedAttribute{
-							Description: "Configure checks for exposed credentials.",
+							Description: "Configuration for exposed credential checking.",
 							Computed:    true,
 							CustomType:  customfield.NewNestedObjectType[RulesetRulesExposedCredentialCheckDataSourceModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"password_expression": schema.StringAttribute{
-									Description: "Expression that selects the password used in the credentials check.",
+									Description: "An expression that selects the password used in the credentials check.",
 									Computed:    true,
+									Validators: []validator.String{
+										stringvalidator.LengthAtLeast(1),
+									},
 								},
 								"username_expression": schema.StringAttribute{
-									Description: "Expression that selects the user ID used in the credentials check.",
+									Description: "An expression that selects the user ID used in the credentials check.",
 									Computed:    true,
+									Validators: []validator.String{
+										stringvalidator.LengthAtLeast(1),
+									},
 								},
 							},
 						},
 						"expression": schema.StringAttribute{
 							Description: "The expression defining which traffic will match the rule.",
 							Computed:    true,
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+							},
 						},
 						"logging": schema.SingleNestedAttribute{
 							Description: "An object configuring the rule's logging behavior.",
 							Computed:    true,
-							CustomType:  customfield.NewNestedObjectType[RulesetRulesLoggingDataSourceModel](ctx),
+							Validators: []validator.Object{
+								objectvalidator.AlsoRequires(path.MatchRelative().AtName("enabled")),
+							},
+							CustomType: customfield.NewNestedObjectType[RulesetRulesLoggingDataSourceModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"enabled": schema.BoolAttribute{
 									Description: "Whether to generate a log when the rule matches.",
@@ -1057,23 +1372,32 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 							},
 						},
 						"ratelimit": schema.SingleNestedAttribute{
-							Description: "An object configuring the rule's ratelimit behavior.",
+							Description: "An object configuring the rule's rate limit behavior.",
 							Computed:    true,
 							CustomType:  customfield.NewNestedObjectType[RulesetRulesRatelimitDataSourceModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"characteristics": schema.ListAttribute{
-									Description: "Characteristics of the request on which the ratelimiter counter will be incremented.",
+									Description: "Characteristics of the request on which the rate limit counter will be incremented.",
 									Computed:    true,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(1),
+									},
 									CustomType:  customfield.NewListType[types.String](ctx),
 									ElementType: types.StringType,
 								},
 								"period": schema.Int64Attribute{
 									Description: "Period in seconds over which the counter is being incremented.",
 									Computed:    true,
+									Validators: []validator.Int64{
+										int64validator.AtLeast(0),
+									},
 								},
 								"counting_expression": schema.StringAttribute{
-									Description: "Defines when the ratelimit counter should be incremented. It is optional and defaults to the same as the rule's expression.",
+									Description: "An expression that defines when the rate limit counter should be incremented. It defaults to the same as the rule's expression.",
 									Computed:    true,
+									Validators: []validator.String{
+										stringvalidator.LengthAtLeast(1),
+									},
 								},
 								"mitigation_timeout": schema.Int64Attribute{
 									Description: "Period of time in seconds after which the action will be disabled following its first execution.",
@@ -1087,7 +1411,7 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 									},
 								},
 								"requests_to_origin": schema.BoolAttribute{
-									Description: "Defines if ratelimit counting is only done when an origin is reached.",
+									Description: "Whether counting is only performed when an origin is reached.",
 									Computed:    true,
 								},
 								"score_per_period": schema.Int64Attribute{
@@ -1095,16 +1419,37 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 									Computed:    true,
 								},
 								"score_response_header_name": schema.StringAttribute{
-									Description: "The response header name provided by the origin which should contain the score to increment ratelimit counter on.",
+									Description: "A response header name provided by the origin, which contains the score to increment rate limit counter with.",
 									Computed:    true,
+									Validators: []validator.String{
+										stringvalidator.LengthAtLeast(1),
+									},
 								},
 							},
 						},
 						"ref": schema.StringAttribute{
-							Description: "The reference of the rule (the rule ID by default).",
+							Description: "The reference of the rule (the rule's ID by default).",
 							Computed:    true,
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+							},
 						},
 					},
+				},
+			},
+			"last_updated": schema.StringAttribute{
+				Description: "The timestamp of when the ruleset was last modified.",
+				Computed:    true,
+				CustomType:  timetypes.RFC3339Type{},
+			},
+			"version": schema.StringAttribute{
+				Description: "The version of the ruleset.",
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile("^[0-9]+$"),
+						"value must be a non-empty string containing only numbers",
+					),
 				},
 			},
 		},
@@ -1116,7 +1461,5 @@ func (d *RulesetDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 }
 
 func (d *RulesetDataSource) ConfigValidators(_ context.Context) []datasource.ConfigValidator {
-	return []datasource.ConfigValidator{
-		datasourcevalidator.Conflicting(path.MatchRoot("account_id"), path.MatchRoot("zone_id")),
-	}
+	return []datasource.ConfigValidator{}
 }

--- a/internal/services/ruleset/list_data_source.go
+++ b/internal/services/ruleset/list_data_source.go
@@ -92,9 +92,10 @@ func (d *RulesetsDataSource) Read(ctx context.Context, req datasource.ReadReques
 	}
 
 	acc = acc[:min(len(acc), maxItems)]
-	result, diags := customfield.NewObjectListFromAttributes[RulesetsResultDataSourceModel](ctx, acc)
+	result, diags := customfield.NewObjectListFromAttributes[RulesetsRulesetDataSourceModel](ctx, acc)
 	resp.Diagnostics.Append(diags...)
-	data.Result = result
+	data.Rulesets = result
+	data.Rulesets = result
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/ruleset/list_data_source_model.go
+++ b/internal/services/ruleset/list_data_source_model.go
@@ -13,14 +13,15 @@ import (
 )
 
 type RulesetsResultListDataSourceEnvelope struct {
-	Result customfield.NestedObjectList[RulesetsResultDataSourceModel] `json:"result,computed"`
+	Result customfield.NestedObjectList[RulesetsRulesetDataSourceModel] `json:"result,computed"`
 }
 
 type RulesetsDataSourceModel struct {
-	AccountID types.String                                                `tfsdk:"account_id" path:"account_id,optional"`
-	ZoneID    types.String                                                `tfsdk:"zone_id" path:"zone_id,optional"`
-	MaxItems  types.Int64                                                 `tfsdk:"max_items"`
-	Result    customfield.NestedObjectList[RulesetsResultDataSourceModel] `tfsdk:"result"`
+	AccountID types.String                                                 `tfsdk:"account_id" path:"account_id,optional"`
+	ZoneID    types.String                                                 `tfsdk:"zone_id" path:"zone_id,optional"`
+	MaxItems  types.Int64                                                  `tfsdk:"max_items"`
+	Rulesets  customfield.NestedObjectList[RulesetsRulesetDataSourceModel] `tfsdk:"rulesets"`
+	Result    customfield.NestedObjectList[RulesetsRulesetDataSourceModel] `tfsdk:"result"`
 }
 
 func (m *RulesetsDataSourceModel) toListParams(_ context.Context) (params rulesets.RulesetListParams, diags diag.Diagnostics) {
@@ -35,7 +36,7 @@ func (m *RulesetsDataSourceModel) toListParams(_ context.Context) (params rulese
 	return
 }
 
-type RulesetsResultDataSourceModel struct {
+type RulesetsRulesetDataSourceModel struct {
 	ID          types.String `tfsdk:"id" json:"id,computed"`
 	Kind        types.String `tfsdk:"kind" json:"kind,computed"`
 	Name        types.String `tfsdk:"name" json:"name,computed"`

--- a/internal/services/ruleset/schema.go
+++ b/internal/services/ruleset/schema.go
@@ -47,7 +47,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description: "The unique ID of the account.",
 				Optional:    true,
 				Validators: []validator.String{
-					stringvalidator.ConflictsWith(path.MatchRoot("zone_id")),
+					stringvalidator.ExactlyOneOf(path.MatchRoot("zone_id")),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile("^[0-9a-f]{32}$"),
+						"value must be a 32-character hexadecimal string",
+					),
 				},
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
@@ -55,7 +59,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description: "The unique ID of the zone.",
 				Optional:    true,
 				Validators: []validator.String{
-					stringvalidator.ConflictsWith(path.MatchRoot("account_id")),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile("^[0-9a-f]{32}$"),
+						"value must be a 32-character hexadecimal string",
+					),
 				},
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},


### PR DESCRIPTION
* Make data sources consistent with the schema of the resource.

* Deprecate `ruleset_id` in favor of `id` for `cloudflare_ruleset` data source.

* Deprecate `result` in favor of `rulesets` for `cloudflare_rulesets` data source.

* Update documentation to reflect latest changes.

* Improve validation on `account_id` and `zone_id` attributes.