### PR TITLE
feat(ruleset): add read-only attributes to data source

### DIFF
--- a/internal/services/ruleset/data_source_model.go
+++ b/internal/services/ruleset/data_source_model.go
@@ -54,6 +54,7 @@ type RulesetRulesDataSourceModel struct {
 	Logging                customfield.NestedObject[RulesetRulesLoggingDataSourceModel]                `tfsdk:"logging" json:"logging,computed"`
 	Ratelimit              customfield.NestedObject[RulesetRulesRatelimitDataSourceModel]              `tfsdk:"ratelimit" json:"ratelimit,computed"`
 	Ref                    types.String                                                                `tfsdk:"ref" json:"ref,computed"`
+	Categories             customfield.List[types.String]                                              `tfsdk:"categories" json:"categories,computed"`
 }
 
 type RulesetRulesActionParametersDataSourceModel struct {
@@ -175,8 +176,9 @@ type RulesetRulesActionParametersHeadersDataSourceModel struct {
 }
 
 type RulesetRulesActionParametersURIDataSourceModel struct {
-	Path  customfield.NestedObject[RulesetRulesActionParametersURIPathDataSourceModel]  `tfsdk:"path" json:"path,computed"`
-	Query customfield.NestedObject[RulesetRulesActionParametersURIQueryDataSourceModel] `tfsdk:"query" json:"query,computed"`
+	Path   customfield.NestedObject[RulesetRulesActionParametersURIPathDataSourceModel]  `tfsdk:"path" json:"path,computed"`
+	Query  customfield.NestedObject[RulesetRulesActionParametersURIQueryDataSourceModel] `tfsdk:"query" json:"query,computed"`
+	Origin types.Bool                                                                    `tfsdk:"origin" json:"origin,computed"`
 }
 
 type RulesetRulesActionParametersURIPathDataSourceModel struct {

--- a/internal/services/ruleset/data_source_schema.go
+++ b/internal/services/ruleset/data_source_schema.go
@@ -564,6 +564,10 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 												},
 											},
 										},
+										"origin": schema.BoolAttribute{
+											Description: "Whether to propagate the rewritten URI to origin.",
+											Computed:    true,
+										},
 									},
 								},
 								"host_header": schema.StringAttribute{
@@ -1433,6 +1437,15 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 							Validators: []validator.String{
 								stringvalidator.LengthAtLeast(1),
 							},
+						},
+						"categories": schema.ListAttribute{
+							Description: "The categories of the rule.",
+							Computed:    true,
+							Validators: []validator.List{
+								listvalidator.SizeAtLeast(1),
+							},
+							CustomType:  customfield.NewListType[types.String](ctx),
+							ElementType: types.StringType,
 						},
 					},
 				},

--- a/internal/services/ruleset/list_data_source.go
+++ b/internal/services/ruleset/list_data_source.go
@@ -95,7 +95,7 @@ func (d *RulesetsDataSource) Read(ctx context.Context, req datasource.ReadReques
 	result, diags := customfield.NewObjectSetFromAttributes[RulesetsRulesetDataSourceModel](ctx, acc)
 	resp.Diagnostics.Append(diags...)
 	data.Rulesets = result
-	data.Rulesets = result
+	data.Result = result
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/ruleset/list_data_source_schema.go
+++ b/internal/services/ruleset/list_data_source_schema.go
@@ -214,6 +214,21 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 							Computed:           true,
 							DeprecationMessage: "Use rulesets.description instead. This attribute will be removed in the next major version of the provider.",
 						},
+						"last_updated": schema.StringAttribute{
+							Description: "The timestamp of when the ruleset was last modified.",
+							Computed:    true,
+							CustomType:  timetypes.RFC3339Type{},
+						},
+						"version": schema.StringAttribute{
+							Description: "The version of the ruleset.",
+							Computed:    true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(
+									regexp.MustCompile("^[0-9]+$"),
+									"value must be a non-empty string containing only numbers",
+								),
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Also fix the deprecated `result` attribute of the `cloudflare_rulesets` data source.