### PR TITLE
Fix incorrect zone setting name in v4 migrations

### DIFF
--- a/cmd/migrate/zone_settings_test.go
+++ b/cmd/migrate/zone_settings_test.go
@@ -100,6 +100,27 @@ import {
 			},
 		},
 		{
+			Name: "zero_rtt setting name mapping",
+			Config: `
+resource "cloudflare_zone_settings_override" "test" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  settings {
+    zero_rtt = "on"
+  }
+}`,
+			Expected: []string{`
+resource "cloudflare_zone_setting" "test_zero_rtt" {
+  zone_id    = "0da42c8d2132a9ddaf714f9e7c920711"
+  setting_id = "0rtt"
+  value      = "on"
+}`, `
+import {
+  to = cloudflare_zone_setting.test_zero_rtt
+  id = "${"0da42c8d2132a9ddaf714f9e7c920711"}/0rtt"
+}`,
+			},
+		},
+		{
 			Name: "empty settings block",
 			Config: `
 resource "cloudflare_zone_settings_override" "zone_settings" {


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Fixes a bug when migrating zone settings where `0_rtt` is incorrectly generated as `zero_rtt`.

## Additional context & links
In the v4 provider, we accepted a setting for "zero_rtt" and under the hood it
changed the API request to use it's actual name `0_rtt`. Because of that, our
generated HCL from the `cmd/migrate` tool still refers to `zero_rtt`.

This patch ensures that we refer to the actual name in v5.

Example v4 config:
```hcl
resource "cloudflare_zone_settings_override" "test" {
  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
  settings {
    zero_rtt = "on"
  }
}
```

Incorrect generated v5 config:
```hcl
resource "cloudflare_zone_setting" "test" {
  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
  setting_id = "zero_rtt"
  value = "on"
}
```

Correct v5 config:
```hcl
resource "cloudflare_zone_setting" "test" {
  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
  setting_id = "0rtt"
  value = "on"
}
```

Changes:

- added a mapping function (`mapSettingName`) in that translates v4 setting
  names to v5 setting names, specifically handling the "zero_rtt" → "0rtt"
  transformation.
- updated the transformation logic in `transformZoneSettingsBlock` at
  to use the mapped setting names for both the `setting_id` value and the
  import block ID.
- added a test case that verifies the `zero_rtt` to `0rtt` mapping works
  correctly.