### PR TITLE
test(ruleset): fix test for rewrite rules

### DIFF
--- a/internal/services/ruleset/data_source_model.go
+++ b/internal/services/ruleset/data_source_model.go
@@ -18,7 +18,7 @@ type RulesetResultDataSourceEnvelope struct {
 }
 
 type RulesetDataSourceModel struct {
-	ID          types.String                                              `tfsdk:"id" path:"id,optional"`
+	ID          types.String                                              `tfsdk:"id" path:"ruleset_id,optional"`
 	RulesetID   types.String                                              `tfsdk:"ruleset_id"`
 	AccountID   types.String                                              `tfsdk:"account_id" path:"account_id,optional"`
 	ZoneID      types.String                                              `tfsdk:"zone_id" path:"zone_id,optional"`

--- a/internal/services/ruleset/ruleset_test.go
+++ b/internal/services/ruleset/ruleset_test.go
@@ -4211,7 +4211,6 @@ func TestAccCloudflareRuleset_RedirectRules(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_RewriteRules(t *testing.T) {
-	t.Skip("Test is failing")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
@@ -4582,7 +4581,8 @@ func TestAccCloudflareRuleset_RewriteRules(t *testing.T) {
 											"value":      knownvalue.StringExact("/foo"),
 											"expression": knownvalue.Null(),
 										}),
-										"query": knownvalue.Null(),
+										"query":  knownvalue.Null(),
+										"origin": knownvalue.Null(),
 									}),
 								}),
 							}),
@@ -4654,6 +4654,7 @@ func TestAccCloudflareRuleset_RewriteRules(t *testing.T) {
 											"value":      knownvalue.StringExact("foo=bar"),
 											"expression": knownvalue.Null(),
 										}),
+										"origin": knownvalue.Null(),
 									}),
 								}),
 							}),
@@ -4734,6 +4735,7 @@ func TestAccCloudflareRuleset_RewriteRules(t *testing.T) {
 											"value":      knownvalue.Null(),
 											"expression": knownvalue.StringExact("regex_replace(http.request.uri.query, \"foo=bar\", \"\")"),
 										}),
+										"origin": knownvalue.Null(),
 									}),
 								}),
 							}),


### PR DESCRIPTION
The data source's `action_parameters.uri.origin` attribute was previously not checked.

Also correct the path parameter name of the data source's `id` attribute.