### PR TITLE
fix(zero_trust_device_custom_profile): resolve API errors and drift issues in device profiles

### DIFF
--- a/internal/services/zero_trust_device_custom_profile/model.go
+++ b/internal/services/zero_trust_device_custom_profile/model.go
@@ -49,7 +49,99 @@ func (m ZeroTrustDeviceCustomProfileModel) MarshalJSON() (data []byte, err error
 }
 
 func (m ZeroTrustDeviceCustomProfileModel) MarshalJSONForUpdate(state ZeroTrustDeviceCustomProfileModel) (data []byte, err error) {
-	return apijson.MarshalForPatch(m, state)
+	// For computed_optional fields that have default values from the server,
+	// we need to avoid sending null values when the user hasn't explicitly set them.
+	// This prevents API errors like "bad device request" (code 2004).
+
+	// For pure optional fields (like description), when user sets them to null
+	// we should NOT send them to the API at all, rather than sending null,
+	// because some API endpoints don't accept null for these fields.
+
+	// Create a copy of the plan model to modify
+	planCopy := m
+
+	// Special handling for description field:
+	// If user wants to remove description (plan is null but state has value),
+	// we send empty string instead of null because API doesn't accept null.
+	if m.Description.IsNull() && !state.Description.IsNull() {
+		planCopy.Description = types.StringValue("") // Send empty string to remove description
+	}
+
+	// Handle other pure optional fields similarly
+	if m.Enabled.IsNull() && !state.Enabled.IsNull() {
+		planCopy.Enabled = state.Enabled
+	}
+	if m.LANAllowMinutes.IsNull() && !state.LANAllowMinutes.IsNull() {
+		planCopy.LANAllowMinutes = state.LANAllowMinutes
+	}
+	if m.LANAllowSubnetSize.IsNull() && !state.LANAllowSubnetSize.IsNull() {
+		planCopy.LANAllowSubnetSize = state.LANAllowSubnetSize
+	}
+
+	// For each computed_optional field that is null in plan but has a value in state,
+	// preserve the state value to avoid nullifying server defaults
+	if m.AllowModeSwitch.IsNull() && !state.AllowModeSwitch.IsNull() {
+		planCopy.AllowModeSwitch = state.AllowModeSwitch
+	}
+	if m.AllowUpdates.IsNull() && !state.AllowUpdates.IsNull() {
+		planCopy.AllowUpdates = state.AllowUpdates
+	}
+	if m.AllowedToLeave.IsNull() && !state.AllowedToLeave.IsNull() {
+		planCopy.AllowedToLeave = state.AllowedToLeave
+	}
+	if m.AutoConnect.IsNull() && !state.AutoConnect.IsNull() {
+		planCopy.AutoConnect = state.AutoConnect
+	}
+	if m.CaptivePortal.IsNull() && !state.CaptivePortal.IsNull() {
+		planCopy.CaptivePortal = state.CaptivePortal
+	}
+	if m.DisableAutoFallback.IsNull() && !state.DisableAutoFallback.IsNull() {
+		planCopy.DisableAutoFallback = state.DisableAutoFallback
+	}
+	if m.ExcludeOfficeIPs.IsNull() && !state.ExcludeOfficeIPs.IsNull() {
+		planCopy.ExcludeOfficeIPs = state.ExcludeOfficeIPs
+	}
+	if m.RegisterInterfaceIPWithDNS.IsNull() && !state.RegisterInterfaceIPWithDNS.IsNull() {
+		planCopy.RegisterInterfaceIPWithDNS = state.RegisterInterfaceIPWithDNS
+	}
+	if m.SccmVpnBoundarySupport.IsNull() && !state.SccmVpnBoundarySupport.IsNull() {
+		planCopy.SccmVpnBoundarySupport = state.SccmVpnBoundarySupport
+	}
+	if m.SupportURL.IsNull() && !state.SupportURL.IsNull() {
+		planCopy.SupportURL = state.SupportURL
+	}
+	if m.SwitchLocked.IsNull() && !state.SwitchLocked.IsNull() {
+		planCopy.SwitchLocked = state.SwitchLocked
+	}
+	if m.TunnelProtocol.IsNull() && !state.TunnelProtocol.IsNull() {
+		planCopy.TunnelProtocol = state.TunnelProtocol
+	} // For optional fields that are lists/objects, handle them carefully
+	if m.Exclude == nil && state.Exclude != nil {
+		planCopy.Exclude = state.Exclude
+	}
+	if m.Include == nil && state.Include != nil {
+		planCopy.Include = state.Include
+	}
+	if m.ServiceModeV2 == nil && state.ServiceModeV2 != nil {
+		planCopy.ServiceModeV2 = state.ServiceModeV2
+	}
+
+	// Computed-only fields should always preserve state values
+	if !state.FallbackDomains.IsNull() {
+		planCopy.FallbackDomains = state.FallbackDomains
+	}
+	if !state.Default.IsNull() {
+		planCopy.Default = state.Default
+	}
+	if !state.GatewayUniqueID.IsNull() {
+		planCopy.GatewayUniqueID = state.GatewayUniqueID
+	}
+	if !state.TargetTests.IsNull() {
+		planCopy.TargetTests = state.TargetTests
+	}
+
+	result, err := apijson.MarshalForPatch(planCopy, state)
+	return result, err
 }
 
 type ZeroTrustDeviceCustomProfileExcludeModel struct {

--- a/internal/services/zero_trust_device_custom_profile/model_test.go
+++ b/internal/services/zero_trust_device_custom_profile/model_test.go
@@ -1,0 +1,89 @@
+package zero_trust_device_custom_profile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMarshalJSONForUpdate_ProblemScenario reproduces the exact scenario from GitHub issue #5514
+func TestMarshalJSONForUpdate_ProblemScenario(t *testing.T) {
+	// Plan: user only specifies required fields, computed_optional fields are null
+	plan := ZeroTrustDeviceCustomProfileModel{
+		AccountID:   types.StringValue("test-account-id"),
+		Match:       types.StringValue(`identity.email == "test@cloudflare.com"`),
+		Name:        types.StringValue("Allow Developers"),
+		Precedence:  types.Float64Value(100),
+		Description: types.StringNull(), // This was causing the problem in the logs!
+		// All other computed_optional fields are null (user didn't specify them)
+		AllowModeSwitch:            types.BoolNull(),
+		AllowUpdates:               types.BoolNull(),
+		AllowedToLeave:             types.BoolNull(),
+		AutoConnect:                types.Float64Null(),
+		CaptivePortal:              types.Float64Null(),
+		DisableAutoFallback:        types.BoolNull(),
+		ExcludeOfficeIPs:           types.BoolNull(),
+		RegisterInterfaceIPWithDNS: types.BoolNull(),
+		SccmVpnBoundarySupport:     types.BoolNull(),
+		SupportURL:                 types.StringNull(),
+		SwitchLocked:               types.BoolNull(),
+		TunnelProtocol:             types.StringNull(),
+		Enabled:                    types.BoolNull(),
+		FallbackDomains:            customfield.NullObjectList[ZeroTrustDeviceCustomProfileFallbackDomainsModel](context.TODO()),
+		TargetTests:                customfield.NullObjectList[ZeroTrustDeviceCustomProfileTargetTestsModel](context.TODO()),
+		Default:                    types.BoolNull(),
+		GatewayUniqueID:            types.StringNull(),
+		PolicyID:                   types.StringNull(),
+		ID:                         types.StringNull(),
+		Exclude:                    nil,
+	}
+
+	// State: API returned default values
+	state := ZeroTrustDeviceCustomProfileModel{
+		AccountID:                  types.StringValue("test-account-id"),
+		Match:                      types.StringValue(`identity.email == "test@cloudflare.com"`),
+		Name:                       types.StringValue("Allow Developers"),
+		Precedence:                 types.Float64Value(100),
+		Description:                types.StringValue(""), // API returns empty string, not null
+		Enabled:                    types.BoolValue(true),
+		AllowModeSwitch:            types.BoolValue(false),
+		AllowUpdates:               types.BoolValue(false),
+		AllowedToLeave:             types.BoolValue(true),
+		AutoConnect:                types.Float64Value(0),
+		CaptivePortal:              types.Float64Value(180),
+		DisableAutoFallback:        types.BoolValue(false),
+		ExcludeOfficeIPs:           types.BoolValue(false),
+		RegisterInterfaceIPWithDNS: types.BoolValue(true),
+		SccmVpnBoundarySupport:     types.BoolValue(false),
+		SupportURL:                 types.StringValue(""),
+		SwitchLocked:               types.BoolValue(false),
+		TunnelProtocol:             types.StringValue(""),
+		FallbackDomains:            customfield.NullObjectList[ZeroTrustDeviceCustomProfileFallbackDomainsModel](context.TODO()),
+		TargetTests:                customfield.NullObjectList[ZeroTrustDeviceCustomProfileTargetTestsModel](context.TODO()),
+		Default:                    types.BoolValue(false),
+		GatewayUniqueID:            types.StringValue("test-gateway-id"),
+		PolicyID:                   types.StringValue("test-policy-id"),
+		ID:                         types.StringValue("test-policy-id"),
+		Exclude:                    nil,
+	}
+
+	// This should NOT produce JSON with null values
+	jsonBytes, err := plan.MarshalJSONForUpdate(state)
+	require.NoError(t, err)
+
+	jsonStr := string(jsonBytes)
+	t.Logf("Generated JSON: '%s'", jsonStr)
+
+	// The key test: we should NOT see null values for ANY field
+	assert.NotContains(t, jsonStr, `null`, "JSON should not contain any null values")
+	assert.NotContains(t, jsonStr, `"description":null`, "description should not be explicitly nullified")
+
+	// An empty JSON (no changes) is perfectly acceptable and prevents API errors
+	if jsonStr == "" {
+		t.Log("Empty JSON indicates no changes needed - this prevents API errors")
+	}
+}

--- a/internal/services/zero_trust_device_custom_profile/resource.go
+++ b/internal/services/zero_trust_device_custom_profile/resource.go
@@ -118,30 +118,63 @@ func (r *ZeroTrustDeviceCustomProfileResource) Update(ctx context.Context, req r
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
 		return
 	}
-	res := new(http.Response)
-	env := ZeroTrustDeviceCustomProfileResultEnvelope{*data}
-	_, err = r.client.ZeroTrust.Devices.Policies.Custom.Edit(
-		ctx,
-		data.PolicyID.ValueString(),
-		zero_trust.DevicePolicyCustomEditParams{
-			AccountID: cloudflare.F(data.AccountID.ValueString()),
-		},
-		option.WithRequestBody("application/json", dataBytes),
-		option.WithResponseBodyInto(&res),
-		option.WithMiddleware(logging.Middleware(ctx)),
-	)
-	if err != nil {
-		resp.Diagnostics.AddError("failed to make http request", err.Error())
-		return
+
+	// If there are no changes (empty JSON), skip the API call and use plan with computed fields from state
+	if len(dataBytes) == 0 || string(dataBytes) == "" {
+		// No API changes needed - but preserve computed fields from state
+		// Keep the plan as-is for user-specified fields (including nulls)
+		// Only update computed fields from state to prevent drift
+		if !state.Default.IsNull() {
+			data.Default = state.Default
+		}
+		if !state.GatewayUniqueID.IsNull() {
+			data.GatewayUniqueID = state.GatewayUniqueID
+		}
+		if !state.FallbackDomains.IsNull() {
+			data.FallbackDomains = state.FallbackDomains
+		}
+		if !state.TargetTests.IsNull() {
+			data.TargetTests = state.TargetTests
+		}
+		data.ID = data.PolicyID
+	} else {
+		// There are changes - proceed with the API call
+		res := new(http.Response)
+		env := ZeroTrustDeviceCustomProfileResultEnvelope{*data}
+		_, err = r.client.ZeroTrust.Devices.Policies.Custom.Edit(
+			ctx,
+			data.PolicyID.ValueString(),
+			zero_trust.DevicePolicyCustomEditParams{
+				AccountID: cloudflare.F(data.AccountID.ValueString()),
+			},
+			option.WithRequestBody("application/json", dataBytes),
+			option.WithResponseBodyInto(&res),
+			option.WithMiddleware(logging.Middleware(ctx)),
+		)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to make http request", err.Error())
+			return
+		}
+		bytes, _ := io.ReadAll(res.Body)
+		err = apijson.UnmarshalComputed(bytes, &env)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
+			return
+		}
+		data = &env.Result
+		data.ID = data.PolicyID
+
+		// After API call, adjust the result to match user's plan for optional fields
+		// If user wanted to remove description (set to null), ensure the final state reflects that
+		// even if API returned empty string
+		var originalPlan *ZeroTrustDeviceCustomProfileModel
+		resp.Diagnostics.Append(req.Plan.Get(ctx, &originalPlan)...)
+		if !resp.Diagnostics.HasError() {
+			if originalPlan.Description.IsNull() {
+				data.Description = types.StringNull()
+			}
+		}
 	}
-	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.UnmarshalComputed(bytes, &env)
-	if err != nil {
-		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
-		return
-	}
-	data = &env.Result
-	data.ID = data.PolicyID
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -176,7 +209,7 @@ func (r *ZeroTrustDeviceCustomProfileResource) Read(ctx context.Context, req res
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
@@ -248,7 +281,7 @@ func (r *ZeroTrustDeviceCustomProfileResource) ImportState(ctx context.Context, 
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
@@ -259,6 +292,107 @@ func (r *ZeroTrustDeviceCustomProfileResource) ImportState(ctx context.Context, 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *ZeroTrustDeviceCustomProfileResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, _ *resource.ModifyPlanResponse) {
+func (r *ZeroTrustDeviceCustomProfileResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// If this is a destroy operation, we don't need to modify the plan
+	if req.Plan.Raw.IsNull() {
+		return
+	}
 
+	// Get the planned and current state
+	var plan, state ZeroTrustDeviceCustomProfileModel
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If there's no state (i.e., create operation), we don't need to modify the plan
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// ONLY modify computed and computed_optional fields in ModifyPlan
+	// Do NOT modify optional fields - they should be handled in MarshalJSONForUpdate
+	planModified := false
+
+	// Computed fields should always be preserved from state to prevent drift
+	if !state.Default.IsNull() {
+		plan.Default = state.Default
+		planModified = true
+	}
+	if !state.GatewayUniqueID.IsNull() {
+		plan.GatewayUniqueID = state.GatewayUniqueID
+		planModified = true
+	}
+	if !state.FallbackDomains.IsNull() {
+		plan.FallbackDomains = state.FallbackDomains
+		planModified = true
+	}
+	if !state.TargetTests.IsNull() {
+		plan.TargetTests = state.TargetTests
+		planModified = true
+	}
+
+	// For computed_optional fields, preserve state values when plan is null/unknown
+	if (plan.AllowModeSwitch.IsNull() || plan.AllowModeSwitch.IsUnknown()) && !state.AllowModeSwitch.IsNull() {
+		plan.AllowModeSwitch = state.AllowModeSwitch
+		planModified = true
+	}
+	if (plan.AllowUpdates.IsNull() || plan.AllowUpdates.IsUnknown()) && !state.AllowUpdates.IsNull() {
+		plan.AllowUpdates = state.AllowUpdates
+		planModified = true
+	}
+	if (plan.AllowedToLeave.IsNull() || plan.AllowedToLeave.IsUnknown()) && !state.AllowedToLeave.IsNull() {
+		plan.AllowedToLeave = state.AllowedToLeave
+		planModified = true
+	}
+	if (plan.AutoConnect.IsNull() || plan.AutoConnect.IsUnknown()) && !state.AutoConnect.IsNull() {
+		plan.AutoConnect = state.AutoConnect
+		planModified = true
+	}
+	if (plan.CaptivePortal.IsNull() || plan.CaptivePortal.IsUnknown()) && !state.CaptivePortal.IsNull() {
+		plan.CaptivePortal = state.CaptivePortal
+		planModified = true
+	}
+	if (plan.DisableAutoFallback.IsNull() || plan.DisableAutoFallback.IsUnknown()) && !state.DisableAutoFallback.IsNull() {
+		plan.DisableAutoFallback = state.DisableAutoFallback
+		planModified = true
+	}
+	if (plan.ExcludeOfficeIPs.IsNull() || plan.ExcludeOfficeIPs.IsUnknown()) && !state.ExcludeOfficeIPs.IsNull() {
+		plan.ExcludeOfficeIPs = state.ExcludeOfficeIPs
+		planModified = true
+	}
+	if (plan.RegisterInterfaceIPWithDNS.IsNull() || plan.RegisterInterfaceIPWithDNS.IsUnknown()) && !state.RegisterInterfaceIPWithDNS.IsNull() {
+		plan.RegisterInterfaceIPWithDNS = state.RegisterInterfaceIPWithDNS
+		planModified = true
+	}
+	if (plan.SccmVpnBoundarySupport.IsNull() || plan.SccmVpnBoundarySupport.IsUnknown()) && !state.SccmVpnBoundarySupport.IsNull() {
+		plan.SccmVpnBoundarySupport = state.SccmVpnBoundarySupport
+		planModified = true
+	}
+	if (plan.SupportURL.IsNull() || plan.SupportURL.IsUnknown()) && !state.SupportURL.IsNull() {
+		plan.SupportURL = state.SupportURL
+		planModified = true
+	}
+	if (plan.SwitchLocked.IsNull() || plan.SwitchLocked.IsUnknown()) && !state.SwitchLocked.IsNull() {
+		plan.SwitchLocked = state.SwitchLocked
+		planModified = true
+	}
+	if (plan.TunnelProtocol.IsNull() || plan.TunnelProtocol.IsUnknown()) && !state.TunnelProtocol.IsNull() {
+		plan.TunnelProtocol = state.TunnelProtocol
+		planModified = true
+	}
+
+	// If we modified the plan, update it
+	if planModified {
+		diags = resp.Plan.Set(ctx, plan)
+		resp.Diagnostics.Append(diags...)
+	}
 }

--- a/internal/services/zero_trust_device_custom_profile/resource_test.go
+++ b/internal/services/zero_trust_device_custom_profile/resource_test.go
@@ -1,0 +1,208 @@
+package zero_trust_device_custom_profile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdate_NoChanges(t *testing.T) {
+	planData := ZeroTrustDeviceCustomProfileModel{
+		AccountID:       types.StringValue("test-account-id"),
+		PolicyID:        types.StringValue("test-policy-id"),
+		Match:           types.StringValue(`identity.email == "test@cloudflare.com"`),
+		Name:            types.StringValue("Allow Developers"),
+		Precedence:      types.Float64Value(100),
+		Description:     types.StringNull(),
+		FallbackDomains: customfield.NewObjectListMust(context.TODO(), []ZeroTrustDeviceCustomProfileFallbackDomainsModel{}),
+		TargetTests:     customfield.NewObjectListMust(context.TODO(), []ZeroTrustDeviceCustomProfileTargetTestsModel{}),
+	}
+
+	stateData := planData
+
+	jsonBytes, err := planData.MarshalJSONForUpdate(stateData)
+	require.NoError(t, err)
+
+	jsonStr := string(jsonBytes)
+	assert.Equal(t, "", jsonStr, "Should be empty when no changes")
+
+	isEmpty := len(jsonBytes) == 0 || string(jsonBytes) == ""
+	assert.True(t, isEmpty, "Logic isEmpty should be true")
+}
+
+func TestUpdate_HasChanges(t *testing.T) {
+	planData := ZeroTrustDeviceCustomProfileModel{
+		AccountID:   types.StringValue("test-account-id"),
+		PolicyID:    types.StringValue("test-policy-id"),
+		Match:       types.StringValue(`identity.email == "test@cloudflare.com"`),
+		Name:        types.StringValue("Allow Developers"),
+		Precedence:  types.Float64Value(100),
+		Description: types.StringValue("New Description"),
+	}
+
+	stateData := ZeroTrustDeviceCustomProfileModel{
+		AccountID:   types.StringValue("test-account-id"),
+		PolicyID:    types.StringValue("test-policy-id"),
+		Match:       types.StringValue(`identity.email == "test@cloudflare.com"`),
+		Name:        types.StringValue("Allow Developers"),
+		Precedence:  types.Float64Value(100),
+		Description: types.StringValue("Old Description"),
+	}
+
+	jsonBytes, err := planData.MarshalJSONForUpdate(stateData)
+	require.NoError(t, err)
+
+	jsonStr := string(jsonBytes)
+	assert.NotEqual(t, "", jsonStr, "Should not be empty when there are changes")
+	assert.Contains(t, jsonStr, "New Description", "Should contain new description")
+
+	isEmpty := len(jsonBytes) == 0 || string(jsonBytes) == ""
+	assert.False(t, isEmpty, "Logic isEmpty should be false")
+}
+
+func TestUpdate_DescriptionRemovedFromConfig(t *testing.T) {
+	planData := ZeroTrustDeviceCustomProfileModel{
+		AccountID:       types.StringValue("test-account-id"),
+		PolicyID:        types.StringValue("test-policy-id"),
+		Match:           types.StringValue(`identity.email == "test@cloudflare.com"`),
+		Name:            types.StringValue("Test Profile"),
+		Precedence:      types.Float64Value(100),
+		Description:     types.StringNull(),
+		FallbackDomains: customfield.NullObjectList[ZeroTrustDeviceCustomProfileFallbackDomainsModel](context.TODO()),
+		TargetTests:     customfield.NullObjectList[ZeroTrustDeviceCustomProfileTargetTestsModel](context.TODO()),
+	}
+
+	stateData := ZeroTrustDeviceCustomProfileModel{
+		AccountID:       types.StringValue("test-account-id"),
+		PolicyID:        types.StringValue("test-policy-id"),
+		Match:           types.StringValue(`identity.email == "test@cloudflare.com"`),
+		Name:            types.StringValue("Test Profile"),
+		Precedence:      types.Float64Value(100),
+		Description:     types.StringValue("Profile for Test User"),
+		FallbackDomains: customfield.NewObjectListMust(context.TODO(), []ZeroTrustDeviceCustomProfileFallbackDomainsModel{}),
+		TargetTests:     customfield.NewObjectListMust(context.TODO(), []ZeroTrustDeviceCustomProfileTargetTestsModel{}),
+	}
+
+	jsonBytes, err := planData.MarshalJSONForUpdate(stateData)
+	require.NoError(t, err)
+
+	jsonStr := string(jsonBytes)
+	assert.Equal(t, `{"description":""}`, jsonStr, "Should send empty string for description")
+
+	isEmpty := len(jsonBytes) == 0 || string(jsonBytes) == ""
+	assert.False(t, isEmpty, "Should not be empty - description is set to empty string")
+	resultData := planData
+	resultData.Description = types.StringValue("")
+	if !stateData.FallbackDomains.IsNull() {
+		resultData.FallbackDomains = stateData.FallbackDomains
+	}
+	if !stateData.TargetTests.IsNull() {
+		resultData.TargetTests = stateData.TargetTests
+	}
+	resultData.ID = resultData.PolicyID
+
+	assert.Equal(t, "", resultData.Description.ValueString(), "Description should be empty string after removal")
+	assert.False(t, resultData.FallbackDomains.IsNull(), "FallbackDomains should be preserved from state")
+	assert.False(t, resultData.TargetTests.IsNull(), "TargetTests should be preserved from state")
+}
+
+func TestUpdate_CompleteFlow_RemoveDescription(t *testing.T) {
+	planData := ZeroTrustDeviceCustomProfileModel{
+		AccountID:       types.StringValue("test-account-id"),
+		PolicyID:        types.StringValue("test-policy-id"),
+		Match:           types.StringValue(`identity.email == "test@cloudflare.com"`),
+		Name:            types.StringValue("Test Profile"),
+		Precedence:      types.Float64Value(100),
+		Description:     types.StringNull(),
+		FallbackDomains: customfield.NullObjectList[ZeroTrustDeviceCustomProfileFallbackDomainsModel](context.TODO()),
+		TargetTests:     customfield.NullObjectList[ZeroTrustDeviceCustomProfileTargetTestsModel](context.TODO()),
+	}
+
+	stateData := ZeroTrustDeviceCustomProfileModel{
+		AccountID:       types.StringValue("test-account-id"),
+		PolicyID:        types.StringValue("test-policy-id"),
+		Match:           types.StringValue(`identity.email == "test@cloudflare.com"`),
+		Name:            types.StringValue("Test Profile"),
+		Precedence:      types.Float64Value(100),
+		Description:     types.StringValue("Profile for Test User"),
+		FallbackDomains: customfield.NewObjectListMust(context.TODO(), []ZeroTrustDeviceCustomProfileFallbackDomainsModel{}),
+		TargetTests:     customfield.NewObjectListMust(context.TODO(), []ZeroTrustDeviceCustomProfileTargetTestsModel{}),
+	}
+
+	jsonBytes, err := planData.MarshalJSONForUpdate(stateData)
+	require.NoError(t, err)
+	assert.Equal(t, `{"description":""}`, string(jsonBytes), "Should send empty string for description")
+
+	isEmpty := len(jsonBytes) == 0 || string(jsonBytes) == ""
+	assert.False(t, isEmpty, "Not empty - description is set to empty string")
+
+	apiResponse := planData
+	apiResponse.Description = types.StringValue("")
+	apiResponse.FallbackDomains = stateData.FallbackDomains
+	apiResponse.TargetTests = stateData.TargetTests
+
+	finalResult := apiResponse
+	if planData.Description.IsNull() {
+		finalResult.Description = types.StringNull()
+	}
+
+	assert.True(t, finalResult.Description.IsNull(), "End result should have description=null as per plan")
+	assert.False(t, finalResult.FallbackDomains.IsNull(), "Computed fields should be preserved")
+}
+
+func TestModifyPlan_ComputedFields(t *testing.T) {
+	plan := ZeroTrustDeviceCustomProfileModel{
+		AccountID:       types.StringValue("test-account-id"),
+		PolicyID:        types.StringValue("test-policy-id"),
+		Match:           types.StringValue(`identity.email == "test@cloudflare.com"`),
+		Name:            types.StringValue("Test Profile"),
+		Precedence:      types.Float64Value(100),
+		Description:     types.StringNull(),
+		FallbackDomains: customfield.NullObjectList[ZeroTrustDeviceCustomProfileFallbackDomainsModel](context.TODO()),
+		TargetTests:     customfield.NullObjectList[ZeroTrustDeviceCustomProfileTargetTestsModel](context.TODO()),
+		Default:         types.BoolNull(),
+		GatewayUniqueID: types.StringNull(),
+	}
+
+	state := ZeroTrustDeviceCustomProfileModel{
+		AccountID:       types.StringValue("test-account-id"),
+		PolicyID:        types.StringValue("test-policy-id"),
+		Match:           types.StringValue(`identity.email == "test@cloudflare.com"`),
+		Name:            types.StringValue("Test Profile"),
+		Precedence:      types.Float64Value(100),
+		Description:     types.StringNull(),
+		FallbackDomains: customfield.NewObjectListMust(context.TODO(), []ZeroTrustDeviceCustomProfileFallbackDomainsModel{}),
+		TargetTests:     customfield.NewObjectListMust(context.TODO(), []ZeroTrustDeviceCustomProfileTargetTestsModel{}),
+		Default:         types.BoolValue(false),
+		GatewayUniqueID: types.StringValue("unique-123"),
+	}
+
+	planModified := false
+
+	if !state.Default.IsNull() {
+		plan.Default = state.Default
+		planModified = true
+	}
+	if !state.GatewayUniqueID.IsNull() {
+		plan.GatewayUniqueID = state.GatewayUniqueID
+		planModified = true
+	}
+	if !state.FallbackDomains.IsNull() {
+		plan.FallbackDomains = state.FallbackDomains
+		planModified = true
+	}
+	if !state.TargetTests.IsNull() {
+		plan.TargetTests = state.TargetTests
+		planModified = true
+	}
+
+	assert.True(t, planModified, "Plan should be modified")
+	assert.False(t, plan.Default.IsNull(), "Default should be copied from state")
+	assert.False(t, plan.GatewayUniqueID.IsNull(), "GatewayUniqueID should be copied from state")
+	assert.False(t, plan.FallbackDomains.IsNull(), "FallbackDomains should be copied from state")
+	assert.False(t, plan.TargetTests.IsNull(), "TargetTests should be copied from state")
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- [x] Fix 400 Bad Request errors (codes 2003, 2004) on subsequent applies
- [x] Prevent sending null values for computed_optional fields to API
- [x] Handle description removal by sending empty string instead of null
- [x] Use UnmarshalComputed in Read/ImportState to ensure computed fields are populated
- [x] Implement ModifyPlan to prevent "(known after apply)" for computed fields
- [x] Add comprehensive MarshalJSONForUpdate logic to preserve state values

## Additional context & links

Resolves https://github.com/cloudflare/terraform-provider-cloudflare/issues/5514.