### PR TITLE
Add regression check for access application computed optional properties

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -296,7 +297,14 @@ func LoadTestCase(filename string, parameters ...interface{}) string {
 func DumpState(s *terraform.State) error {
 	fmt.Println()
 	for name, rs := range s.RootModule().Resources {
-		for attr, key := range rs.Primary.Attributes {
+		// sort the keys
+		keys := make([]string, 0, len(rs.Primary.Attributes))
+		for attr := range rs.Primary.Attributes {
+			keys = append(keys, attr)
+		}
+		sort.Strings(keys)
+		for _, attr := range keys {
+			key := rs.Primary.Attributes[attr]
 			fmt.Println(strings.Join([]string{name, attr}, "."), "=", key)
 		}
 	}
@@ -409,9 +417,9 @@ func isSetNestedAttributeField(resourceAddress, fieldName string) bool {
 	// This prevents ambiguity when multiple resources have fields with the same name
 	setFieldsByResource := map[string][]string{
 		"cloudflare_zero_trust_access_policy": {"include", "exclude", "require", "approval_groups"},
-		"cloudflare_access_policy": {"include", "exclude", "require", "approval_group"}, // v4 resource name
-		"cloudflare_ruleset": {"rules"},
-		"cloudflare_load_balancer_pool": {"origins"},
+		"cloudflare_access_policy":            {"include", "exclude", "require", "approval_group"}, // v4 resource name
+		"cloudflare_ruleset":                  {"rules"},
+		"cloudflare_load_balancer_pool":       {"origins"},
 		// Add other resources with SetNestedAttribute fields as needed
 	}
 

--- a/internal/services/zero_trust_access_application/resource_test.go
+++ b/internal/services/zero_trust_access_application/resource_test.go
@@ -105,6 +105,12 @@ func TestAccCloudflareAccessApplication_BasicZone(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("cors_headers"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("auto_redirect_to_identity"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service_auth_401_redirect"), knownvalue.Bool(false)),
+
+					// destinations and self_hosted_domains should be populated from the API
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("destinations"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("destinations").AtSliceIndex(0).AtMapKey("type"), knownvalue.StringExact("public")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("destinations").AtSliceIndex(0).AtMapKey("uri"), knownvalue.StringExact(fmt.Sprintf("%s.%s", rnd, domain))),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("self_hosted_domains"), knownvalue.ListSizeExact(1)),
 				},
 			},
 			{


### PR DESCRIPTION
This adds some assertions to validate that destinations and self_hosted_domains are populated from the API as intended.

It currently fails due to https://github.com/cloudflare/terraform-provider-cloudflare/issues/5736 

We have a codegen fix for this, so once that makes it into next, this can be merged as a regression test.

(Also, as a drive-by improvement, I'm sorting the keys in `acctest.DumpState` because that makes it easier to read)
