### PR TITLE
DS-15398: Add import tests for cloudflare_logpush_jobs resource

### DIFF
--- a/internal/services/logpush_job/resource_test.go
+++ b/internal/services/logpush_job/resource_test.go
@@ -97,6 +97,11 @@ func TestAccCloudflareLogpushJob_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "destination_conf", toString(logpushJobConfigUpdate.destinationConf)),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -165,6 +170,11 @@ func TestAccCloudflareLogpushJob_BasicOutputOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "output_options.sample_rate", toString(logpushJobConfigUpdate.outputOptions.sampleRate)),
 					resource.TestCheckResourceAttr(resourceName, "output_options.timestamp_format", toString(logpushJobConfigUpdate.outputOptions.timestampFormat)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -247,6 +257,11 @@ func TestAccCloudflareLogpushJob_Full(t *testing.T) {
 			{
 				Config: testCloudflareLogpushJobFull(rnd, logpushJobConfigUpdate),
 				Check:  resource.ComposeTestCheckFunc(getTestCheckResourceAttrs(resourceName, logpushJobConfigUpdate)...),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -356,6 +371,11 @@ func TestAccCloudflareLogpushJob_ImmutableFields(t *testing.T) {
 			{
 				Config:      testCloudflareLogpushJobImmutableFields(rnd, logpushJobConfigUpdate),
 				ExpectError: regexp.MustCompile(regexp.QuoteMeta("400 Bad Request")),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
This adds import tests for `cloudflare_logpush_jobs` resource, per https://wiki.cfdata.org/display/API/Terraform+Acceptance+Tests

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged
