### PR TITLE
Fix detected drift in `zero_trust_device_custom_profile` and `zero_trust_device_custom_profile_local_domain_fallback`

### DIFF
--- a/internal/services/zero_trust_device_custom_profile/model.go
+++ b/internal/services/zero_trust_device_custom_profile/model.go
@@ -23,9 +23,9 @@ type ZeroTrustDeviceCustomProfileModel struct {
 	Enabled                    types.Bool                                                                     `tfsdk:"enabled" json:"enabled,optional"`
 	LANAllowMinutes            types.Float64                                                                  `tfsdk:"lan_allow_minutes" json:"lan_allow_minutes,optional"`
 	LANAllowSubnetSize         types.Float64                                                                  `tfsdk:"lan_allow_subnet_size" json:"lan_allow_subnet_size,optional"`
-	Exclude                    *[]*ZeroTrustDeviceCustomProfileExcludeModel                                   `tfsdk:"exclude" json:"exclude,optional"`
-	Include                    *[]*ZeroTrustDeviceCustomProfileIncludeModel                                   `tfsdk:"include" json:"include,optional"`
-	ServiceModeV2              *ZeroTrustDeviceCustomProfileServiceModeV2Model                                `tfsdk:"service_mode_v2" json:"service_mode_v2,optional"`
+	Exclude                    customfield.NestedObjectList[ZeroTrustDeviceCustomProfileExcludeModel]         `tfsdk:"exclude" json:"exclude,computed_optional"`
+	Include                    customfield.NestedObjectList[ZeroTrustDeviceCustomProfileIncludeModel]         `tfsdk:"include" json:"include,computed_optional"`
+	ServiceModeV2              customfield.NestedObject[ZeroTrustDeviceCustomProfileServiceModeV2Model]       `tfsdk:"service_mode_v2" json:"service_mode_v2,computed_optional"`
 	AllowModeSwitch            types.Bool                                                                     `tfsdk:"allow_mode_switch" json:"allow_mode_switch,computed_optional"`
 	AllowUpdates               types.Bool                                                                     `tfsdk:"allow_updates" json:"allow_updates,computed_optional"`
 	AllowedToLeave             types.Bool                                                                     `tfsdk:"allowed_to_leave" json:"allowed_to_leave,computed_optional"`
@@ -53,20 +53,20 @@ func (m ZeroTrustDeviceCustomProfileModel) MarshalJSONForUpdate(state ZeroTrustD
 }
 
 type ZeroTrustDeviceCustomProfileExcludeModel struct {
-	Address     types.String `tfsdk:"address" json:"address,optional"`
-	Description types.String `tfsdk:"description" json:"description,optional"`
-	Host        types.String `tfsdk:"host" json:"host,optional"`
+	Address     types.String `tfsdk:"address" json:"address,computed_optional"`
+	Description types.String `tfsdk:"description" json:"description,computed_optional"`
+	Host        types.String `tfsdk:"host" json:"host,computed_optional"`
 }
 
 type ZeroTrustDeviceCustomProfileIncludeModel struct {
-	Address     types.String `tfsdk:"address" json:"address,optional"`
-	Description types.String `tfsdk:"description" json:"description,optional"`
-	Host        types.String `tfsdk:"host" json:"host,optional"`
+	Address     types.String `tfsdk:"address" json:"address,computed_optional"`
+	Description types.String `tfsdk:"description" json:"description,computed_optional"`
+	Host        types.String `tfsdk:"host" json:"host,computed_optional"`
 }
 
 type ZeroTrustDeviceCustomProfileServiceModeV2Model struct {
-	Mode types.String  `tfsdk:"mode" json:"mode,optional"`
-	Port types.Float64 `tfsdk:"port" json:"port,optional"`
+	Mode types.String  `tfsdk:"mode" json:"mode,computed_optional"`
+	Port types.Float64 `tfsdk:"port" json:"port,computed_optional"`
 }
 
 type ZeroTrustDeviceCustomProfileFallbackDomainsModel struct {

--- a/internal/services/zero_trust_device_custom_profile/resource_test.go
+++ b/internal/services/zero_trust_device_custom_profile/resource_test.go
@@ -1,0 +1,222 @@
+package zero_trust_device_custom_profile_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v5"
+	"github.com/cloudflare/cloudflare-go/v5/zero_trust"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareZeroTrustDeviceCustomProfile_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_device_custom_profile.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustDeviceCustomProfileDestroy,
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: testAccCloudflareZeroTrustDeviceCustomProfileBasic(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("match"), knownvalue.StringExact("identity.email == \"test@example.com\"")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("precedence"), knownvalue.Float64Exact(100)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("Test custom device profile")),
+				},
+			},
+			// Import
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZeroTrustDeviceCustomProfile_Complete(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_device_custom_profile.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustDeviceCustomProfileDestroy,
+		Steps: []resource.TestStep{
+			// Create with all optional fields
+			{
+				Config: testAccCloudflareZeroTrustDeviceCustomProfileComplete(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("match"), knownvalue.StringExact("identity.groups.name == \"Engineering\"")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("precedence"), knownvalue.Float64Exact(50)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("Complete custom device profile with all settings")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("allow_mode_switch"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("allow_updates"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("allowed_to_leave"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("auto_connect"), knownvalue.Float64Exact(60)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("captive_portal"), knownvalue.Float64Exact(300)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("disable_auto_fallback"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("exclude_office_ips"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("switch_locked"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tunnel_protocol"), knownvalue.StringExact("wireguard")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("support_url"), knownvalue.StringExact("https://support.example.com")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("lan_allow_minutes"), knownvalue.Float64Exact(30)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("lan_allow_subnet_size"), knownvalue.Float64Exact(24)),
+				},
+			},
+			// Update
+			{
+				Config: testAccCloudflareZeroTrustDeviceCustomProfileUpdated(accountID, rnd),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(fmt.Sprintf("%s-updated", rnd))),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("precedence"), knownvalue.Float64Exact(75)),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(fmt.Sprintf("%s-updated", rnd))),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("precedence"), knownvalue.Float64Exact(75)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("Updated custom device profile")),
+				},
+			},
+			// Import
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZeroTrustDeviceCustomProfile_WithExclude(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_device_custom_profile.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustDeviceCustomProfileDestroy,
+		Steps: []resource.TestStep{
+			// Create with exclude
+			{
+				Config: testAccCloudflareZeroTrustDeviceCustomProfileWithExclude(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("exclude"), knownvalue.ListSizeExact(2)),
+				},
+			},
+			// Update to include
+			{
+				Config: testAccCloudflareZeroTrustDeviceCustomProfileWithInclude(accountID, rnd),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("include"), knownvalue.ListSizeExact(2)),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZeroTrustDeviceCustomProfile_ServiceMode(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_device_custom_profile.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustDeviceCustomProfileDestroy,
+		Steps: []resource.TestStep{
+			// Create with service_mode_v2
+			{
+				Config: testAccCloudflareZeroTrustDeviceCustomProfileWithServiceMode(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service_mode_v2", "mode"), knownvalue.StringExact("proxy")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service_mode_v2", "port"), knownvalue.Float64Exact(3128)),
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareZeroTrustDeviceCustomProfileDestroy(s *terraform.State) error {
+	client := acctest.SharedClient()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_zero_trust_device_custom_profile" {
+			continue
+		}
+
+		_, err := client.ZeroTrust.Devices.Policies.Custom.Get(
+			context.Background(),
+			zero_trust.DevicePolicyCustomGetParams{
+				AccountID: cloudflare.F(accountID),
+				PolicyID:  cloudflare.F(rs.Primary.ID),
+			},
+		)
+		if err == nil {
+			return fmt.Errorf("Zero Trust Device Custom Profile still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCloudflareZeroTrustDeviceCustomProfileBasic(accountID, rnd string) string {
+	return acctest.LoadTestCase("devicecustomprofilebasic.tf", rnd, accountID)
+}
+
+func testAccCloudflareZeroTrustDeviceCustomProfileComplete(accountID, rnd string) string {
+	return acctest.LoadTestCase("devicecustomprofilecomplete.tf", rnd, accountID)
+}
+
+func testAccCloudflareZeroTrustDeviceCustomProfileUpdated(accountID, rnd string) string {
+	return acctest.LoadTestCase("devicecustomprofileupdated.tf", rnd, accountID)
+}
+
+func testAccCloudflareZeroTrustDeviceCustomProfileWithExclude(accountID, rnd string) string {
+	return acctest.LoadTestCase("devicecustomprofilewithexclude.tf", rnd, accountID)
+}
+
+func testAccCloudflareZeroTrustDeviceCustomProfileWithInclude(accountID, rnd string) string {
+	return acctest.LoadTestCase("devicecustomprofilewithinclude.tf", rnd, accountID)
+}
+
+func testAccCloudflareZeroTrustDeviceCustomProfileWithServiceMode(accountID, rnd string) string {
+	return acctest.LoadTestCase("devicecustomprofilewithservicemode.tf", rnd, accountID)
+}

--- a/internal/services/zero_trust_device_custom_profile/schema.go
+++ b/internal/services/zero_trust_device_custom_profile/schema.go
@@ -67,6 +67,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"exclude": schema.ListNestedAttribute{
 				Description: "List of routes excluded in the WARP client's tunnel. Both 'exclude' and 'include' cannot be set in the same request.",
 				Optional:    true,
+				Computed:    true,
+				CustomType:  customfield.NewNestedObjectListType[ZeroTrustDeviceCustomProfileExcludeModel](ctx),
 				Validators: []validator.List{
 					listvalidator.ConflictsWith(path.MatchRoot("include")),
 				},
@@ -75,14 +77,17 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"address": schema.StringAttribute{
 							Description: "The address in CIDR format to exclude from the tunnel. If `address` is present, `host` must not be present.",
 							Optional:    true,
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
 							Description: "A description of the Split Tunnel item, displayed in the client UI.",
 							Optional:    true,
+							Computed:    true,
 						},
 						"host": schema.StringAttribute{
 							Description: "The domain name to exclude from the tunnel. If `host` is present, `address` must not be present.",
 							Optional:    true,
+							Computed:    true,
 						},
 					},
 				},
@@ -90,6 +95,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"include": schema.ListNestedAttribute{
 				Description: "List of routes included in the WARP client's tunnel. Both 'exclude' and 'include' cannot be set in the same request.",
 				Optional:    true,
+				Computed:    true,
+				CustomType:  customfield.NewNestedObjectListType[ZeroTrustDeviceCustomProfileIncludeModel](ctx),
 				Validators: []validator.List{
 					listvalidator.ConflictsWith(path.MatchRoot("exclude")),
 				},
@@ -98,28 +105,35 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"address": schema.StringAttribute{
 							Description: "The address in CIDR format to include in the tunnel. If `address` is present, `host` must not be present.",
 							Optional:    true,
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
 							Description: "A description of the Split Tunnel item, displayed in the client UI.",
 							Optional:    true,
+							Computed:    true,
 						},
 						"host": schema.StringAttribute{
 							Description: "The domain name to include in the tunnel. If `host` is present, `address` must not be present.",
 							Optional:    true,
+							Computed:    true,
 						},
 					},
 				},
 			},
 			"service_mode_v2": schema.SingleNestedAttribute{
-				Optional: true,
+				Optional:   true,
+				Computed:   true,
+				CustomType: customfield.NewNestedObjectType[ZeroTrustDeviceCustomProfileServiceModeV2Model](ctx),
 				Attributes: map[string]schema.Attribute{
 					"mode": schema.StringAttribute{
 						Description: "The mode to run the WARP client under.",
 						Optional:    true,
+						Computed:    true,
 					},
 					"port": schema.Float64Attribute{
 						Description: "The port number when used with proxy mode.",
 						Optional:    true,
+						Computed:    true,
 					},
 				},
 			},

--- a/internal/services/zero_trust_device_custom_profile/sweep_test.go
+++ b/internal/services/zero_trust_device_custom_profile/sweep_test.go
@@ -1,0 +1,71 @@
+package zero_trust_device_custom_profile_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v5"
+	"github.com/cloudflare/cloudflare-go/v5/zero_trust"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("cloudflare_zero_trust_device_custom_profile", &resource.Sweeper{
+		Name: "cloudflare_zero_trust_device_custom_profile",
+		F:    testSweepCloudflareZeroTrustDeviceCustomProfile,
+	})
+}
+
+func testSweepCloudflareZeroTrustDeviceCustomProfile(region string) error {
+	client := acctest.SharedClient()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	if accountID == "" {
+		log.Print("[DEBUG] CLOUDFLARE_ACCOUNT_ID not set, skipping sweep")
+		return nil
+	}
+
+	ctx := context.Background()
+
+	// List all custom device profiles
+	profiles, err := client.ZeroTrust.Devices.Policies.Custom.List(
+		ctx,
+		zero_trust.DevicePolicyCustomListParams{
+			AccountID: cloudflare.F(accountID),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("error listing device custom profiles for sweep: %w", err)
+	}
+
+	log.Printf("[DEBUG] Found %d device custom profiles to sweep", len(profiles.Result))
+
+	for _, profile := range profiles.Result {
+		// Only delete test resources (those with random test prefixes)
+		if acctest.IsTestResource(profile.Name) {
+			log.Printf("[INFO] Deleting device custom profile: %s (%s)", profile.Name, profile.PolicyID)
+			
+			err := client.ZeroTrust.Devices.Policies.Custom.Delete(
+				ctx,
+				zero_trust.DevicePolicyCustomDeleteParams{
+					AccountID: cloudflare.F(accountID),
+					PolicyID:  cloudflare.F(profile.PolicyID),
+				},
+			)
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete device custom profile %s: %v", profile.PolicyID, err)
+				continue
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}

--- a/internal/services/zero_trust_device_custom_profile/sweep_test.go
+++ b/internal/services/zero_trust_device_custom_profile/sweep_test.go
@@ -45,21 +45,18 @@ func testSweepCloudflareZeroTrustDeviceCustomProfile(region string) error {
 	log.Printf("[DEBUG] Found %d device custom profiles to sweep", len(profiles.Result))
 
 	for _, profile := range profiles.Result {
-		// Only delete test resources (those with random test prefixes)
-		if acctest.IsTestResource(profile.Name) {
-			log.Printf("[INFO] Deleting device custom profile: %s (%s)", profile.Name, profile.PolicyID)
-			
-			err := client.ZeroTrust.Devices.Policies.Custom.Delete(
-				ctx,
-				zero_trust.DevicePolicyCustomDeleteParams{
-					AccountID: cloudflare.F(accountID),
-					PolicyID:  cloudflare.F(profile.PolicyID),
-				},
-			)
-			if err != nil {
-				log.Printf("[ERROR] Failed to delete device custom profile %s: %v", profile.PolicyID, err)
-				continue
-			}
+		log.Printf("[INFO] Deleting device custom profile: %s (%s)", profile.Name, profile.PolicyID)
+
+		_, err := client.ZeroTrust.Devices.Policies.Custom.Delete(
+			ctx,
+			profile.PolicyID,
+			zero_trust.DevicePolicyCustomDeleteParams{
+				AccountID: cloudflare.F(accountID),
+			},
+		)
+		if err != nil {
+			log.Printf("[ERROR] Failed to delete device custom profile %s: %v", profile.PolicyID, err)
+			continue
 		}
 	}
 
@@ -69,3 +66,4 @@ func testSweepCloudflareZeroTrustDeviceCustomProfile(region string) error {
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
+

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilebasic.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilebasic.tf
@@ -2,7 +2,7 @@ resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
   account_id  = "%[2]s"
   name        = "%[1]s"
   match       = "identity.email == \"test@example.com\""
-  precedence  = 100
+  precedence  = %[3]d
   enabled     = true
   description = "Test custom device profile"
 }

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilebasic.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilebasic.tf
@@ -1,0 +1,8 @@
+resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "%[1]s"
+  match       = "identity.email == \"test@example.com\""
+  precedence  = 100
+  enabled     = true
+  description = "Test custom device profile"
+}

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilecomplete.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilecomplete.tf
@@ -1,8 +1,8 @@
 resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
   account_id               = "%[2]s"
   name                     = "%[1]s"
-  match                    = "identity.groups.name == \"Engineering\""
-  precedence               = 50
+  match                    = "os.version == \"10.15\""
+  precedence               = %[3]d
   enabled                  = true
   description              = "Complete custom device profile with all settings"
   allow_mode_switch        = true

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilecomplete.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilecomplete.tf
@@ -1,0 +1,24 @@
+resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
+  account_id               = "%[2]s"
+  name                     = "%[1]s"
+  match                    = "identity.groups.name == \"Engineering\""
+  precedence               = 50
+  enabled                  = true
+  description              = "Complete custom device profile with all settings"
+  allow_mode_switch        = true
+  allow_updates            = true
+  allowed_to_leave         = false
+  auto_connect             = 60
+  captive_portal           = 300
+  disable_auto_fallback    = true
+  exclude_office_ips       = true
+  switch_locked            = true
+  tunnel_protocol          = "wireguard"
+  support_url              = "https://support.example.com"
+  lan_allow_minutes        = 30
+  lan_allow_subnet_size    = 24
+  
+  service_mode_v2 = {
+    mode = "warp"
+  }
+}

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofileupdated.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofileupdated.tf
@@ -1,8 +1,8 @@
 resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
   account_id               = "%[2]s"
   name                     = "%[1]s-updated"
-  match                    = "identity.groups.name == \"Engineering\""
-  precedence               = 75
+  match                    = "os.version == \"10.15\""
+  precedence               = %[3]d
   enabled                  = false
   description              = "Updated custom device profile"
   allow_mode_switch        = false

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofileupdated.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofileupdated.tf
@@ -1,0 +1,18 @@
+resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
+  account_id               = "%[2]s"
+  name                     = "%[1]s-updated"
+  match                    = "identity.groups.name == \"Engineering\""
+  precedence               = 75
+  enabled                  = false
+  description              = "Updated custom device profile"
+  allow_mode_switch        = false
+  allow_updates            = false
+  allowed_to_leave         = true
+  auto_connect             = 0
+  captive_portal           = 180
+  disable_auto_fallback    = false
+  exclude_office_ips       = false
+  switch_locked            = false
+  tunnel_protocol          = "masque"
+  support_url              = "https://help.example.com"
+}

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithexclude.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithexclude.tf
@@ -1,0 +1,19 @@
+resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "%[1]s"
+  match       = "os.name == \"Windows\""
+  precedence  = 100
+  enabled     = true
+  description = "Profile with exclude list"
+  
+  exclude = [
+    {
+      address     = "10.0.0.0/8"
+      description = "Private network range"
+    },
+    {
+      host        = "internal.example.com"
+      description = "Internal domain"
+    }
+  ]
+}

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithexclude.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithexclude.tf
@@ -2,7 +2,7 @@ resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
   account_id  = "%[2]s"
   name        = "%[1]s"
   match       = "os.name == \"Windows\""
-  precedence  = 100
+  precedence  = %[3]d
   enabled     = true
   description = "Profile with exclude list"
   

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithinclude.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithinclude.tf
@@ -2,7 +2,7 @@ resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
   account_id  = "%[2]s"
   name        = "%[1]s"
   match       = "os.name == \"Windows\""
-  precedence  = 100
+  precedence  = %[3]d
   enabled     = true
   description = "Profile with include list"
   

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithinclude.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithinclude.tf
@@ -1,0 +1,19 @@
+resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "%[1]s"
+  match       = "os.name == \"Windows\""
+  precedence  = 100
+  enabled     = true
+  description = "Profile with include list"
+  
+  include = [
+    {
+      address     = "192.168.1.0/24"
+      description = "Corporate network"
+    },
+    {
+      host        = "app.example.com"
+      description = "Corporate application"
+    }
+  ]
+}

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithservicemode.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithservicemode.tf
@@ -1,0 +1,13 @@
+resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "%[1]s"
+  match       = "os.version == \"10.15\""
+  precedence  = 100
+  enabled     = true
+  description = "Profile with service mode configuration"
+  
+  service_mode_v2 = {
+    mode = "proxy"
+    port = 3128
+  }
+}

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithservicemode.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithservicemode.tf
@@ -2,7 +2,7 @@ resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
   account_id  = "%[2]s"
   name        = "%[1]s"
   match       = "os.version == \"10.15\""
-  precedence  = 100
+  precedence  = %[3]d
   enabled     = true
   description = "Profile with service mode configuration"
   

--- a/internal/services/zero_trust_device_custom_profile_local_domain_fallback/testdata/fallbackdomain_multiple-domains.tf
+++ b/internal/services/zero_trust_device_custom_profile_local_domain_fallback/testdata/fallbackdomain_multiple-domains.tf
@@ -1,0 +1,36 @@
+resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
+	account_id                = "%[2]s"
+	allow_mode_switch         = true
+	allow_updates             = true
+	allowed_to_leave          = true
+	auto_connect              = 0
+	captive_portal            = 5
+	disable_auto_fallback     = true
+	enabled                   = true
+	match                     = "identity.email == \"foo@example.com\""
+	name                      = "%[1]s"
+	precedence                = %[3]d
+	support_url               = "support_url"
+	switch_locked             = true
+	exclude_office_ips		  = false
+	description               = "%[1]s"
+}
+
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "%[1]s" {
+    account_id = "%[2]s"
+    domains = [
+        {
+            suffix = "internal"
+        },
+        {
+            suffix = "home"
+        },
+        {
+            suffix = "corp"
+        },
+        {
+            suffix = "localdomain"
+        },
+    ]
+	policy_id = cloudflare_zero_trust_device_custom_profile.%[1]s.id
+}

--- a/internal/services/zero_trust_device_custom_profile_local_domain_fallback/testdata/fallbackdomain_multiple-domains_updated.tf
+++ b/internal/services/zero_trust_device_custom_profile_local_domain_fallback/testdata/fallbackdomain_multiple-domains_updated.tf
@@ -1,0 +1,33 @@
+resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
+	account_id                = "%[2]s"
+	allow_mode_switch         = true
+	allow_updates             = true
+	allowed_to_leave          = true
+	auto_connect              = 0
+	captive_portal            = 5
+	disable_auto_fallback     = true
+	enabled                   = true
+	match                     = "identity.email == \"foo@example.com\""
+	name                      = "%[1]s"
+	precedence                = %[3]d
+	support_url               = "support_url"
+	switch_locked             = true
+	exclude_office_ips		  = false
+	description               = "%[1]s"
+}
+
+resource "cloudflare_zero_trust_device_custom_profile_local_domain_fallback" "%[1]s" {
+    account_id = "%[2]s"
+    domains = [
+        {
+            suffix = "home"
+        },
+        {
+            suffix = "corp"
+        },
+        {
+            suffix = "localdomain"
+        },
+    ]
+	policy_id = cloudflare_zero_trust_device_custom_profile.%[1]s.id
+}

--- a/scripts/run-ci-tests
+++ b/scripts/run-ci-tests
@@ -82,6 +82,8 @@ SERVICES=(
     "./internal/services/zero_trust_access_service_token"
     "./internal/services/zero_trust_access_short_lived_certificate"
     "./internal/services/zero_trust_access_tag"
+    "./internal/services/zero_trust_device_custom_profile"
+    "./internal/services/zero_trust_device_custom_profile_local_domain_fallback"
     "./internal/services/zero_trust_device_default_profile_certificates"
     "./internal/services/zero_trust_device_managed_networks"
     "./internal/services/zero_trust_gateway_proxy_endpoint"


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

The configurability of these attributes were changed in the source schema, but the changes didn't take effect, likely due to a merge conflict resolution. I've also added tests.
