### PR TITLE
feat: customize `cloudflare_worker` and `cloudflare_worker_version` resources

### DIFF
--- a/examples/resources/cloudflare_worker_version/resource.tf
+++ b/examples/resources/cloudflare_worker_version/resource.tf
@@ -41,12 +41,11 @@ resource "cloudflare_worker_version" "example_worker_version" {
     }]
   }
   modules = [{
-    content_base64 = "ZXhwb3J0IGRlZmF1bHQgewogIGFzeW5jIGZldGNoKHJlcXVlc3QsIGVudiwgY3R4KSB7CiAgICByZXR1cm4gbmV3IFJlc3BvbnNlKCdIZWxsbyBXb3JsZCEnKQogIH0KfQ=="
+    content_file = "dist/index.js"
     content_type = "application/javascript+module"
     name = "index.js"
   }]
   placement = {
     mode = "smart"
   }
-  usage_model = "standard"
 }

--- a/internal/services/worker/data_source_test.go
+++ b/internal/services/worker/data_source_test.go
@@ -1,0 +1,83 @@
+package worker_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareWorkerDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_worker." + rnd
+	dataSourceName := "data.cloudflare_worker." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkerDataSourceConfig(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Check the resource was created properly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					// Verify computed attributes
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("logpush"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("observability"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"enabled":            knownvalue.Bool(false),
+						"head_sampling_rate": knownvalue.Float64Exact(1),
+						"logs": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"enabled":            knownvalue.Bool(false),
+							"head_sampling_rate": knownvalue.Float64Exact(1),
+							"invocation_logs":    knownvalue.Bool(true),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subdomain"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"enabled":          knownvalue.Bool(false),
+						"previews_enabled": knownvalue.Bool(false),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tail_consumers"), knownvalue.SetExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("created_on"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("updated_on"), knownvalue.NotNull()),
+
+					// Check the data source fetches the resource correctly
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("logpush"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("observability"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"enabled":            knownvalue.Bool(false),
+						"head_sampling_rate": knownvalue.Float64Exact(1),
+						"logs": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"enabled":            knownvalue.Bool(false),
+							"head_sampling_rate": knownvalue.Float64Exact(1),
+							"invocation_logs":    knownvalue.Bool(true),
+						}),
+					})),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("subdomain"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"enabled":          knownvalue.Bool(false),
+						"previews_enabled": knownvalue.Bool(false),
+					})),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("tail_consumers"), knownvalue.SetExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("created_on"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("updated_on"), knownvalue.NotNull()),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("id"), dataSourceName, tfjsonpath.New("worker_id"), compare.ValuesSame()),
+				},
+			},
+		},
+	})
+}
+
+func testAccWorkerDataSourceConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("datasource_basic.tf", rnd, accountID)
+}

--- a/internal/services/worker/resource_test.go
+++ b/internal/services/worker/resource_test.go
@@ -1,0 +1,96 @@
+package worker_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareWorker_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_worker." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_worker." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareWorkerConfig(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					// Verify computed attributes
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("logpush"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("observability"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"enabled":            knownvalue.Bool(false),
+						"head_sampling_rate": knownvalue.Float64Exact(1),
+						"logs": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"enabled":            knownvalue.Bool(false),
+							"head_sampling_rate": knownvalue.Float64Exact(1),
+							"invocation_logs":    knownvalue.Bool(true),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subdomain"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"enabled":          knownvalue.Bool(false),
+						"previews_enabled": knownvalue.Bool(false),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tail_consumers"), knownvalue.SetExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("created_on"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("updated_on"), knownvalue.NotNull()),
+				},
+			},
+			{
+				Config: testAccCloudflareWorkerConfigUpdate(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tags"), knownvalue.SetExact([]knownvalue.Check{knownvalue.StringExact("environment=production")})),
+					// Verify computed attributes
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("logpush"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("observability"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"enabled":            knownvalue.Bool(false),
+						"head_sampling_rate": knownvalue.Float64Exact(1),
+						"logs": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"enabled":            knownvalue.Bool(false),
+							"head_sampling_rate": knownvalue.Float64Exact(1),
+							"invocation_logs":    knownvalue.Bool(true),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subdomain"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"enabled":          knownvalue.Bool(false),
+						"previews_enabled": knownvalue.Bool(false),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tail_consumers"), knownvalue.SetExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("created_on"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("updated_on"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:        name,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func testAccCloudflareWorkerConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("basic.tf", rnd, accountID)
+}
+
+func testAccCloudflareWorkerConfigUpdate(rnd, accountID string) string {
+	return acctest.LoadTestCase("basic_update.tf", rnd, accountID)
+}

--- a/internal/services/worker/testdata/basic.tf
+++ b/internal/services/worker/testdata/basic.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_worker" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[1]s"
+}

--- a/internal/services/worker/testdata/basic_update.tf
+++ b/internal/services/worker/testdata/basic_update.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_worker" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[1]s"
+  tags = ["environment=production"]
+}

--- a/internal/services/worker/testdata/datasource_basic.tf
+++ b/internal/services/worker/testdata/datasource_basic.tf
@@ -1,0 +1,9 @@
+resource "cloudflare_worker" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[1]s"
+}
+
+data "cloudflare_worker" "%[1]s" {
+  account_id = "%[2]s"
+  worker_id = cloudflare_worker.%[1]s.id
+}

--- a/internal/services/worker_version/custom.go
+++ b/internal/services/worker_version/custom.go
@@ -1,0 +1,82 @@
+package worker_version
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// UnknownOnlyIfModifier only allows a value to be marked as unknown if
+// some other attribute is equal to a given value.
+//
+// This can be useful in cases where a collection type is polymorphic and a
+// Computed nested attribute is causing unwanted plan diffs for unaffected element types.
+// Essentially, this plan modifier is a workaround for the lack of support for
+// discriminated unions in Terraform's resource schemas.
+type UnknownOnlyIfModifier struct {
+	conditionAttributeName string
+	triggerValue           attr.Value
+}
+
+func (m UnknownOnlyIfModifier) Description(_ context.Context) string {
+	return fmt.Sprintf("Marks attribute as known unless %s equals %s", m.conditionAttributeName, m.triggerValue.String())
+}
+
+func (m UnknownOnlyIfModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m UnknownOnlyIfModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	m.planModify(ctx, req.Path, req.ConfigValue, req.Plan, &resp.Diagnostics, func(knownValue attr.Value) {
+		resp.PlanValue = knownValue.(types.String)
+	})
+}
+
+func (m UnknownOnlyIfModifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	m.planModify(ctx, req.Path, req.ConfigValue, req.Plan, &resp.Diagnostics, func(knownValue attr.Value) {
+		resp.PlanValue = knownValue.(types.Int64)
+	})
+}
+
+func (m UnknownOnlyIfModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	m.planModify(ctx, req.Path, req.ConfigValue, req.Plan, &resp.Diagnostics, func(knownValue attr.Value) {
+		resp.PlanValue = knownValue.(types.Bool)
+	})
+}
+
+func (m UnknownOnlyIfModifier) planModify(ctx context.Context, attrPath path.Path, configValue attr.Value, plan tfsdk.Plan, diags *diag.Diagnostics, setPlanValue func(attr.Value)) {
+	parentPath := attrPath.ParentPath()
+	conditionPath := parentPath.AtName(m.conditionAttributeName)
+
+	var planValue attr.Value
+	var conditionValue attr.Value
+
+	diags.Append(plan.GetAttribute(ctx, attrPath, &planValue)...)
+	diags.Append(plan.GetAttribute(ctx, conditionPath, &conditionValue)...)
+
+	if diags.HasError() {
+		return
+	}
+
+	if conditionValue.Equal(m.triggerValue) {
+		return
+	}
+
+	if planValue.IsUnknown() {
+		setPlanValue(configValue)
+	}
+}
+
+// UnknownOnlyIf creates a modifier that keeps an attribute from being marked as unknown unless a sibling attribute has a given value
+func UnknownOnlyIf(siblingName string, triggerValue string) planmodifier.String {
+	return UnknownOnlyIfModifier{
+		conditionAttributeName: siblingName,
+		triggerValue:           types.StringValue(triggerValue),
+	}
+}

--- a/internal/services/worker_version/data_source_test.go
+++ b/internal/services/worker_version/data_source_test.go
@@ -1,0 +1,92 @@
+package worker_version_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareWorkerVersionDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	workerName := "cloudflare_worker." + rnd
+	resourceName := "cloudflare_worker_version." + rnd
+	dataSourceName := "data.cloudflare_worker_version." + rnd
+
+	tmpDir := t.TempDir()
+	contentFile := path.Join(tmpDir, "index.js")
+
+	writeContentFile := func(t *testing.T, content string) {
+		err := os.WriteFile(contentFile, []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("Error creating temp file at path %s: %s", contentFile, err.Error())
+		}
+	}
+
+	cleanup := func(t *testing.T) {
+		err := os.Remove(contentFile)
+		if err != nil {
+			t.Logf("Error removing temp file at path %s: %s", contentFile, err.Error())
+		}
+	}
+
+	defer cleanup(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					writeContentFile(t, `export default {fetch() {return new Response()}}`)
+				},
+				Config: testAccWorkerVersionDataSourceConfig(rnd, accountID, contentFile),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Check the resource was created properly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+
+					// Check the data source fetches the resource correctly
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("version_id"), resourceName, tfjsonpath.New("id"), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("worker_id"), workerName, tfjsonpath.New("id"), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("main_module"), knownvalue.StringExact("index.js")),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("modules"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"name":           knownvalue.StringExact("index.js"),
+							"content_type":   knownvalue.StringExact("application/javascript+module"),
+							"content_base64": knownvalue.StringExact("ZXhwb3J0IGRlZmF1bHQge2ZldGNoKCkge3JldHVybiBuZXcgUmVzcG9uc2UoKX19"),
+						}),
+					})),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("compatibility_date"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("assets"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("migrations"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("placement"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("usage_model"), knownvalue.StringExact("standard")),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("compatibility_flags"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("annotations"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"workers_message":      knownvalue.Null(),
+						"workers_tag":          knownvalue.Null(),
+						"workers_triggered_by": knownvalue.NotNull(),
+					})),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("bindings"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("limits"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("created_on"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("number"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("source"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+func testAccWorkerVersionDataSourceConfig(rnd, accountID, contentFile string) string {
+	return acctest.LoadTestCase("datasource_basic.tf", rnd, accountID, contentFile)
+}

--- a/internal/services/worker_version/model.go
+++ b/internal/services/worker_version/model.go
@@ -27,7 +27,7 @@ type WorkerVersionModel struct {
 	UsageModel         types.String                                             `tfsdk:"usage_model" json:"usage_model,computed_optional"`
 	CompatibilityFlags customfield.Set[types.String]                            `tfsdk:"compatibility_flags" json:"compatibility_flags,computed_optional"`
 	Annotations        customfield.NestedObject[WorkerVersionAnnotationsModel]  `tfsdk:"annotations" json:"annotations,computed_optional"`
-	Bindings           customfield.NestedObjectList[WorkerVersionBindingsModel] `tfsdk:"bindings" json:"bindings,computed_optional"`
+	Bindings           customfield.NestedObjectList[WorkerVersionBindingsModel] `tfsdk:"bindings" json:"bindings,optional"`
 	Limits             customfield.NestedObject[WorkerVersionLimitsModel]       `tfsdk:"limits" json:"limits,computed_optional"`
 	CreatedOn          timetypes.RFC3339                                        `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
 	Number             types.Int64                                              `tfsdk:"number" json:"number,computed"`

--- a/internal/services/worker_version/model.go
+++ b/internal/services/worker_version/model.go
@@ -133,7 +133,7 @@ type WorkerVersionBindingsModel struct {
 	StoreID       types.String                        `tfsdk:"store_id" json:"store_id,optional"`
 	Algorithm     jsontypes.Normalized                `tfsdk:"algorithm" json:"algorithm,optional"`
 	Format        types.String                        `tfsdk:"format" json:"format,optional"`
-	Usages        *[]types.String                     `tfsdk:"usages" json:"usages,optional"`
+	Usages        customfield.Set[types.String]       `tfsdk:"usages" json:"usages,optional"`
 	KeyBase64     types.String                        `tfsdk:"key_base64" json:"key_base64,optional"`
 	KeyJwk        jsontypes.Normalized                `tfsdk:"key_jwk" json:"key_jwk,optional"`
 	WorkflowName  types.String                        `tfsdk:"workflow_name" json:"workflow_name,optional"`

--- a/internal/services/worker_version/model.go
+++ b/internal/services/worker_version/model.go
@@ -95,9 +95,11 @@ type WorkerVersionMigrationsStepsTransferredClassesModel struct {
 }
 
 type WorkerVersionModulesModel struct {
-	ContentBase64 types.String `tfsdk:"content_base64" json:"content_base64,required"`
+	ContentBase64 types.String `tfsdk:"-" json:"content_base64"`
 	ContentType   types.String `tfsdk:"content_type" json:"content_type,required"`
 	Name          types.String `tfsdk:"name" json:"name,required"`
+	ContentFile   types.String `tfsdk:"content_file" json:"-,required"`
+	ContentSHA256 types.String `tfsdk:"content_sha256" json:"-,computed"`
 }
 
 type WorkerVersionPlacementModel struct {

--- a/internal/services/worker_version/resource.go
+++ b/internal/services/worker_version/resource.go
@@ -4,6 +4,7 @@ package worker_version
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -75,6 +76,17 @@ func (r *WorkerVersionResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	modules := data.Modules
+	if modules != nil {
+		for _, mod := range *data.Modules {
+			content, err := readFile(mod.ContentFile.ValueString())
+			if err != nil {
+				resp.Diagnostics.AddError("Error reading file", err.Error())
+			}
+			mod.ContentBase64 = types.StringValue(base64.StdEncoding.EncodeToString([]byte(content)))
+		}
+	}
+
 	dataBytes, err := data.MarshalJSON()
 	if err != nil {
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
@@ -103,6 +115,7 @@ func (r *WorkerVersionResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 	data = &env.Result
+	data.Modules = modules
 	data.Assets = assets
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -121,6 +134,7 @@ func (r *WorkerVersionResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
+	stateModules := data.Modules
 	assets := data.Assets // "assets" is not returned by the API, so preserve its state value
 
 	res := new(http.Response)
@@ -153,6 +167,30 @@ func (r *WorkerVersionResource) Read(ctx context.Context, req resource.ReadReque
 	}
 	data = &env.Result
 	data.Assets = assets
+
+	// Refresh content_sha256 on each module
+	moduleNameMap := make(map[string]*WorkerVersionModulesModel, len(*stateModules))
+	for _, mod := range *stateModules {
+		moduleNameMap[mod.Name.ValueString()] = mod
+	}
+	for _, mod := range *data.Modules {
+		contentBase64 := mod.ContentBase64.ValueString()
+		content, err := base64.StdEncoding.DecodeString(contentBase64)
+		if err != nil {
+			resp.Diagnostics.AddError("Refresh Error", err.Error())
+			return
+		}
+		contentSHA256, err := calculateStringHash(string(content))
+		if err != nil {
+			resp.Diagnostics.AddError("Refresh Error", err.Error())
+			return
+		}
+
+		mod.ContentSHA256 = types.StringValue(contentSHA256)
+		if stateMod, ok := moduleNameMap[mod.Name.ValueString()]; ok {
+			mod.ContentFile = stateMod.ContentFile
+		}
+	}
 
 	// restore any secret_text `text` values from state since they aren't returned by the API
 	var state *WorkerVersionModel

--- a/internal/services/worker_version/resource.go
+++ b/internal/services/worker_version/resource.go
@@ -131,6 +131,7 @@ func (r *WorkerVersionResource) Read(ctx context.Context, req resource.ReadReque
 		workers.BetaWorkerVersionGetParamsVersionID(data.ID.ValueString()),
 		workers.BetaWorkerVersionGetParams{
 			AccountID: cloudflare.F(data.AccountID.ValueString()),
+			Include:   cloudflare.F(workers.BetaWorkerVersionGetParamsIncludeModules),
 		},
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),

--- a/internal/services/worker_version/resource_test.go
+++ b/internal/services/worker_version/resource_test.go
@@ -1,0 +1,155 @@
+package worker_version_test
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareWorkerVersion_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_worker." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	workerName := "cloudflare_worker." + rnd
+	resourceName := "cloudflare_worker_version." + rnd
+
+	tmpDir := t.TempDir()
+	contentFile := path.Join(tmpDir, "index.js")
+
+	writeContentFile := func(t *testing.T, content string) {
+		err := os.WriteFile(contentFile, []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("Error creating temp file at path %s: %s", contentFile, err.Error())
+		}
+	}
+
+	cleanup := func(t *testing.T) {
+		err := os.Remove(contentFile)
+		if err != nil {
+			t.Logf("Error removing temp file at path %s: %s", contentFile, err.Error())
+		}
+	}
+
+	defer cleanup(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					writeContentFile(t, `export default {fetch() {return new Response()}}`)
+				},
+				Config: testAccCloudflareWorkerVersionConfig(rnd, accountID, contentFile),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.CompareValuePairs(workerName, tfjsonpath.New("id"), resourceName, tfjsonpath.New("worker_id"), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("main_module"), knownvalue.StringExact("index.js")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("modules"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"name":           knownvalue.StringExact("index.js"),
+							"content_file":   knownvalue.StringExact(contentFile),
+							"content_type":   knownvalue.StringExact("application/javascript+module"),
+							"content_sha256": knownvalue.StringExact("e06650aadafc1df60cbf34d68dab2bb20b20d175c9310ed0006169f1a266ef08"),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("compatibility_date"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("assets"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("migrations"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("placement"), knownvalue.Null()),
+					// Verify computed attributes
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("usage_model"), knownvalue.StringExact("standard")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("compatibility_flags"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("annotations"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"workers_message":      knownvalue.Null(),
+						"workers_tag":          knownvalue.Null(),
+						"workers_triggered_by": knownvalue.NotNull(),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("bindings"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("limits"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("created_on"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("number"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("source"), knownvalue.NotNull()),
+				},
+			},
+			{
+				PreConfig: func() {
+					// Update the content file
+					writeContentFile(t, `export default {fetch() {return new Response("Hello World!")}}`)
+				},
+				Config: testAccCloudflareWorkerVersionConfigUpdate(rnd, accountID, contentFile),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.CompareValuePairs(workerName, tfjsonpath.New("id"), resourceName, tfjsonpath.New("worker_id"), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("main_module"), knownvalue.StringExact("index.js")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("modules"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"name":           knownvalue.StringExact("index.js"),
+							"content_file":   knownvalue.StringExact(contentFile),
+							"content_type":   knownvalue.StringExact("application/javascript+module"),
+							"content_sha256": knownvalue.StringExact("abba0df0e36536eb43b5f543dfd4ce55afc9059fa6a400ccaed8002dbcbedb7b"),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("compatibility_date"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("assets"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("migrations"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("bindings"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"name": knownvalue.StringExact("NODE_ENV"),
+							"type": knownvalue.StringExact("plain_text"),
+							"text": knownvalue.StringExact("production"),
+						}),
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"name": knownvalue.StringExact("VERSION_METADATA"),
+							"type": knownvalue.StringExact("version_metadata"),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("placement"), knownvalue.Null()),
+					// Verify computed attributes
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("usage_model"), knownvalue.StringExact("standard")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("compatibility_flags"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("annotations"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"workers_message":      knownvalue.Null(),
+						"workers_tag":          knownvalue.Null(),
+						"workers_triggered_by": knownvalue.NotNull(),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("limits"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("created_on"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("number"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("source"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:        name,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func testAccCloudflareWorkerVersionConfig(rnd, accountID, contentFile string) string {
+	return acctest.LoadTestCase("basic.tf", rnd, accountID, contentFile)
+}
+
+func testAccCloudflareWorkerVersionConfigUpdate(rnd, accountID, contentFile string) string {
+	return acctest.LoadTestCase("basic_update.tf", rnd, accountID, contentFile)
+}

--- a/internal/services/worker_version/schema.go
+++ b/internal/services/worker_version/schema.go
@@ -373,6 +373,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Description: "The exported class name of the Durable Object.",
 							Computed:    true,
 							Optional:    true,
+							PlanModifiers: []planmodifier.String{
+								UnknownOnlyIf("type", "durable_object_namespace"),
+							},
 						},
 						"environment": schema.StringAttribute{
 							Description: "The environment of the script_name to bind to.",
@@ -382,11 +385,17 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Description: "Namespace identifier tag.",
 							Computed:    true,
 							Optional:    true,
+							PlanModifiers: []planmodifier.String{
+								UnknownOnlyIf("type", "durable_object_namespace"),
+							},
 						},
 						"script_name": schema.StringAttribute{
 							Description: "The script where the Durable Object is defined, if it is external to this Worker.",
 							Computed:    true,
 							Optional:    true,
+							PlanModifiers: []planmodifier.String{
+								UnknownOnlyIf("type", "durable_object_namespace"),
+							},
 						},
 						"json": schema.StringAttribute{
 							Description: "JSON data to use.",

--- a/internal/services/worker_version/schema.go
+++ b/internal/services/worker_version/schema.go
@@ -293,7 +293,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"bindings": schema.ListNestedAttribute{
 				Description: "List of bindings attached to a Worker. You can find more about bindings on our docs: https://developers.cloudflare.com/workers/configuration/multipart-upload-metadata/#bindings.",
-				Computed:    true,
 				Optional:    true,
 				CustomType:  customfield.NewNestedObjectListType[WorkerVersionBindingsModel](ctx),
 				NestedObject: schema.NestedAttributeObject{

--- a/internal/services/worker_version/schema.go
+++ b/internal/services/worker_version/schema.go
@@ -450,6 +450,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"usages": schema.SetAttribute{
 							Description: "Allowed operations with the key. [Learn more](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#keyUsages).",
 							Optional:    true,
+							CustomType:  customfield.NewSetType[types.String](ctx),
 							ElementType: types.StringType,
 						},
 						"key_base64": schema.StringAttribute{

--- a/internal/services/worker_version/schema.go
+++ b/internal/services/worker_version/schema.go
@@ -93,6 +93,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Description: "Token provided upon successful upload of all files from a registered manifest.",
 						Optional:    true,
 						Sensitive:   true,
+						WriteOnly:   true,
 					},
 				},
 				PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace()},

--- a/internal/services/worker_version/schema.go
+++ b/internal/services/worker_version/schema.go
@@ -218,8 +218,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Optional:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"content_base64": schema.StringAttribute{
-							Description: "The base64-encoded module content.",
+						"content_file": schema.StringAttribute{
+							Description: "The file path of the module content.",
 							Required:    true,
 						},
 						"content_type": schema.StringAttribute{
@@ -229,6 +229,13 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"name": schema.StringAttribute{
 							Description: "The name of the module.",
 							Required:    true,
+						},
+						"content_sha256": schema.StringAttribute{
+							Description: "The SHA-256 hash of the module content.",
+							Computed:    true,
+							PlanModifiers: []planmodifier.String{
+								ComputeSHA256HashOfContentFile(),
+							},
 						},
 					},
 				},

--- a/internal/services/worker_version/testdata/basic.tf
+++ b/internal/services/worker_version/testdata/basic.tf
@@ -1,0 +1,17 @@
+resource "cloudflare_worker" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[1]s"
+}
+
+resource "cloudflare_worker_version" "%[1]s" {
+  account_id = "%[2]s"
+  worker_id = cloudflare_worker.%[1]s.id
+  modules = [
+    {
+      name         = "index.js"
+      content_file = "%[3]s"
+      content_type = "application/javascript+module"
+    }
+  ]
+  main_module = "index.js"
+}

--- a/internal/services/worker_version/testdata/basic_update.tf
+++ b/internal/services/worker_version/testdata/basic_update.tf
@@ -1,0 +1,28 @@
+resource "cloudflare_worker" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[1]s"
+}
+
+resource "cloudflare_worker_version" "%[1]s" {
+  account_id = "%[2]s"
+  worker_id = cloudflare_worker.%[1]s.id
+  modules = [
+    {
+      name         = "index.js"
+      content_file = "%[3]s"
+      content_type = "application/javascript+module"
+    }
+  ]
+  main_module = "index.js"
+  bindings = [
+    {
+      type = "plain_text"
+      name = "NODE_ENV"
+      text = "production"
+    },
+    {
+      type = "version_metadata"
+      name = "VERSION_METADATA"
+    }
+  ]
+}

--- a/internal/services/worker_version/testdata/datasource_basic.tf
+++ b/internal/services/worker_version/testdata/datasource_basic.tf
@@ -1,0 +1,25 @@
+resource "cloudflare_worker" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[1]s"
+}
+
+resource "cloudflare_worker_version" "%[1]s" {
+  account_id = "%[2]s"
+  worker_id = cloudflare_worker.%[1]s.id
+  modules = [
+    {
+      name         = "index.js"
+      content_file = "%[3]s"
+      content_type = "application/javascript+module"
+    }
+  ]
+  main_module = "index.js"
+}
+
+data "cloudflare_worker_version" "%[1]s" {
+  account_id = "%[2]s"
+  worker_id = cloudflare_worker.%[1]s.id
+  version_id = cloudflare_worker_version.%[1]s.id
+  include = "modules"
+}
+


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
This PR adds a handful of custom code updates on the newly introduced `cloudflare_worker` and `cloudflare_worker_version` resources to handle idiosyncrasies with our API. Particularly...
* `bindings` is intended to be a polymorphic collection type (discriminated by a `type` attribute), but can not be represented that way in Terraform's type system. We need to include plan modifiers to treat avoid treating null computed attributes as unknown when the respective `type` doesn't correspond.
* We use a bespoke `content_file` / `content_sha256` attribute pair to avoid bloating state with large base64-encoded binary data the API sends and receives.
* Paper over certain attributes not being returned by the API (`assets`, secret binding `text`).
* Including a special param when fetching `cloudflare_worker_version` resources to include module content in the response.

Included are a suite of acceptance tests covering all of the new resources and data sources.

## Additional context & links
