### PR TITLE
fix(load_balancer_pool): handle null nested objects and preserve created_on timestamp

### DIFF
--- a/internal/apijson/json_test.go
+++ b/internal/apijson/json_test.go
@@ -793,6 +793,217 @@ var updateTests = map[string]struct {
 		`{"bool_value":null,"data":null,"float_value":null,"optional_array":null,"string_value":null}`,
 	},
 
+	"nested object null to non-null": {
+		TfsdkStructs{
+			DataObject: customfield.NullObject[EmbeddedTfsdkStruct](ctx),
+		},
+		TfsdkStructs{
+			DataObject: customfield.NewObjectMust(ctx, &EmbeddedTfsdkStruct{
+				EmbeddedString: types.StringValue("new_value"),
+				EmbeddedInt:    types.Int64Value(42),
+				DataObject:     customfield.NullObject[DoubleNestedStruct](ctx),
+			}),
+		},
+		`{"data_object":{"embedded_int":42,"embedded_string":"new_value"}}`,
+		`{"data_object":{"embedded_int":42,"embedded_string":"new_value"}}`,
+	},
+
+	"nested object non-null to null": {
+		TfsdkStructs{
+			DataObject: customfield.NewObjectMust(ctx, &EmbeddedTfsdkStruct{
+				EmbeddedString: types.StringValue("old_value"),
+				EmbeddedInt:    types.Int64Value(10),
+				DataObject:     customfield.NullObject[DoubleNestedStruct](ctx),
+			}),
+		},
+		TfsdkStructs{
+			DataObject: customfield.NullObject[EmbeddedTfsdkStruct](ctx),
+		},
+		`{"data_object":null}`,
+		`{"data_object":null}`,
+	},
+
+	"nested object with null state preserves null": {
+		customfield.NullObject[TfsdkStructs](ctx),
+		customfield.NullObject[TfsdkStructs](ctx),
+		``,
+		``,
+	},
+
+	"nested object list null to non-null": {
+		customfield.NullObjectList[TfsdkStructs](ctx),
+		customfield.NewObjectListMust(ctx, []TfsdkStructs{
+			{
+				BoolValue:   types.BoolValue(true),
+				StringValue: types.StringValue("test"),
+			},
+		}),
+		`[{"bool_value":true,"string_value":"test"}]`,
+		`[{"bool_value":true,"string_value":"test"}]`,
+	},
+
+	"nested object list non-null to null": {
+		customfield.NewObjectListMust(ctx, []TfsdkStructs{
+			{
+				BoolValue:   types.BoolValue(true),
+				StringValue: types.StringValue("test"),
+			},
+		}),
+		customfield.NullObjectList[TfsdkStructs](ctx),
+		`null`,
+		`null`,
+	},
+
+	"nested object list with null state preserves null": {
+		customfield.NullObjectList[TfsdkStructs](ctx),
+		customfield.NullObjectList[TfsdkStructs](ctx),
+		``,
+		``,
+	},
+
+	"nested object map null to non-null": {
+		customfield.NullObjectMap[TfsdkStructs](ctx),
+		customfield.NewObjectMapMust(ctx, map[string]TfsdkStructs{
+			"key1": {
+				BoolValue:   types.BoolValue(true),
+				StringValue: types.StringValue("test"),
+			},
+		}),
+		`{"key1":{"bool_value":true,"string_value":"test"}}`,
+		`{"key1":{"bool_value":true,"string_value":"test"}}`,
+	},
+
+	"nested object map non-null to null": {
+		customfield.NewObjectMapMust(ctx, map[string]TfsdkStructs{
+			"key1": {
+				BoolValue:   types.BoolValue(true),
+				StringValue: types.StringValue("test"),
+			},
+		}),
+		customfield.NullObjectMap[TfsdkStructs](ctx),
+		`null`,
+		`null`,
+	},
+
+	"nested object map with null state preserves null": {
+		customfield.NullObjectMap[TfsdkStructs](ctx),
+		customfield.NullObjectMap[TfsdkStructs](ctx),
+		``,
+		``,
+	},
+
+	"nested object set null to non-null": {
+		customfield.NullObjectSet[TfsdkStructs](ctx),
+		customfield.NewObjectSetMust(ctx, []TfsdkStructs{
+			{
+				BoolValue:   types.BoolValue(true),
+				StringValue: types.StringValue("test"),
+			},
+		}),
+		`[{"bool_value":true,"string_value":"test"}]`,
+		`[{"bool_value":true,"string_value":"test"}]`,
+	},
+
+	"nested object set non-null to null": {
+		customfield.NewObjectSetMust(ctx, []TfsdkStructs{
+			{
+				BoolValue:   types.BoolValue(true),
+				StringValue: types.StringValue("test"),
+			},
+		}),
+		customfield.NullObjectSet[TfsdkStructs](ctx),
+		`null`,
+		`null`,
+	},
+
+	"nested object set with null state preserves null": {
+		customfield.NullObjectSet[TfsdkStructs](ctx),
+		customfield.NullObjectSet[TfsdkStructs](ctx),
+		``,
+		``,
+	},
+
+	"list null to non-null": {
+		customfield.NullList[types.String](ctx),
+		customfield.NewListMust[types.String](ctx, []attr.Value{
+			types.StringValue("test1"),
+			types.StringValue("test2"),
+		}),
+		`["test1","test2"]`,
+		`["test1","test2"]`,
+	},
+
+	"list non-null to null": {
+		customfield.NewListMust[types.String](ctx, []attr.Value{
+			types.StringValue("test1"),
+			types.StringValue("test2"),
+		}),
+		customfield.NullList[types.String](ctx),
+		`null`,
+		`null`,
+	},
+
+	"list with null state preserves null": {
+		customfield.NullList[types.String](ctx),
+		customfield.NullList[types.String](ctx),
+		``,
+		``,
+	},
+
+	"map null to non-null": {
+		customfield.NullMap[types.String](ctx),
+		customfield.NewMapMust[types.String](ctx, map[string]types.String{
+			"key1": types.StringValue("value1"),
+			"key2": types.StringValue("value2"),
+		}),
+		`{"key1":"value1","key2":"value2"}`,
+		`{"key1":"value1","key2":"value2"}`,
+	},
+
+	"map non-null to null": {
+		customfield.NewMapMust[types.String](ctx, map[string]types.String{
+			"key1": types.StringValue("value1"),
+			"key2": types.StringValue("value2"),
+		}),
+		customfield.NullMap[types.String](ctx),
+		`null`,
+		`null`,
+	},
+
+	"map with null state preserves null": {
+		customfield.NullMap[types.String](ctx),
+		customfield.NullMap[types.String](ctx),
+		``,
+		``,
+	},
+
+	"set null to non-null": {
+		customfield.NullSet[types.String](ctx),
+		customfield.NewSetMust[types.String](ctx, []attr.Value{
+			types.StringValue("test1"),
+			types.StringValue("test2"),
+		}),
+		`["test1","test2"]`,
+		`["test1","test2"]`,
+	},
+
+	"set non-null to null": {
+		customfield.NewSetMust[types.String](ctx, []attr.Value{
+			types.StringValue("test1"),
+			types.StringValue("test2"),
+		}),
+		customfield.NullSet[types.String](ctx),
+		`null`,
+		`null`,
+	},
+
+	"set with null state preserves null": {
+		customfield.NullSet[types.String](ctx),
+		customfield.NullSet[types.String](ctx),
+		``,
+		``,
+	},
+
 	"set empty array": {
 		TfsdkStructs{
 			FloatValue:    types.Float64Value(3.14),

--- a/internal/customfield/object.go
+++ b/internal/customfield/object.go
@@ -182,6 +182,11 @@ func (v NestedObject[T]) ValueAny(ctx context.Context) (any, diag.Diagnostics) {
 func (v NestedObject[T]) Value(ctx context.Context) (*T, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	// If the value is null, return nil
+	if v.ObjectValue.IsNull() {
+		return nil, diags
+	}
+
 	ptr := new(T)
 
 	diags.Append(v.ObjectValue.As(ctx, ptr, basetypes.ObjectAsOptions{})...)

--- a/internal/services/load_balancer_pool/resource.go
+++ b/internal/services/load_balancer_pool/resource.go
@@ -141,6 +141,10 @@ func (r *LoadBalancerPoolResource) Update(ctx context.Context, req resource.Upda
 	}
 	data = &env.Result
 
+	// Reset created_on to the value from state
+	// The API seems to return 0001-01-01T00:00:00Z on update
+	data.CreatedOn = state.CreatedOn
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/services/load_balancer_pool/resource_test.go
+++ b/internal/services/load_balancer_pool/resource_test.go
@@ -210,7 +210,6 @@ func TestAccCloudflareLoadBalancerPool_VirtualNetworkID(t *testing.T) {
 }
 
 func TestAccCloudflareLoadBalancerPool_PatchBehavior(t *testing.T) {
-	t.Skip("value conversion error due to codegen bug")
 	t.Parallel()
 	testStartTime := time.Now().UTC()
 	var loadBalancerPool cfold.LoadBalancerPool

--- a/internal/services/load_balancer_pool/schema.go
+++ b/internal/services/load_balancer_pool/schema.go
@@ -268,6 +268,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"created_on": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"disabled_at": schema.StringAttribute{
 				Description: "This field shows up only if the pool is disabled. This field is set with the time the pool was disabled at.",


### PR DESCRIPTION
## Summary
- Fixed null handling in customfield.NestedObject to prevent marshaling errors
- Preserved created_on timestamp from state after updates to work around API issue
- Re-enabled previously skipped PatchBehavior test

## Problem
The `TestAccCloudflareLoadBalancerPool_PatchBehavior` test was failing with two issues:

1. **Null value marshaling error**: When updating a load balancer pool that initially had no `load_shedding` configuration (null in state), the encoder would fail with "target type cannot handle null values" when trying to unmarshal the null ObjectValue into a struct type.

2. **Invalid created_on timestamp**: The Cloudflare API returns `"0001-01-01T00:00:00Z"` for `created_on` in PUT responses instead of the actual creation timestamp, causing test assertions to fail.
    - might want to ask the owning team about this - seems like a bug? a small amount of custom code works around it though.

## Solution

1. **Added null check in `customfield.NestedObject.Value()`**: Now returns nil when the ObjectValue is null instead of attempting to unmarshal, preventing the conversion error.
    - note: this change should be part of codegen, so i will make a PR for that on our end shortly.

4. **Preserve created_on from state**: After updates, we now preserve the original `created_on` value from state rather than using the invalid value from the API response. Also added `UseStateForUnknown` plan modifier to prevent unnecessary updates.

## Test Results
The previously skipped `TestAccCloudflareLoadBalancerPool_PatchBehavior` test now passes successfully.