### PR TITLE
fix(test): add planmodifiers for dynamic type

### DIFF
--- a/internal/services/hostname_tls_setting/model.go
+++ b/internal/services/hostname_tls_setting/model.go
@@ -4,6 +4,7 @@ package hostname_tls_setting
 
 import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -13,14 +14,14 @@ type HostnameTLSSettingResultEnvelope struct {
 }
 
 type HostnameTLSSettingModel struct {
-	ID        types.String      `tfsdk:"id" json:"-,computed"`
-	SettingID types.String      `tfsdk:"setting_id" path:"setting_id,required"`
-	ZoneID    types.String      `tfsdk:"zone_id" path:"zone_id,required"`
-	Hostname  types.String      `tfsdk:"hostname" path:"hostname,required"`
-	Value     types.Dynamic     `tfsdk:"value" json:"value,required"`
-	CreatedAt timetypes.RFC3339 `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
-	Status    types.String      `tfsdk:"status" json:"status,computed"`
-	UpdatedAt timetypes.RFC3339 `tfsdk:"updated_at" json:"updated_at,computed" format:"date-time"`
+	ID        types.String                       `tfsdk:"id" json:"-,computed"`
+	SettingID types.String                       `tfsdk:"setting_id" path:"setting_id,required"`
+	ZoneID    types.String                       `tfsdk:"zone_id" path:"zone_id,required"`
+	Hostname  types.String                       `tfsdk:"hostname" path:"hostname,required"`
+	Value     customfield.NormalizedDynamicValue `tfsdk:"value" json:"value,required"`
+	CreatedAt timetypes.RFC3339                  `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
+	Status    types.String                       `tfsdk:"status" json:"status,computed"`
+	UpdatedAt timetypes.RFC3339                  `tfsdk:"updated_at" json:"updated_at,computed" format:"date-time"`
 }
 
 func (m HostnameTLSSettingModel) MarshalJSON() (data []byte, err error) {

--- a/internal/services/hostname_tls_setting/schema.go
+++ b/internal/services/hostname_tls_setting/schema.go
@@ -5,6 +5,7 @@ package hostname_tls_setting
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -41,7 +42,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"http2",
 					),
 				},
-				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown(), stringplanmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
@@ -56,6 +60,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"value": schema.DynamicAttribute{
 				Description: "The tls setting value.",
 				Required:    true,
+				CustomType:  customfield.NormalizedDynamicType{},
+				PlanModifiers: []planmodifier.Dynamic{
+					customfield.NormalizeDynamicPlanModifier(),
+				},
 			},
 			"created_at": schema.StringAttribute{
 				Description: "This is the time the tls setting was originally created for this hostname.",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Attempts to fix instances like [this](https://github.com/cloudflare/terraform-provider-cloudflare/actions/runs/17248634193/job/48944771913?pr=6028#step:5:3282) in a similar way we did https://github.com/cloudflare/terraform-provider-cloudflare/pull/5986
```
     integrity.go:126: missing at ".@HostnameTLSSettingModel.value" on schema: "PlanModifiers: []planmodifier.Dynamic{customfield.NormalizeDynamicPlanModifier()}"
    integrity.go:129: If you are implementing a custom solution, you can suppress these warning(s) by adding the following to the test, as an example:
         + errs.Ignore(".@HostnameTLSSettingModel.value")
--- FAIL: TestHostnameTLSSettingModelSchemaParity (0.00s)
=== NAME  TestAccCloudflareHostnameTLSSetting_Basic
    resource_test.go:73: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccCloudflareHostnameTLSSetting_Basic (0.00s)
=== NAME  TestAccCloudflareHostnameTLSSetting_ListOfStrings
    resource_test.go:97: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccCloudflareHostnameTLSSetting_ListOfStrings (0.01s)
FAIL
FAIL	github.com/cloudflare/terraform-provider-cloudflare/internal/services/hostname_tls_setting	0.029s
```

## Additional context & links

It's unclear if this patch is working effectively or not. I get failures with this resource when running locally on both `next` and this branch. I suspect it's also possible this resource just doesn't work -- I don't see it running as part of [the CI inclusion list](https://github.com/cloudflare/terraform-provider-cloudflare/blob/579c51a126910325fc16d43f195b6b73fc20c121/scripts/run-ci-acceptance-tests#L8).