### PR TITLE
fix: resolve type mismatches in zero trust access policy and applicat…

### DIFF
--- a/internal/services/zero_trust_access_application/migrations.go
+++ b/internal/services/zero_trust_access_application/migrations.go
@@ -524,7 +524,7 @@ func upgradeZeroTrustAccessApplicationStateV0toV1(ctx context.Context, req resou
 	if tags, ok := oldState["tags"].([]interface{}); ok {
 		migratedTags := migrateStringSliceToList(tags)
 		if len(migratedTags) > 0 {
-			newState.Tags, _ = customfield.NewList[types.String](ctx, migratedTags)
+			newState.Tags, _ = customfield.NewSet[types.String](ctx, migratedTags)
 		}
 	}
 

--- a/internal/services/zero_trust_access_application/normalizations.go
+++ b/internal/services/zero_trust_access_application/normalizations.go
@@ -228,18 +228,18 @@ func normalizeImportZeroTrustAccessApplicationAPIData(ctx context.Context, data 
 			if !policy.ID.IsNull() && !policy.ID.IsUnknown() {
 				policy.Decision = types.StringNull()
 				policy.Name = types.StringNull()
-				policy.Include = customfield.NullObjectList[ZeroTrustAccessApplicationPoliciesIncludeModel](ctx)
-				policy.Require = customfield.NullObjectList[ZeroTrustAccessApplicationPoliciesRequireModel](ctx)
-				policy.Exclude = customfield.NullObjectList[ZeroTrustAccessApplicationPoliciesExcludeModel](ctx)
+				policy.Include = customfield.NullObjectSet[ZeroTrustAccessApplicationPoliciesIncludeModel](ctx)
+				policy.Require = customfield.NullObjectSet[ZeroTrustAccessApplicationPoliciesRequireModel](ctx)
+				policy.Exclude = customfield.NullObjectSet[ZeroTrustAccessApplicationPoliciesExcludeModel](ctx)
 			} else {
 				if !policy.Include.IsNull() && len(policy.Include.Elements()) == 0 {
-					policy.Include = customfield.NullObjectList[ZeroTrustAccessApplicationPoliciesIncludeModel](ctx)
+					policy.Include = customfield.NullObjectSet[ZeroTrustAccessApplicationPoliciesIncludeModel](ctx)
 				}
 				if !policy.Require.IsNull() && len(policy.Require.Elements()) == 0 {
-					policy.Require = customfield.NullObjectList[ZeroTrustAccessApplicationPoliciesRequireModel](ctx)
+					policy.Require = customfield.NullObjectSet[ZeroTrustAccessApplicationPoliciesRequireModel](ctx)
 				}
 				if !policy.Exclude.IsNull() && len(policy.Exclude.Elements()) == 0 {
-					policy.Exclude = customfield.NullObjectList[ZeroTrustAccessApplicationPoliciesExcludeModel](ctx)
+					policy.Exclude = customfield.NullObjectSet[ZeroTrustAccessApplicationPoliciesExcludeModel](ctx)
 				}
 			}
 		}
@@ -247,7 +247,7 @@ func normalizeImportZeroTrustAccessApplicationAPIData(ctx context.Context, data 
 
 	if !data.Tags.IsNull() && !data.Tags.IsUnknown() {
 		if len(data.Tags.Elements()) == 0 {
-			data.Tags = customfield.NullList[types.String](ctx)
+			data.Tags = customfield.NullSet[types.String](ctx)
 		}
 	}
 

--- a/internal/services/zero_trust_access_application/plan_modifiers.go
+++ b/internal/services/zero_trust_access_application/plan_modifiers.go
@@ -146,7 +146,7 @@ func modifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resour
 	res.Plan.Set(ctx, &planApp)
 }
 
-func normalizeTagsOrder(ctx context.Context, planTags *customfield.List[types.String], stateTags customfield.List[types.String]) {
+func normalizeTagsOrder(ctx context.Context, planTags *customfield.Set[types.String], stateTags customfield.Set[types.String]) {
 	var stateStrings, planStrings []string
 
 	for _, elem := range stateTags.Elements() {
@@ -161,6 +161,7 @@ func normalizeTagsOrder(ctx context.Context, planTags *customfield.List[types.St
 		}
 	}
 
+	// For Sets, order doesn't matter, so we just check if they contain the same elements
 	if len(stateStrings) == len(planStrings) {
 		slices.Sort(stateStrings)
 		slices.Sort(planStrings)

--- a/internal/services/zero_trust_access_policy/migrations.go
+++ b/internal/services/zero_trust_access_policy/migrations.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -273,11 +274,7 @@ func upgradeZeroTrustAccessPolicyStateV0toV1(ctx context.Context, req resource.U
 			}
 		}
 		if len(includeRules) > 0 {
-			var includeRulesPtrs []*ZeroTrustAccessPolicyIncludeModel
-			for i := range includeRules {
-				includeRulesPtrs = append(includeRulesPtrs, &includeRules[i])
-			}
-			newState.Include = &includeRulesPtrs
+			newState.Include, _ = customfield.NewObjectSet[ZeroTrustAccessPolicyIncludeModel](ctx, includeRules)
 		}
 	}
 
@@ -291,11 +288,7 @@ func upgradeZeroTrustAccessPolicyStateV0toV1(ctx context.Context, req resource.U
 			}
 		}
 		if len(excludeRules) > 0 {
-			var excludeRulesPtrs []*ZeroTrustAccessPolicyExcludeModel
-			for i := range excludeRules {
-				excludeRulesPtrs = append(excludeRulesPtrs, &excludeRules[i])
-			}
-			newState.Exclude = &excludeRulesPtrs
+			newState.Exclude, _ = customfield.NewObjectSet[ZeroTrustAccessPolicyExcludeModel](ctx, excludeRules)
 		}
 	}
 
@@ -309,11 +302,7 @@ func upgradeZeroTrustAccessPolicyStateV0toV1(ctx context.Context, req resource.U
 			}
 		}
 		if len(requireRules) > 0 {
-			var requireRulesPtrs []*ZeroTrustAccessPolicyRequireModel
-			for i := range requireRules {
-				requireRulesPtrs = append(requireRulesPtrs, &requireRules[i])
-			}
-			newState.Require = &requireRulesPtrs
+			newState.Require, _ = customfield.NewObjectSet[ZeroTrustAccessPolicyRequireModel](ctx, requireRules)
 		}
 	}
 

--- a/internal/services/zero_trust_access_policy/normalizations.go
+++ b/internal/services/zero_trust_access_policy/normalizations.go
@@ -3,6 +3,8 @@ package zero_trust_access_policy
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -13,6 +15,21 @@ type IsNull interface {
 
 func normalizeEmptyAndNullSlice[T any](data **[]T, stateData *[]T) {
 	if (*data != nil && len(**data) != 0) || (stateData != nil && len(*stateData) != 0) {
+		return
+	}
+	*data = stateData
+}
+
+type SetValueInterface interface {
+	IsNull() bool
+	Elements() []attr.Value
+}
+
+func normalizeEmptyAndNullNestedObjectSet[T SetValueInterface](data *T, stateData T) {
+	if (*data).IsNull() && stateData.IsNull() {
+		return
+	}
+	if (!(*data).IsNull() && len((*data).Elements()) != 0) || (!stateData.IsNull() && len(stateData.Elements()) != 0) {
 		return
 	}
 	*data = stateData
@@ -31,9 +48,9 @@ func normalizeFalseAndNullBool(data *basetypes.BoolValue, stateData basetypes.Bo
 func normalizeReadZeroTrustAccessPolicyAPIData(ctx context.Context, data, sourceData *ZeroTrustAccessPolicyModel) diag.Diagnostics {
 	diags := make(diag.Diagnostics, 0)
 
-	normalizeEmptyAndNullSlice(&data.Include, sourceData.Include)
-	normalizeEmptyAndNullSlice(&data.Require, sourceData.Require)
-	normalizeEmptyAndNullSlice(&data.Exclude, sourceData.Exclude)
+	normalizeEmptyAndNullNestedObjectSet(&data.Include, sourceData.Include)
+	normalizeEmptyAndNullNestedObjectSet(&data.Require, sourceData.Require)
+	normalizeEmptyAndNullNestedObjectSet(&data.Exclude, sourceData.Exclude)
 	normalizeEmptyAndNullSlice(&data.ApprovalGroups, sourceData.ApprovalGroups)
 	normalizeFalseAndNullBool(&data.PurposeJustificationRequired, sourceData.PurposeJustificationRequired)
 	normalizeFalseAndNullBool(&data.ApprovalRequired, sourceData.ApprovalRequired)
@@ -46,16 +63,16 @@ func normalizeReadZeroTrustAccessPolicyAPIData(ctx context.Context, data, source
 func normalizeImportZeroTrustAccessPolicyAPIData(ctx context.Context, data *ZeroTrustAccessPolicyModel) diag.Diagnostics {
 	diags := make(diag.Diagnostics, 0)
 
-	if data.Include != nil && len(*data.Include) == 0 {
-		data.Include = nil
+	if !data.Include.IsNull() && len(data.Include.Elements()) == 0 {
+		data.Include = customfield.NullObjectSet[ZeroTrustAccessPolicyIncludeModel](ctx)
 	}
 
-	if data.Require != nil && len(*data.Require) == 0 {
-		data.Require = nil
+	if !data.Require.IsNull() && len(data.Require.Elements()) == 0 {
+		data.Require = customfield.NullObjectSet[ZeroTrustAccessPolicyRequireModel](ctx)
 	}
 
-	if data.Exclude != nil && len(*data.Exclude) == 0 {
-		data.Exclude = nil
+	if !data.Exclude.IsNull() && len(data.Exclude.Elements()) == 0 {
+		data.Exclude = customfield.NullObjectSet[ZeroTrustAccessPolicyExcludeModel](ctx)
 	}
 
 	return diags


### PR DESCRIPTION
Fixes compilation errors in zero trust access policy and application services
  caused by type mismatches between customfield types (Set vs List, ObjectSet vs
  ObjectList, NestedObjectSet vs pointer arrays).

  Changes Made

  zero_trust_access_policy service:
  - migrations.go: Updated Include, Exclude, and Require rules migration logic from
  pointer array pattern to customfield.NewObjectSet
  - normalizations.go:
    - Created proper interface for NestedObjectSet types with correct Elements()
  []attr.Value signature
    - Replaced normalizeEmptyAndNullSlice calls with
  normalizeEmptyAndNullNestedObjectSet for Set types
    - Fixed import normalization to use customfield.NullObjectSet

  zero_trust_access_application service:
  - migrations.go: Fixed Tags field migration to use customfield.NewSet instead of
  customfield.NewList
  - normalizations.go: Updated all policy field references from ObjectList to
  ObjectSet and Tags from NullList to NullSet
  - plan_modifiers.go: Updated normalizeTagsOrder function signature to handle
  customfield.Set[types.String]

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
