### PR TITLE
reverting permission group order tests that only work in staging

### DIFF
--- a/internal/services/account_token/resource_test.go
+++ b/internal/services/account_token/resource_test.go
@@ -185,121 +185,185 @@ func TestAccAccountToken_TokenTTL(t *testing.T) {
 }
 
 func TestAccAccountToken_PermissionGroupOrder(t *testing.T) {
-	rnd := utils.GenerateRandomResourceName()
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	permissionID0 := ""
-	permissionID1 := ""
 
-	var policyId string
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_account_token." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	permissionID1 := "82e64a83756745bbbb1c9c2701bf816b" // DNS read
+	permissionID2 := "e199d584e69344eba202452019deafe3" // Disable ESC read
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				// not seting permission IDs first, retrieving them from API by name
-				Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd, accountID, "", ""),
+				Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd, accountID, permissionID1, permissionID2),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "name", rnd),
-					resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "policies.#", "1"),
-					resource.TestCheckResourceAttrSet("cloudflare_account_token.test_account_token", "policies.0.id"),
-					resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.id", func(value string) error {
-						policyId = value
-						return nil
-					}),
-					resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "policies.0.permission_groups.#", "2"),
-					resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.permission_groups.0.id", func(value string) error {
-						permissionID0 = value
-						return nil
-					}),
-					resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.permission_groups.1.id", func(value string) error {
-						permissionID1 = value
-						return nil
-					}),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "policies.0.permission_groups.0.id", permissionID1),
+					resource.TestCheckResourceAttr(name, "policies.0.permission_groups.1.id", permissionID2),
 				),
 			},
-			// below we try changing the order of the permission group IDs and
-			// verify there are no plan changes
 			{
-				Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd, accountID, permissionID0, permissionID1),
+				Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd, accountID, permissionID2, permissionID1),
+				// changing the order of permission groups should not affect plan
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
 					},
 				},
-			},
-			{
-				Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd, accountID, permissionID1, permissionID0),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-			// try updating the token and ensure policy information hasn't
-			// changed
-			{
-				Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd+"updated", accountID, permissionID1, permissionID0),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectNonEmptyPlan(),
-					},
-				},
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "name", rnd+"updated"),
-					resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "policies.#", "1"),
-					resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.id", func(value string) error {
-						if value != policyId {
-							return fmt.Errorf("policy ID changed from %s to %s", policyId, value)
-						}
-						return nil
-					}),
-					resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "policies.0.permission_groups.#", "2"),
-					resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.permission_groups.0.id", func(value string) error {
-						if value != permissionID0 {
-							return fmt.Errorf("permission ID 0 changed from %s to %s", permissionID0, value)
-						}
-						return nil
-					}),
-					resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.permission_groups.1.id", func(value string) error {
-						if value != permissionID1 {
-							return fmt.Errorf("permission ID 1 changed from %s to %s", permissionID1, value)
-						}
-						return nil
-					}),
-				),
-			},
-			{
-				Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd+"updated2", accountID, permissionID0, permissionID1),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectNonEmptyPlan(),
-					},
-				},
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "name", rnd+"updated2"),
-					resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "policies.#", "1"),
-					resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.id", func(value string) error {
-						if value != policyId {
-							return fmt.Errorf("policy ID changed from %s to %s", policyId, value)
-						}
-						return nil
-					}),
-					resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "policies.0.permission_groups.#", "2"),
-					resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.permission_groups.0.id", func(value string) error {
-						if value != permissionID0 {
-							return fmt.Errorf("permission ID 0 changed from %s to %s", permissionID0, value)
-						}
-						return nil
-					}),
-					resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.permission_groups.1.id", func(value string) error {
-						if value != permissionID1 {
-							return fmt.Errorf("permission ID 1 changed from %s to %s", permissionID1, value)
-						}
-						return nil
-					}),
-				),
 			},
 		},
 	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd, accountID, permissionID2, permissionID1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "policies.0.permission_groups.0.id", permissionID1),
+					resource.TestCheckResourceAttr(name, "policies.0.permission_groups.1.id", permissionID2),
+				),
+			},
+			{
+				Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd, accountID, permissionID2, permissionID1),
+				// re-applying same change does not produce drift
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd, accountID, permissionID1, permissionID2),
+				// changing the order of permission groups should not affect plan
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+
+	// rnd := utils.GenerateRandomResourceName()
+	// accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	// permissionID0 := ""
+	// permissionID1 := ""
+
+	// var policyId string
+
+	// resource.Test(t, resource.TestCase{
+	// 	PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+	// 	ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+	// 	Steps: []resource.TestStep{
+	// 		{
+	// 			// not seting permission IDs first, retrieving them from API by name
+	// 			Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd, accountID, "", ""),
+	// 			Check: resource.ComposeTestCheckFunc(
+	// 				resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "name", rnd),
+	// 				resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "policies.#", "1"),
+	// 				resource.TestCheckResourceAttrSet("cloudflare_account_token.test_account_token", "policies.0.id"),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.id", func(value string) error {
+	// 					policyId = value
+	// 					return nil
+	// 				}),
+	// 				resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "policies.0.permission_groups.#", "2"),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.permission_groups.0.id", func(value string) error {
+	// 					permissionID0 = value
+	// 					return nil
+	// 				}),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.permission_groups.1.id", func(value string) error {
+	// 					permissionID1 = value
+	// 					return nil
+	// 				}),
+	// 			),
+	// 		},
+	// 		// below we try changing the order of the permission group IDs and
+	// 		// verify there are no plan changes
+	// 		{
+	// 			Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd, accountID, permissionID0, permissionID1),
+	// 			ConfigPlanChecks: resource.ConfigPlanChecks{
+	// 				PreApply: []plancheck.PlanCheck{
+	// 					plancheck.ExpectEmptyPlan(),
+	// 				},
+	// 			},
+	// 		},
+	// 		{
+	// 			Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd, accountID, permissionID1, permissionID0),
+	// 			ConfigPlanChecks: resource.ConfigPlanChecks{
+	// 				PreApply: []plancheck.PlanCheck{
+	// 					plancheck.ExpectEmptyPlan(),
+	// 				},
+	// 			},
+	// 		},
+	// 		// try updating the token and ensure policy information hasn't
+	// 		// changed
+	// 		{
+	// 			Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd+"updated", accountID, permissionID1, permissionID0),
+	// 			ConfigPlanChecks: resource.ConfigPlanChecks{
+	// 				PreApply: []plancheck.PlanCheck{
+	// 					plancheck.ExpectNonEmptyPlan(),
+	// 				},
+	// 			},
+	// 			Check: resource.ComposeTestCheckFunc(
+	// 				resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "name", rnd+"updated"),
+	// 				resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "policies.#", "1"),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.id", func(value string) error {
+	// 					if value != policyId {
+	// 						return fmt.Errorf("policy ID changed from %s to %s", policyId, value)
+	// 					}
+	// 					return nil
+	// 				}),
+	// 				resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "policies.0.permission_groups.#", "2"),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.permission_groups.0.id", func(value string) error {
+	// 					if value != permissionID0 {
+	// 						return fmt.Errorf("permission ID 0 changed from %s to %s", permissionID0, value)
+	// 					}
+	// 					return nil
+	// 				}),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.permission_groups.1.id", func(value string) error {
+	// 					if value != permissionID1 {
+	// 						return fmt.Errorf("permission ID 1 changed from %s to %s", permissionID1, value)
+	// 					}
+	// 					return nil
+	// 				}),
+	// 			),
+	// 		},
+	// 		{
+	// 			Config: acctest.LoadTestCase("account_token-permissiongroup-order.tf", rnd+"updated2", accountID, permissionID0, permissionID1),
+	// 			ConfigPlanChecks: resource.ConfigPlanChecks{
+	// 				PreApply: []plancheck.PlanCheck{
+	// 					plancheck.ExpectNonEmptyPlan(),
+	// 				},
+	// 			},
+	// 			Check: resource.ComposeTestCheckFunc(
+	// 				resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "name", rnd+"updated2"),
+	// 				resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "policies.#", "1"),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.id", func(value string) error {
+	// 					if value != policyId {
+	// 						return fmt.Errorf("policy ID changed from %s to %s", policyId, value)
+	// 					}
+	// 					return nil
+	// 				}),
+	// 				resource.TestCheckResourceAttr("cloudflare_account_token.test_account_token", "policies.0.permission_groups.#", "2"),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.permission_groups.0.id", func(value string) error {
+	// 					if value != permissionID0 {
+	// 						return fmt.Errorf("permission ID 0 changed from %s to %s", permissionID0, value)
+	// 					}
+	// 					return nil
+	// 				}),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_account_token.test_account_token", "policies.0.permission_groups.1.id", func(value string) error {
+	// 					if value != permissionID1 {
+	// 						return fmt.Errorf("permission ID 1 changed from %s to %s", permissionID1, value)
+	// 					}
+	// 					return nil
+	// 				}),
+	// 			),
+	// 		},
+	// 	},
+	// })
 }

--- a/internal/services/account_token/testdata/account_token-permissiongroup-order.tf
+++ b/internal/services/account_token/testdata/account_token-permissiongroup-order.tf
@@ -1,28 +1,51 @@
-data "cloudflare_account_api_token_permission_groups_list" "dns_read" {
-  account_id = "%[2]s"
-  name       = "DNS Read"
-  scope      = "com.cloudflare.api.account.zone"
-}
-
-data "cloudflare_account_api_token_permission_groups_list" "disable_esc_read" {
-  account_id = "%[2]s"
-  name       = "Disable ESC Read"
-  scope      = "com.cloudflare.api.account.zone"
-}
-
-resource "cloudflare_account_token" "test_account_token" {
-  name       = "%[1]s"
+resource "cloudflare_account_token" "%[1]s" {
+  name = "%[1]s"
   account_id = "%[2]s"
 
   policies = [{
     effect = "allow"
     permission_groups = [{
-      id = "%[3]s" != "" ? "%[3]s" : data.cloudflare_account_api_token_permission_groups_list.dns_read.result[0].id
-      }, {
-      id = "%[4]s" != "" ? "%[4]s" : data.cloudflare_account_api_token_permission_groups_list.disable_esc_read.result[0].id
+      id = "%[3]s"
+    },{
+      id = "%[4]s"
     }]
     resources = {
       "com.cloudflare.api.account.%[2]s" = "*"
     }
   }]
 }
+
+data "cloudflare_account_token" "%[1]s" {
+  account_id = "%[2]s"
+  token_id = cloudflare_account_token.%[1]s.id
+  depends_on = [cloudflare_account_token.%[1]s]
+}
+
+# data "cloudflare_account_api_token_permission_groups_list" "dns_read" {
+#   account_id = "%[2]s"
+#   name       = "DNS Read"
+#   scope      = "com.cloudflare.api.account.zone"
+# }
+
+# data "cloudflare_account_api_token_permission_groups_list" "disable_esc_read" {
+#   account_id = "%[2]s"
+#   name       = "Disable ESC Read"
+#   scope      = "com.cloudflare.api.account.zone"
+# }
+
+# resource "cloudflare_account_token" "test_account_token" {
+#   name       = "%[1]s"
+#   account_id = "%[2]s"
+
+#   policies = [{
+#     effect = "allow"
+#     permission_groups = [{
+#       id = "%[3]s" != "" ? "%[3]s" : data.cloudflare_account_api_token_permission_groups_list.dns_read.result[0].id
+#       }, {
+#       id = "%[4]s" != "" ? "%[4]s" : data.cloudflare_account_api_token_permission_groups_list.disable_esc_read.result[0].id
+#     }]
+#     resources = {
+#       "com.cloudflare.api.account.%[2]s" = "*"
+#     }
+#   }]
+# }

--- a/internal/services/api_token/resource_test.go
+++ b/internal/services/api_token/resource_test.go
@@ -174,119 +174,181 @@ func TestAccAPIToken_TokenTTL(t *testing.T) {
 
 func TestAccAPIToken_PermissionGroupOrder(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
-	permissionID0 := ""
-	permissionID1 := ""
-
-	var policyId string
+	name := "cloudflare_api_token." + rnd
+	permissionID1 := "82e64a83756745bbbb1c9c2701bf816b" // DNS read
+	permissionID2 := "e199d584e69344eba202452019deafe3" // Disable ESC read
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck:                 func() { acctest.TestAccPreCheck_APIToken(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				// not seting permission IDs first, retrieving them from API by name
-				Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd, "", ""),
+				Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd, permissionID1, permissionID2),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "name", rnd),
-					resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "policies.#", "1"),
-					resource.TestCheckResourceAttrSet("cloudflare_api_token.test_account_token", "policies.0.id"),
-					resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.id", func(value string) error {
-						policyId = value
-						return nil
-					}),
-					resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "policies.0.permission_groups.#", "2"),
-					resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.permission_groups.0.id", func(value string) error {
-						permissionID0 = value
-						return nil
-					}),
-					resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.permission_groups.1.id", func(value string) error {
-						permissionID1 = value
-						return nil
-					}),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "policies.0.permission_groups.0.id", permissionID1),
+					resource.TestCheckResourceAttr(name, "policies.0.permission_groups.1.id", permissionID2),
 				),
 			},
-			// below we try changing the order of the permission group IDs and
-			// verify there are no plan changes
 			{
-				Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd, permissionID0, permissionID1),
+				Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd, permissionID2, permissionID1),
+				// changing the order of permission groups should not affect plan
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
 					},
 				},
-			},
-			{
-				Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd, permissionID1, permissionID0),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-			// try updating the token and ensure policy information hasn't
-			// changed
-			{
-				Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd+"updated", permissionID1, permissionID0),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectNonEmptyPlan(),
-					},
-				},
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "name", rnd+"updated"),
-					resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "policies.#", "1"),
-					resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.id", func(value string) error {
-						if value != policyId {
-							return fmt.Errorf("policy ID changed from %s to %s", policyId, value)
-						}
-						return nil
-					}),
-					resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "policies.0.permission_groups.#", "2"),
-					resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.permission_groups.0.id", func(value string) error {
-						if value != permissionID0 {
-							return fmt.Errorf("permission ID 0 changed from %s to %s", permissionID0, value)
-						}
-						return nil
-					}),
-					resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.permission_groups.1.id", func(value string) error {
-						if value != permissionID1 {
-							return fmt.Errorf("permission ID 1 changed from %s to %s", permissionID1, value)
-						}
-						return nil
-					}),
-				),
-			},
-			{
-				Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd+"updated2", permissionID0, permissionID1),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectNonEmptyPlan(),
-					},
-				},
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "name", rnd+"updated2"),
-					resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "policies.#", "1"),
-					resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.id", func(value string) error {
-						if value != policyId {
-							return fmt.Errorf("policy ID changed from %s to %s", policyId, value)
-						}
-						return nil
-					}),
-					resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "policies.0.permission_groups.#", "2"),
-					resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.permission_groups.0.id", func(value string) error {
-						if value != permissionID0 {
-							return fmt.Errorf("permission ID 0 changed from %s to %s", permissionID0, value)
-						}
-						return nil
-					}),
-					resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.permission_groups.1.id", func(value string) error {
-						if value != permissionID1 {
-							return fmt.Errorf("permission ID 1 changed from %s to %s", permissionID1, value)
-						}
-						return nil
-					}),
-				),
 			},
 		},
 	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_APIToken(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd, permissionID2, permissionID1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "policies.0.permission_groups.0.id", permissionID1),
+					resource.TestCheckResourceAttr(name, "policies.0.permission_groups.1.id", permissionID2),
+				),
+			},
+			{
+				Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd, permissionID2, permissionID1),
+				// re-applying same change does not produce drift
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd, permissionID1, permissionID2),
+				// changing the order of permission groups should not affect plan
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+
+	// rnd := utils.GenerateRandomResourceName()
+	// permissionID0 := ""
+	// permissionID1 := ""
+
+	// var policyId string
+
+	// resource.Test(t, resource.TestCase{
+	// 	PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+	// 	ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+	// 	Steps: []resource.TestStep{
+	// 		{
+	// 			// not seting permission IDs first, retrieving them from API by name
+	// 			Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd, "", ""),
+	// 			Check: resource.ComposeTestCheckFunc(
+	// 				resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "name", rnd),
+	// 				resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "policies.#", "1"),
+	// 				resource.TestCheckResourceAttrSet("cloudflare_api_token.test_account_token", "policies.0.id"),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.id", func(value string) error {
+	// 					policyId = value
+	// 					return nil
+	// 				}),
+	// 				resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "policies.0.permission_groups.#", "2"),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.permission_groups.0.id", func(value string) error {
+	// 					permissionID0 = value
+	// 					return nil
+	// 				}),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.permission_groups.1.id", func(value string) error {
+	// 					permissionID1 = value
+	// 					return nil
+	// 				}),
+	// 			),
+	// 		},
+	// 		// below we try changing the order of the permission group IDs and
+	// 		// verify there are no plan changes
+	// 		{
+	// 			Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd, permissionID0, permissionID1),
+	// 			ConfigPlanChecks: resource.ConfigPlanChecks{
+	// 				PreApply: []plancheck.PlanCheck{
+	// 					plancheck.ExpectEmptyPlan(),
+	// 				},
+	// 			},
+	// 		},
+	// 		{
+	// 			Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd, permissionID1, permissionID0),
+	// 			ConfigPlanChecks: resource.ConfigPlanChecks{
+	// 				PreApply: []plancheck.PlanCheck{
+	// 					plancheck.ExpectEmptyPlan(),
+	// 				},
+	// 			},
+	// 		},
+	// 		// try updating the token and ensure policy information hasn't
+	// 		// changed
+	// 		{
+	// 			Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd+"updated", permissionID1, permissionID0),
+	// 			ConfigPlanChecks: resource.ConfigPlanChecks{
+	// 				PreApply: []plancheck.PlanCheck{
+	// 					plancheck.ExpectNonEmptyPlan(),
+	// 				},
+	// 			},
+	// 			Check: resource.ComposeTestCheckFunc(
+	// 				resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "name", rnd+"updated"),
+	// 				resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "policies.#", "1"),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.id", func(value string) error {
+	// 					if value != policyId {
+	// 						return fmt.Errorf("policy ID changed from %s to %s", policyId, value)
+	// 					}
+	// 					return nil
+	// 				}),
+	// 				resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "policies.0.permission_groups.#", "2"),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.permission_groups.0.id", func(value string) error {
+	// 					if value != permissionID0 {
+	// 						return fmt.Errorf("permission ID 0 changed from %s to %s", permissionID0, value)
+	// 					}
+	// 					return nil
+	// 				}),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.permission_groups.1.id", func(value string) error {
+	// 					if value != permissionID1 {
+	// 						return fmt.Errorf("permission ID 1 changed from %s to %s", permissionID1, value)
+	// 					}
+	// 					return nil
+	// 				}),
+	// 			),
+	// 		},
+	// 		{
+	// 			Config: acctest.LoadTestCase("api_token-permissiongroup-order.tf", rnd+"updated2", permissionID0, permissionID1),
+	// 			ConfigPlanChecks: resource.ConfigPlanChecks{
+	// 				PreApply: []plancheck.PlanCheck{
+	// 					plancheck.ExpectNonEmptyPlan(),
+	// 				},
+	// 			},
+	// 			Check: resource.ComposeTestCheckFunc(
+	// 				resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "name", rnd+"updated2"),
+	// 				resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "policies.#", "1"),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.id", func(value string) error {
+	// 					if value != policyId {
+	// 						return fmt.Errorf("policy ID changed from %s to %s", policyId, value)
+	// 					}
+	// 					return nil
+	// 				}),
+	// 				resource.TestCheckResourceAttr("cloudflare_api_token.test_account_token", "policies.0.permission_groups.#", "2"),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.permission_groups.0.id", func(value string) error {
+	// 					if value != permissionID0 {
+	// 						return fmt.Errorf("permission ID 0 changed from %s to %s", permissionID0, value)
+	// 					}
+	// 					return nil
+	// 				}),
+	// 				resource.TestCheckResourceAttrWith("cloudflare_api_token.test_account_token", "policies.0.permission_groups.1.id", func(value string) error {
+	// 					if value != permissionID1 {
+	// 						return fmt.Errorf("permission ID 1 changed from %s to %s", permissionID1, value)
+	// 					}
+	// 					return nil
+	// 				}),
+	// 			),
+	// 		},
+	// 	},
+	// })
 }

--- a/internal/services/api_token/testdata/api_token-permissiongroup-order.tf
+++ b/internal/services/api_token/testdata/api_token-permissiongroup-order.tf
@@ -1,26 +1,48 @@
-data "cloudflare_api_token_permission_groups_list" "dns_read" {
-  name  = "DNS Read"
-  scope = "com.cloudflare.api.account.zone"
-}
-
-data "cloudflare_api_token_permission_groups_list" "disable_esc_read" {
-  name  = "Disable ESC Read"
-  scope = "com.cloudflare.api.account.zone"
-}
-
-resource "cloudflare_api_token" "test_account_token" {
-  name   = "%[1]s"
+resource "cloudflare_api_token" "%[1]s" {
+  name = "%[1]s"
   status = "active"
 
   policies = [{
     effect = "allow"
     permission_groups = [{
-      id = "%[2]s" != "" ? "%[2]s" : data.cloudflare_api_token_permission_groups_list.dns_read.result[0].id
-      }, {
-      id = "%[3]s" != "" ? "%[3]s" : data.cloudflare_api_token_permission_groups_list.disable_esc_read.result[0].id
+      id = "%[2]s"
+    },{
+      id = "%[3]s"
     }]
     resources = {
       "com.cloudflare.api.account.zone.*" = "*"
     }
   }]
 }
+
+data "cloudflare_api_token" "%[1]s" {
+  token_id = cloudflare_api_token.%[1]s.id
+  depends_on = [cloudflare_api_token.%[1]s]
+}
+
+# data "cloudflare_api_token_permission_groups_list" "dns_read" {
+#   name  = "DNS Read"
+#   scope = "com.cloudflare.api.account.zone"
+# }
+
+# data "cloudflare_api_token_permission_groups_list" "disable_esc_read" {
+#   name  = "Disable ESC Read"
+#   scope = "com.cloudflare.api.account.zone"
+# }
+
+# resource "cloudflare_api_token" "test_account_token" {
+#   name   = "%[1]s"
+#   status = "active"
+
+#   policies = [{
+#     effect = "allow"
+#     permission_groups = [{
+#       id = "%[2]s" != "" ? "%[2]s" : data.cloudflare_api_token_permission_groups_list.dns_read.result[0].id
+#       }, {
+#       id = "%[3]s" != "" ? "%[3]s" : data.cloudflare_api_token_permission_groups_list.disable_esc_read.result[0].id
+#     }]
+#     resources = {
+#       "com.cloudflare.api.account.zone.*" = "*"
+#     }
+#   }]
+# }


### PR DESCRIPTION
- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Reverting permission group order tests that only pass in staging

## Additional context & links

In a previous PR I updated the token tests to work in any environment but for some reason the permission group order tests only work properly in staging and not prod. I am not sure why they don't work in prod yet but in order to unblock the release I am reverting these specific test changes. 

Left the new tests commented out so I can return to them.