### PR TITLE
fix: 'created_on' API inconsistencies in LB pool

### DIFF
--- a/internal/services/load_balancer_pool/resource.go
+++ b/internal/services/load_balancer_pool/resource.go
@@ -141,6 +141,10 @@ func (r *LoadBalancerPoolResource) Update(ctx context.Context, req resource.Upda
 	}
 	data = &env.Result
 
+	// Reset created_on to the value from state
+	// The API seems to return 0001-01-01T00:00:00Z on update
+	data.CreatedOn = state.CreatedOn
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/services/load_balancer_pool/resource_test.go
+++ b/internal/services/load_balancer_pool/resource_test.go
@@ -210,7 +210,6 @@ func TestAccCloudflareLoadBalancerPool_VirtualNetworkID(t *testing.T) {
 }
 
 func TestAccCloudflareLoadBalancerPool_PatchBehavior(t *testing.T) {
-	t.Skip("value conversion error due to codegen bug")
 	t.Parallel()
 	testStartTime := time.Now().UTC()
 	var loadBalancerPool cfold.LoadBalancerPool

--- a/internal/services/load_balancer_pool/schema.go
+++ b/internal/services/load_balancer_pool/schema.go
@@ -268,6 +268,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"created_on": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"disabled_at": schema.StringAttribute{
 				Description: "This field shows up only if the pool is disabled. This field is set with the time the pool was disabled at.",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
