### PR TITLE
Fix v5 -> v6 imports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.34
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.63.0
 	github.com/cloudflare/cloudflare-go v0.115.0
-	github.com/cloudflare/cloudflare-go/v5 v5.1.0
 	github.com/cloudflare/cloudflare-go/v6 v6.0.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cloudflare/cloudflare-go v0.115.0 h1:84/dxeeXweCc0PN5Cto44iTA8AkG1fyT11yPO5ZB7sM=
 github.com/cloudflare/cloudflare-go v0.115.0/go.mod h1:Ds6urDwn/TF2uIU24mu7H91xkKP8gSAHxQ44DSZgVmU=
-github.com/cloudflare/cloudflare-go/v5 v5.1.0 h1:vvWUtrt5ZPEBFidL2ik64QipXLZmhMBgtRTw4bYvPwE=
-github.com/cloudflare/cloudflare-go/v5 v5.1.0/go.mod h1:C6OjOlDHOk/g7lXehothXJRFZrSIJMLzOZB2SXQhcjk=
 github.com/cloudflare/cloudflare-go/v6 v6.0.0 h1:dJ6o3NUWeJnRQ6jlLi+y/ZE7vvAWTEm5hBWPlaiUxCM=
 github.com/cloudflare/cloudflare-go/v6 v6.0.0/go.mod h1:bNIqRTGO0VC9lqJYanVbO+UDJPqo+zoG3Gs9ioL9PIA=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 
 	cfv1 "github.com/cloudflare/cloudflare-go"
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/option"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/config"
@@ -670,14 +670,14 @@ func RunMigrationCommand(t *testing.T, v4Config string, tmpDir string) {
 func MigrationTestStepWithPlan(t *testing.T, v4Config string, tmpDir string, exactVersion string, stateChecks []statecheck.StateCheck) []resource.TestStep {
 	// First step: run migration
 	migrationStep := MigrationTestStep(t, v4Config, tmpDir, exactVersion, nil) // No state checks yet
-	
+
 	// Second step: run plan to process import blocks and state corrections
 	planStep := resource.TestStep{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		ConfigDirectory:          config.StaticDirectory(tmpDir),
 		PlanOnly:                 true, // Just run plan to process imports/corrections
 	}
-	
+
 	// Third step: verify final plan is clean and state is correct
 	validationStep := resource.TestStep{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
@@ -690,7 +690,7 @@ func MigrationTestStepWithPlan(t *testing.T, v4Config string, tmpDir string, exa
 		},
 		ConfigStateChecks: stateChecks,
 	}
-	
+
 	return []resource.TestStep{migrationStep, planStep, validationStep}
 }
 

--- a/internal/services/api_shield_operation/resource_test.go
+++ b/internal/services/api_shield_operation/resource_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/cloudflare/cloudflare-go"
-	cfv3 "github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/api_gateway"
+	cfv3 "github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/api_gateway"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"

--- a/internal/services/certificate_pack/resource_test.go
+++ b/internal/services/certificate_pack/resource_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/ssl"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/ssl"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -75,7 +75,7 @@ func testAccCheckCloudflareCertificatePackDestroy(s *terraform.State) error {
 			// If certificate pack is not found, it was successfully deleted
 			continue
 		}
-		
+
 		// If we can still retrieve the certificate pack, it might not be fully cleaned up
 		// but this is expected behavior for certificate packs - they don't always get immediately deleted
 		tflog.Warn(context.Background(), fmt.Sprintf("Certificate pack %s still exists but this may be expected", rs.Primary.ID))
@@ -111,10 +111,10 @@ func TestAccCertificatePack_AdvancedLetsEncrypt(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      name,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdPrefix: fmt.Sprintf("%s/", zoneID),
+				ResourceName:            name,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", zoneID),
 				ImportStateVerifyIgnore: []string{"certificate_authority", "cloudflare_branding", "hosts", "status", "type", "validation_method", "validity_days"},
 			},
 		},
@@ -152,10 +152,10 @@ func TestAccCertificatePack_WaitForActive(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      name,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdPrefix: fmt.Sprintf("%s/", zoneID),
+				ResourceName:            name,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", zoneID),
 				ImportStateVerifyIgnore: []string{"certificate_authority", "cloudflare_branding", "hosts", "status", "type", "validation_method", "validity_days"},
 			},
 		},
@@ -231,10 +231,10 @@ func TestAccCertificatePack_Basic(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      name,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdPrefix: fmt.Sprintf("%s/", zoneID),
+				ResourceName:            name,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", zoneID),
 				ImportStateVerifyIgnore: []string{"certificate_authority", "cloudflare_branding", "hosts", "status", "type", "validation_method", "validity_days"},
 			},
 		},
@@ -269,10 +269,10 @@ func TestAccCertificatePack_GoogleCA(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      name,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdPrefix: fmt.Sprintf("%s/", zoneID),
+				ResourceName:            name,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", zoneID),
 				ImportStateVerifyIgnore: []string{"certificate_authority", "cloudflare_branding", "hosts", "status", "type", "validation_method", "validity_days"},
 			},
 		},
@@ -307,10 +307,10 @@ func TestAccCertificatePack_SSLComCA(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      name,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdPrefix: fmt.Sprintf("%s/", zoneID),
+				ResourceName:            name,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", zoneID),
 				ImportStateVerifyIgnore: []string{"certificate_authority", "cloudflare_branding", "hosts", "status", "type", "validation_method", "validity_days"},
 			},
 		},
@@ -345,10 +345,10 @@ func TestAccCertificatePack_HttpValidation(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      name,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdPrefix: fmt.Sprintf("%s/", zoneID),
+				ResourceName:            name,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", zoneID),
 				ImportStateVerifyIgnore: []string{"certificate_authority", "cloudflare_branding", "hosts", "status", "type", "validation_method", "validity_days"},
 			},
 		},
@@ -406,10 +406,10 @@ func TestAccCertificatePack_ValidityDays(t *testing.T) {
 						},
 					},
 					{
-						ResourceName:      name,
-						ImportState:       true,
-						ImportStateVerify: true,
-						ImportStateIdPrefix: fmt.Sprintf("%s/", zoneID),
+						ResourceName:            name,
+						ImportState:             true,
+						ImportStateVerify:       true,
+						ImportStateIdPrefix:     fmt.Sprintf("%s/", zoneID),
 						ImportStateVerifyIgnore: []string{"certificate_authority", "cloudflare_branding", "hosts", "status", "type", "validation_method", "validity_days"},
 					},
 				},
@@ -446,10 +446,10 @@ func TestAccCertificatePack_CloudflareBranding(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      name,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdPrefix: fmt.Sprintf("%s/", zoneID),
+				ResourceName:            name,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", zoneID),
 				ImportStateVerifyIgnore: []string{"certificate_authority", "cloudflare_branding", "hosts", "status", "type", "validation_method", "validity_days"},
 			},
 		},

--- a/internal/services/dns_firewall/resource_test.go
+++ b/internal/services/dns_firewall/resource_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/dns_firewall"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/dns_firewall"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -16,7 +16,6 @@ import (
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
-
 
 func init() {
 	resource.AddTestSweepers("cloudflare_dns_firewall", &resource.Sweeper{

--- a/internal/services/dns_record/resource_test.go
+++ b/internal/services/dns_record/resource_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	cfold "github.com/cloudflare/cloudflare-go"
-	cloudflare "github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/dns"
+	cloudflare "github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/dns"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
@@ -60,15 +60,15 @@ func testSweepCloudflareRecord(r string) error {
 	}
 
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
-	
+
 	for _, record := range records {
 		shouldDelete := false
-		
+
 		// Delete test records - those that start with tf-acctest- or contain terraform test patterns
 		if strings.HasPrefix(record.Name, "tf-acctest-") || strings.Contains(record.Name, "tf-acctest") {
 			shouldDelete = true
 		}
-		
+
 		// Also clean up apex domain records if they are A/AAAA/CNAME records that could conflict with tests
 		// Only delete apex records that are likely from tests (A/AAAA records pointing to test IPs or CNAME records)
 		if domain != "" && record.Name == domain {
@@ -80,7 +80,7 @@ func testSweepCloudflareRecord(r string) error {
 				shouldDelete = true
 			}
 		}
-		
+
 		if shouldDelete {
 			tflog.Info(ctx, fmt.Sprintf("Deleting test DNS record ID: %s, Name: %s, Type: %s, Content: %s", record.ID, record.Name, record.Type, record.Content))
 			err := client.DeleteDNSRecord(context.Background(), cfold.ZoneIdentifier(zoneID), record.ID)

--- a/internal/services/dns_settings_internal_view/resource_test.go
+++ b/internal/services/dns_settings_internal_view/resource_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/dns"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/dns"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"

--- a/internal/services/dns_zone_transfers_acl/resource_test.go
+++ b/internal/services/dns_zone_transfers_acl/resource_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/dns"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/dns"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"

--- a/internal/services/dns_zone_transfers_incoming/resource_test.go
+++ b/internal/services/dns_zone_transfers_incoming/resource_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/dns"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/dns"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"

--- a/internal/services/dns_zone_transfers_outgoing/resource_test.go
+++ b/internal/services/dns_zone_transfers_outgoing/resource_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/dns"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/dns"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -19,7 +19,6 @@ import (
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
-
 
 func init() {
 	resource.AddTestSweepers("cloudflare_dns_zone_transfers_outgoing", &resource.Sweeper{

--- a/internal/services/dns_zone_transfers_tsig/resource_test.go
+++ b/internal/services/dns_zone_transfers_tsig/resource_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/dns"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/dns"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"

--- a/internal/services/list/resource_test.go
+++ b/internal/services/list/resource_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/rules"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/rules"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -22,7 +22,6 @@ import (
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
-
 
 const listTestPrefix = "tf_test_list_"
 

--- a/internal/services/load_balancer/resource_test.go
+++ b/internal/services/load_balancer/resource_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	cfold "github.com/cloudflare/cloudflare-go"
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/load_balancers"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/load_balancers"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"

--- a/internal/services/load_balancer_pool/resource_test.go
+++ b/internal/services/load_balancer_pool/resource_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	cfold "github.com/cloudflare/cloudflare-go"
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/load_balancers"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/load_balancers"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"

--- a/internal/services/magic_transit_connector/resource_test.go
+++ b/internal/services/magic_transit_connector/resource_test.go
@@ -13,8 +13,8 @@ import (
 
 	"strconv"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/magic_transit"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/magic_transit"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"

--- a/internal/services/managed_transforms/resource_test.go
+++ b/internal/services/managed_transforms/resource_test.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"testing"
 
-	cloudflare "github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/managed_transforms"
-	"github.com/cloudflare/cloudflare-go/v5/option"
+	cloudflare "github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/managed_transforms"
+	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
@@ -28,7 +28,6 @@ import (
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
-
 
 func init() {
 	resource.AddTestSweepers("cloudflare_managed_headers", &resource.Sweeper{
@@ -74,7 +73,7 @@ func cleanup(t *testing.T) {
 
 func makeTransform(id string, enabled bool) map[string]string {
 	return map[string]string{
-		"id": id,
+		"id":      id,
 		"enabled": strconv.FormatBool(enabled),
 	}
 }
@@ -330,9 +329,9 @@ func TestAccCloudflareManagedHeaders_Basic(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:        resourceName,
-				ImportState:         true,
-				ImportStateVerify:   true,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -389,9 +388,9 @@ func TestAccCloudflareManagedHeaders_RequestOnly(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:        resourceName,
-				ImportState:         true,
-				ImportStateVerify:   true,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -420,9 +419,9 @@ func TestAccCloudflareManagedHeaders_ResponseOnly(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:        resourceName,
-				ImportState:         true,
-				ImportStateVerify:   true,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -451,9 +450,9 @@ func TestAccCloudflareManagedHeaders_VisitorLocationHeaders(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:        resourceName,
-				ImportState:         true,
-				ImportStateVerify:   true,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -509,9 +508,9 @@ func TestAccCloudflareManagedHeaders_RemoveVisitorIP(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:        resourceName,
-				ImportState:         true,
-				ImportStateVerify:   true,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -568,9 +567,9 @@ func TestAccCloudflareManagedHeaders_MultipleRequestHeaders(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:        resourceName,
-				ImportState:         true,
-				ImportStateVerify:   true,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -674,7 +673,7 @@ func TestAccCloudflareManagedHeaders_ConflictDetection(t *testing.T) {
 		CheckDestroy:             testAccCheckCloudflareManagedTransformsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudflareManagedTransformsConflictTest(rnd, zoneID),
+				Config:      testAccCheckCloudflareManagedTransformsConflictTest(rnd, zoneID),
 				ExpectError: regexp.MustCompile("404"),
 			},
 		},
@@ -725,9 +724,9 @@ func TestAccCloudflareManagedHeaders_NonConflictingTransforms(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:        resourceName,
-				ImportState:         true,
-				ImportStateVerify:   true,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -762,9 +761,9 @@ func TestAccCloudflareManagedHeaders_Enterprise(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:        resourceName,
-				ImportState:         true,
-				ImportStateVerify:   true,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/services/page_rule/custom.go
+++ b/internal/services/page_rule/custom.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudflare/cloudflare-go/v5/page_rules"
+	"github.com/cloudflare/cloudflare-go/v6/page_rules"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"

--- a/internal/services/regional_hostname/resource_test.go
+++ b/internal/services/regional_hostname/resource_test.go
@@ -6,16 +6,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/addressing"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/addressing"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
-	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
-	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 var zoneID = os.Getenv("CLOUDFLARE_ZONE_ID")
@@ -209,4 +205,3 @@ func testAccCheckCloudflareRegionalHostnameDestroy(s *terraform.State) error {
 
 	return nil
 }
-

--- a/internal/services/ruleset/data_source.go
+++ b/internal/services/ruleset/data_source.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/option"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijsoncustom"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"

--- a/internal/services/ruleset/data_source_model.go
+++ b/internal/services/ruleset/data_source_model.go
@@ -5,8 +5,8 @@ package ruleset
 import (
 	"context"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/rulesets"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/rulesets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/internal/services/ruleset/list_data_source.go
+++ b/internal/services/ruleset/list_data_source.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudflare/cloudflare-go/v5"
+	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework/attr"

--- a/internal/services/ruleset/list_data_source_model.go
+++ b/internal/services/ruleset/list_data_source_model.go
@@ -5,8 +5,8 @@ package ruleset
 import (
 	"context"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/rulesets"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/rulesets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/internal/services/ruleset/resource.go
+++ b/internal/services/ruleset/resource.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/option"
-	"github.com/cloudflare/cloudflare-go/v5/rulesets"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/cloudflare-go/v6/rulesets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijsoncustom"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"

--- a/internal/services/ruleset/ruleset_test.go
+++ b/internal/services/ruleset/ruleset_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/rulesets"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/rulesets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/internal/services/snippet/resource_test.go
+++ b/internal/services/snippet/resource_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/snippets"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/snippets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
@@ -21,7 +21,6 @@ import (
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
-
 
 func init() {
 	resource.AddTestSweepers("cloudflare_snippet", &resource.Sweeper{

--- a/internal/services/snippet_rules/list_data_source.go
+++ b/internal/services/snippet_rules/list_data_source.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/cloudflare/cloudflare-go/v6"
-	"github.com/cloudflare/cloudflare-go/v5/option"
-	"github.com/cloudflare/cloudflare-go/v5/snippets"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/cloudflare-go/v6/snippets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"

--- a/internal/services/snippet_rules/resource_test.go
+++ b/internal/services/snippet_rules/resource_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/snippets"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/snippets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"

--- a/internal/services/snippets/data_source.go
+++ b/internal/services/snippets/data_source.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/option"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"

--- a/internal/services/snippets/data_source_model.go
+++ b/internal/services/snippets/data_source_model.go
@@ -5,8 +5,8 @@ package snippets
 import (
 	"context"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/snippets"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/snippets"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/services/snippets/list_data_source.go
+++ b/internal/services/snippets/list_data_source.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudflare/cloudflare-go/v5"
+	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework/attr"

--- a/internal/services/snippets/list_data_source_model.go
+++ b/internal/services/snippets/list_data_source_model.go
@@ -5,8 +5,8 @@ package snippets
 import (
 	"context"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/snippets"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/snippets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/internal/services/snippets/resource.go
+++ b/internal/services/snippets/resource.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudflare/cloudflare-go/v5"
+	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 

--- a/internal/services/snippets/resource_test.go
+++ b/internal/services/snippets/resource_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/snippets"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/snippets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
@@ -22,7 +22,6 @@ func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
 
-
 func init() {
 	resource.AddTestSweepers("cloudflare_snippets", &resource.Sweeper{
 		Name: "cloudflare_snippets",
@@ -34,7 +33,7 @@ func testSweepCloudflareSnippets(r string) error {
 	ctx := context.Background()
 	client := acctest.SharedClient()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
-	
+
 	if zoneID == "" {
 		// Skip sweeping if no zone ID is set
 		return nil
@@ -60,7 +59,7 @@ func testSweepCloudflareSnippets(r string) error {
 				continue
 			}
 		}
-		
+
 		list, err = list.GetNextPage()
 		if err != nil {
 			break
@@ -123,7 +122,7 @@ func testAccCheckCloudflareSnippetsDestroy(s *terraform.State) error {
 
 		zoneID := rs.Primary.Attributes[consts.ZoneIDSchemaKey]
 		snippetName := rs.Primary.Attributes["snippet_name"]
-		
+
 		_, err := client.Snippets.Get(context.Background(), snippetName, snippets.SnippetGetParams{
 			ZoneID: cloudflare.F(zoneID),
 		})

--- a/internal/services/tiered_cache/resource_test.go
+++ b/internal/services/tiered_cache/resource_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/cache"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/cache"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
@@ -50,7 +50,7 @@ func testAccCheckCloudflareTieredCacheDestroy(s *terraform.State) error {
 		if err != nil {
 			continue
 		}
-		
+
 		// For tiered cache, "deleted" means it's set back to the default "off" state
 		if resp.Value == cache.SmartTieredCacheGetResponseValueOn {
 			return fmt.Errorf("tiered cache still enabled (should be off after destroy)")

--- a/internal/services/url_normalization_settings/resource_test.go
+++ b/internal/services/url_normalization_settings/resource_test.go
@@ -8,10 +8,10 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5/url_normalization"
+	"github.com/cloudflare/cloudflare-go/v6/url_normalization"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	cloudflare "github.com/cloudflare/cloudflare-go/v5"
+	cloudflare "github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
@@ -25,7 +25,6 @@ import (
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
-
 
 func init() {
 	resource.AddTestSweepers("cloudflare_url_normalization_settings", &resource.Sweeper{

--- a/internal/services/workers_kv/resource_test.go
+++ b/internal/services/workers_kv/resource_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/kv"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/kv"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"

--- a/internal/services/workers_route/resource_test.go
+++ b/internal/services/workers_route/resource_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/workers"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/workers"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
@@ -22,7 +22,6 @@ func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
 
-
 func init() {
 	resource.AddTestSweepers("cloudflare_workers_route", &resource.Sweeper{
 		Name: "cloudflare_workers_route",
@@ -34,7 +33,7 @@ func testSweepCloudflareWorkersRoute(r string) error {
 	ctx := context.Background()
 	client := acctest.SharedClient()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
-	
+
 	if zoneID == "" {
 		// Skip sweeping if no zone ID is set
 		return nil
@@ -60,7 +59,7 @@ func testSweepCloudflareWorkersRoute(r string) error {
 				continue
 			}
 		}
-		
+
 		page, err = page.GetNextPage()
 		if err != nil {
 			break

--- a/internal/services/workers_script/resource_test.go
+++ b/internal/services/workers_script/resource_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/option"
-	"github.com/cloudflare/cloudflare-go/v5/workers"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/cloudflare-go/v6/workers"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/internal/services/workers_secret/resource_test.go
+++ b/internal/services/workers_secret/resource_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/workers_for_platforms"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/workers_for_platforms"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/internal/services/zero_trust_access_policy/resource_test.go
+++ b/internal/services/zero_trust_access_policy/resource_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	cloudflare "github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/zero_trust"
+	cloudflare "github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"

--- a/internal/services/zero_trust_device_custom_profile/resource_test.go
+++ b/internal/services/zero_trust_device_custom_profile/resource_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/zero_trust"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/internal/services/zero_trust_device_custom_profile/sweep_test.go
+++ b/internal/services/zero_trust_device_custom_profile/sweep_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/zero_trust"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -66,4 +66,3 @@ func testSweepCloudflareZeroTrustDeviceCustomProfile(region string) error {
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
-

--- a/internal/services/zone_dnssec/custom.go
+++ b/internal/services/zone_dnssec/custom.go
@@ -3,9 +3,9 @@ package zone_dnssec
 import (
 	"context"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/dns"
-	"github.com/cloudflare/cloudflare-go/v5/option"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/dns"
+	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )

--- a/internal/services/zone_setting/resource_test.go
+++ b/internal/services/zone_setting/resource_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go/v5"
-	"github.com/cloudflare/cloudflare-go/v5/zones"
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/zones"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- updates all explicit `cloudflare-go/v5` imports to `cloudflare-go/v6`
- runs `goimports` on changed files

## Additional context & links

After the cf-go v6 bump, we need to update all imports that codgen doesn't know about.