### PR TITLE
fix: revert bad commit that resulted in customer complaints

### DIFF
--- a/examples/resources/cloudflare_account_token/resource.tf
+++ b/examples/resources/cloudflare_account_token/resource.tf
@@ -17,7 +17,9 @@ resource "cloudflare_account_token" "example_account_token" {
       }
     }]
     resources = {
-      foo = "string"
+      foo = {
+        foo = "string"
+      }
     }
   }]
   condition = {

--- a/examples/resources/cloudflare_api_token/resource.tf
+++ b/examples/resources/cloudflare_api_token/resource.tf
@@ -16,7 +16,9 @@ resource "cloudflare_api_token" "example_api_token" {
       }
     }]
     resources = {
-      foo = "string"
+      foo = {
+        foo = "string"
+      }
     }
   }]
   condition = {

--- a/internal/services/account_token/data_source_model.go
+++ b/internal/services/account_token/data_source_model.go
@@ -66,7 +66,7 @@ type AccountTokenPoliciesDataSourceModel struct {
 	ID               types.String                                                                      `tfsdk:"id" json:"id,computed,force_encode,encode_state_for_unknown"`
 	Effect           types.String                                                                      `tfsdk:"effect" json:"effect,computed"`
 	PermissionGroups customfield.NestedObjectList[AccountTokenPoliciesPermissionGroupsDataSourceModel] `tfsdk:"permission_groups" json:"permission_groups,computed"`
-	Resources        customfield.Map[types.String]                                                     `tfsdk:"resources" json:"resources,computed"`
+	Resources        customfield.Map[customfield.Map[types.String]]                                    `tfsdk:"resources" json:"resources,computed"`
 }
 
 type AccountTokenPoliciesPermissionGroupsDataSourceModel struct {

--- a/internal/services/account_token/data_source_schema.go
+++ b/internal/services/account_token/data_source_schema.go
@@ -148,8 +148,10 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 						"resources": schema.MapAttribute{
 							Description: "A list of resource names that the policy applies to.",
 							Computed:    true,
-							CustomType:  customfield.NewMapType[types.String](ctx),
-							ElementType: types.StringType,
+							CustomType:  customfield.NewMapType[customfield.Map[types.String]](ctx),
+							ElementType: types.MapType{
+								ElemType: types.StringType,
+							},
 						},
 					},
 				},

--- a/internal/services/account_token/list_data_source_model.go
+++ b/internal/services/account_token/list_data_source_model.go
@@ -62,7 +62,7 @@ type AccountTokensPoliciesDataSourceModel struct {
 	ID               types.String                                                                       `tfsdk:"id" json:"id,computed,force_encode,encode_state_for_unknown"`
 	Effect           types.String                                                                       `tfsdk:"effect" json:"effect,computed"`
 	PermissionGroups customfield.NestedObjectList[AccountTokensPoliciesPermissionGroupsDataSourceModel] `tfsdk:"permission_groups" json:"permission_groups,computed"`
-	Resources        customfield.Map[types.String]                                                      `tfsdk:"resources" json:"resources,computed"`
+	Resources        customfield.Map[customfield.Map[types.String]]                                     `tfsdk:"resources" json:"resources,computed"`
 }
 
 type AccountTokensPoliciesPermissionGroupsDataSourceModel struct {

--- a/internal/services/account_token/list_data_source_schema.go
+++ b/internal/services/account_token/list_data_source_schema.go
@@ -152,8 +152,10 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 									"resources": schema.MapAttribute{
 										Description: "A list of resource names that the policy applies to.",
 										Computed:    true,
-										CustomType:  customfield.NewMapType[types.String](ctx),
-										ElementType: types.StringType,
+										CustomType:  customfield.NewMapType[customfield.Map[types.String]](ctx),
+										ElementType: types.MapType{
+											ElemType: types.StringType,
+										},
 									},
 								},
 							},

--- a/internal/services/account_token/model.go
+++ b/internal/services/account_token/model.go
@@ -40,7 +40,7 @@ type AccountTokenPoliciesModel struct {
 	ID               types.String                                  `tfsdk:"id" json:"id,computed,force_encode,encode_state_for_unknown"`
 	Effect           types.String                                  `tfsdk:"effect" json:"effect,required"`
 	PermissionGroups *[]*AccountTokenPoliciesPermissionGroupsModel `tfsdk:"permission_groups" json:"permission_groups,required"`
-	Resources        *map[string]types.String                      `tfsdk:"resources" json:"resources,required"`
+	Resources        *map[string]*map[string]types.String          `tfsdk:"resources" json:"resources,required"`
 }
 
 type AccountTokenPoliciesPermissionGroupsModel struct {

--- a/internal/services/account_token/schema.go
+++ b/internal/services/account_token/schema.go
@@ -87,7 +87,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"resources": schema.MapAttribute{
 							Description: "A list of resource names that the policy applies to.",
 							Required:    true,
-							ElementType: types.StringType,
+							ElementType: types.MapType{
+								ElemType: types.StringType,
+							},
 						},
 					},
 				},

--- a/internal/services/api_token/data_source_model.go
+++ b/internal/services/api_token/data_source_model.go
@@ -55,7 +55,7 @@ type APITokenPoliciesDataSourceModel struct {
 	ID               types.String                                                                  `tfsdk:"id" json:"id,computed,force_encode,encode_state_for_unknown"`
 	Effect           types.String                                                                  `tfsdk:"effect" json:"effect,computed"`
 	PermissionGroups customfield.NestedObjectList[APITokenPoliciesPermissionGroupsDataSourceModel] `tfsdk:"permission_groups" json:"permission_groups,computed"`
-	Resources        customfield.Map[types.String]                                                 `tfsdk:"resources" json:"resources,computed"`
+	Resources        customfield.Map[customfield.Map[types.String]]                                `tfsdk:"resources" json:"resources,computed"`
 }
 
 type APITokenPoliciesPermissionGroupsDataSourceModel struct {

--- a/internal/services/api_token/data_source_schema.go
+++ b/internal/services/api_token/data_source_schema.go
@@ -144,8 +144,10 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 						"resources": schema.MapAttribute{
 							Description: "A list of resource names that the policy applies to.",
 							Computed:    true,
-							CustomType:  customfield.NewMapType[types.String](ctx),
-							ElementType: types.StringType,
+							CustomType:  customfield.NewMapType[customfield.Map[types.String]](ctx),
+							ElementType: types.MapType{
+								ElemType: types.StringType,
+							},
 						},
 					},
 				},

--- a/internal/services/api_token/list_data_source_model.go
+++ b/internal/services/api_token/list_data_source_model.go
@@ -59,7 +59,7 @@ type APITokensPoliciesDataSourceModel struct {
 	ID               types.String                                                                   `tfsdk:"id" json:"id,computed,force_encode,encode_state_for_unknown"`
 	Effect           types.String                                                                   `tfsdk:"effect" json:"effect,computed"`
 	PermissionGroups customfield.NestedObjectList[APITokensPoliciesPermissionGroupsDataSourceModel] `tfsdk:"permission_groups" json:"permission_groups,computed"`
-	Resources        customfield.Map[types.String]                                                  `tfsdk:"resources" json:"resources,computed"`
+	Resources        customfield.Map[customfield.Map[types.String]]                                 `tfsdk:"resources" json:"resources,computed"`
 }
 
 type APITokensPoliciesPermissionGroupsDataSourceModel struct {

--- a/internal/services/api_token/list_data_source_schema.go
+++ b/internal/services/api_token/list_data_source_schema.go
@@ -148,8 +148,10 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 									"resources": schema.MapAttribute{
 										Description: "A list of resource names that the policy applies to.",
 										Computed:    true,
-										CustomType:  customfield.NewMapType[types.String](ctx),
-										ElementType: types.StringType,
+										CustomType:  customfield.NewMapType[customfield.Map[types.String]](ctx),
+										ElementType: types.MapType{
+											ElemType: types.StringType,
+										},
 									},
 								},
 							},

--- a/internal/services/api_token/model.go
+++ b/internal/services/api_token/model.go
@@ -38,7 +38,7 @@ type APITokenPoliciesModel struct {
 	ID               types.String                              `tfsdk:"id" json:"id,computed,force_encode,encode_state_for_unknown"`
 	Effect           types.String                              `tfsdk:"effect" json:"effect,required"`
 	PermissionGroups *[]*APITokenPoliciesPermissionGroupsModel `tfsdk:"permission_groups" json:"permission_groups,required"`
-	Resources        *map[string]types.String                  `tfsdk:"resources" json:"resources,required"`
+	Resources        *map[string]*map[string]types.String      `tfsdk:"resources" json:"resources,required"`
 }
 
 type APITokenPoliciesPermissionGroupsModel struct {

--- a/internal/services/api_token/schema.go
+++ b/internal/services/api_token/schema.go
@@ -79,7 +79,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"resources": schema.MapAttribute{
 							Description: "A list of resource names that the policy applies to.",
 							Required:    true,
-							ElementType: types.StringType,
+							ElementType: types.MapType{
+								ElemType: types.StringType,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
It looks like the shape that we have for creating API tokens is wrong.

example token creation call

```json
{
  "condition": {},
  "name": "Edit zone DNS",
  "policies": [
    {
      "effect": "allow",
      "permission_groups": [
        {
          "id": "4755a26eedb94da69e1066d98aa820be"
        }
      ],
      "resources": {
        "com.cloudflare.api.account.17836761c182f4a2c520082c842eaa11": {
          "com.cloudflare.api.account.zone.*": "*"
        }
      }
    }
  ]
}
```

see: https://github.com/cloudflare/terraform-provider-cloudflare/issues/5733 for more context

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
