### PR TITLE
fix(workers_script): referenced attribute renames

### DIFF
--- a/cmd/migrate/workers_references_test.go
+++ b/cmd/migrate/workers_references_test.go
@@ -43,6 +43,31 @@ resource "cloudflare_workers_cron_trigger" "my_cron" {
   cron        = "0 0 * * *"
 }`},
 		},
+		{
+			Name: "workers references with mixed v4/v5 syntax",
+			Config: `resource "cloudflare_workers_script" "my_script" {
+  account_id  = "f037e56e89293a057740de681ac9abbe"
+  script_name = "my-worker"
+  content     = "// worker code"
+}
+
+resource "cloudflare_workers_route" "my_route" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  pattern = "example.cfapi.net/*"
+  script  = cloudflare_workers_script.my_script.name
+}`,
+			Expected: []string{`resource "cloudflare_workers_script" "my_script" {
+  account_id  = "f037e56e89293a057740de681ac9abbe"
+  script_name = "my-worker"
+  content     = "// worker code"
+}
+
+resource "cloudflare_workers_route" "my_route" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  pattern = "example.cfapi.net/*"
+  script  = cloudflare_workers_script.my_script.script_name
+}`},
+		},
 	}
 
 	RunTransformationTests(t, tests, transformFile)


### PR DESCRIPTION
When migrating from v4 -> v5, references to `workers_script.name` weren't being correctly renamed due to a faulty lookup map.

- updates `resourceTypeRenames` (lookup map) to include v4 and v5 resource names
- updates conditional in `renameWorkerAttribute` to include v5 resource names
- adds test for partial migration cases

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
