### PR TITLE
feat: support for handling Workers Assets uploads

### DIFF
--- a/internal/services/worker_version/assets.go
+++ b/internal/services/worker_version/assets.go
@@ -1,0 +1,309 @@
+package worker_version
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/textproto"
+	"os"
+	"path/filepath"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/cloudflare-go/v6/workers"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type AssetUploadSessionRequestBody struct {
+	Manifest AssetManifest `json:"manifest"`
+}
+
+type AssetManifest map[string]AssetManifestEntry
+
+type AssetManifestEntry struct {
+	Filepath string `json:"-"`
+	Hash     string `json:"hash"`
+	Size     int64  `json:"size"`
+}
+
+type Bucket []AssetManifestEntry
+
+func (b Bucket) MarshalMultipart() (data []byte, formDataContentType string, err error) {
+	buf := bytes.NewBuffer(nil)
+	writer := multipart.NewWriter(buf)
+
+	for _, entry := range b {
+		reader, err := os.Open(entry.Filepath)
+		if err != nil {
+			return nil, "", err
+		}
+		defer reader.Close()
+
+		contentType := mime.TypeByExtension(filepath.Ext(entry.Filepath))
+
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, entry.Hash, entry.Filepath))
+		h.Set("Content-Type", contentType)
+		filewriter, err := writer.CreatePart(h)
+		if err != nil {
+			return nil, "", err
+		}
+
+		// Stream base64 encoding directly to the form field
+		encoder := base64.NewEncoder(base64.StdEncoding, filewriter)
+		_, err = io.Copy(encoder, reader)
+		if err != nil {
+			return nil, "", err
+		}
+
+		err = encoder.Close()
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return nil, "", err
+	}
+	return buf.Bytes(), writer.FormDataContentType(), nil
+}
+
+func getAssetManifest(directory string) (AssetManifest, error) {
+	// Convert to absolute path to handle relative paths properly
+	absBasePath, err := filepath.Abs(directory)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest := make(AssetManifest)
+
+	// Scan directory and generate manifest
+	err = filepath.WalkDir(absBasePath, func(filePath string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories
+		if d.IsDir() {
+			return nil
+		}
+
+		// Calculate relative path from the base directory
+		relPath, err := filepath.Rel(absBasePath, filePath)
+		if err != nil {
+			return fmt.Errorf("failed to calculate relative path for %s: %w", filePath, err)
+		}
+
+		// Normalize path separators for consistent keys
+		relPath = filepath.ToSlash(relPath)
+
+		// Add leading slash
+		relPath = fmt.Sprintf("/%s", relPath)
+
+		// Calculate SHA256 hash
+		hash, err := calculateFileHash(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to calculate hash for %s: %w", filePath, err)
+		}
+
+		// Get file info for size
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("failed to get file info for %s: %w", filePath, err)
+		}
+
+		manifest[relPath] = AssetManifestEntry{
+			Filepath: filePath,
+			Hash:     hash[:32],
+			Size:     info.Size(),
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return manifest, nil
+}
+
+func getAssetManifestHash(manifest AssetManifest) (string, error) {
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return "", err
+	}
+
+	return calculateStringHash(string(manifestBytes))
+}
+
+func handleAssets(ctx context.Context, client *cloudflare.Client, data *WorkerVersionModel) error {
+	if data == nil {
+		return nil
+	}
+
+	if data.Assets == nil {
+		return nil
+	}
+
+	if data.Assets.Directory.IsNull() || data.Assets.Directory.IsUnknown() {
+		return nil
+	}
+
+	if data.Assets.JWT.ValueString() != "" {
+		return nil
+	}
+
+	directory := data.Assets.Directory.ValueString()
+
+	manifest, err := getAssetManifest(directory)
+	if err != nil {
+		return err
+	}
+
+	accountID := data.AccountID.ValueString()
+	workerID := data.WorkerID.ValueString()
+
+	worker, err := client.Workers.Beta.Workers.Get(ctx, workerID, workers.BetaWorkerGetParams{AccountID: cloudflare.F(accountID)})
+	if err != nil {
+		return err
+	}
+
+	scriptName := worker.Name
+
+	requestBody := AssetUploadSessionRequestBody{
+		Manifest: manifest,
+	}
+
+	dataBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		return err
+	}
+
+	res, err := client.Workers.Scripts.Assets.Upload.New(
+		ctx,
+		scriptName,
+		workers.ScriptAssetUploadNewParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+		},
+		option.WithRequestBody("application/json", dataBytes),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+
+	if err != nil {
+		return err
+	}
+
+	// Nothing to upload...
+	if len(res.Buckets) == 0 {
+		if res.JWT == "" {
+			return fmt.Errorf("failed to upload assets: no completion token received from upload session")
+		}
+		data.Assets.JWT = types.StringValue(res.JWT)
+		return nil
+	}
+
+	sessionToken := res.JWT
+
+	hashLookup := make(map[string]string)
+	for filename, manifest := range manifest {
+		hashLookup[manifest.Hash] = filename
+	}
+
+	// Upload each bucket of assets
+	for _, bucketHashes := range res.Buckets {
+		files := Bucket{}
+		for _, hash := range bucketHashes {
+			filename := hashLookup[hash]
+			entry := manifest[filename]
+
+			files = append(files, entry)
+		}
+
+		bucketBytes, formDataContentType, err := files.MarshalMultipart()
+		if err != nil {
+			return err
+		}
+
+		res, err := client.Workers.Assets.Upload.New(ctx,
+			workers.AssetUploadNewParams{
+				AccountID: cloudflare.F(data.AccountID.ValueString()),
+				Base64:    cloudflare.F(workers.AssetUploadNewParamsBase64True),
+			},
+			option.WithRequestBody(formDataContentType, bucketBytes),
+			option.WithHeader("Authorization", fmt.Sprintf("Bearer %s", sessionToken)),
+			option.WithMiddleware(logging.Middleware(ctx)),
+		)
+		if err != nil {
+			return err
+		}
+		if res.JWT != "" {
+			data.Assets.JWT = types.StringValue(res.JWT)
+		}
+	}
+
+	if res.JWT == "" {
+		return fmt.Errorf("failed to upload assets: no completion token received from upload session")
+	}
+
+	return nil
+}
+
+// =========================== Plan modifiers ===========================
+
+func ComputeSHA256HashOfAssetManifest() planmodifier.String {
+	return computeSHA256HashOfAssetManifestModifier{}
+}
+
+var _ planmodifier.String = &computeSHA256HashOfAssetManifestModifier{}
+
+type computeSHA256HashOfAssetManifestModifier struct{}
+
+func (c computeSHA256HashOfAssetManifestModifier) Description(_ context.Context) string {
+	return "Calculates the SHA-256 hash of the manifest of asset files in the specified directory."
+}
+
+func (c computeSHA256HashOfAssetManifestModifier) MarkdownDescription(ctx context.Context) string {
+	return c.Description(ctx)
+}
+
+func (c computeSHA256HashOfAssetManifestModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Don't modify during destroy
+	if req.Config.Raw.IsNull() {
+		return
+	}
+
+	directoryPath := req.Path.ParentPath().AtName("directory")
+
+	var directory types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, directoryPath, &directory)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if directory.IsNull() || directory.IsUnknown() {
+		return
+	}
+
+	manifest, err := getAssetManifest(directory.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Error reading asset files", err.Error())
+		return
+	}
+
+	manifestHash, err := getAssetManifestHash(manifest)
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Error computing SHA-256 hash of asset manifest", err.Error())
+		return
+	}
+
+	resp.PlanValue = types.StringValue(manifestHash)
+}

--- a/internal/services/worker_version/model.go
+++ b/internal/services/worker_version/model.go
@@ -26,7 +26,7 @@ type WorkerVersionModel struct {
 	UsageModel         types.String                                             `tfsdk:"usage_model" json:"usage_model,computed_optional"`
 	CompatibilityFlags customfield.Set[types.String]                            `tfsdk:"compatibility_flags" json:"compatibility_flags,computed_optional"`
 	Annotations        customfield.NestedObject[WorkerVersionAnnotationsModel]  `tfsdk:"annotations" json:"annotations,computed_optional"`
-	Assets             customfield.NestedObject[WorkerVersionAssetsModel]       `tfsdk:"assets" json:"assets,computed_optional"`
+	Assets             *WorkerVersionAssetsModel                                `tfsdk:"assets" json:"assets,optional"`
 	Bindings           customfield.NestedObjectList[WorkerVersionBindingsModel] `tfsdk:"bindings" json:"bindings,optional"`
 	Limits             customfield.NestedObject[WorkerVersionLimitsModel]       `tfsdk:"limits" json:"limits,computed_optional"`
 	CreatedOn          timetypes.RFC3339                                        `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
@@ -102,8 +102,10 @@ type WorkerVersionAnnotationsModel struct {
 }
 
 type WorkerVersionAssetsModel struct {
-	Config customfield.NestedObject[WorkerVersionAssetsConfigModel] `tfsdk:"config" json:"config,computed_optional"`
-	JWT    types.String                                             `tfsdk:"jwt" json:"jwt,optional"`
+	Config              customfield.NestedObject[WorkerVersionAssetsConfigModel] `tfsdk:"config" json:"config,computed_optional"`
+	JWT                 types.String                                             `tfsdk:"jwt" json:"jwt,optional"`
+	Directory           types.String                                             `tfsdk:"directory" json:"-,optional"`
+	AssetManifestSHA256 types.String                                             `tfsdk:"asset_manifest_sha256" json:"-,computed"`
 }
 
 type WorkerVersionAssetsConfigModel struct {

--- a/internal/services/worker_version/testdata/assets.tf
+++ b/internal/services/worker_version/testdata/assets.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_worker" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[1]s"
+}
+
+resource "cloudflare_worker_version" "%[1]s" {
+  account_id = "%[2]s"
+  worker_id = cloudflare_worker.%[1]s.id
+  assets = {
+    directory = "%[3]s"
+  }
+}

--- a/internal/services/workers_script/assets.go
+++ b/internal/services/workers_script/assets.go
@@ -1,0 +1,301 @@
+package workers_script
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/textproto"
+	"os"
+	"path/filepath"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/cloudflare-go/v6/workers"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type AssetUploadSessionRequestBody struct {
+	Manifest AssetManifest `json:"manifest"`
+}
+
+type AssetManifest map[string]AssetManifestEntry
+
+type AssetManifestEntry struct {
+	Filepath string `json:"-"`
+	Hash     string `json:"hash"`
+	Size     int64  `json:"size"`
+}
+
+type Bucket []AssetManifestEntry
+
+func (b Bucket) MarshalMultipart() (data []byte, formDataContentType string, err error) {
+	buf := bytes.NewBuffer(nil)
+	writer := multipart.NewWriter(buf)
+
+	for _, entry := range b {
+		reader, err := os.Open(entry.Filepath)
+		if err != nil {
+			return nil, "", err
+		}
+		defer reader.Close()
+
+		contentType := mime.TypeByExtension(filepath.Ext(entry.Filepath))
+
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, entry.Hash, entry.Filepath))
+		h.Set("Content-Type", contentType)
+		filewriter, err := writer.CreatePart(h)
+		if err != nil {
+			return nil, "", err
+		}
+
+		// Stream base64 encoding directly to the form field
+		encoder := base64.NewEncoder(base64.StdEncoding, filewriter)
+		_, err = io.Copy(encoder, reader)
+		if err != nil {
+			return nil, "", err
+		}
+
+		err = encoder.Close()
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return nil, "", err
+	}
+	return buf.Bytes(), writer.FormDataContentType(), nil
+}
+
+func getAssetManifest(directory string) (AssetManifest, error) {
+	// Convert to absolute path to handle relative paths properly
+	absBasePath, err := filepath.Abs(directory)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest := make(AssetManifest)
+
+	// Scan directory and generate manifest
+	err = filepath.WalkDir(absBasePath, func(filePath string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories
+		if d.IsDir() {
+			return nil
+		}
+
+		// Calculate relative path from the base directory
+		relPath, err := filepath.Rel(absBasePath, filePath)
+		if err != nil {
+			return fmt.Errorf("failed to calculate relative path for %s: %w", filePath, err)
+		}
+
+		// Normalize path separators for consistent keys
+		relPath = filepath.ToSlash(relPath)
+
+		// Add leading slash
+		relPath = fmt.Sprintf("/%s", relPath)
+
+		// Calculate SHA256 hash
+		hash, err := calculateFileHash(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to calculate hash for %s: %w", filePath, err)
+		}
+
+		// Get file info for size
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("failed to get file info for %s: %w", filePath, err)
+		}
+
+		manifest[relPath] = AssetManifestEntry{
+			Filepath: filePath,
+			Hash:     hash[:32],
+			Size:     info.Size(),
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return manifest, nil
+}
+
+func getAssetManifestHash(manifest AssetManifest) (string, error) {
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return "", err
+	}
+
+	return calculateStringHash(string(manifestBytes))
+}
+
+func handleAssets(ctx context.Context, client *cloudflare.Client, data *WorkersScriptModel) error {
+	if data == nil {
+		return nil
+	}
+
+	if data.Assets == nil {
+		return nil
+	}
+
+	if data.Assets.Directory.IsNull() || data.Assets.Directory.IsUnknown() {
+		return nil
+	}
+
+	if data.Assets.JWT.ValueString() != "" {
+		return nil
+	}
+
+	directory := data.Assets.Directory.ValueString()
+
+	manifest, err := getAssetManifest(directory)
+	if err != nil {
+		return err
+	}
+
+	scriptName := data.ScriptName.ValueString()
+
+	requestBody := AssetUploadSessionRequestBody{
+		Manifest: manifest,
+	}
+
+	dataBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		return err
+	}
+
+	res, err := client.Workers.Scripts.Assets.Upload.New(
+		ctx,
+		scriptName,
+		workers.ScriptAssetUploadNewParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+		},
+		option.WithRequestBody("application/json", dataBytes),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+
+	if err != nil {
+		return err
+	}
+
+	// Nothing to upload...
+	if len(res.Buckets) == 0 {
+		if res.JWT == "" {
+			return fmt.Errorf("failed to upload assets: no completion token received from upload session")
+		}
+		data.Assets.JWT = types.StringValue(res.JWT)
+		return nil
+	}
+
+	sessionToken := res.JWT
+
+	hashLookup := make(map[string]string)
+	for filename, manifest := range manifest {
+		hashLookup[manifest.Hash] = filename
+	}
+
+	// Upload each bucket of assets
+	for _, bucketHashes := range res.Buckets {
+		files := Bucket{}
+		for _, hash := range bucketHashes {
+			filename := hashLookup[hash]
+			entry := manifest[filename]
+
+			files = append(files, entry)
+		}
+
+		bucketBytes, formDataContentType, err := files.MarshalMultipart()
+		if err != nil {
+			return err
+		}
+
+		res, err := client.Workers.Assets.Upload.New(ctx,
+			workers.AssetUploadNewParams{
+				AccountID: cloudflare.F(data.AccountID.ValueString()),
+				Base64:    cloudflare.F(workers.AssetUploadNewParamsBase64True),
+			},
+			option.WithRequestBody(formDataContentType, bucketBytes),
+			option.WithHeader("Authorization", fmt.Sprintf("Bearer %s", sessionToken)),
+			option.WithMiddleware(logging.Middleware(ctx)),
+		)
+		if err != nil {
+			return err
+		}
+		if res.JWT != "" {
+			data.Assets.JWT = types.StringValue(res.JWT)
+		}
+	}
+
+	if res.JWT == "" {
+		return fmt.Errorf("failed to upload assets: no completion token received from upload session")
+	}
+
+	return nil
+}
+
+// =========================== Plan modifiers ===========================
+
+func ComputeSHA256HashOfAssetManifest() planmodifier.String {
+	return computeSHA256HashOfAssetManifestModifier{}
+}
+
+var _ planmodifier.String = &computeSHA256HashOfAssetManifestModifier{}
+
+type computeSHA256HashOfAssetManifestModifier struct{}
+
+func (c computeSHA256HashOfAssetManifestModifier) Description(_ context.Context) string {
+	return "Calculates the SHA-256 hash of the manifest of asset files in the specified directory."
+}
+
+func (c computeSHA256HashOfAssetManifestModifier) MarkdownDescription(ctx context.Context) string {
+	return c.Description(ctx)
+}
+
+func (c computeSHA256HashOfAssetManifestModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Don't modify during destroy
+	if req.Config.Raw.IsNull() {
+		return
+	}
+
+	directoryPath := req.Path.ParentPath().AtName("directory")
+
+	var directory types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, directoryPath, &directory)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if directory.IsNull() || directory.IsUnknown() {
+		return
+	}
+
+	manifest, err := getAssetManifest(directory.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Error reading asset files", err.Error())
+		return
+	}
+
+	manifestHash, err := getAssetManifestHash(manifest)
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Error computing SHA-256 hash of asset manifest", err.Error())
+		return
+	}
+
+	resp.PlanValue = types.StringValue(manifestHash)
+}

--- a/internal/services/workers_script/model.go
+++ b/internal/services/workers_script/model.go
@@ -60,22 +60,25 @@ func (r WorkersScriptModel) MarshalMultipart() (data []byte, formDataContentType
 	buf := bytes.NewBuffer(nil)
 	writer := multipart.NewWriter(buf)
 	var metadata WorkersScriptMetadataModel
-	workerBody := bytes.NewReader([]byte(r.Content.ValueString()))
 
-	contentType := r.ContentType.ValueString()
+	if r.Content.ValueString() != "" {
+		workerBody := bytes.NewReader([]byte(r.Content.ValueString()))
 
-	if r.MainModule.ValueString() != "" {
-		if contentType == "" {
-			contentType = "application/javascript+module"
+		contentType := r.ContentType.ValueString()
+
+		if r.MainModule.ValueString() != "" {
+			if contentType == "" {
+				contentType = "application/javascript+module"
+			}
+			mainModuleName := r.MainModule.ValueString()
+			writeFileBytes(mainModuleName, mainModuleName, contentType, workerBody, writer)
+		} else {
+			if contentType == "" {
+				contentType = "application/javascript"
+			}
+			writeFileBytes("script", "script", contentType, workerBody, writer)
+			r.BodyPart = types.StringValue("script")
 		}
-		mainModuleName := r.MainModule.ValueString()
-		writeFileBytes(mainModuleName, mainModuleName, contentType, workerBody, writer)
-	} else {
-		if contentType == "" {
-			contentType = "application/javascript"
-		}
-		writeFileBytes("script", "script", contentType, workerBody, writer)
-		r.BodyPart = types.StringValue("script")
 	}
 
 	topLevelMetadata := r.WorkersScriptMetadataModel
@@ -112,8 +115,10 @@ type WorkersScriptMetadataModel struct {
 }
 
 type WorkersScriptMetadataAssetsModel struct {
-	Config *WorkersScriptMetadataAssetsConfigModel `tfsdk:"config" json:"config,optional"`
-	JWT    types.String                            `tfsdk:"jwt" json:"jwt,optional"`
+	Config              *WorkersScriptMetadataAssetsConfigModel `tfsdk:"config" json:"config,optional"`
+	JWT                 types.String                            `tfsdk:"jwt" json:"jwt,optional"`
+	Directory           types.String                            `tfsdk:"directory" json:"-,optional"`
+	AssetManifestSHA256 types.String                            `tfsdk:"asset_manifest_sha256" json:"-,computed"`
 }
 
 type WorkersScriptMetadataAssetsConfigModel struct {

--- a/internal/services/workers_script/resource.go
+++ b/internal/services/workers_script/resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -77,6 +78,21 @@ func (r *WorkersScriptResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	var assets *WorkersScriptMetadataAssetsModel
+	if data.Assets != nil {
+		assets = &WorkersScriptMetadataAssetsModel{
+			Config:              data.Assets.Config,
+			JWT:                 data.Assets.JWT,
+			Directory:           data.Assets.Directory,
+			AssetManifestSHA256: data.Assets.AssetManifestSHA256,
+		}
+	}
+	err := handleAssets(ctx, r.client, data)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to upload assets", err.Error())
+		return
+	}
+
 	contentSHA256 := data.ContentSHA256
 	contentType := data.ContentType
 
@@ -120,6 +136,7 @@ func (r *WorkersScriptResource) Create(ctx context.Context, req resource.CreateR
 	data.ID = data.ScriptName
 	data.ContentSHA256 = contentSHA256
 	data.ContentType = contentType
+	data.Assets = assets
 
 	// avoid storing `content` in state if `content_file` is configured
 	if !data.ContentFile.IsNull() {
@@ -141,6 +158,21 @@ func (r *WorkersScriptResource) Update(ctx context.Context, req resource.UpdateR
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("migrations"), &data.Migrations)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var assets *WorkersScriptMetadataAssetsModel
+	if data.Assets != nil {
+		assets = &WorkersScriptMetadataAssetsModel{
+			Config:              data.Assets.Config,
+			JWT:                 data.Assets.JWT,
+			Directory:           data.Assets.Directory,
+			AssetManifestSHA256: data.Assets.AssetManifestSHA256,
+		}
+	}
+	err := handleAssets(ctx, r.client, data)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to upload assets", err.Error())
 		return
 	}
 
@@ -195,6 +227,7 @@ func (r *WorkersScriptResource) Update(ctx context.Context, req resource.UpdateR
 	data.ID = data.ScriptName
 	data.ContentSHA256 = contentSHA256
 	data.ContentType = contentType
+	data.Assets = assets
 
 	// avoid storing `content` in state if `content_file` is configured
 	if !data.ContentFile.IsNull() {
@@ -257,13 +290,13 @@ func (r *WorkersScriptResource) Read(ctx context.Context, req resource.ReadReque
 		&res,
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to make http request", err.Error())
+		return
+	}
 	if res != nil && res.StatusCode == 404 {
 		resp.Diagnostics.AddWarning("Resource not found", "The resource was not found on the server and will be removed from state.")
 		resp.State.RemoveResource(ctx)
-		return
-	}
-	if err != nil {
-		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
 	bytes, _ = io.ReadAll(res.Body)
@@ -298,34 +331,46 @@ func (r *WorkersScriptResource) Read(ctx context.Context, req resource.ReadReque
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
-	var content string
-	mediaType, mediaTypeParams, err := mime.ParseMediaType(scriptContentRes.Header.Get("Content-Type"))
-	if strings.HasPrefix(mediaType, "multipart/") {
-		mr := multipart.NewReader(scriptContentRes.Body, mediaTypeParams["boundary"])
-		p, err := mr.NextPart()
+	switch scriptContentRes.StatusCode {
+	case http.StatusOK:
+		var content string
+		mediaType, mediaTypeParams, err := mime.ParseMediaType(scriptContentRes.Header.Get("Content-Type"))
 		if err != nil {
-			resp.Diagnostics.AddError("failed to read response body", err.Error())
-		}
-		c, _ := io.ReadAll(p)
-		content = string(c)
-	} else {
-		bytes, err = io.ReadAll(scriptContentRes.Body)
-		if err != nil {
-			resp.Diagnostics.AddError("failed to read response body", err.Error())
+			resp.Diagnostics.AddError("failed parsing content-type", err.Error())
 			return
 		}
-		content = string(bytes)
-	}
+		if strings.HasPrefix(mediaType, "multipart/") {
+			mr := multipart.NewReader(scriptContentRes.Body, mediaTypeParams["boundary"])
+			p, err := mr.NextPart()
+			if err != nil {
+				resp.Diagnostics.AddError("failed to read response body", err.Error())
+			}
+			c, _ := io.ReadAll(p)
+			content = string(c)
+		} else {
+			bytes, err = io.ReadAll(scriptContentRes.Body)
+			if err != nil {
+				resp.Diagnostics.AddError("failed to read response body", err.Error())
+				return
+			}
+			content = string(bytes)
+		}
 
-	// only update `content` if `content_file` isn't being used instead
-	if data.ContentFile.IsNull() {
-		data.Content = types.StringValue(content)
-	}
+		// only update `content` if `content_file` isn't being used instead
+		if data.ContentFile.IsNull() {
+			data.Content = types.StringValue(content)
+		}
 
-	// refresh the content hash in case the remote state has drifted
-	if !data.ContentSHA256.IsNull() {
-		hash, _ := calculateStringHash(content)
-		data.ContentSHA256 = types.StringValue(hash)
+		// refresh the content hash in case the remote state has drifted
+		if !data.ContentSHA256.IsNull() {
+			hash, _ := calculateStringHash(content)
+			data.ContentSHA256 = types.StringValue(hash)
+		}
+	case http.StatusNoContent:
+		data.Content = types.StringNull()
+	default:
+		resp.Diagnostics.AddError("failed to fetch script content", fmt.Sprintf("%v %s", scriptContentRes.StatusCode, scriptContentRes.Status))
+		return
 	}
 
 	// If the API returned an empty object for `placement`, treat it as null
@@ -406,6 +451,22 @@ func (r *WorkersScriptResource) ImportState(ctx context.Context, req resource.Im
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *WorkersScriptResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, _ *resource.ModifyPlanResponse) {
+func (r *WorkersScriptResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
 
+	// After running all the provider plan modification, if there are no differences/updates, return.
+	if req.Plan.Raw.Equal(req.State.Raw) {
+		return
+	}
+
+	// Terraform Framework checks if there are planned changes and if so, marks computed attribute values as unknown.
+	// This occurs before any plan modifiers are run, so if a change doesn't get planned until running a plan modifier (such as recomputing `asset_manifest_sha256`),
+	// any computed attribute values from the previous state are carried over without being marked as unknown.
+	// Since these are now considered "known values", they MUST match after apply, or else Terraform will throw
+	// "Error: Provider produced inconsistent result after apply".
+	// To prevent this, we must explicitly mark any computed attributes we know can change as unknown.
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("modified_on"), timetypes.NewRFC3339Unknown())...)
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("has_assets"), types.BoolUnknown())...)
 }

--- a/internal/services/workers_script/resource_test.go
+++ b/internal/services/workers_script/resource_test.go
@@ -366,6 +366,83 @@ func TestAccCloudflareWorkerScript_PythonWorker(t *testing.T) {
 	})
 }
 
+func TestAcc_WorkerScriptWithAssets(t *testing.T) {
+	t.Parallel()
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_workers_script." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	assetsDir := t.TempDir()
+	assetFile := path.Join(assetsDir, "index.html")
+
+	writeAssetFile := func(t *testing.T, content string) {
+		err := os.WriteFile(assetFile, []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("Error creating temp file at path %s: %s", assetFile, err.Error())
+		}
+	}
+
+	cleanup := func(t *testing.T) {
+		err := os.Remove(assetFile)
+		if err != nil {
+			t.Logf("Error removing temp file at path %s: %s", assetFile, err.Error())
+		}
+	}
+
+	defer cleanup(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					writeAssetFile(t, "v1")
+				},
+				Config: testAccWorkersScriptConfigWithAssets(rnd, accountID, assetsDir),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("assets").AtMapKey("directory"), knownvalue.StringExact(assetsDir)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("assets").AtMapKey("asset_manifest_sha256"), knownvalue.StringExact("b098d2898ca7ae5677c7291d97323e7894137515043f3e560f3bd155870eea9e")),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("has_assets"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				PreConfig: func() {
+					writeAssetFile(t, "v2")
+				},
+				Config: testAccWorkersScriptConfigWithAssets(rnd, accountID, assetsDir),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("assets").AtMapKey("directory"), knownvalue.StringExact(assetsDir)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("assets").AtMapKey("asset_manifest_sha256"), knownvalue.StringExact("46f07eb8a3fa881af81ce2b6b3fc1627edccf115526aa5c631308c45c75d2fb1")),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("has_assets"), knownvalue.Bool(true)),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccWorkersScriptConfigWithAssets(rnd, accountID, assetsDir),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:            name,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"assets.%", "assets.directory", "assets.asset_manifest_sha256", "startup_time_ms"},
+			},
+		},
+	})
+}
+
 func TestAccCloudflareWorkerScript_ModuleWithDurableObject(t *testing.T) {
 	t.Parallel()
 
@@ -425,4 +502,8 @@ func testAccWorkersScriptConfigWithContentFile(rnd, accountID, contentFile strin
 
 func testAccWorkersScriptConfigWithInvalidContentSHA256(rnd, accountID, contentFile string) string {
 	return acctest.LoadTestCase("module_with_invalid_content_sha256.tf", rnd, accountID, contentFile)
+}
+
+func testAccWorkersScriptConfigWithAssets(rnd, accountID, assetsDir string) string {
+	return acctest.LoadTestCase("module_with_assets.tf", rnd, accountID, assetsDir)
 }

--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"script_name": schema.StringAttribute{
 				Description:   "Name of the script, used in URLs and route configuration.",
 				Required:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown(), stringplanmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
@@ -43,7 +43,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"content": schema.StringAttribute{
-				Description: "Module or Service Worker contents of the Worker. Exactly one of `content` or `content_file` must be specified.",
+				Description: "Module or Service Worker contents of the Worker. Conflicts with `content_file`.",
 				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.Expressions{
@@ -52,7 +52,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"content_file": schema.StringAttribute{
-				Description: "Path to a file containing the Module or Service Worker contents of the Worker. Exactly one of `content` or `content_file` must be specified. Must be paired with `content_sha256`.",
+				Description: "Path to a file containing the Module or Service Worker contents of the Worker. Conflicts with `content`. Must be paired with `content_sha256`.",
 				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.Expressions{
@@ -139,6 +139,20 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Description: "Token provided upon successful upload of all files from a registered manifest.",
 						Optional:    true,
 						Sensitive:   true,
+					},
+					"directory": schema.StringAttribute{
+						Description: "Path to the directory containing asset files to upload.",
+						Optional:    true,
+						Validators: []validator.String{
+							stringvalidator.ConflictsWith(path.MatchRoot("assets").AtName("jwt")),
+						},
+					},
+					"asset_manifest_sha256": schema.StringAttribute{
+						Description: "The SHA-256 hash of the asset manifest of files to upload.",
+						Computed:    true,
+						PlanModifiers: []planmodifier.String{
+							ComputeSHA256HashOfAssetManifest(),
+						},
 					},
 				},
 			},
@@ -743,7 +757,12 @@ func (r *WorkersScriptResource) Schema(ctx context.Context, req resource.SchemaR
 
 func (r *WorkersScriptResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
-		resourcevalidator.ExactlyOneOf(
+		resourcevalidator.AtLeastOneOf(
+			path.MatchRoot("content"),
+			path.MatchRoot("content_file"),
+			path.MatchRoot("assets"),
+		),
+		resourcevalidator.Conflicting(
 			path.MatchRoot("content"),
 			path.MatchRoot("content_file"),
 		),

--- a/internal/services/workers_script/testdata/module_with_assets.tf
+++ b/internal/services/workers_script/testdata/module_with_assets.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_workers_script" "%[1]s" {
+  account_id = "%[2]s"
+  script_name = "%[1]s"
+  assets = {
+    directory = "%[3]s"
+  }
+}


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
This PR introduces a new `assets.directory` attribute to the `cloudflare_workers_script` and `cloudflare_worker_version` resources. If this attribute is set, the referenced assets directory will be uploaded as part of the resource creation or update operation.

```tf
resource "cloudflare_worker_version" "static_site" {
  account_id = var.account_id
  worker_id  = cloudflare_worker.static_site.id
  assets = {
    directory = "../path/to/assets"
  }
}
```
```tf
resource "cloudflare_workers_script" "static_site" {
  account_id  = var.account_id
  script_name = "static-site"
  assets = {
    directory = "../path/to/assets"
  }
}
```

## Additional context & links
