### PR TITLE
feat(migrate): handle zone settings in modules

### DIFF
--- a/cmd/migrate/access_application_test.go
+++ b/cmd/migrate/access_application_test.go
@@ -105,7 +105,7 @@ func TestAccessApplicationPoliciesTransformation(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 func TestAccessApplicationDomainTypeRemoval(t *testing.T) {
@@ -169,7 +169,7 @@ func TestAccessApplicationDomainTypeRemoval(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 func TestAccessApplicationDestinationsBlocksToAttribute(t *testing.T) {
@@ -299,7 +299,7 @@ func TestAccessApplicationDestinationsBlocksToAttribute(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 func TestAccessApplicationCombinedMigrations(t *testing.T) {
@@ -372,7 +372,7 @@ func TestAccessApplicationCombinedMigrations(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 
@@ -454,5 +454,5 @@ func TestAccessApplicationSkipAppLauncherLoginPageRemoval(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/argo_test.go
+++ b/cmd/migrate/argo_test.go
@@ -143,5 +143,5 @@ func TestArgoTransformation(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/dns_record_test.go
+++ b/cmd/migrate/dns_record_test.go
@@ -229,7 +229,7 @@ resource "cloudflare_dns_record" "caa_test2" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 func TestDNSRecordStateTransformation(t *testing.T) {

--- a/cmd/migrate/list_dynamic_test.go
+++ b/cmd/migrate/list_dynamic_test.go
@@ -341,7 +341,7 @@ resource "cloudflare_list" "test" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 func TestCloudflareListEdgeCases(t *testing.T) {
@@ -425,5 +425,5 @@ resource "cloudflare_list" "test" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/list_item_merge_test.go
+++ b/cmd/migrate/list_item_merge_test.go
@@ -269,5 +269,5 @@ resource "cloudflare_list" "example" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/list_test.go
+++ b/cmd/migrate/list_test.go
@@ -249,5 +249,5 @@ resource "cloudflare_list" "mixed_list" {
 		},
 	}
 	
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/load_balancer_pool_test.go
+++ b/cmd/migrate/load_balancer_pool_test.go
@@ -237,7 +237,7 @@ resource "cloudflare_load_balancer_pool" "test" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 // State transformation tests
@@ -505,5 +505,5 @@ resource "cloudflare_load_balancer_pool" "test" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/load_balancer_test.go
+++ b/cmd/migrate/load_balancer_test.go
@@ -433,7 +433,7 @@ func TestLoadBalancerRulesTransformation(t *testing.T) {
 		//		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 // Configuration transformation tests for pool blocks to maps
@@ -554,7 +554,7 @@ func TestLoadBalancerPoolBlockTransformation(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 // Test the new region_pools consolidation from v4 to v5 format
@@ -606,10 +606,10 @@ func TestLoadBalancerRegionPoolsConsolidation(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
-// Test random_steering pool_weights migration issue  
+// Test random_steering pool_weights migration issue
 func TestLoadBalancerRandomSteeringPoolWeights(t *testing.T) {
 	tests := []TestCase{
 		{
@@ -727,5 +727,5 @@ func TestLoadBalancerDynamicRulesTransformation(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/managed_transforms_test.go
+++ b/cmd/migrate/managed_transforms_test.go
@@ -96,5 +96,5 @@ func TestManagedTransformsTransformation(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/regional_hostname_test.go
+++ b/cmd/migrate/regional_hostname_test.go
@@ -123,7 +123,7 @@ resource "cloudflare_regional_hostname" "test" {
 // runTransformationTest is a helper function for testing HCL transformations
 func runTransformationTest(t *testing.T, input, expected string) {
 	// Transform the input
-	result, err := transformFile([]byte(input), "test.tf")
+	result, err := transformFileDefault([]byte(input), "test.tf")
 	assert.NoError(t, err)
 
 	resultStr := string(result)
@@ -141,7 +141,7 @@ func runTransformationTest(t *testing.T, input, expected string) {
 // runSpecialTransformationTest handles the case where we need to check both removal and preservation
 func runSpecialTransformationTest(t *testing.T, input, expected string) {
 	// Transform the input
-	result, err := transformFile([]byte(input), "test.tf")
+	result, err := transformFileDefault([]byte(input), "test.tf")
 	assert.NoError(t, err)
 
 	resultStr := string(result)

--- a/cmd/migrate/renames_test.go
+++ b/cmd/migrate/renames_test.go
@@ -29,7 +29,7 @@ resource "cloudflare_custom_pages" "example" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 func TestResourceReferenceRename(t *testing.T) {

--- a/cmd/migrate/snippet_rules_test.go
+++ b/cmd/migrate/snippet_rules_test.go
@@ -168,7 +168,7 @@ resource "cloudflare_snippet_rules" "test" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 func TestTransformSnippetRulesStateJSON(t *testing.T) {

--- a/cmd/migrate/snippet_test.go
+++ b/cmd/migrate/snippet_test.go
@@ -170,7 +170,7 @@ resource "cloudflare_snippet" "test" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 func TestMigrateCloudflareSnippetState(t *testing.T) {

--- a/cmd/migrate/spectrum_application_test.go
+++ b/cmd/migrate/spectrum_application_test.go
@@ -181,5 +181,5 @@ func TestSpectrumApplicationTransformation(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/test_helpers.go
+++ b/cmd/migrate/test_helpers.go
@@ -352,7 +352,7 @@ func transformFileWithYAML(content []byte, filename string) ([]byte, error) {
 	}
 
 	// Then apply Go transformations
-	return transformFile(transformed, filename)
+	return transformFileDefault(transformed, filename)
 }
 
 // applyYAMLTransformationsToFile applies all YAML transformations to a file

--- a/cmd/migrate/tiered_cache_test.go
+++ b/cmd/migrate/tiered_cache_test.go
@@ -194,7 +194,7 @@ resource "cloudflare_tiered_cache" "example" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 // State transformation tests

--- a/cmd/migrate/workers_cron_trigger_test.go
+++ b/cmd/migrate/workers_cron_trigger_test.go
@@ -34,5 +34,5 @@ func TestWorkersCronTriggerTransformation(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/workers_references_test.go
+++ b/cmd/migrate/workers_references_test.go
@@ -70,5 +70,5 @@ resource "cloudflare_workers_route" "my_route" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/workers_route_test.go
+++ b/cmd/migrate/workers_route_test.go
@@ -45,5 +45,5 @@ func TestWorkersRouteTransformation(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/workers_script_test.go
+++ b/cmd/migrate/workers_script_test.go
@@ -221,5 +221,5 @@ func TestWorkersScriptTransformation(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/workers_secret_test.go
+++ b/cmd/migrate/workers_secret_test.go
@@ -154,7 +154,7 @@ resource "cloudflare_worker_secret" "my_secret" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 func TestWorkersSecretStateMigration(t *testing.T) {

--- a/cmd/migrate/zero_trust_access_group_test.go
+++ b/cmd/migrate/zero_trust_access_group_test.go
@@ -478,5 +478,5 @@ func TestZeroTrustAccessGroupTransformation(t *testing.T) {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/zero_trust_access_identity_provider_test.go
+++ b/cmd/migrate/zero_trust_access_identity_provider_test.go
@@ -188,7 +188,7 @@ func TestTransformZeroTrustAccessIdentityProvider(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			output, err := transformFile([]byte(test.input), "test.tf")
+			output, err := transformFileDefault([]byte(test.input), "test.tf")
 			if err != nil {
 				t.Fatalf("transformFile failed: %v", err)
 			}

--- a/cmd/migrate/zero_trust_access_mtls_certificate_test.go
+++ b/cmd/migrate/zero_trust_access_mtls_certificate_test.go
@@ -42,5 +42,5 @@ resource "cloudflare_zero_trust_access_mtls_certificate" "example" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/zero_trust_access_mtls_hostname_settings_test.go
+++ b/cmd/migrate/zero_trust_access_mtls_hostname_settings_test.go
@@ -128,7 +128,7 @@ resource "cloudflare_zero_trust_access_mtls_hostname_settings" "test" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 func TestAccessMutualTLSHostnameSettingsTransformation(t *testing.T) {
@@ -211,5 +211,5 @@ resource "cloudflare_access_mutual_tls_hostname_settings" "example" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }

--- a/cmd/migrate/zone_settings.go
+++ b/cmd/migrate/zone_settings.go
@@ -36,7 +36,7 @@ func isZoneSettingsOverrideResource(block *hclwrite.Block) bool {
 }
 
 // transformZoneSettingsBlock transforms a zone settings override block into individual zone setting resources
-func transformZoneSettingsBlock(oldBlock *hclwrite.Block) []*hclwrite.Block {
+func transformZoneSettingsBlock(oldBlock *hclwrite.Block, skipImports bool) []*hclwrite.Block {
 	var newBlocks []*hclwrite.Block
 
 	// Get the resource name from the old block
@@ -69,9 +69,11 @@ func transformZoneSettingsBlock(oldBlock *hclwrite.Block) []*hclwrite.Block {
 				)
 				newBlocks = append(newBlocks, newBlock)
 
-				// Create import block for this resource
-				importBlock := createImportBlock(resourceFullName, mappedSettingName, zoneIDAttr)
-				newBlocks = append(newBlocks, importBlock)
+				// Create import block for this resource if not skipping imports
+				if !skipImports {
+					importBlock := createImportBlock(resourceFullName, mappedSettingName, zoneIDAttr)
+					newBlocks = append(newBlocks, importBlock)
+				}
 			}
 
 			// Process nested blocks (security_header, nel)
@@ -79,15 +81,19 @@ func transformZoneSettingsBlock(oldBlock *hclwrite.Block) []*hclwrite.Block {
 				if nestedBlock.Type() == "security_header" {
 					resourceFullName := resourceName + "_security_header"
 					newBlocks = append(newBlocks, transformSecurityHeaderBlock(resourceName, zoneIDAttr, nestedBlock))
-					// Create import block for security_header
-					importBlock := createImportBlock(resourceFullName, "security_header", zoneIDAttr)
-					newBlocks = append(newBlocks, importBlock)
+					// Create import block for security_header if not skipping imports
+					if !skipImports {
+						importBlock := createImportBlock(resourceFullName, "security_header", zoneIDAttr)
+						newBlocks = append(newBlocks, importBlock)
+					}
 				} else if nestedBlock.Type() == "nel" {
 					resourceFullName := resourceName + "_nel"
 					newBlocks = append(newBlocks, transformNELBlock(resourceName, zoneIDAttr, nestedBlock))
-					// Create import block for nel
-					importBlock := createImportBlock(resourceFullName, "nel", zoneIDAttr)
-					newBlocks = append(newBlocks, importBlock)
+					// Create import block for nel if not skipping imports
+					if !skipImports {
+						importBlock := createImportBlock(resourceFullName, "nel", zoneIDAttr)
+						newBlocks = append(newBlocks, importBlock)
+					}
 				}
 			}
 		}

--- a/cmd/migrate/zone_settings_module.go
+++ b/cmd/migrate/zone_settings_module.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// Zone setting mapping from the zone_settings module
+var zoneSettingMappings = map[string]string{
+	"always_use_https":             "always_use_https",
+	"automatic_https_rewrites":     "automatic_https_rewrites",
+	"browser_check":                "browser_check",
+	"challenge_ttl":                "challenge_ttl",
+	"tls_client_auth":              "tls_client_auth",
+	"ciphers":                      "ciphers",
+	"http2":                        "http2",
+	"http3":                        "http3",
+	"origin_max_http_version":      "origin_max_http_version",
+	"h2_prioritization":            "h2_prioritization",
+	"zero_rtt":                     "0rtt", // Note: v4 uses zero_rtt but API expects 0rtt
+	"always_online":                "always_online",
+	"ipv6":                         "ipv6",
+	"max_upload":                   "max_upload",
+	"websockets":                   "websockets",
+	"proxy_read_timeout":           "proxy_read_timeout",
+	"security_level":               "security_level",
+	"ip_geolocation":               "ip_geolocation",
+	"email_obfuscation":            "email_obfuscation",
+	"polish":                       "polish",
+	"mirage":                       "mirage",
+	"image_resizing":               "image_resizing",
+	"fonts":                        "fonts",
+	"binary_ast":                   "binary_ast",
+	"min_tls_version":              "min_tls_version",
+	"tls_1_3":                      "tls_1_3",
+	"ssl":                          "ssl",
+	"origin_error_page_pass_thru":  "origin_error_page_pass_thru",
+}
+
+// Special settings that need complex transformation
+var complexSettings = map[string]bool{
+	"security_header_enabled":              true,
+	"security_header_include_subdomains":   true,
+	"security_header_max_age":              true,
+	"security_header_nosniff":              true,
+	"security_header_preload":              true,
+	"enable_network_error_logging":         true,
+}
+
+// expandZoneSettingsModules finds zone_settings module calls and expands them to individual resources
+func expandZoneSettingsModules(content string, skipImports bool) string {
+	// Pattern to match module "zone_settings" blocks
+	modulePattern := `module\s+"zone_settings"\s*\{[^}]*\}`
+	re := regexp.MustCompile(modulePattern)
+
+	// Find all zone_settings module blocks
+	matches := re.FindAllString(content, -1)
+
+	for _, match := range matches {
+		expanded := expandSingleZoneSettingsModule(match, skipImports)
+		if expanded != "" {
+			content = strings.Replace(content, match, expanded, 1)
+		}
+	}
+
+	return content
+}
+
+// expandSingleZoneSettingsModule expands a single zone_settings module call
+func expandSingleZoneSettingsModule(moduleBlock string, skipImports bool) string {
+	// Parse the module block to extract attributes
+	file, diags := hclwrite.ParseConfig([]byte(moduleBlock), "module.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		fmt.Printf("Warning: Could not parse zone_settings module block: %v\n", diags)
+		return moduleBlock // Return original if can't parse
+	}
+
+	// Find the module block
+	var moduleBlockParsed *hclwrite.Block
+	for _, block := range file.Body().Blocks() {
+		if block.Type() == "module" && len(block.Labels()) > 0 && block.Labels()[0] == "zone_settings" {
+			moduleBlockParsed = block
+			break
+		}
+	}
+
+	if moduleBlockParsed == nil {
+		return moduleBlock // Return original if can't find module
+	}
+
+	var results []string
+
+	// Extract zone_id attribute
+	var zoneIdAttr *hclwrite.Attribute
+	if attr := moduleBlockParsed.Body().GetAttribute("zone_id"); attr != nil {
+		zoneIdAttr = attr
+	}
+
+	// Generate unique resource name prefix
+	resourcePrefix := "zone_settings"
+
+	// Process each attribute in the module
+	for _, attr := range AttributesOrdered(moduleBlockParsed.Body()) {
+		attrName := attr.Name
+
+		// Skip source attribute
+		if attrName == "source" {
+			continue
+		}
+
+		// Skip zone_id as it's used for all resources
+		if attrName == "zone_id" {
+			continue
+		}
+
+		// Handle special complex settings
+		if strings.HasPrefix(attrName, "security_header_") {
+			// Group all security_header_* attributes
+			continue // Will be handled separately
+		}
+
+		if attrName == "enable_network_error_logging" {
+			// Handle NEL setting
+			settingId := "nel"
+			resourceName := fmt.Sprintf("%s_%s", resourcePrefix, "nel")
+
+			resource := createZoneSettingResourceFromModule(resourceName, settingId, zoneIdAttr, attr.Attribute, true)
+			results = append(results, resource)
+
+			if !skipImports {
+				importBlock := createImportBlockFromModule(resourceName, settingId, zoneIdAttr)
+				results = append(results, importBlock)
+			}
+			continue
+		}
+
+		// Handle standard settings
+		if settingId, exists := zoneSettingMappings[attrName]; exists {
+			resourceName := fmt.Sprintf("%s_%s", resourcePrefix, attrName)
+
+			resource := createZoneSettingResourceFromModule(resourceName, settingId, zoneIdAttr, attr.Attribute, false)
+			results = append(results, resource)
+
+			if !skipImports {
+				importBlock := createImportBlockFromModule(resourceName, settingId, zoneIdAttr)
+				results = append(results, importBlock)
+			}
+		}
+	}
+
+	// Handle security_header settings as a group
+	securityHeaderAttrs := extractSecurityHeaderAttributes(moduleBlockParsed.Body())
+	if len(securityHeaderAttrs) > 0 {
+		resourceName := fmt.Sprintf("%s_security_header", resourcePrefix)
+		settingId := "security_header"
+
+		resource := createSecurityHeaderResourceFromModule(resourceName, settingId, zoneIdAttr, securityHeaderAttrs)
+		results = append(results, resource)
+
+		if !skipImports {
+			importBlock := createImportBlockFromModule(resourceName, settingId, zoneIdAttr)
+			results = append(results, importBlock)
+		}
+	}
+
+	return strings.Join(results, "\n\n")
+}
+
+// extractSecurityHeaderAttributes extracts all security_header_* attributes
+func extractSecurityHeaderAttributes(body *hclwrite.Body) map[string]*hclwrite.Attribute {
+	attrs := make(map[string]*hclwrite.Attribute)
+
+	for _, attr := range AttributesOrdered(body) {
+		if strings.HasPrefix(attr.Name, "security_header_") {
+			// Map attribute names to security header field names
+			fieldName := strings.TrimPrefix(attr.Name, "security_header_")
+			attrs[fieldName] = attr.Attribute
+		}
+	}
+
+	return attrs
+}
+
+// createZoneSettingResourceFromModule creates a zone_setting resource from module attributes
+func createZoneSettingResourceFromModule(resourceName, settingId string, zoneIdAttr, valueAttr *hclwrite.Attribute, isNEL bool) string {
+	var lines []string
+	lines = append(lines, fmt.Sprintf(`resource "cloudflare_zone_setting" "%s" {`, resourceName))
+
+	// Add zone_id
+	if zoneIdAttr != nil {
+		zoneIdStr := tokensToString(zoneIdAttr.Expr().BuildTokens(nil))
+		lines = append(lines, fmt.Sprintf("  zone_id    = %s", zoneIdStr))
+	}
+
+	// Add setting_id
+	lines = append(lines, fmt.Sprintf(`  setting_id = "%s"`, settingId))
+
+	// Add value
+	if valueAttr != nil {
+		if isNEL {
+			// NEL requires wrapping the boolean value in an object with "enabled" field
+			valueStr := tokensToString(valueAttr.Expr().BuildTokens(nil))
+			lines = append(lines, fmt.Sprintf("  value      = { enabled = %s }", valueStr))
+		} else {
+			valueStr := tokensToString(valueAttr.Expr().BuildTokens(nil))
+			lines = append(lines, fmt.Sprintf("  value      = %s", valueStr))
+		}
+	}
+
+	lines = append(lines, "}")
+
+	return strings.Join(lines, "\n")
+}
+
+// createSecurityHeaderResourceFromModule creates a security_header zone_setting resource
+func createSecurityHeaderResourceFromModule(resourceName, settingId string, zoneIdAttr *hclwrite.Attribute, securityAttrs map[string]*hclwrite.Attribute) string {
+	var lines []string
+	lines = append(lines, fmt.Sprintf(`resource "cloudflare_zone_setting" "%s" {`, resourceName))
+
+	// Add zone_id
+	if zoneIdAttr != nil {
+		zoneIdStr := tokensToString(zoneIdAttr.Expr().BuildTokens(nil))
+		lines = append(lines, fmt.Sprintf("  zone_id    = %s", zoneIdStr))
+	}
+
+	// Add setting_id
+	lines = append(lines, fmt.Sprintf(`  setting_id = "%s"`, settingId))
+
+	// Build security header object
+	var valueLines []string
+	valueLines = append(valueLines, "  value = {")
+	valueLines = append(valueLines, "    strict_transport_security = {")
+
+	// Map the security header attributes
+	for fieldName, attr := range securityAttrs {
+		valueStr := tokensToString(attr.Expr().BuildTokens(nil))
+		valueLines = append(valueLines, fmt.Sprintf("      %s = %s", fieldName, valueStr))
+	}
+
+	valueLines = append(valueLines, "    }")
+	valueLines = append(valueLines, "  }")
+
+	lines = append(lines, strings.Join(valueLines, "\n"))
+	lines = append(lines, "}")
+
+	return strings.Join(lines, "\n")
+}
+
+// createImportBlockFromModule creates an import block for zone_setting resources
+func createImportBlockFromModule(resourceName, settingId string, zoneIdAttr *hclwrite.Attribute) string {
+	var lines []string
+	lines = append(lines, "import {")
+	lines = append(lines, fmt.Sprintf(`  to = cloudflare_zone_setting.%s`, resourceName))
+
+	if zoneIdAttr != nil {
+		zoneIdStr := tokensToString(zoneIdAttr.Expr().BuildTokens(nil))
+		lines = append(lines, fmt.Sprintf(`  id = "${%s}/%s"`, zoneIdStr, settingId))
+	}
+
+	lines = append(lines, "}")
+
+	return strings.Join(lines, "\n")
+}
+
+// tokensToString converts HCL tokens to a string representation
+func tokensToString(tokens hclwrite.Tokens) string {
+	var parts []string
+	for _, token := range tokens {
+		parts = append(parts, string(token.Bytes))
+	}
+	return strings.Join(parts, "")
+}

--- a/cmd/migrate/zone_settings_module_test.go
+++ b/cmd/migrate/zone_settings_module_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpandZoneSettingsModules(t *testing.T) {
+	tests := []TestCase{
+		{
+			Name: "expand simple zone_settings module",
+			Config: `module "zone_settings" {
+  source         = "../zone_settings"
+  zone_id        = cloudflare_zone.example_com.id
+  security_level = "high"
+  ssl            = "origin_pull"
+}`,
+			Expected: []string{
+				`resource "cloudflare_zone_setting" "zone_settings_security_level" {
+  zone_id    = cloudflare_zone.example_com.id
+  setting_id = "security_level"
+  value      = "high"
+}`,
+				`import {
+  to = cloudflare_zone_setting.zone_settings_security_level
+  id = "${cloudflare_zone.example_com.id}/security_level"
+}`,
+				`resource "cloudflare_zone_setting" "zone_settings_ssl" {
+  zone_id    = cloudflare_zone.example_com.id
+  setting_id = "ssl"
+  value      = "origin_pull"
+}`,
+				`import {
+  to = cloudflare_zone_setting.zone_settings_ssl
+  id = "${cloudflare_zone.example_com.id}/ssl"
+}`,
+			},
+		},
+		{
+			Name: "expand zone_settings module with zero_rtt mapping",
+			Config: `module "zone_settings" {
+  source   = "../zone_settings"
+  zone_id  = var.zone_id
+  zero_rtt = "on"
+}`,
+			Expected: []string{
+				`resource "cloudflare_zone_setting" "zone_settings_zero_rtt" {
+  zone_id    = var.zone_id
+  setting_id = "0rtt"
+  value      = "on"
+}`,
+				`import {
+  to = cloudflare_zone_setting.zone_settings_zero_rtt
+  id = "${var.zone_id}/0rtt"
+}`,
+			},
+		},
+		{
+			Name: "expand zone_settings module with NEL setting",
+			Config: `module "zone_settings" {
+  source                        = "../zone_settings"
+  zone_id                       = var.zone_id
+  enable_network_error_logging  = true
+}`,
+			Expected: []string{
+				`resource "cloudflare_zone_setting" "zone_settings_nel" {
+  zone_id    = var.zone_id
+  setting_id = "nel"
+  value      = { enabled = true }
+}`,
+				`import {
+  to = cloudflare_zone_setting.zone_settings_nel
+  id = "${var.zone_id}/nel"
+}`,
+			},
+		},
+		{
+			Name: "expand zone_settings module with security headers",
+			Config: `module "zone_settings" {
+  source                              = "../zone_settings"
+  zone_id                             = var.zone_id
+  security_header_enabled             = true
+  security_header_include_subdomains  = true
+  security_header_max_age            = 31536000
+}`,
+			Expected: []string{
+				`resource "cloudflare_zone_setting" "zone_settings_security_header" {
+  zone_id    = var.zone_id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled = true
+      include_subdomains = true
+      max_age = 31536000
+    }
+  }
+}`,
+				`import {
+  to = cloudflare_zone_setting.zone_settings_security_header
+  id = "${var.zone_id}/security_header"
+}`,
+			},
+		},
+	}
+
+	// Test the expand function directly since it's string-based
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			result := expandZoneSettingsModules(test.Config, false) // skipImports = false
+
+			// Check that each expected string is present in the result
+			for _, expected := range test.Expected {
+				if !strings.Contains(result, expected) {
+					t.Errorf("Expected output to contain '%s', but it didn't.\nActual output:\n%s", expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestExpandZoneSettingsModulesSkipImports(t *testing.T) {
+	tests := []TestCase{
+		{
+			Name: "skip imports - expand simple zone_settings module",
+			Config: `module "zone_settings" {
+  source         = "../zone_settings"
+  zone_id        = cloudflare_zone.example_com.id
+  security_level = "high"
+  ssl            = "origin_pull"
+}`,
+			Expected: []string{
+				`resource "cloudflare_zone_setting" "zone_settings_security_level" {`,
+				`zone_id    = cloudflare_zone.example_com.id`,
+				`setting_id = "security_level"`,
+				`value      = "high"`,
+				`resource "cloudflare_zone_setting" "zone_settings_ssl" {`,
+				`zone_id    = cloudflare_zone.example_com.id`,
+				`setting_id = "ssl"`,
+				`value      = "origin_pull"`,
+			},
+		},
+	}
+
+	// Test the expand function with skipImports = true
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			result := expandZoneSettingsModules(test.Config, true) // skipImports = true
+
+			// Check that each expected string is present in the result
+			for _, expected := range test.Expected {
+				if !strings.Contains(result, expected) {
+					t.Errorf("Expected output to contain '%s', but it didn't.\nActual output:\n%s", expected, result)
+				}
+			}
+
+			// Verify that no import blocks are present
+			if strings.Contains(result, "import {") {
+				t.Errorf("Expected no import blocks when skipImports=true, but found some.\nActual output:\n%s", result)
+			}
+		})
+	}
+}
+

--- a/cmd/migrate/zone_test.go
+++ b/cmd/migrate/zone_test.go
@@ -133,7 +133,7 @@ resource "cloudflare_zone" "secondary" {
 		},
 	}
 
-	RunTransformationTests(t, tests, transformFile)
+	RunTransformationTests(t, tests, transformFileDefault)
 }
 
 func TestZoneStateTransformation(t *testing.T) {


### PR DESCRIPTION
Improves how zone settings are migrated from v4 -> v5 of the provider by adding
two new flags:

- `--zone-settings-module` for handling a common pattern in the v4 provider
  where `zone_settings_override` is wrapped in a module and settings are passed
  in as module input variables. When provided, we will expand the vars into
  `zone_setting` resources and imports at the call site.

- `--skip-imports` for skipping import generation, which is useful in cases
  where imports could be generated in invalid locations (read: outside the root
  module).

Module definition: `modules/zone_settings/main.tf`
```hcl
resource "cloudflare_zone_settings_override" "zone_settings" {
  zone_id = var.zone_id

  settings {
    security_level = var.security_level
    ssl            = var.ssl
  }
}
```

Module call: `sites/example_com/main.tf`
```hcl
module "zone_settings" {
  source         = "../modules/zone_settings"
  zone_id        = cloudflare_zone.example_com.id
  security_level = "high"
  ssl            = "origin_pull"
}
```

When the `--zone-settings-module` flag is set, the migrator tool will replace
module calls with inline zone setting definitions and their imports.

```hcl
resource "cloudflare_zone_setting" "zone_settings_zone_settings_security_level" {
  zone_id    = cloudflare_zone.example_com.id
  setting_id = "security_level"
  value      = "high"
}
resource "cloudflare_zone_setting" "zone_settings_zone_settings_ssl" {
  zone_id    = cloudflare_zone.example_com.id
  setting_id = "ssl"
  value      = "origin_pull"
}
import {
  to = cloudflare_zone_setting.zone_settings_zone_settings_security_level
  id = "${cloudflare_zone.example_com.id}/security_level"
}
import {
  to = cloudflare_zone_setting.zone_settings_zone_settings_ssl
  id = "${cloudflare_zone.example_com.id}/ssl"
}
```

Import generation can be skipped entirely with the `--skip-imports` flag.