### PR TITLE
fix: preserve heredoc expressions in cloudflare_ruleset migration

### DIFF
--- a/cmd/migrate/transformations/complex_heredoc_test.go
+++ b/cmd/migrate/transformations/complex_heredoc_test.go
@@ -1,0 +1,222 @@
+package transformations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+func TestComplexCloudflareRulesetWithMultipleHeredocAndRatelimit(t *testing.T) {
+	input := `resource "cloudflare_ruleset" "global-rate-limit" {
+  account_id  = local.account_id
+  kind        = "custom"
+  name        = "Global rate limit"
+  phase       = "http_ratelimit"
+  description = "*These rules are managed by Terraform*"
+  rules {
+    action      = "log"
+    description = "Log Global rate limit 1000/10s non authenticated"
+    enabled     = true
+    expression  = <<-EOF
+      not (
+        any(http.request.headers["authorization"][*] contains "sess-")
+        or any(http.request.headers["authorization"][*] contains "sk-")
+        or any(http.request.headers["authorization"][*] contains "eyJhbGc")
+        or http.cookie contains "__Secure-next-auth."
+        or http.cookie contains "__Host-next-auth.csrf-token="
+        or http.cookie contains "oai-did="
+      )
+      and not http.user_agent eq "Stripe/1.0 (+https://stripe.com/docs/webhooks)"
+    EOF
+    ratelimit {
+      characteristics     = ["cf.unique_visitor_id", "cf.colo.id"]
+      mitigation_timeout  = 3600
+      period              = 10
+      requests_per_period = 1000
+    }
+  }
+  rules {
+    action      = "log"
+    description = "Log Global rate limit 2500/1m non authenticated"
+    enabled     = true
+    expression  = <<-EOF
+      not (
+        any(http.request.headers["authorization"][*] contains "sess-")
+        or any(http.request.headers["authorization"][*] contains "sk-")
+        or any(http.request.headers["authorization"][*] contains "eyJhbGc")
+        or http.cookie contains "__Secure-next-auth."
+        or http.cookie contains "__Host-next-auth.csrf-token="
+        or http.cookie contains "oai-did="
+      )
+      and not http.user_agent eq "Stripe/1.0 (+https://stripe.com/docs/webhooks)"
+    EOF
+    ratelimit {
+      characteristics     = ["cf.unique_visitor_id", "cf.colo.id"]
+      mitigation_timeout  = 3600
+      period              = 60
+      requests_per_period = 2500
+    }
+  }
+}`
+
+	// Test the transformation
+	config := &TransformationConfig{
+		Transformations: map[string]ResourceTransform{
+			"cloudflare_ruleset": {
+				ToList: []string{"rules"},
+			},
+		},
+	}
+
+	// Parse the input
+	file, diags := hclwrite.ParseConfig([]byte(input), "test.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatalf("Failed to parse input: %v", diags)
+	}
+
+	// Find the cloudflare_ruleset resource block and apply transformations
+	blocks := file.Body().Blocks()
+	var transformed *hclwrite.File
+	for _, block := range blocks {
+		if block.Type() == "resource" && len(block.Labels()) >= 2 && block.Labels()[0] == "cloudflare_ruleset" {
+			err := TransformResourceBlock(config, block, "cloudflare_ruleset")
+			if err != nil {
+				t.Fatalf("Failed to transform resource block: %v", err)
+			}
+			transformed = file
+			break
+		}
+	}
+	if transformed == nil {
+		t.Fatalf("Could not find cloudflare_ruleset resource block to transform")
+	}
+
+	// Format and apply post-processing
+	output := hclwrite.Format(transformed.Bytes())
+	output = fixCloudflareRulesetDoubleDollarSigns(output)
+
+	// Verify the output is valid HCL
+	_, diags = hclwrite.ParseConfig(output, "output.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Errorf("Transformed output is not valid HCL: %v\nOutput:\n%s", diags, string(output))
+	} else {
+		t.Logf("✅ Transformation succeeded - output is valid HCL")
+	}
+
+	// Check that transformation actually happened (should contain "rules = [")
+	if !strings.Contains(string(output), "rules = [") {
+		t.Errorf("Expected transformation to convert rules blocks to list, but output doesn't contain 'rules = ['")
+	} else {
+		t.Logf("✅ Rules blocks correctly converted to list format")
+	}
+
+	// Check that heredoc expressions are preserved
+	if !strings.Contains(string(output), "<<-EOF") {
+		t.Errorf("Expected heredoc expressions to be preserved, but output doesn't contain '<<-EOF'")
+	} else {
+		t.Logf("✅ Heredoc expressions preserved correctly")
+	}
+
+	// Check for balanced EOF markers
+	eofCount := strings.Count(string(output), "EOF")
+	if eofCount%2 != 0 {
+		t.Errorf("Expected balanced EOF markers (pairs), but found %d total EOF occurrences", eofCount)
+	} else {
+		t.Logf("✅ EOF markers are balanced (%d pairs)", eofCount/2)
+	}
+
+	t.Logf("Successfully transformed complex heredoc with ratelimit rules")
+}
+
+// TestExactMigrationTestCase tests the exact same configuration that fails in the migration tests
+func TestExactMigrationTestCase(t *testing.T) {
+	input := `resource "cloudflare_ruleset" "test" {
+  account_id  = "test123"
+  kind        = "zone"
+  name        = "Complex Heredoc Test"
+  phase       = "http_ratelimit"
+  description = "Test complex heredoc with ratelimit"
+  
+  rules {
+    action      = "log"
+    description = "Log rate limit with complex expression"
+    enabled     = true
+    expression  = <<-EOF
+      not (
+        any(http.request.headers["authorization"][*] contains "sess-")
+        or any(http.request.headers["authorization"][*] contains "sk-")
+        or http.cookie contains "__Secure-next-auth."
+      )
+      and not http.user_agent eq "Stripe/1.0 (+https://stripe.com/docs/webhooks)"
+    EOF
+    ratelimit {
+      characteristics     = ["cf.unique_visitor_id", "cf.colo.id"]
+      mitigation_timeout  = 3600
+      period              = 10
+      requests_per_period = 1000
+    }
+  }
+}`
+
+	// Test the transformation
+	config := &TransformationConfig{
+		Transformations: map[string]ResourceTransform{
+			"cloudflare_ruleset": {
+				ToList: []string{"rules"},
+			},
+		},
+	}
+
+	// Parse the input
+	file, diags := hclwrite.ParseConfig([]byte(input), "test.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatalf("Failed to parse input: %v", diags)
+	}
+
+	// Find the cloudflare_ruleset resource block and apply transformations
+	blocks := file.Body().Blocks()
+	var transformed *hclwrite.File
+	for _, block := range blocks {
+		if block.Type() == "resource" && len(block.Labels()) >= 2 && block.Labels()[0] == "cloudflare_ruleset" {
+			err := TransformResourceBlock(config, block, "cloudflare_ruleset")
+			if err != nil {
+				t.Fatalf("Failed to transform resource block: %v", err)
+			}
+			transformed = file
+			break
+		}
+	}
+	if transformed == nil {
+		t.Fatalf("Could not find cloudflare_ruleset resource block to transform")
+	}
+
+	// Format and apply post-processing
+	output := hclwrite.Format(transformed.Bytes())
+	output = fixCloudflareRulesetDoubleDollarSigns(output)
+
+	// Verify the output is valid HCL
+	_, diags = hclwrite.ParseConfig(output, "output.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatalf("Transformed output is not valid HCL: %v\nOutput:\n%s", diags, string(output))
+	}
+
+	// Check that it has the expected structure
+	if !strings.Contains(string(output), "rules = [") {
+		t.Errorf("Expected rules to be converted to list format")
+	}
+
+	if !strings.Contains(string(output), "ratelimit = {") {
+		t.Errorf("Expected ratelimit to be converted to object format")
+	}
+
+	// Debug: log the output before and after post-processing
+	outputBeforeProcessing := hclwrite.Format(transformed.Bytes())
+	t.Logf("Before post-processing (raw):\n%q", string(outputBeforeProcessing))
+	t.Logf("Before post-processing (formatted):\n%s", string(outputBeforeProcessing))
+	
+	// Log the output for inspection
+	t.Logf("After post-processing (raw):\n%q", string(output))
+	t.Logf("After post-processing (formatted):\n%s", string(output))
+}

--- a/cmd/migrate/transformations/config/cloudflare_terraform_v5_block_to_attribute_configuration.yaml
+++ b/cmd/migrate/transformations/config/cloudflare_terraform_v5_block_to_attribute_configuration.yaml
@@ -267,7 +267,7 @@ transformations:
     to_list:
       - behavior
 
-  # Ruleset (complex - many nested transformations)
+  # Ruleset (uses specialized rules handling to preserve expressions)
   cloudflare_ruleset:
     to_map:
       - action_parameters

--- a/internal/services/ruleset/migrations_test.go
+++ b/internal/services/ruleset/migrations_test.go
@@ -3,6 +3,7 @@ package ruleset_test
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -244,6 +245,225 @@ func TestMigrateCloudflareRulesetCacheKeyQueryString(t *testing.T) {
 		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("action_parameters").AtMapKey("cache"), knownvalue.Bool(true)),
 		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("action_parameters").AtMapKey("cache_key").AtMapKey("custom_key").AtMapKey("query_string").AtMapKey("include"), knownvalue.NotNull()),
 		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(1).AtMapKey("action"), knownvalue.StringExact("set_cache_settings")),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: append([]resource.TestStep{{
+			ExternalProviders: map[string]resource.ExternalProvider{
+				"cloudflare": {
+					Source:            "cloudflare/cloudflare",
+					VersionConstraint: "4.52.1",
+				},
+			},
+			Config: v4Config,
+		}}, migrationSteps...),
+	})
+}
+
+// TestMigrateCloudflareRulesetExpressionDoubleDollar tests that heredoc expressions with variables don't get double dollar signs
+func TestMigrateCloudflareRulesetExpressionDoubleDollar(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	tmpDir := t.TempDir()
+	resourceName := fmt.Sprintf("cloudflare_ruleset.%s", rnd)
+
+	v4Config := acctest.LoadTestCase("migrations/literal_expression_double_dollar_v4.tf", zoneID, rnd)
+
+	migrationSteps := acctest.MigrationTestStepWithPlan(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(fmt.Sprintf("Literal Expression Test %s", rnd))),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("phase"), knownvalue.StringExact("http_request_firewall_custom")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kind"), knownvalue.StringExact("zone")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules"), knownvalue.ListSizeExact(1)),
+		// Test that the expression is preserved correctly
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("action"), knownvalue.StringExact("block")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("description"), knownvalue.StringExact("Literal heredoc test")),
+		// Verify expression is preserved correctly (literal content, not variables)
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("expression"), knownvalue.StringFunc(func(v string) error {
+			if !strings.Contains(v, "ip.geoip.country eq \"CN\"") {
+				return fmt.Errorf("expected expression to contain literal content, got: %s", v)
+			}
+			if !strings.Contains(v, "http.host eq \"example.com\"") {
+				return fmt.Errorf("expected expression to contain literal content, got: %s", v)
+			}
+			return nil
+		})),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: append([]resource.TestStep{{
+			ExternalProviders: map[string]resource.ExternalProvider{
+				"cloudflare": {
+					Source:            "cloudflare/cloudflare",
+					VersionConstraint: "4.52.1",
+				},
+			},
+			Config: v4Config,
+		}}, migrationSteps...),
+	})
+}
+
+// TestMigrateCloudflareRulesetComplexHeredocRatelimit tests complex heredoc expressions with ratelimit blocks
+func TestMigrateCloudflareRulesetComplexHeredocRatelimit(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	tmpDir := t.TempDir()
+	resourceName := fmt.Sprintf("cloudflare_ruleset.%s", rnd)
+
+	v4Config := acctest.LoadTestCase("migrations/complex_heredoc_ratelimit_v4.tf", zoneID, rnd)
+
+	migrationSteps := acctest.MigrationTestStepWithPlan(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(fmt.Sprintf("Complex Heredoc Test %s", rnd))),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("phase"), knownvalue.StringExact("http_ratelimit")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kind"), knownvalue.StringExact("zone")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules"), knownvalue.ListSizeExact(1)),
+		// Test that the complex heredoc expression is preserved correctly
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("action"), knownvalue.StringExact("log")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("description"), knownvalue.StringExact("Log rate limit with complex expression")),
+		// Verify ratelimit block is converted properly
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("ratelimit").AtMapKey("period"), knownvalue.Int64Exact(10)),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("ratelimit").AtMapKey("requests_per_period"), knownvalue.Int64Exact(1000)),
+		// Verify expression contains expected content and is syntactically valid
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("expression"), knownvalue.StringFunc(func(v string) error {
+			if !strings.Contains(v, "authorization") {
+				return fmt.Errorf("expected expression to contain 'authorization', got: %s", v)
+			}
+			if !strings.Contains(v, "__Secure-next-auth") {
+				return fmt.Errorf("expected expression to contain '__Secure-next-auth', got: %s", v)
+			}
+			return nil
+		})),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: append([]resource.TestStep{{
+			ExternalProviders: map[string]resource.ExternalProvider{
+				"cloudflare": {
+					Source:            "cloudflare/cloudflare",
+					VersionConstraint: "4.52.1",
+				},
+			},
+			Config: v4Config,
+		}}, migrationSteps...),
+	})
+}
+
+// TestMigrateCloudflareRulesetComplexMultipleRulesRatelimit tests multiple rules with heredoc expressions and ratelimit blocks
+func TestMigrateCloudflareRulesetComplexMultipleRulesRatelimit(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	tmpDir := t.TempDir()
+	resourceName := fmt.Sprintf("cloudflare_ruleset.%s", rnd)
+
+	v4Config := acctest.LoadTestCase("migrations/complex_multiple_rules_ratelimit_v4.tf", zoneID, rnd)
+
+	migrationSteps := acctest.MigrationTestStepWithPlan(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(fmt.Sprintf("Global rate limit %s", rnd))),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("phase"), knownvalue.StringExact("http_ratelimit")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kind"), knownvalue.StringExact("zone")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules"), knownvalue.ListSizeExact(3)),
+		// Test that all rules are preserved correctly
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("action"), knownvalue.StringExact("log")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("description"), knownvalue.StringExact("Log Global rate limit 1000/10s non authenticated")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(1).AtMapKey("action"), knownvalue.StringExact("log")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(1).AtMapKey("description"), knownvalue.StringExact("Log Global rate limit 2500/1m non authenticated")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(2).AtMapKey("action"), knownvalue.StringExact("log")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(2).AtMapKey("description"), knownvalue.StringExact("Log Unauthed rate limit DDoS User Agents")),
+		// Test that ratelimit blocks are converted properly for all rules
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("ratelimit").AtMapKey("period"), knownvalue.Int64Exact(10)),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("ratelimit").AtMapKey("requests_per_period"), knownvalue.Int64Exact(1000)),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(1).AtMapKey("ratelimit").AtMapKey("period"), knownvalue.Int64Exact(60)),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(1).AtMapKey("ratelimit").AtMapKey("requests_per_period"), knownvalue.Int64Exact(2500)),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(2).AtMapKey("ratelimit").AtMapKey("period"), knownvalue.Int64Exact(10)),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(2).AtMapKey("ratelimit").AtMapKey("requests_per_period"), knownvalue.Int64Exact(300)),
+		// Verify expressions are syntactically valid and properly terminated
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("expression"), knownvalue.StringFunc(func(v string) error {
+			if !strings.Contains(v, "authorization") {
+				return fmt.Errorf("expected expression to contain 'authorization', got: %s", v)
+			}
+			return nil
+		})),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(1).AtMapKey("expression"), knownvalue.StringFunc(func(v string) error {
+			if !strings.Contains(v, "__Secure-next-auth") {
+				return fmt.Errorf("expected expression to contain '__Secure-next-auth', got: %s", v)
+			}
+			return nil
+		})),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(2).AtMapKey("expression"), knownvalue.StringFunc(func(v string) error {
+			if !strings.Contains(v, "Chrome/117.0.0.0") {
+				return fmt.Errorf("expected expression to contain 'Chrome/117.0.0.0', got: %s", v)
+			}
+			return nil
+		})),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: append([]resource.TestStep{{
+			ExternalProviders: map[string]resource.ExternalProvider{
+				"cloudflare": {
+					Source:            "cloudflare/cloudflare",
+					VersionConstraint: "4.52.1",
+				},
+			},
+			Config: v4Config,
+		}}, migrationSteps...),
+	})
+}
+
+// TestMigrateCloudflareRulesetHeredocExpressionPreservation tests that heredoc expressions are properly preserved during migration
+func TestMigrateCloudflareRulesetHeredocExpressionPreservation(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	tmpDir := t.TempDir()
+	resourceName := fmt.Sprintf("cloudflare_ruleset.%s", rnd)
+
+	v4Config := acctest.LoadTestCase("migrations/complex_heredoc_ratelimit_v4.tf", zoneID, rnd)
+
+	migrationSteps := acctest.MigrationTestStepWithPlan(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(fmt.Sprintf("Complex Heredoc Test %s", rnd))),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("phase"), knownvalue.StringExact("http_ratelimit")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kind"), knownvalue.StringExact("zone")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules"), knownvalue.ListSizeExact(1)),
+		// Test that the rule is preserved correctly
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("action"), knownvalue.StringExact("log")),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("description"), knownvalue.StringExact("Log rate limit with complex expression")),
+		// Test that ratelimit block is converted properly
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("ratelimit").AtMapKey("period"), knownvalue.Int64Exact(10)),
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("ratelimit").AtMapKey("requests_per_period"), knownvalue.Int64Exact(1000)),
+		// Critical test: verify heredoc expression is properly preserved and not converted to escaped string
+		statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("expression"), knownvalue.StringFunc(func(v string) error {
+			if !strings.Contains(v, "authorization") {
+				return fmt.Errorf("expected expression to contain 'authorization', got: %s", v)
+			}
+			// Verify the expression doesn't contain escaped newlines (would indicate corruption)
+			if strings.Contains(v, "\\n") {
+				return fmt.Errorf("expression contains escaped newlines (\\n), indicating heredoc was corrupted. Got: %s", v)
+			}
+			// Verify it contains proper newlines and formatting
+			if !strings.Contains(v, "\n") {
+				return fmt.Errorf("expression should contain actual newlines for proper heredoc format, got: %s", v)
+			}
+			return nil
+		})),
 	})
 
 	resource.Test(t, resource.TestCase{

--- a/internal/services/ruleset/testdata/migrations/complex_heredoc_ratelimit_v4.tf
+++ b/internal/services/ruleset/testdata/migrations/complex_heredoc_ratelimit_v4.tf
@@ -1,0 +1,27 @@
+resource "cloudflare_ruleset" "%[2]s" {
+  account_id  = "%[1]s"
+  kind        = "zone"
+  name        = "Complex Heredoc Test %[2]s"
+  phase       = "http_ratelimit"
+  description = "Test complex heredoc with ratelimit"
+  
+  rules {
+    action      = "log"
+    description = "Log rate limit with complex expression"
+    enabled     = true
+    expression  = <<-EOF
+      not (
+        any(http.request.headers["authorization"][*] contains "sess-")
+        or any(http.request.headers["authorization"][*] contains "sk-")
+        or http.cookie contains "__Secure-next-auth."
+      )
+      and not http.user_agent eq "Stripe/1.0 (+https://stripe.com/docs/webhooks)"
+    EOF
+    ratelimit {
+      characteristics     = ["cf.unique_visitor_id", "cf.colo.id"]
+      mitigation_timeout  = 3600
+      period              = 10
+      requests_per_period = 1000
+    }
+  }
+}

--- a/internal/services/ruleset/testdata/migrations/complex_multiple_rules_ratelimit_v4.tf
+++ b/internal/services/ruleset/testdata/migrations/complex_multiple_rules_ratelimit_v4.tf
@@ -1,0 +1,70 @@
+resource "cloudflare_ruleset" "%[2]s" {
+  account_id  = "%[1]s"
+  kind        = "zone"
+  name        = "Global rate limit %[2]s"
+  phase       = "http_ratelimit"
+  description = "Test multiple rules with ratelimit"
+  
+  rules {
+    action      = "log"
+    description = "Log Global rate limit 1000/10s non authenticated"
+    enabled     = true
+    expression  = <<-EOF
+      not (
+        any(http.request.headers["authorization"][*] contains "sess-")
+        or any(http.request.headers["authorization"][*] contains "sk-")
+        or http.cookie contains "__Secure-next-auth."
+      )
+      and not http.user_agent eq "Stripe/1.0 (+https://stripe.com/docs/webhooks)"
+    EOF
+    ratelimit {
+      characteristics     = ["cf.unique_visitor_id", "cf.colo.id"]
+      mitigation_timeout  = 3600
+      period              = 10
+      requests_per_period = 1000
+    }
+  }
+  
+  rules {
+    action      = "log"
+    description = "Log Global rate limit 2500/1m non authenticated"
+    enabled     = true
+    expression  = <<-EOF
+      not (
+        any(http.request.headers["authorization"][*] contains "sess-")
+        or any(http.request.headers["authorization"][*] contains "sk-")
+        or http.cookie contains "__Secure-next-auth."
+      )
+      and not http.user_agent eq "Stripe/1.0 (+https://stripe.com/docs/webhooks)"
+    EOF
+    ratelimit {
+      characteristics     = ["cf.unique_visitor_id", "cf.colo.id"]
+      mitigation_timeout  = 3600
+      period              = 60
+      requests_per_period = 2500
+    }
+  }
+  
+  rules {
+    action      = "log"
+    description = "Log Unauthed rate limit DDoS User Agents"
+    enabled     = true
+    expression  = <<-EOF
+      (
+        (http.user_agent eq "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36")
+        or (http.user_agent eq "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36")
+      )
+      and not (
+        any(http.request.headers["authorization"][*] contains "sess-")
+        or any(http.request.headers["authorization"][*] contains "sk-")
+        or http.cookie contains "__Secure-next-auth."
+      )
+    EOF
+    ratelimit {
+      characteristics     = ["ip.src", "cf.colo.id"]
+      mitigation_timeout  = 300
+      period              = 10
+      requests_per_period = 300
+    }
+  }
+}

--- a/internal/services/ruleset/testdata/migrations/expression_double_dollar_v4.tf
+++ b/internal/services/ruleset/testdata/migrations/expression_double_dollar_v4.tf
@@ -1,0 +1,78 @@
+locals {
+  disallowed_regions_expression = "ip.geoip.country in {\"CN\" \"RU\" \"IR\"}"
+}
+
+variable "android_chat_openai_com_domain" {
+  type    = string
+  default = "android-chat.openai.com"
+}
+
+variable "ios_chat_openai_com_domain" {
+  type    = string
+  default = "ios-chat.openai.com"
+}
+
+variable "api_chatgpt_com_domain" {
+  type    = string
+  default = "api.chatgpt.com"
+}
+
+variable "api_openai_com_domain" {
+  type    = string
+  default = "api.openai.com"
+}
+
+variable "auth_openai_com_domain" {
+  type    = string
+  default = "auth.openai.com"
+}
+
+resource "cloudflare_ruleset" "%[2]s" {
+  zone_id     = "%[1]s"
+  name        = "Disallowed Countries %[2]s"
+  description = "Test ruleset for expression double dollar issue"
+  kind        = "zone"
+  phase       = "http_request_firewall_custom"
+
+  # Rule with complex heredoc expression containing multiple variables
+  rules {
+    action = "block"
+    action_parameters {
+      response {
+        content = jsonencode({
+          error = {
+            message = "Country, region, or territory not supported"
+            type    = "request_forbidden"
+            param   = null
+            code    = "unsupported_country_region_territory"
+          }
+        })
+        content_type = "application/json"
+        status_code  = 403
+      }
+    }
+    description = "Block API traffic from disallowed countries"
+    enabled     = true
+    expression  = <<EOF
+    ${local.disallowed_regions_expression}
+    and (
+      (cf.zone.name in {"${var.android_chat_openai_com_domain}" "${var.ios_chat_openai_com_domain}" "${var.api_chatgpt_com_domain}" "${var.api_openai_com_domain}"})
+      or
+      (
+        (cf.zone.name eq "${var.auth_openai_com_domain}") and
+        (http.request.uri.path matches "^/(api|oauth)/.*")
+      )
+    )
+    EOF
+  }
+
+  # Rule with simple heredoc expression
+  rules {
+    action = "log"
+    expression = <<EOF
+    ${local.disallowed_regions_expression}
+    EOF
+    description = "Log simple condition"
+    enabled = true
+  }
+}

--- a/internal/services/ruleset/testdata/migrations/literal_expression_double_dollar_v4.tf
+++ b/internal/services/ruleset/testdata/migrations/literal_expression_double_dollar_v4.tf
@@ -1,0 +1,16 @@
+resource "cloudflare_ruleset" "%[2]s" {
+  zone_id = "%[1]s"
+  name    = "Literal Expression Test %[2]s"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+
+  rules {
+    action = "block"
+    expression = <<EOF
+    ip.geoip.country eq "CN" and
+    http.host eq "example.com"
+    EOF
+    description = "Literal heredoc test"
+    enabled = true
+  }
+}

--- a/internal/services/ruleset/testdata/migrations/simple_expression_double_dollar_v4.tf
+++ b/internal/services/ruleset/testdata/migrations/simple_expression_double_dollar_v4.tf
@@ -1,0 +1,19 @@
+locals {
+  test_expression = "ip.geoip.country eq \"CN\""
+}
+
+resource "cloudflare_ruleset" "%[2]s" {
+  zone_id = "%[1]s"
+  name    = "Simple Expression Test %[2]s"
+  phase   = "http_request_firewall_custom"
+  kind    = "zone"
+
+  rules {
+    action = "block"
+    expression = <<EOF
+    ${local.test_expression}
+    EOF
+    description = "Simple heredoc test"
+    enabled = true
+  }
+}


### PR DESCRIPTION
- Add special post-processing to restore escaped heredoc expressions in cloudflare_ruleset resources
- Scope double-dollar-sign fixes to only cloudflare_ruleset resources to avoid breaking variable references in other resources
- Fix 'Unterminated template string' errors during v4 to v5 migration
- Add comprehensive tests for complex ruleset configurations with heredoc expressions and nested ratelimit blocks

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
