### PR TITLE
fix(workers_script): fix `run_worker_first` type mismatch

### DIFF
--- a/internal/services/workers_script/model.go
+++ b/internal/services/workers_script/model.go
@@ -117,12 +117,12 @@ type WorkersScriptMetadataAssetsModel struct {
 }
 
 type WorkersScriptMetadataAssetsConfigModel struct {
-	Headers          types.String    `tfsdk:"headers" json:"_headers,optional"`
-	Redirects        types.String    `tfsdk:"redirects" json:"_redirects,optional"`
-	HTMLHandling     types.String    `tfsdk:"html_handling" json:"html_handling,optional"`
-	NotFoundHandling types.String    `tfsdk:"not_found_handling" json:"not_found_handling,optional"`
-	RunWorkerFirst   *[]types.String `tfsdk:"run_worker_first" json:"run_worker_first,optional"`
-	ServeDirectly    types.Bool      `tfsdk:"serve_directly" json:"serve_directly,optional"`
+	Headers          types.String `tfsdk:"headers" json:"_headers,optional"`
+	Redirects        types.String `tfsdk:"redirects" json:"_redirects,optional"`
+	HTMLHandling     types.String `tfsdk:"html_handling" json:"html_handling,optional"`
+	NotFoundHandling types.String `tfsdk:"not_found_handling" json:"not_found_handling,optional"`
+	RunWorkerFirst   types.Bool   `tfsdk:"run_worker_first" json:"run_worker_first,optional"`
+	ServeDirectly    types.Bool   `tfsdk:"serve_directly" json:"serve_directly,optional"`
 }
 
 type WorkersScriptMetadataBindingsModel struct {


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
This PR fixes an incorrect type in the `cloudflare_workers_script` resource model for the `run_worker_first` attribute that was causing the following error:
```
│ Error: Value Conversion Error
│
│ An unexpected error was encountered trying to convert tftypes.Value into []basetypes.StringValue. This is always an error in the provider.
│ Please report the following to the provider developer:
│ 
│ can't unmarshal tftypes.Bool into *[]tftypes.Value expected []tftypes.Value
```

The resource schema defined the type of the attribute as a boolean, but the model had been incorrectly updated to expect a list of strings.

In the future, both booleans and lists of strings will be accepted (#6178), but this PR fixes the existing support for providing a boolean value.

## Additional context & links
Refs #6182
Refs #5956 