### PR TITLE
docs(list_item): add import documentation

### DIFF
--- a/docs/resources/list_item.md
+++ b/docs/resources/list_item.md
@@ -70,4 +70,10 @@ Optional:
 - `status_code` (Number) Available values: 301, 302, 307, 308.
 - `subpath_matching` (Boolean)
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+$ terraform import cloudflare_list_item.example '<account_id>/<list_id>/<item_id>'
+```

--- a/examples/resources/cloudflare_list_item/import.sh
+++ b/examples/resources/cloudflare_list_item/import.sh
@@ -1,0 +1,1 @@
+$ terraform import cloudflare_list_item.example '<account_id>/<list_id>/<item_id>'

--- a/scripts/generate-docs
+++ b/scripts/generate-docs
@@ -4,6 +4,11 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+# update list item docs to account for custom code
+cat << EOT >> examples/resources/cloudflare_list_item/import.sh
+$ terraform import cloudflare_list_item.example '<account_id>/<list_id>/<item_id>'
+EOT
+
 echo "==> Generating Terraform provider documentation"
 if ! command -v "tfplugindocs" &> /dev/null
 then


### PR DESCRIPTION
List item uses custom code for imports so its invisible to codegen. Since docs are generated automatically, any custom docs changes will be ovewritten with every release.

This patch updates the generator script to first create any missing examples that couldn't be codegen'd, then it runs `tfplugindocs` which ensures that import examples are appended to the generated markdown docs.

Changes:
- adds manual `import.sh` for `cloudflare_list_item`

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged