### PR TITLE
ci(page_rule): disable parallel tests

### DIFF
--- a/scripts/run-ci-tests
+++ b/scripts/run-ci-tests
@@ -83,7 +83,7 @@ declare -a ALL_SERVICES=(
     "resource=./internal/services/notification_policy_webhooks"
     "resource=./internal/services/observatory_scheduled_test"
     "resource=./internal/services/origin_ca_certificate"
-    "resource=./internal/services/page_rule"
+    "resource=./internal/services/page_rule parallel=1"
     "resource=./internal/services/pages_domain"
     "resource=./internal/services/pages_project"
     "resource=./internal/services/queue"


### PR DESCRIPTION
Fixes flaky `page_rule` tests in CI. Parallel tests causes issues with it's strange `priority` behavior.

Changes:
- set `parallel=1` for `page_rule` tests

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
