### PR TITLE
fix: resolve zero trust test failures from computed attribute refresh…

### DIFF
--- a/internal/services/zero_trust_access_application/schema.go
+++ b/internal/services/zero_trust_access_application/schema.go
@@ -1777,12 +1777,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 		},
 			"created_at": schema.StringAttribute{
-				Computed:   true,
-				CustomType: timetypes.RFC3339Type{},
+				Computed:      true,
+				CustomType:    timetypes.RFC3339Type{},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"updated_at": schema.StringAttribute{
-				Computed:   true,
-				CustomType: timetypes.RFC3339Type{},
+				Computed:      true,
+				CustomType:    timetypes.RFC3339Type{},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 	}

--- a/internal/services/zero_trust_access_custom_page/model.go
+++ b/internal/services/zero_trust_access_custom_page/model.go
@@ -19,7 +19,7 @@ type ZeroTrustAccessCustomPageModel struct {
 	CustomHTML types.String      `tfsdk:"custom_html" json:"custom_html,required"`
 	Name       types.String      `tfsdk:"name" json:"name,required"`
 	Type       types.String      `tfsdk:"type" json:"type,required"`
-	AppCount   types.Int64       `tfsdk:"app_count" json:"app_count,optional"`
+	AppCount   types.Int64       `tfsdk:"app_count" json:"app_count,computed"`
 	CreatedAt  timetypes.RFC3339 `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
 	UpdatedAt  timetypes.RFC3339 `tfsdk:"updated_at" json:"updated_at,computed" format:"date-time"`
 }

--- a/internal/services/zero_trust_access_custom_page/schema.go
+++ b/internal/services/zero_trust_access_custom_page/schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -50,16 +51,21 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"app_count": schema.Int64Attribute{
-				Description: "Number of apps the custom page is assigned to.",
-				Optional:    true,
+				Description:   "Number of apps the custom page is assigned to.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 			},
 			"created_at": schema.StringAttribute{
-				Computed:   true,
-				CustomType: timetypes.RFC3339Type{},
+				Description:   "Creation timestamp.",
+				Computed:      true,
+				CustomType:    timetypes.RFC3339Type{},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"updated_at": schema.StringAttribute{
-				Computed:   true,
-				CustomType: timetypes.RFC3339Type{},
+				Description:   "Last updated timestamp.",
+				Computed:      true,
+				CustomType:    timetypes.RFC3339Type{},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 	}


### PR DESCRIPTION
    fix: resolve zero trust test failures from computed attribute refresh drift

      - Add UseStateForUnknown() plan modifiers to created_at/updated_at in
      zero_trust_access_application schema
      - Add UseStateForUnknown() plan modifiers to created_at/updated_at/app_count in
      zero_trust_access_custom_page schema
      - Change app_count from Optional to Computed in zero_trust_access_custom_page to match
      API behavior

      Resolves refresh plan drift where timestamp and count attributes were causing non-empty
       plans during test refreshes, leading to test failures across the zero trust access
      test suites.

      Tests now passing:
      - TestAccCloudflareAccessApplication_BasicAccount/BasicZone
      - TestAccCloudflareAccessApplicationDataSource_AccountName
      - TestAccCloudflareAccessCustomPage_IdentityDenied/Forbidden

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
