### PR TITLE
fix: resolve compilation and schema parity errors across multiple ser…

### DIFF
--- a/internal/services/zero_trust_access_application/plan_modifiers.go
+++ b/internal/services/zero_trust_access_application/plan_modifiers.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 )
 

--- a/internal/services/zero_trust_tunnel_cloudflared_config/model.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_config/model.go
@@ -4,6 +4,7 @@ package zero_trust_tunnel_cloudflared_config
 
 import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -16,7 +17,7 @@ type ZeroTrustTunnelCloudflaredConfigModel struct {
 	ID        types.String                                 `tfsdk:"id" json:"-,computed"`
 	TunnelID  types.String                                 `tfsdk:"tunnel_id" path:"tunnel_id,required"`
 	AccountID types.String                                 `tfsdk:"account_id" path:"account_id,required"`
-	Config    *ZeroTrustTunnelCloudflaredConfigConfigModel `tfsdk:"config" json:"config,optional"`
+	Config    *ZeroTrustTunnelCloudflaredConfigConfigModel `tfsdk:"config" json:"config,computed_optional"`
 	CreatedAt timetypes.RFC3339                            `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
 	Source    types.String                                 `tfsdk:"source" json:"source,computed_optional"`
 	Version   types.Int64                                  `tfsdk:"version" json:"version,computed"`
@@ -87,4 +88,8 @@ type ZeroTrustTunnelCloudflaredConfigConfigOriginRequestAccessModel struct {
 	AUDTag   *[]types.String `tfsdk:"aud_tag" json:"audTag,required"`
 	TeamName types.String    `tfsdk:"team_name" json:"teamName,required"`
 	Required types.Bool      `tfsdk:"required" json:"required,optional"`
+}
+
+type ZeroTrustTunnelCloudflaredConfigConfigWARPRoutingModel struct {
+	Enabled types.Bool `tfsdk:"enabled" json:"enabled,computed"`
 }

--- a/internal/services/zero_trust_tunnel_cloudflared_config/schema.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_config/schema.go
@@ -5,6 +5,7 @@ package zero_trust_tunnel_cloudflared_config
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"


### PR DESCRIPTION
fix: resolve compilation and schema parity errors across multiple services

  - worker_version: fix duplicate imports and correct customfield.NewObject
  usage
  - zero_trust_access_application: remove unused basetypes import
  - zero_trust_tunnel_cloudflared_config: add missing customfield import and
  WARPRoutingModel definition
  - zero_trust_tunnel_cloudflared_config: fix JSON tag mismatches for schema
  parity tests