### PR TITLE
Don't treat `bindings.*.version_id` as a Computed attribute

### DIFF
--- a/internal/services/worker_version/model.go
+++ b/internal/services/worker_version/model.go
@@ -125,7 +125,7 @@ type WorkerVersionBindingsModel struct {
 	NamespaceID                 types.String                        `tfsdk:"namespace_id" json:"namespace_id,computed_optional"`
 	ScriptName                  types.String                        `tfsdk:"script_name" json:"script_name,computed_optional"`
 	OldName                     types.String                        `tfsdk:"old_name" json:"old_name,optional"`
-	VersionID                   types.String                        `tfsdk:"version_id" json:"version_id,computed_optional"`
+	VersionID                   types.String                        `tfsdk:"version_id" json:"version_id,optional"`
 	Json                        types.String                        `tfsdk:"json" json:"json,optional"`
 	CertificateID               types.String                        `tfsdk:"certificate_id" json:"certificate_id,optional"`
 	Text                        types.String                        `tfsdk:"text" json:"text,optional"`
@@ -142,7 +142,7 @@ type WorkerVersionBindingsModel struct {
 	StoreID                     types.String                        `tfsdk:"store_id" json:"store_id,optional"`
 	Algorithm                   jsontypes.Normalized                `tfsdk:"algorithm" json:"algorithm,optional"`
 	Format                      types.String                        `tfsdk:"format" json:"format,optional"`
-	Usages        customfield.Set[types.String]       `tfsdk:"usages" json:"usages,optional"`
+	Usages                      customfield.Set[types.String]       `tfsdk:"usages" json:"usages,optional"`
 	KeyBase64                   types.String                        `tfsdk:"key_base64" json:"key_base64,optional"`
 	KeyJwk                      jsontypes.Normalized                `tfsdk:"key_jwk" json:"key_jwk,optional"`
 	WorkflowName                types.String                        `tfsdk:"workflow_name" json:"workflow_name,optional"`

--- a/internal/services/worker_version/resource_test.go
+++ b/internal/services/worker_version/resource_test.go
@@ -89,7 +89,6 @@ func TestAccCloudflareWorkerVersion_Basic(t *testing.T) {
 					writeContentFile(t, `export default {fetch() {return new Response("Hello World!")}}`)
 				},
 				Config: testAccCloudflareWorkerVersionConfigUpdate(rnd, accountID, contentFile),
-				ExpectNonEmptyPlan: true,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),

--- a/internal/services/worker_version/schema.go
+++ b/internal/services/worker_version/schema.go
@@ -430,9 +430,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"version_id": schema.StringAttribute{
 							Description: `Identifier for the version to inherit the binding from, which can be the version ID or the literal "latest" to inherit from the latest version. Defaults to inheriting the binding from the latest version.`,
-							Computed:    true,
 							Optional:    true,
-							Default:     stringdefault.StaticString("latest"),
 						},
 						"json": schema.StringAttribute{
 							Description: "JSON data to use.",

--- a/internal/services/workers_script/model.go
+++ b/internal/services/workers_script/model.go
@@ -146,11 +146,11 @@ type WorkersScriptMetadataBindingsModel struct {
 	StoreID                     types.String                                `tfsdk:"store_id" json:"store_id,optional"`
 	Algorithm                   jsontypes.Normalized                        `tfsdk:"algorithm" json:"algorithm,optional"`
 	Format                      types.String                                `tfsdk:"format" json:"format,optional"`
-	Usages        customfield.Set[types.String]               `tfsdk:"usages" json:"usages,optional"`
+	Usages                      customfield.Set[types.String]               `tfsdk:"usages" json:"usages,optional"`
 	KeyBase64                   types.String                                `tfsdk:"key_base64" json:"key_base64,optional"`
 	KeyJwk                      jsontypes.Normalized                        `tfsdk:"key_jwk" json:"key_jwk,optional"`
 	WorkflowName                types.String                                `tfsdk:"workflow_name" json:"workflow_name,optional"`
-	VersionID     types.String                                `tfsdk:"version_id" json:"version_id,computed_optional"`
+	VersionID                   types.String                                `tfsdk:"version_id" json:"version_id,optional"`
 	Part                        types.String                                `tfsdk:"part" json:"part,optional"`
 	Namespace                   types.String                                `tfsdk:"namespace" json:"namespace,optional"`
 	Environment                 types.String                                `tfsdk:"environment" json:"environment,optional"`

--- a/internal/services/workers_script/resource.go
+++ b/internal/services/workers_script/resource.go
@@ -240,7 +240,7 @@ func (r *WorkersScriptResource) Read(ctx context.Context, req resource.ReadReque
 
 	bytes, _ := io.ReadAll(res.Body)
 	var service WorkersServiceResultEnvelope
-	err = apijson.UnmarshalComputed(bytes, &service)
+	err = apijson.Unmarshal(bytes, &service)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
@@ -268,7 +268,7 @@ func (r *WorkersScriptResource) Read(ctx context.Context, req resource.ReadReque
 	}
 	bytes, _ = io.ReadAll(res.Body)
 	var metadata WorkersScriptMetadataResultEnvelope
-	err = apijson.UnmarshalComputed(bytes, &metadata)
+	err = apijson.Unmarshal(bytes, &metadata)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return

--- a/internal/services/workers_script/resource_test.go
+++ b/internal/services/workers_script/resource_test.go
@@ -120,7 +120,7 @@ func TestAccCloudflareWorkerScript_ServiceWorker(t *testing.T) {
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"startup_time_ms", "bindings.0.version_id", "bindings.1.version_id"},
+				ImportStateVerifyIgnore: []string{"startup_time_ms"},
 			},
 		},
 	})
@@ -143,7 +143,6 @@ func TestAccCloudflareWorkerScript_ModuleUpload(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckCloudflareWorkerScriptUploadModule(rnd, accountID),
-				ExpectNonEmptyPlan: true,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("script_name"), knownvalue.StringExact(rnd)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("content"), knownvalue.StringExact(moduleContent)),
@@ -178,7 +177,7 @@ func TestAccCloudflareWorkerScript_ModuleUpload(t *testing.T) {
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"bindings.2", "bindings.#", "main_module", "startup_time_ms", "bindings.0.version_id", "bindings.1.version_id", "bindings.2.version_id", "observability.%", "observability.enabled", "observability.head_sampling_rate"},
+				ImportStateVerifyIgnore: []string{"bindings.2", "bindings.#", "main_module", "startup_time_ms"},
 			},
 		},
 	})

--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -355,8 +355,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"version_id": schema.StringAttribute{
 							Description: `Identifier for the version to inherit the binding from, which can be the version ID or the literal "latest" to inherit from the latest version. Defaults to inheriting the binding from the latest version.`,
 							Optional:    true,
-							Computed:    true,
-							Default:     stringdefault.StaticString("latest"),
 						},
 						"allowed_destination_addresses": schema.ListAttribute{
 							Description: "List of allowed destination addresses.",


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
RE: `cloudflare_workers_script` and `cloudflare_worker_version`

The `version_id` binding property is only relevant to bindings of type `inherit`, which allow a user to specify a binding whose value should be copied from another version. If `version_id` is unspecified on an inherit binding, it's assumed to be `latest` by default As a result, the attribute was codegen'd to be Computed and have a `Default` value. 

However, `inherit` bindings are only valid in the context of a request and will never be returned by the API. Thus, it doesn't make sense for this attribute to be Computed (or have a default).

This PR fixes the schema and model of these resources to treat this attribute as purely Optional, and reverts some previous changes intended to work around the test failures this attribute was causing.

cc @tamas-jozsa 

## Additional context & links
Refs #6234
