### PR TITLE
bug(cloudflare_list): don't explicitly import nested items

### DIFF
--- a/internal/services/list/resource.go
+++ b/internal/services/list/resource.go
@@ -309,22 +309,6 @@ func (r *ListResource) ImportState(ctx context.Context, req resource.ImportState
 	}
 	data = &env.Result
 
-	itemsSet, diags := getAllListItems[ListItemModel](ctx, r.client, data.AccountID.ValueString(), data.ID.ValueString(), "")
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	var items customfield.NestedObjectSet[ListItemModel]
-
-	if len(itemsSet) == 0 {
-		items = customfield.NullObjectSet[ListItemModel](ctx)
-	} else {
-		items, diags = customfield.NewObjectSet[ListItemModel](ctx, itemsSet)
-		resp.Diagnostics.Append(diags...)
-	}
-	data.Items = items
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/services/list/resource_test.go
+++ b/internal/services/list/resource_test.go
@@ -583,6 +583,67 @@ func TestAccCloudflareListWithItems_Redirect(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareList_ImportWithSeparateListItem(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
+	resourceNameList := fmt.Sprintf("cloudflare_list.%s", listName)
+	resourceNameItem := fmt.Sprintf("cloudflare_list_item.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	var listItemID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareListWithIpListItem(rnd, listName, rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameList, "account_id", accountID),
+					resource.TestCheckResourceAttr(resourceNameList, "name", listName),
+					resource.TestCheckResourceAttr(resourceNameList, "kind", "ip"),
+					resource.TestCheckNoResourceAttr(resourceNameList, "items"),
+					resource.TestCheckResourceAttr(resourceNameItem, "ip", "1.1.1.1"),
+					func(state *terraform.State) error {
+						listItemID = state.RootModule().Resources[resourceNameItem].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				ImportState:  true,
+				ResourceName: resourceNameList,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameList].Primary.ID), nil
+				},
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"modified_on", "num_items"},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameList, "account_id", accountID),
+					resource.TestCheckResourceAttr(resourceNameList, "name", listName),
+					resource.TestCheckResourceAttr(resourceNameList, "kind", "ip"),
+
+					// Verify nested items are not populated during import
+					resource.TestCheckNoResourceAttr(resourceNameList, "items"),
+					// Verify the separate list item still exists
+					resource.TestCheckResourceAttr(resourceNameItem, "ip", "1.1.1.1"),
+					testAccCheckCloudflareListItemExists(resourceNameItem, accountID),
+					func(state *terraform.State) error {
+						id := state.RootModule().Resources[resourceNameItem].Primary.ID
+						if id != listItemID {
+							return errors.New("list item id does not match")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCloudflareList(resourceName, listName, description, accountID, kind string) string {
 	return acctest.LoadTestCase("list.tf", resourceName, listName, description, accountID, kind)
 }
@@ -605,6 +666,39 @@ func testAccCheckCloudflareListWithRedirectItems(resourceName, listName, descrip
 
 func testAccCheckCloudflareListDataSource(resourceName, accountID, listName, description, kind string) string {
 	return acctest.LoadTestCase("listdatasource.tf", resourceName, accountID, listName, description, kind)
+}
+
+func testAccCheckCloudflareListWithIpListItem(resourceName, listName, description, accountID string) string {
+	return acctest.LoadTestCase("listwithiplistitem.tf", resourceName, listName, description, accountID)
+}
+
+func testAccCheckCloudflareListItemExists(resourceName, accountID string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("list item ID is not set")
+		}
+
+		listID := rs.Primary.Attributes["list_id"]
+		if listID == "" {
+			return fmt.Errorf("list ID is not set on list item")
+		}
+
+		client := acctest.SharedClient()
+		ctx := context.Background()
+
+		// Make direct API call to verify the list item exists
+		_, err := client.Rules.Lists.Items.Get(ctx, listID, rs.Primary.ID, rules.ListItemGetParams{AccountID: cloudflare.F(accountID)})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
 }
 
 func checkListAndPopulate(resourceName string, list *rules.ListsList) func(*terraform.State) error {

--- a/internal/services/list/testdata/listwithiplistitem.tf
+++ b/internal/services/list/testdata/listwithiplistitem.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_list" "%[2]s" {
+  account_id  = "%[4]s"
+  name        = "%[2]s"
+  kind        = "ip"
+}
+
+resource "cloudflare_list_item" "%[1]s" {
+  account_id = "%[4]s"
+  list_id    = cloudflare_list.%[2]s.id
+  ip         = "1.1.1.1"
+  comment    = "Test item for import test"
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Currently we explicitly import any existing list items into the nested `items` property for `cloudflare_list`.

This causes the next Terraform plan, for a list with no `items` set, to think that `cloudflare_list.items` is going from a set containing items to a null set. Which will cause it to remove all existing items.


## Additional context & links


Because we want to maintain compatibility with `cloudflare_list_item` we should not import the nested items. Instead when a Terraform plan is run the `Read` method will determine whether to read the nested items into state based on whether `items` was configured or is null.