### PR TITLE
feat: modernize zero_trust_tunnel_cloudflared_virtual_network tests a…

### DIFF
--- a/internal/services/zero_trust_tunnel_cloudflared_virtual_network/resource_test.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_virtual_network/resource_test.go
@@ -8,13 +8,17 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -60,6 +64,26 @@ func testSweepCloudflareTunnelVirtualNetwork(r string) error {
 	return nil
 }
 
+func testAccCheckCloudflareTunnelVirtualNetworkDestroy(s *terraform.State) error {
+	client := acctest.SharedClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" {
+			continue
+		}
+
+		accountID := rs.Primary.Attributes[consts.AccountIDSchemaKey]
+		_, err := client.ZeroTrust.Networks.VirtualNetworks.Get(context.Background(), rs.Primary.ID, zero_trust.NetworkVirtualNetworkGetParams{
+			AccountID: cloudflare.F(accountID),
+		})
+		if err == nil {
+			return fmt.Errorf("tunnel virtual network still exists")
+		}
+	}
+
+	return nil
+}
+
 func TestAccCloudflareTunnelVirtualNetwork_Basic(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_zero_trust_tunnel_cloudflared_virtual_network.%s", rnd)
@@ -71,14 +95,16 @@ func TestAccCloudflareTunnelVirtualNetwork_Basic(t *testing.T) {
 			acctest.TestAccPreCheck_AccountID(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareTunnelVirtualNetworkDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudflareTunnelVirtualNetworkSimple(rnd, rnd, accountID, rnd, false),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "name", rnd),
-					resource.TestCheckResourceAttr(name, "comment", rnd),
-					resource.TestCheckResourceAttr(name, "is_default_network", "false"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("comment"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("is_default_network"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+				},
 			},
 			// Update
 			{
@@ -103,11 +129,12 @@ func TestAccCloudflareTunnelVirtualNetwork_Basic(t *testing.T) {
 						),
 					},
 				},
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "name", rnd),
-					resource.TestCheckResourceAttr(name, "comment", rnd+"-updated"),
-					resource.TestCheckResourceAttr(name, "is_default_network", "false"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("comment"), knownvalue.StringExact(rnd+"-updated")),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("is_default_network"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+				},
 			},
 			// Re-applying same change does not produce drift
 			{
@@ -129,6 +156,52 @@ func TestAccCloudflareTunnelVirtualNetwork_Basic(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareTunnelVirtualNetwork_Minimal(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_zero_trust_tunnel_cloudflared_virtual_network.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareTunnelVirtualNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareTunnelVirtualNetworkMinimal(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("comment"), knownvalue.StringExact("")), // Default value
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("is_default_network"), knownvalue.Bool(false)), // Default value
+					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("created_at"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("deleted_at"), knownvalue.Null()),
+				},
+			},
+			{
+				ResourceName:        name,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
+
 func testAccCloudflareTunnelVirtualNetworkSimple(ID, comment, accountID, name string, isDefault bool) string {
 	return acctest.LoadTestCase("tunnelvirtualnetworksimple.tf", ID, comment, accountID, name, isDefault)
 }
+
+func testAccCloudflareTunnelVirtualNetworkMinimal(name, accountID string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "%s" {
+	account_id = "%s"
+	name       = "%s"
+}`, name, accountID, name)
+}
+
+


### PR DESCRIPTION
## Summary
  - Modernized `zero_trust_tunnel_cloudflared_virtual_network` acceptance tests
  to use latest Terraform testing patterns
  - Added proper resource destruction verification
  - Enhanced test coverage with additional test scenarios

  ## Key Changes
  - **Test Modernization**: Replaced legacy `resource.TestCheckResourceAttr` with
   modern `ConfigStateChecks` using `statecheck.ExpectKnownValue()`
  - **CheckDestroy Addition**: Added
  `testAccCheckCloudflareTunnelVirtualNetworkDestroy` function to verify resource
   cleanup
  - **Enhanced Coverage**: Added `TestAccCloudflareTunnelVirtualNetwork_Minimal`
  test case for required-only attributes
  - **State Validation**: Added comprehensive checks for computed attributes like
   `created_at`, `deleted_at`, and `id`

  ## Test Coverage Improvements
  - **Minimal Configuration Test**: Validates default values and computed
  attributes when only required fields are provided
  - **Type-Safe Assertions**: Used `knownvalue.StringExact()`,
  `knownvalue.Bool()`, `knownvalue.NotNull()`, and `knownvalue.Null()` for robust
   validation
  - **Import Testing**: Added proper import verification to new test cases
  - **Plan Validation**: Maintained existing `ConfigPlanChecks` for update
  scenarios

  ## Technical Details
  The existing test was partially modernized but missing proper destroy
  verification and comprehensive coverage. This update brings it fully up to
  modern Terraform testing standards while ensuring all optional attributes and
  computed fields are properly validated.