### PR TITLE
chore: only sweep pages projects resources created during testing

### DIFF
--- a/internal/services/pages_project/testdata/pagesprojectbuildconfig.tf
+++ b/internal/services/pages_project/testdata/pagesprojectbuildconfig.tf
@@ -1,15 +1,13 @@
-
-		resource "cloudflare_pages_project" "%[1]s" {
-		  account_id = "%[2]s"
-		  name = "%[1]s"
-		  production_branch = "main"
-		  build_config = {
-  build_caching = true
-			build_command = "npm run build"
-			destination_dir = "build"
-			root_dir = "/"
-			web_analytics_tag = "cee1c73f6e4743d0b5e6bb1a0bcaabcc"
-			web_analytics_token = "021e1057c18547eca7b79f2516f06o7x"
+resource "cloudflare_pages_project" "%[1]s" {
+	account_id = "%[2]s"
+	name = "%[3]s"
+	production_branch = "main"
+	build_config = {
+		build_caching = true
+		build_command = "npm run build"
+		destination_dir = "build"
+		root_dir = "/"
+		web_analytics_tag = "cee1c73f6e4743d0b5e6bb1a0bcaabcc"
+		web_analytics_token = "021e1057c18547eca7b79f2516f06o7x"
+	}
 }
-		}
-		

--- a/internal/services/pages_project/testdata/pagesprojectdeploymentconfig.tf
+++ b/internal/services/pages_project/testdata/pagesprojectdeploymentconfig.tf
@@ -1,4 +1,3 @@
-
 resource "cloudflare_pages_project" "%[1]s" {
   account_id        = "%[2]s"
   name              = "%[3]s"

--- a/internal/services/pages_project/testdata/pagesprojectdirectupload.tf
+++ b/internal/services/pages_project/testdata/pagesprojectdirectupload.tf
@@ -1,8 +1,5 @@
-
-		resource "cloudflare_pages_project" "%[1]s" {
-		  account_id = "%[2]s"
-		  name = "%[1]s"
-		  production_branch = "main"
-		}
-
-		
+resource "cloudflare_pages_project" "%[1]s" {
+	account_id = "%[2]s"
+	name = "%[3]s"
+	production_branch = "main"
+}

--- a/internal/services/pages_project/testdata/pagesprojectenvvars.tf
+++ b/internal/services/pages_project/testdata/pagesprojectenvvars.tf
@@ -1,34 +1,33 @@
-		resource "cloudflare_pages_project" "%[1]s" {
-		  account_id = "%[2]s"
-		  name = "%[1]s"
-		  production_branch = "main"
-		  
-		  deployment_configs = {
-			preview = {
-			  env_vars = {
+resource "cloudflare_pages_project" "%[1]s" {
+	account_id = "%[2]s"
+	name = "%[3]s"
+	production_branch = "main"
+	
+	deployment_configs = {
+		preview = {
+			env_vars = {
 				PLAIN_TEXT_VAR = {
-				  type = "plain_text"
-				  value = "plain-text-value"
+					type = "plain_text"
+					value = "plain-text-value"
 				}
 				SECRET_VAR = {
-				  type = "secret_text" 
-				  value = "secret-value-123"
+					type = "secret_text" 
+					value = "secret-value-123"
 				}
-			  }
 			}
-			
-			production = {
-			  env_vars = {
+		}
+	
+		production = {
+			env_vars = {
 				PROD_PLAIN = {
-				  type = "plain_text"
-				  value = "production-plain"
+					type = "plain_text"
+					value = "production-plain"
 				}
 				PROD_SECRET = {
-				  type = "secret_text"
-				  value = "production-secret-456"
+					type = "secret_text"
+					value = "production-secret-456"
 				}
-			  }
 			}
-		  }
 		}
-		
+	}
+}

--- a/internal/services/pages_project/testdata/pagesprojectfullconfig.tf
+++ b/internal/services/pages_project/testdata/pagesprojectfullconfig.tf
@@ -1,143 +1,142 @@
-		resource "cloudflare_pages_project" "%[1]s" {
-		  account_id = "%[2]s"
-		  name = "%[1]s"
-		  production_branch = "main"
-		  
-		  build_config = {
-			build_caching = true
-			build_command = "npm run build"
-			destination_dir = "dist"
-			root_dir = "/app"
-			web_analytics_tag = "test-tag-123"
-			web_analytics_token = "test-token-456"
-		  }
+resource "cloudflare_pages_project" "%[1]s" {
+	account_id = "%[2]s"
+	name = "%[3]s"
+	production_branch = "main"
+	
+	build_config = {
+		build_caching = true
+		build_command = "npm run build"
+		destination_dir = "dist"
+		root_dir = "/app"
+		web_analytics_tag = "test-tag-123"
+		web_analytics_token = "test-token-456"
+	}
 
-		  deployment_configs = {
-			preview = {
-			  compatibility_date = "2023-01-15"
-			  compatibility_flags = ["preview_flag_1", "preview_flag_2"]
-			  
-			  env_vars = {
+	deployment_configs = {
+		preview = {
+			compatibility_date = "2023-01-15"
+			compatibility_flags = ["preview_flag_1", "preview_flag_2"]
+			
+			env_vars = {
 				ENVIRONMENT = {
-				  type = "plain_text"
-				  value = "preview"
+					type = "plain_text"
+					value = "preview"
 				}
 				SECRET_KEY = {
-				  type = "secret_text"
-				  value = "preview-secret-123"
+					type = "secret_text"
+					value = "preview-secret-123"
 				}
-			  }
-			  
-			  kv_namespaces = {
-				KV_PREVIEW = {
-				  namespace_id = "preview-kv-namespace-id"
-				}
-			  }
-			  
-			  d1_databases = {
-				D1_PREVIEW = {
-				  id = "preview-d1-database-id"
-				}
-			  }
-			  
-			  r2_buckets = {
-				R2_PREVIEW = {
-				  name = "preview-bucket"
-				  jurisdiction = "us"
-				}
-			  }
-			  
-			  ai_bindings = {
-				AI_PREVIEW = {
-				  project_id = "preview-ai-project-id"
-				}
-			  }
-			  
-			  analytics_engine_datasets = {
-				ANALYTICS_PREVIEW = {
-				  dataset = "preview-analytics-dataset"
-				}
-			  }
-			  
-			  browsers = {
-				BROWSER_PREVIEW = {}
-			  }
-			  
-			  hyperdrive_bindings = {
-				HYPERDRIVE_PREVIEW = {
-				  id = "preview-hyperdrive-id"
-				}
-			  }
-			  
-			  mtls_certificates = {
-				MTLS_PREVIEW = {
-				  certificate_id = "preview-mtls-cert-id"
-				}
-			  }
-			  
-			  queue_producers = {
-				QUEUE_PREVIEW = {
-				  name = "preview-queue"
-				}
-			  }
-			  
-			  services = {
-				SERVICE_PREVIEW = {
-				  service = "preview-service"
-				  environment = "preview"
-				  entrypoint = "main"
-				}
-			  }
-			  
-			  vectorize_bindings = {
-				VECTORIZE_PREVIEW = {
-				  index_name = "preview-vector-index"
-				}
-			  }
-			  
-			  placement = {
-				mode = "smart"
-			  }
 			}
 			
-			production = {
-			  compatibility_date = "2023-01-16"
-			  compatibility_flags = ["production_flag"]
-			  
-			  env_vars = {
-				ENVIRONMENT = {
-				  type = "plain_text"
-				  value = "production"
+			kv_namespaces = {
+				KV_PREVIEW = {
+					namespace_id = "preview-kv-namespace-id"
 				}
-			  }
-			  
-			  kv_namespaces = {
-				KV_PROD = {
-				  namespace_id = "prod-kv-namespace-id"
+			}
+			
+			d1_databases = {
+				D1_PREVIEW = {
+					id = "preview-d1-database-id"
 				}
-			  }
-			  
-			  placement = {
+			}
+			
+			r2_buckets = {
+				R2_PREVIEW = {
+					name = "preview-bucket"
+					jurisdiction = "us"
+				}
+			}
+			
+			ai_bindings = {
+				AI_PREVIEW = {
+					project_id = "preview-ai-project-id"
+				}
+			}
+			
+			analytics_engine_datasets = {
+				ANALYTICS_PREVIEW = {
+					dataset = "preview-analytics-dataset"
+				}
+			}
+				
+			browsers = {
+				BROWSER_PREVIEW = {}
+			}
+			
+			hyperdrive_bindings = {
+				HYPERDRIVE_PREVIEW = {
+					id = "preview-hyperdrive-id"
+				}
+			}
+			
+			mtls_certificates = {
+				MTLS_PREVIEW = {
+					certificate_id = "preview-mtls-cert-id"
+				}
+			}
+			
+			queue_producers = {
+				QUEUE_PREVIEW = {
+					name = "preview-queue"
+				}
+			}
+			
+			services = {
+				SERVICE_PREVIEW = {
+					service = "preview-service"
+					environment = "preview"
+					entrypoint = "main"
+				}
+			}
+			
+			vectorize_bindings = {
+				VECTORIZE_PREVIEW = {
+					index_name = "preview-vector-index"
+				}
+			}
+			
+			placement = {
 				mode = "smart"
-			  }
 			}
-		  }
-
-		  source = {
-			type = "github"
-			config = {
-			  owner = "%[3]s"
-			  repo_name = "%[4]s"
-			  production_branch = "main"
-			  pr_comments_enabled = true
-			  deployments_enabled = true
-			  production_deployment_enabled = true
-			  preview_deployment_setting = "all"
-			  path_includes = ["src/**", "public/**"]
-			  path_excludes = ["*.test.js", "node_modules/**"]
-			  preview_branch_includes = ["dev", "staging"]
-			  preview_branch_excludes = ["main"]
-			}
-		  }
 		}
 		
+		production = {
+			compatibility_date = "2023-01-16"
+			compatibility_flags = ["production_flag"]
+			
+			env_vars = {
+				ENVIRONMENT = {
+					type = "plain_text"
+					value = "production"
+				}
+			}
+			
+			kv_namespaces = {
+				KV_PROD = {
+					namespace_id = "prod-kv-namespace-id"
+				}
+			}
+			
+			placement = {
+				mode = "smart"
+			}
+		}
+	}
+
+	source = {
+		type = "github"
+		config = {
+			owner = "%[3]s"
+			repo_name = "%[4]s"
+			production_branch = "main"
+			pr_comments_enabled = true
+			deployments_enabled = true
+			production_deployment_enabled = true
+			preview_deployment_setting = "all"
+			path_includes = ["src/**", "public/**"]
+			path_excludes = ["*.test.js", "node_modules/**"]
+			preview_branch_includes = ["dev", "staging"]
+			preview_branch_excludes = ["main"]
+		}
+	}
+}

--- a/internal/services/pages_project/testdata/pagesprojectminimal.tf
+++ b/internal/services/pages_project/testdata/pagesprojectminimal.tf
@@ -1,6 +1,5 @@
-		resource "cloudflare_pages_project" "%[1]s" {
-		  account_id = "%[2]s"
-		  name = "%[1]s"
-		  production_branch = "main"
-		}
-		
+resource "cloudflare_pages_project" "%[1]s" {
+	account_id = "%[2]s"
+	name = "%[3]s"
+	production_branch = "main"
+}

--- a/internal/services/pages_project/testdata/pagesprojectpreviewsettings.tf
+++ b/internal/services/pages_project/testdata/pagesprojectpreviewsettings.tf
@@ -1,17 +1,16 @@
-		resource "cloudflare_pages_project" "%[1]s" {
-		  account_id = "%[2]s"
-		  name = "%[1]s"
-		  production_branch = "main"
-		  
-		  source = {
-			type = "github"
-			config = {
-			  owner = "%[3]s"
-			  repo_name = "%[4]s"
-			  production_branch = "main"
-			  preview_deployment_setting = "%[5]s"
-			  %[6]s
-			}
-		  }
+resource "cloudflare_pages_project" "%[1]s" {
+	account_id = "%[2]s"
+	name = "%[3]s"
+	production_branch = "main"
+	
+	source = {
+		type = "github"
+		config = {
+			owner = "%[3]s"
+			repo_name = "%[4]s"
+			production_branch = "main"
+			preview_deployment_setting = "%[5]s"
+			%[6]s
 		}
-		
+	}
+}

--- a/internal/services/pages_project/testdata/pagesprojectsource.tf
+++ b/internal/services/pages_project/testdata/pagesprojectsource.tf
@@ -1,21 +1,19 @@
-
-		resource "cloudflare_pages_project" "%[1]s" {
-		  account_id = "%[2]s"
-		  name = "%[1]s"
-		  production_branch = "main"
-		  source = [{
-			type = "github"
-			config = [{
-				owner = "%[4]s"
-				repo_name = "%[5]s"
-				production_branch = "main"
-				pr_comments_enabled = true
-				deployments_enabled = true
-				production_deployment_enabled = true
-				preview_deployment_setting = "custom"
-				preview_branch_includes = ["dev","preview"]
-				preview_branch_excludes = ["main", "prod"]
-			}]
-		  }]
-		}
-		
+resource "cloudflare_pages_project" "%[1]s" {
+	account_id = "%[2]s"
+	name = "%[3]s"
+	production_branch = "main"
+	source = [{
+		type = "github"
+		config = [{
+			owner = "%[4]s"
+			repo_name = "%[5]s"
+			production_branch = "main"
+			pr_comments_enabled = true
+			deployments_enabled = true
+			production_deployment_enabled = true
+			preview_deployment_setting = "custom"
+			preview_branch_includes = ["dev","preview"]
+			preview_branch_excludes = ["main", "prod"]
+		}]
+	}]
+}

--- a/internal/services/pages_project/testdata/pagesprojectupdated.tf
+++ b/internal/services/pages_project/testdata/pagesprojectupdated.tf
@@ -1,37 +1,36 @@
-		resource "cloudflare_pages_project" "%[1]s" {
-		  account_id = "%[2]s"
-		  name = "%[1]s"
-		  production_branch = "develop"
-		  
-		  build_config = {
-			build_caching = false
-			build_command = "yarn build"
-			destination_dir = "build"
-			root_dir = "/"
-		  }
+resource "cloudflare_pages_project" "%[1]s" {
+	account_id = "%[2]s"
+	name = "%[3]s"
+	production_branch = "develop"
+	
+	build_config = {
+		build_caching = false
+		build_command = "yarn build"
+		destination_dir = "build"
+		root_dir = "/"
+	}
 
-		  deployment_configs = {
-			preview = {
-			  compatibility_date = "2023-06-01"
-			  
-			  env_vars = {
-				UPDATED_VAR = {
-				  type = "plain_text"
-				  value = "updated-value"
-				}
-			  }
-			}
+	deployment_configs = {
+		preview = {
+			compatibility_date = "2023-06-01"
 			
-			production = {
-			  compatibility_date = "2023-06-01"
-			  
-			  env_vars = {
-				PROD_UPDATED = {
-				  type = "secret_text"
-				  value = "updated-secret"
+			env_vars = {
+				UPDATED_VAR = {
+					type = "plain_text"
+					value = "updated-value"
 				}
-			  }
 			}
-		  }
 		}
-		
+	
+		production = {
+			compatibility_date = "2023-06-01"
+			
+			env_vars = {
+				PROD_UPDATED = {
+					type = "secret_text"
+					value = "updated-secret"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Instead of sweeping all Pages projects on the account, we should only delete ones with a test prefix just to be safe in case the acceptance tests were run using an account not strictly used for testing.

## Additional context & links
