### PR TITLE
Fix Account Member policies acceptance test by selecting the correct account-scoped resource group

### DIFF
--- a/internal/services/account_member/testdata/cloudflareaccountmemberpoliciesconfig.tf
+++ b/internal/services/account_member/testdata/cloudflareaccountmemberpoliciesconfig.tf
@@ -1,18 +1,20 @@
 data "cloudflare_resource_groups" "example_resource_groups" {
-  account_id = "%s"
+  account_id = "%[1]s"
+  name       = "com.cloudflare.api.account.%[1]s"
 }
 
-resource "cloudflare_account_member" "%s" {
-  account_id = "%s"
-  email      = "%s"
+resource "cloudflare_account_member" "%[2]s" {
+  account_id = "%[3]s"
+  email      = "%[4]s"
   status     = "pending"
   policies = [{
     access = "allow"
     permission_groups = [{
-      id = "%s"
+      id = "%[5]s"
     }]
     resource_groups = [{
       id = data.cloudflare_resource_groups.example_resource_groups.result[0].id
     }]
   }]
 }
+


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
The account_member TestAccCloudflareAccountMember_Policies test fails locally with the following error: 

```
  | POST
  | "https://api.cloudflare.com/client/v4/accounts/a67e14daa5f8dceeb91fe5449ba496eb/members":
  | 400 Bad Request
  | {"result":[],"success":false,"errors":[{"code":1006,"message":"Unknown error
  | when processing member, please try again. Error: invalid permission group and
  | resource group combination"}],"messages":[]}
```
After digging into the issue, the tests were failing because the test was grabbing data.cloudflare_resource_groups.example_resource_groups.result[0].id without constraining the query, so it could return a non–account-scoped (or empty) resource group, which would result in an invalid request. 

The fix was to filter the data source by name to always select an account resource group, and update the template to use positional specifiers (%[n]s) where account_id is referenced multiple times. After adding this, the test passes locally 

## Additional context & links
N/A
