### PR TITLE
Fix client secret versioning

### DIFF
--- a/internal/services/zero_trust_access_service_token/resource.go
+++ b/internal/services/zero_trust_access_service_token/resource.go
@@ -156,7 +156,12 @@ func (r *ZeroTrustAccessServiceTokenResource) Update(ctx context.Context, req re
 	}
 
 	data = &env.Result
-	data.ClientSecret = secret
+
+	// Preserve the old client_secret if the API didn't return a new one
+	// New secret happens on Create and if Version changes
+	if data.ClientSecret.IsNull() {
+		data.ClientSecret = secret
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/zero_trust_access_service_token/schema.go
+++ b/internal/services/zero_trust_access_service_token/schema.go
@@ -6,12 +6,16 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 var _ resource.ResourceWithConfigValidators = (*ZeroTrustAccessServiceTokenResource)(nil)
@@ -42,12 +46,22 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description: "The expiration of the previous `client_secret`. This can be modified at any point after a rotation. For example, you may extend it further into the future if you need more time to update services with the new secret; or move it into the past to immediately invalidate the previous token in case of compromise.",
 				Optional:    true,
 				CustomType:  timetypes.RFC3339Type{},
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.Expressions{
+						path.MatchRoot("client_secret_version"),
+					}...),
+				},
 			},
 			"client_secret_version": schema.Float64Attribute{
 				Description: "A version number identifying the current `client_secret` associated with the service token. Incrementing it triggers a rotation; the previous secret will still be accepted until the time indicated by `previous_client_secret_expires_at`.",
 				Computed:    true,
 				Optional:    true,
 				Default:     float64default.StaticFloat64(1),
+				Validators: []validator.Float64{
+					float64validator.AlsoRequires(path.Expressions{
+						path.MatchRoot("previous_client_secret_expires_at"),
+					}...),
+				},
 			},
 			"duration": schema.StringAttribute{
 				Description: "The duration for how long the service token will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. The default is 1 year in hours (8760h).",


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

Ran with TF_ACC=1:
```
=== RUN   TestAccCloudflareAccessServiceToken_BasicAccount
--- PASS: TestAccCloudflareAccessServiceToken_BasicAccount (5.35s)
=== RUN   TestAccCloudflareAccessServiceToken_BasicZone
--- PASS: TestAccCloudflareAccessServiceToken_BasicZone (4.88s)
=== RUN   TestAccCloudflareAccessServiceToken_DeleteAccount
--- PASS: TestAccCloudflareAccessServiceToken_DeleteAccount (2.44s)
=== RUN   TestAccCloudflareAccessServiceToken_DeleteZone
--- PASS: TestAccCloudflareAccessServiceToken_DeleteZone (2.44s)
=== RUN   TestAccCloudflareAccessServiceToken_WithDurationAccount
--- PASS: TestAccCloudflareAccessServiceToken_WithDurationAccount (5.10s)
=== RUN   TestAccCloudflareAccessServiceToken_WithDurationZone
--- PASS: TestAccCloudflareAccessServiceToken_WithDurationZone (5.61s)
=== RUN   TestAccCloudflareAccessServiceToken_PlanModifiers_ClientSecretPersistence
--- PASS: TestAccCloudflareAccessServiceToken_PlanModifiers_ClientSecretPersistence (9.81s)
=== RUN   TestAccCloudflareAccessServiceToken_Import
--- PASS: TestAccCloudflareAccessServiceToken_Import (6.20s)
=== RUN   TestAccCloudflareAccessServiceToken_ClientSecretBehavior
--- PASS: TestAccCloudflareAccessServiceToken_ClientSecretBehavior (4.78s)
=== RUN   TestAccCloudflareAccessServiceToken_ClientSecretPersistsAcrossUpdates
--- PASS: TestAccCloudflareAccessServiceToken_ClientSecretPersistsAcrossUpdates (3.81s)
=== RUN   TestAccCloudflareAccessServiceToken_ClientSecretNoRefresh
--- PASS: TestAccCloudflareAccessServiceToken_ClientSecretNoRefresh (3.37s)
=== RUN   TestAccCloudflareAccessServiceToken_Minimal
--- PASS: TestAccCloudflareAccessServiceToken_Minimal (3.24s)
=== RUN   TestAccCloudflareAccessServiceToken_SecretRotation
--- PASS: TestAccCloudflareAccessServiceToken_SecretRotation (6.55s)
=== RUN   TestAccCloudflareAccessServiceToken_PreviousSecretExpiry
--- PASS: TestAccCloudflareAccessServiceToken_PreviousSecretExpiry (2.86s)
PASS
ok      command-line-arguments  67.735s
```

## Changes being requested

## Additional context & links
