### PR TITLE
fix: cloudflare_worker_version is replaced when module content_sha256 value changes

### DIFF
--- a/internal/services/worker_version/schema.go
+++ b/internal/services/worker_version/schema.go
@@ -189,6 +189,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Computed:    true,
 							PlanModifiers: []planmodifier.String{
 								ComputeSHA256HashOfContentFile(),
+								stringplanmodifier.RequiresReplace(),
 							},
 						},
 					},


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Previously, Terraform would attempt to update the resource in-place when module content_sha256 was the only change, but this resource can't be updated in-place
- Instead, the resource should be replaced when any module content_sha256 value changes

## Additional context & links

Fixes #6303 