### PR TITLE
DS-15398: Add tests in logpush_jobs for changing from basic to full fields, and changes on omitempty field

### DIFF
--- a/internal/services/logpush_job/testdata/omitempty_field.tf
+++ b/internal/services/logpush_job/testdata/omitempty_field.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_logpush_job" "%s" {
+  zone_id            = "%s"
+  dataset            = "%s"
+  destination_conf   = "%s"
+  max_upload_records = %d
+}


### PR DESCRIPTION
This adds tests in `logpush_jobs` for changing from basic to full fields, and changes on `omitempty` field.

Applicable tests pass locally:
```
go test ./internal/services/logpush_job -run "^TestAccCloudflareLogpushJob_BasicToFull$" -v -count 1
=== RUN   TestAccCloudflareLogpushJob_BasicToFull
--- PASS: TestAccCloudflareLogpushJob_BasicToFull (20.75s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/logpush_job       20.826s
```

```
go test ./internal/services/logpush_job -run "^TestAccCloudflareLogpushJob_OmitemptyField$" -v -count 1
=== RUN   TestAccCloudflareLogpushJob_OmitemptyField
--- PASS: TestAccCloudflareLogpushJob_OmitemptyField (11.42s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/logpush_job       11.433s
```

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged
