### PR TITLE
fix: inconsistent binding order causing inconsistent result after apply

### DIFF
--- a/internal/services/worker_version/testdata/basic_binding_order.tf
+++ b/internal/services/worker_version/testdata/basic_binding_order.tf
@@ -1,0 +1,75 @@
+resource "cloudflare_worker" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[1]s"
+}
+
+resource "cloudflare_worker_version" "%[1]s" {
+  account_id = "%[2]s"
+  worker_id = cloudflare_worker.%[1]s.id
+  modules = [
+    {
+      name         = "index.js"
+      content_file = "%[3]s"
+      content_type = "application/javascript+module"
+    }
+  ]
+  main_module = "index.js"
+  bindings = [
+    {
+      name         = "KV1"
+      type         = "kv_namespace"
+      namespace_id = cloudflare_workers_kv_namespace.%[1]s_kv1.id
+    },
+    {
+      name         = "KV2"
+      type         = "kv_namespace"
+      namespace_id = cloudflare_workers_kv_namespace.%[1]s_kv2.id
+    },
+    {
+      name = "DB1"
+      type = "d1"
+      id   = cloudflare_d1_database.%[1]s_db1.id
+    },
+    {
+      name = "DB2"
+      type = "d1"
+      id   = cloudflare_d1_database.%[1]s_db2.id
+    },
+    {
+      name         = "KV3"
+      type         = "kv_namespace"
+      namespace_id = cloudflare_workers_kv_namespace.%[1]s_kv3.id
+    }
+  ]
+}
+
+resource "cloudflare_d1_database" "%[1]s_db1" {
+  account_id = "%[2]s"
+  name       = "%[1]s-db1"
+  read_replication = {
+    mode = "disabled"
+  }
+}
+
+resource "cloudflare_d1_database" "%[1]s_db2" {
+  account_id = "%[2]s"
+  name       = "%[1]s-db2"
+  read_replication = {
+    mode = "disabled"
+  }
+}
+
+resource "cloudflare_workers_kv_namespace" "%[1]s_kv1" {
+  account_id = "%[2]s"
+  title      = "%[1]s-kv1"
+}
+
+resource "cloudflare_workers_kv_namespace" "%[1]s_kv2" {
+  account_id = "%[2]s"
+  title      = "%[1]s-kv2"
+}
+
+resource "cloudflare_workers_kv_namespace" "%[1]s_kv3" {
+  account_id = "%[2]s"
+  title      = "%[1]s-kv3"
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes binding order inconsistencies between plan and API response, which were causing errors on apply. Fixes an issue where binding order in the plan was different from binding order in the create version API response, resulting in computed binding properties being assigned to the wrong bindings and incorrectly written to state.

## Additional context & links

Fixes #6285