### PR TITLE
Fix Account Member policies acceptance test by selecting the correct account-scoped resource group

### DIFF
--- a/internal/services/account_member/testdata/cloudflareaccountmemberpoliciesconfig.tf
+++ b/internal/services/account_member/testdata/cloudflareaccountmemberpoliciesconfig.tf
@@ -1,18 +1,20 @@
 data "cloudflare_resource_groups" "example_resource_groups" {
-  account_id = "%s"
+  account_id = "%[1]s"
+  name       = "com.cloudflare.api.account.%[1]s"
 }
 
-resource "cloudflare_account_member" "%s" {
-  account_id = "%s"
-  email      = "%s"
+resource "cloudflare_account_member" "%[2]s" {
+  account_id = "%[3]s"
+  email      = "%[4]s"
   status     = "pending"
   policies = [{
     access = "allow"
     permission_groups = [{
-      id = "%s"
+      id = "%[5]s"
     }]
     resource_groups = [{
       id = data.cloudflare_resource_groups.example_resource_groups.result[0].id
     }]
   }]
 }
+


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
The account_member TestAccCloudflareAccountMember_Policies test fails locally with the following error: 

```
  | POST
  | "https://api.cloudflare.com/client/v4/accounts/a67e14daa5f8dceeb91fe5449ba496eb/members":
  | 400 Bad Request
  | {"result":[],"success":false,"errors":[{"code":1006,"message":"Unknown error
  | when processing member, please try again. Error: invalid permission group and
  | resource group combination"}],"messages":[]}
```
The test was taking the first resource group returned from the data source `data.cloudflare_resource_groups.example_resource_groups.result[0].id` without filtering, so it could grab the wrong group or none at all which made the API request invalid 

The fix was to filter the data source by name to always select an account resource group, and update the template to use positional specifiers (%[n]s) where account_id is referenced multiple times. After adding this, the test passes locally 

## Additional context & links
N/A
