### PR TITLE
fix(zero_trust_dex_test): ensure model/schema parity

### DIFF
--- a/internal/services/zero_trust_dex_test/data_source_model.go
+++ b/internal/services/zero_trust_dex_test/data_source_model.go
@@ -27,7 +27,7 @@ type ZeroTrustDEXTestDataSourceModel struct {
 	Targeted       types.Bool                                                                  `tfsdk:"targeted" json:"targeted,computed"`
 	TestID         types.String                                                                `tfsdk:"test_id" json:"test_id,computed"`
 	Data           customfield.NestedObject[ZeroTrustDEXTestDataDataSourceModel]               `tfsdk:"data" json:"data,computed"`
-	TargetPolicies customfield.NestedObjectList[ZeroTrustDEXTestTargetPoliciesDataSourceModel] `tfsdk:"target_policies" json:"target_policies,computed"`
+	TargetPolicies customfield.NestedObjectList[ZeroTrustDEXTestTargetPoliciesDataSourceModel] `tfsdk:"target_policies" json:"target_policies,computed_optional"`
 }
 
 func (m *ZeroTrustDEXTestDataSourceModel) toReadParams(_ context.Context) (params zero_trust.DeviceDEXTestGetParams, diags diag.Diagnostics) {

--- a/internal/services/zero_trust_dex_test/data_source_schema.go
+++ b/internal/services/zero_trust_dex_test/data_source_schema.go
@@ -70,6 +70,7 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 			},
 			"target_policies": schema.ListNestedAttribute{
 				Description: "DEX rules targeted by this test",
+				Optional:    true,
 				Computed:    true,
 				CustomType:  customfield.NewNestedObjectListType[ZeroTrustDEXTestTargetPoliciesDataSourceModel](ctx),
 				NestedObject: schema.NestedAttributeObject{

--- a/internal/services/zero_trust_dex_test/list_data_source_model.go
+++ b/internal/services/zero_trust_dex_test/list_data_source_model.go
@@ -36,7 +36,7 @@ type ZeroTrustDEXTestsResultDataSourceModel struct {
 	Interval       types.String                                                                 `tfsdk:"interval" json:"interval,computed"`
 	Name           types.String                                                                 `tfsdk:"name" json:"name,computed"`
 	Description    types.String                                                                 `tfsdk:"description" json:"description,computed"`
-	TargetPolicies customfield.NestedObjectList[ZeroTrustDEXTestsTargetPoliciesDataSourceModel] `tfsdk:"target_policies" json:"target_policies,computed"`
+	TargetPolicies customfield.NestedObjectList[ZeroTrustDEXTestsTargetPoliciesDataSourceModel] `tfsdk:"target_policies" json:"target_policies,computed_optional"`
 	Targeted       types.Bool                                                                   `tfsdk:"targeted" json:"targeted,computed"`
 	TestID         types.String                                                                 `tfsdk:"test_id" json:"test_id,computed"`
 }

--- a/internal/services/zero_trust_dex_test/list_data_source_schema.go
+++ b/internal/services/zero_trust_dex_test/list_data_source_schema.go
@@ -70,6 +70,7 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 						},
 						"target_policies": schema.ListNestedAttribute{
 							Description: "DEX rules targeted by this test",
+							Optional:    true,
 							Computed:    true,
 							CustomType:  customfield.NewNestedObjectListType[ZeroTrustDEXTestsTargetPoliciesDataSourceModel](ctx),
 							NestedObject: schema.NestedAttributeObject{

--- a/internal/services/zero_trust_dex_test/model.go
+++ b/internal/services/zero_trust_dex_test/model.go
@@ -4,6 +4,7 @@ package zero_trust_dex_test
 
 import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -12,16 +13,16 @@ type ZeroTrustDEXTestResultEnvelope struct {
 }
 
 type ZeroTrustDEXTestModel struct {
-	ID             types.String                            `tfsdk:"id" json:"-,computed"`
-	TestID         types.String                            `tfsdk:"test_id" json:"test_id,computed"`
-	AccountID      types.String                            `tfsdk:"account_id" path:"account_id,required"`
-	Enabled        types.Bool                              `tfsdk:"enabled" json:"enabled,required"`
-	Interval       types.String                            `tfsdk:"interval" json:"interval,required"`
-	Name           types.String                            `tfsdk:"name" json:"name,required"`
-	Data           *ZeroTrustDEXTestDataModel              `tfsdk:"data" json:"data,required"`
-	Description    types.String                            `tfsdk:"description" json:"description,optional"`
-	Targeted       types.Bool                              `tfsdk:"targeted" json:"targeted,optional"`
-	TargetPolicies *[]*ZeroTrustDEXTestTargetPoliciesModel `tfsdk:"target_policies" json:"target_policies,optional"`
+	ID             types.String                                                                 `tfsdk:"id" json:"-,computed"`
+	TestID         types.String                                                                 `tfsdk:"test_id" json:"test_id,computed"`
+	AccountID      types.String                                                                 `tfsdk:"account_id" path:"account_id,required"`
+	Enabled        types.Bool                                                                   `tfsdk:"enabled" json:"enabled,required"`
+	Interval       types.String                                                                 `tfsdk:"interval" json:"interval,required"`
+	Name           types.String                                                                 `tfsdk:"name" json:"name,required"`
+	Data           *ZeroTrustDEXTestDataModel                                                   `tfsdk:"data" json:"data,required"`
+	Description    types.String                                                                 `tfsdk:"description" json:"description,optional"`
+	Targeted       types.Bool                                                                   `tfsdk:"targeted" json:"targeted,optional"`
+	TargetPolicies customfield.NestedObjectList[ZeroTrustDEXTestsTargetPoliciesDataSourceModel] `tfsdk:"target_policies" json:"target_policies,computed_optional"`
 }
 
 func (m ZeroTrustDEXTestModel) MarshalJSON() (data []byte, err error) {

--- a/internal/services/zero_trust_dex_test/schema.go
+++ b/internal/services/zero_trust_dex_test/schema.go
@@ -76,6 +76,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"target_policies": schema.ListNestedAttribute{
 				Description: "DEX rules targeted by this test",
 				Optional:    true,
+				Computed:    true,
 				Default:     listdefault.StaticValue(customfield.NewObjectListMust(ctx, []ZeroTrustDEXTestTargetPoliciesModel{}).ListValue),
 				CustomType:  customfield.NewNestedObjectListType[ZeroTrustDEXTestTargetPoliciesModel](ctx),
 				NestedObject: schema.NestedAttributeObject{


### PR DESCRIPTION
Updates the `zero_trust_dex_test` resource to align the models' and schemas' `target_policies` attribute.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Ensures that the `target_policies` attribute is `computed_optional`.

## Additional context & links

Fixes the failing acceptance tests for the release:
https://github.com/cloudflare/terraform-provider-cloudflare/actions/runs/18787496970/job/53609323600?pr=6292

```
 --- FAIL: TestAccCloudflareStaticRoute_Exists (1.29s)
    resource_test.go:90: Step 1/3 error: Error running pre-apply plan: exit status 1
        
        Error: Failed to load plugin schemas
        
        Error while loading schemas for plugin components: Failed to obtain provider
        schema: Could not load the schema for provider
        registry.terraform.io/hashicorp/cloudflare: failed to retrieve schema from
        provider "registry.terraform.io/hashicorp/cloudflare": Schema Using Attribute
        Default For Non-Computed Attribute: Attribute "target_policies" must be
        computed when using default. This is an issue with the provider and should be
        reported to the provider developers...
```