### PR TITLE
chore: loading metadata from its own endpoint

### DIFF
--- a/internal/services/workers_kv/model.go
+++ b/internal/services/workers_kv/model.go
@@ -20,7 +20,7 @@ type WorkersKVModel struct {
 	AccountID   types.String         `tfsdk:"account_id" path:"account_id,required"`
 	NamespaceID types.String         `tfsdk:"namespace_id" path:"namespace_id,required"`
 	Value       types.String         `tfsdk:"value" json:"value,required,no_refresh"`
-	Metadata    jsontypes.Normalized `tfsdk:"metadata" json:"metadata,optional,no_refresh"`
+	Metadata    jsontypes.Normalized `tfsdk:"metadata" json:"metadata,optional"`
 }
 
 func (r WorkersKVModel) MarshalMultipart() (data []byte, contentType string, err error) {

--- a/internal/services/workers_kv/resource_test.go
+++ b/internal/services/workers_kv/resource_test.go
@@ -37,7 +37,7 @@ func testSweepCloudflareWorkersKV(r string) error {
 	ctx := context.Background()
 	client := acctest.SharedClient()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	
+
 	if accountID == "" {
 		return nil
 	}
@@ -106,9 +106,10 @@ func TestAccCloudflareWorkersKV_Basic(t *testing.T) {
 				),
 			},
 			{
-				ImportState:       true,
-				ImportStateVerify: true,
-				ResourceName:      resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
+				ResourceName:            resourceName,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					namespaceResourceName := fmt.Sprintf("cloudflare_workers_kv_namespace.%s", name)
 					return fmt.Sprintf("%s/%s/%s", accountID, s.RootModule().Resources[namespaceResourceName].Primary.ID, key), nil
@@ -156,7 +157,7 @@ func TestAccCloudflareWorkersKV_NameForcesRecreation(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.StringExact(value)),
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareWorkersKVExists(key+"-updated"),
+					testAccCheckCloudflareWorkersKVExists(key + "-updated"),
 				),
 			},
 		},
@@ -202,9 +203,10 @@ func TestAccCloudflareWorkersKV_ValueUpdate(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					namespaceResourceName := fmt.Sprintf("cloudflare_workers_kv_namespace.%s", name)
 					return fmt.Sprintf("%s/%s/%s", accountID, s.RootModule().Resources[namespaceResourceName].Primary.ID, key), nil


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Updated the Metadata attribute to be loaded from its endpoint. Also updates the Read method to honor the Value attribute's no_refresh tag.