### PR TITLE
fix(pages_project): Fix unintended resource state drift

### DIFF
--- a/internal/services/pages_project/custom.go
+++ b/internal/services/pages_project/custom.go
@@ -1,0 +1,142 @@
+package pages_project
+
+import (
+	"context"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// PreserveSecretEnvVars returns a copy of the destination deployment configs with
+// secret_text environment variable values carried over from the source deployment configs,
+// since the API returns empty strings for secret environment variable values.
+// This prevents false positive drift detection for secret environment variables.
+func PreserveSecretEnvVars(
+	ctx context.Context,
+	sourceConfigs customfield.NestedObject[PagesProjectDeploymentConfigsModel],
+	destConfigs customfield.NestedObject[PagesProjectDeploymentConfigsModel],
+) (customfield.NestedObject[PagesProjectDeploymentConfigsModel], diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if destConfigs.IsNull() || sourceConfigs.IsNull() || sourceConfigs.IsUnknown() {
+		return destConfigs, diags
+	}
+
+	destConfigsValue, d := destConfigs.Value(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return destConfigs, diags
+	}
+
+	sourceConfigsValue, d := sourceConfigs.Value(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return destConfigs, diags
+	}
+
+	// Process Preview environment
+	if !destConfigsValue.Preview.IsNull() && !sourceConfigsValue.Preview.IsNull() {
+		destPreview, d := destConfigsValue.Preview.Value(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return destConfigs, diags
+		}
+
+		sourcePreview, d := sourceConfigsValue.Preview.Value(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return destConfigs, diags
+		}
+
+		if destPreview.EnvVars != nil && sourcePreview.EnvVars != nil {
+			destPreview.EnvVars = preserveSecretEnvVarsInMap(
+				*sourcePreview.EnvVars,
+				*destPreview.EnvVars,
+			)
+		}
+
+		destConfigsValue.Preview, d = customfield.NewObject(ctx, destPreview)
+		diags.Append(d...)
+		if diags.HasError() {
+			return destConfigs, diags
+		}
+	}
+
+	// Process Production environment
+	if !destConfigsValue.Production.IsNull() && !sourceConfigsValue.Production.IsNull() {
+		destProduction, d := destConfigsValue.Production.Value(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return destConfigs, diags
+		}
+
+		sourceProduction, d := sourceConfigsValue.Production.Value(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return destConfigs, diags
+		}
+
+		if destProduction.EnvVars != nil && sourceProduction.EnvVars != nil {
+			destProduction.EnvVars = preserveSecretEnvVarsInMap(
+				*sourceProduction.EnvVars,
+				*destProduction.EnvVars,
+			)
+		}
+
+		destConfigsValue.Production, d = customfield.NewObject(ctx, destProduction)
+		diags.Append(d...)
+		if diags.HasError() {
+			return destConfigs, diags
+		}
+	}
+
+	result, d := customfield.NewObject(ctx, destConfigsValue)
+	diags.Append(d...)
+	return result, diags
+}
+
+type EnvVarModel interface {
+	PagesProjectDeploymentConfigsPreviewEnvVarsModel | PagesProjectDeploymentConfigsProductionEnvVarsModel
+}
+
+func preserveSecretEnvVarsInMap[T EnvVarModel](
+	sourceEnvVars map[string]T,
+	destEnvVars map[string]T,
+) *map[string]T {
+	updatedEnvVars := make(map[string]T)
+
+	for name, destVar := range destEnvVars {
+		var varType, varValue, sourceValue string
+
+		switch v := any(destVar).(type) {
+		case PagesProjectDeploymentConfigsPreviewEnvVarsModel:
+			varType = v.Type.ValueString()
+			varValue = v.Value.ValueString()
+			if sourceVar, exists := sourceEnvVars[name]; exists {
+				sourceValue = any(sourceVar).(PagesProjectDeploymentConfigsPreviewEnvVarsModel).Value.ValueString()
+				if varType == "secret_text" && varValue == "" && sourceValue != "" {
+					if sv := any(sourceVar).(PagesProjectDeploymentConfigsPreviewEnvVarsModel).Value; !sv.IsNull() && !sv.IsUnknown() {
+						v.Value = sv
+						destVar = any(v).(T)
+					}
+				}
+			}
+		case PagesProjectDeploymentConfigsProductionEnvVarsModel:
+			varType = v.Type.ValueString()
+			varValue = v.Value.ValueString()
+			if sourceVar, exists := sourceEnvVars[name]; exists {
+				sourceValue = any(sourceVar).(PagesProjectDeploymentConfigsProductionEnvVarsModel).Value.ValueString()
+				if varType == "secret_text" && varValue == "" && sourceValue != "" {
+					if sv := any(sourceVar).(PagesProjectDeploymentConfigsProductionEnvVarsModel).Value; !sv.IsNull() && !sv.IsUnknown() {
+						v.Value = sv
+						destVar = any(v).(T)
+					}
+				}
+			}
+		}
+
+		updatedEnvVars[name] = destVar
+	}
+
+	return &updatedEnvVars
+}

--- a/internal/services/pages_project/resource.go
+++ b/internal/services/pages_project/resource.go
@@ -64,6 +64,8 @@ func (r *PagesProjectResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	planDeploymentConfigs := data.DeploymentConfigs
+
 	dataBytes, err := data.MarshalJSON()
 	if err != nil {
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
@@ -93,6 +95,13 @@ func (r *PagesProjectResource) Create(ctx context.Context, req resource.CreateRe
 	data = &env.Result
 	data.ID = data.Name
 
+	updatedDeploymentConfigs, diags := PreserveSecretEnvVars(ctx, planDeploymentConfigs, data.DeploymentConfigs)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	data.DeploymentConfigs = updatedDeploymentConfigs
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -112,6 +121,8 @@ func (r *PagesProjectResource) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	planDeploymentConfigs := data.DeploymentConfigs
 
 	dataBytes, err := data.MarshalJSONForUpdate(*state)
 	if err != nil {
@@ -143,6 +154,13 @@ func (r *PagesProjectResource) Update(ctx context.Context, req resource.UpdateRe
 	data = &env.Result
 	data.ID = data.Name
 
+	updatedDeploymentConfigs, diags := PreserveSecretEnvVars(ctx, planDeploymentConfigs, data.DeploymentConfigs)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	data.DeploymentConfigs = updatedDeploymentConfigs
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -154,6 +172,8 @@ func (r *PagesProjectResource) Read(ctx context.Context, req resource.ReadReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	stateDeploymentConfigs := data.DeploymentConfigs
 
 	res := new(http.Response)
 	env := PagesProjectResultEnvelope{*data}
@@ -183,6 +203,13 @@ func (r *PagesProjectResource) Read(ctx context.Context, req resource.ReadReques
 	}
 	data = &env.Result
 	data.ID = data.Name
+
+	updatedDeploymentConfigs, diags := PreserveSecretEnvVars(ctx, stateDeploymentConfigs, data.DeploymentConfigs)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	data.DeploymentConfigs = updatedDeploymentConfigs
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/pages_project/resource_test.go
+++ b/internal/services/pages_project/resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -134,7 +135,6 @@ func testAccCheckCloudflarePageProjectDestroy(s *terraform.State) error {
 }
 
 func TestAccCloudflarePagesProject_Basic(t *testing.T) {
-	t.Skip("FIXME: waiting on upstream fixes to the Cloudflare Pages OpenAPI schema")
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_pages_project." + rnd
 	projectName := resourcePrefix + rnd
@@ -182,7 +182,6 @@ func TestAccCloudflarePagesProject_Basic(t *testing.T) {
 }
 
 func TestAccCloudflarePagesProject_BuildConfig(t *testing.T) {
-	t.Skip("FIXME: waiting on upstream fixes to the Cloudflare Pages OpenAPI schema")
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_pages_project." + rnd
 	projectName := resourcePrefix + rnd
@@ -220,7 +219,6 @@ func TestAccCloudflarePagesProject_BuildConfig(t *testing.T) {
 }
 
 func TestAccCloudflarePagesProject_DeploymentConfig(t *testing.T) {
-	t.Skip("FIXME: waiting on upstream fixes to the Cloudflare Pages OpenAPI schema")
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_pages_project." + rnd
 	projectName := resourcePrefix + rnd
@@ -246,7 +244,7 @@ func TestAccCloudflarePagesProject_DeploymentConfig(t *testing.T) {
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("env_vars").AtMapKey("TURNSTILE_SECRET").AtMapKey("type"), knownvalue.StringExact("secret_text")),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("env_vars").AtMapKey("TURNSTILE_SECRET").AtMapKey("value"), knownvalue.StringExact("1x0000000000000000000000000000000AA")),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("kv_namespaces"), knownvalue.MapSizeExact(1)),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("kv_namespaces").AtMapKey("KV_BINDING").AtMapKey("namespace_id"), knownvalue.StringExact("5eb63bbbe01eeed093cb22bb8f5acdc3")),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("kv_namespaces").AtMapKey("KV_BINDING").AtMapKey("namespace_id"), knownvalue.StringRegexp(regexp.MustCompile("^[0-9a-f]{32}$"))),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("durable_object_namespaces"), knownvalue.MapSizeExact(1)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("durable_object_namespaces").AtMapKey("DO_BINDING").AtMapKey("namespace_id"), knownvalue.StringExact("5eb63bbbe01eeed093cb22bb8f5acdc3")),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("d1_databases"), knownvalue.MapSizeExact(1)),
@@ -272,8 +270,8 @@ func TestAccCloudflarePagesProject_DeploymentConfig(t *testing.T) {
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("production").AtMapKey("env_vars").AtMapKey("TURNSTILE_INVIS_SECRET").AtMapKey("type"), knownvalue.StringExact("secret_text")),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("production").AtMapKey("env_vars").AtMapKey("TURNSTILE_INVIS_SECRET").AtMapKey("value"), knownvalue.StringExact("2x0000000000000000000000000000000AA")),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("production").AtMapKey("kv_namespaces"), knownvalue.MapSizeExact(2)),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("production").AtMapKey("kv_namespaces").AtMapKey("KV_BINDING_1").AtMapKey("namespace_id"), knownvalue.StringExact("5eb63bbbe01eeed093cb22bb8f5acdc3")),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("production").AtMapKey("kv_namespaces").AtMapKey("KV_BINDING_2").AtMapKey("namespace_id"), knownvalue.StringExact("3cdca5f8bb22bc390deee10ebbb36be5")),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("production").AtMapKey("kv_namespaces").AtMapKey("KV_BINDING_1").AtMapKey("namespace_id"), knownvalue.StringRegexp(regexp.MustCompile("^[0-9a-f]{32}$"))),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("production").AtMapKey("kv_namespaces").AtMapKey("KV_BINDING_2").AtMapKey("namespace_id"), knownvalue.StringRegexp(regexp.MustCompile("^[0-9a-f]{32}$"))),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("production").AtMapKey("durable_object_namespaces"), knownvalue.MapSizeExact(2)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("production").AtMapKey("durable_object_namespaces").AtMapKey("DO_BINDING_1").AtMapKey("namespace_id"), knownvalue.StringExact("5eb63bbbe01eeed093cb22bb8f5acdc3")),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("production").AtMapKey("durable_object_namespaces").AtMapKey("DO_BINDING_2").AtMapKey("namespace_id"), knownvalue.StringExact("3cdca5f8bb22bc390deee10ebbb36be5")),
@@ -298,13 +296,17 @@ func TestAccCloudflarePagesProject_DeploymentConfig(t *testing.T) {
 				ImportState:         true,
 				ImportStateVerify:   true,
 				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				ImportStateVerifyIgnore: []string{
+					"deployment_configs.preview.env_vars.TURNSTILE_SECRET.value",
+					"deployment_configs.production.env_vars.TURNSTILE_SECRET.value",
+					"deployment_configs.production.env_vars.TURNSTILE_INVIS_SECRET.value",
+				},
 			},
 		},
 	})
 }
 
 func TestAccCloudflarePagesProject_DirectUpload(t *testing.T) {
-	t.Skip("FIXME: waiting on upstream fixes to the Cloudflare Pages OpenAPI schema")
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_pages_project." + rnd
 	projectName := resourcePrefix + rnd
@@ -339,7 +341,6 @@ func TestAccCloudflarePagesProject_DirectUpload(t *testing.T) {
 }
 
 func TestAccCloudflarePagesProject_Update_AddOptionalAttributes(t *testing.T) {
-	t.Skip("FIXME: waiting on upstream fixes to the Cloudflare Pages OpenAPI schema")
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_pages_project." + rnd
 	projectName := resourcePrefix + rnd
@@ -358,8 +359,8 @@ func TestAccCloudflarePagesProject_Update_AddOptionalAttributes(t *testing.T) {
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("name"), knownvalue.StringExact(projectName)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("production_branch"), knownvalue.StringExact("main")),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("build_config"), knownvalue.Null()),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("build_config"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("source"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("created_on"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("subdomain"), knownvalue.NotNull()),
@@ -375,7 +376,7 @@ func TestAccCloudflarePagesProject_Update_AddOptionalAttributes(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("name"), knownvalue.StringExact(projectName)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("production_branch"), knownvalue.StringExact("develop")),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("build_config").AtMapKey("build_caching"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("build_config").AtMapKey("build_caching"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("build_config").AtMapKey("build_command"), knownvalue.StringExact("yarn build")),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("compatibility_date"), knownvalue.StringExact("2023-06-01")),
 				},
@@ -385,14 +386,15 @@ func TestAccCloudflarePagesProject_Update_AddOptionalAttributes(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-				ImportStateVerifyIgnore: []string{"build_config", "deployment_configs", "canonical_deployment", "latest_deployment", "created_on", "subdomain", "domains"},
+				ImportStateVerifyIgnore: []string{"deployment_configs.production.env_vars.PROD_UPDATED.value"},
 			},
 		},
 	})
 }
 
 func TestAccCloudflarePagesProject_Update_RemoveOptionalAttributes(t *testing.T) {
-	t.Skip("FIXME: waiting on upstream fixes to the Cloudflare Pages OpenAPI schema")
+	t.Skip("FIXME: waiting on fixes to apijson.MarshalForPatch()")
+
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_pages_project." + rnd
 	projectName := resourcePrefix + rnd
@@ -409,7 +411,7 @@ func TestAccCloudflarePagesProject_Update_RemoveOptionalAttributes(t *testing.T)
 				Config: testPagesProjectUpdated(rnd, accountID, projectName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("production_branch"), knownvalue.StringExact("develop")),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("build_config").AtMapKey("build_caching"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("build_config").AtMapKey("build_caching"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("compatibility_date"), knownvalue.StringExact("2023-06-01")),
 				},
 			},
@@ -423,22 +425,21 @@ func TestAccCloudflarePagesProject_Update_RemoveOptionalAttributes(t *testing.T)
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("name"), knownvalue.StringExact(projectName)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("production_branch"), knownvalue.StringExact("main")),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("build_config"), knownvalue.Null()),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("build_config"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs"), knownvalue.NotNull()),
 				},
 			},
 			{
-				ResourceName:            name,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-				ImportStateVerifyIgnore: []string{"build_config", "deployment_configs", "canonical_deployment", "latest_deployment", "created_on", "subdomain", "domains"},
+				ResourceName:        name,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				// ImportStateVerifyIgnore: []string{"build_config", "deployment_configs", "canonical_deployment", "latest_deployment", "created_on", "subdomain", "domains"},
 			},
 		},
 	})
 }
 func TestAccCloudflarePagesProject_FullConfiguration(t *testing.T) {
-	t.Skip("FIXME: waiting on upstream fixes to the Cloudflare Pages OpenAPI schema")
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_pages_project." + rnd
 	projectName := resourcePrefix + rnd
@@ -494,7 +495,7 @@ func TestAccCloudflarePagesProject_FullConfiguration(t *testing.T) {
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("vectorize_bindings"), knownvalue.MapSizeExact(1)),
 
 					// Placement
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("placement").AtSliceIndex(0).AtMapKey("mode"), knownvalue.StringExact("smart")),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("preview").AtMapKey("placement").AtMapKey("mode"), knownvalue.StringExact("smart")),
 
 					// Production deployment configs
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("deployment_configs").AtMapKey("production").AtMapKey("compatibility_date"), knownvalue.StringExact("2023-01-16")),
@@ -511,13 +512,15 @@ func TestAccCloudflarePagesProject_FullConfiguration(t *testing.T) {
 				ImportState:         true,
 				ImportStateVerify:   true,
 				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				ImportStateVerifyIgnore: []string{
+					"deployment_configs.preview.env_vars.SECRET_KEY.value",
+				},
 			},
 		},
 	})
 }
 
 func TestAccCloudflarePagesProject_EnvVarTypes(t *testing.T) {
-	t.Skip("FIXME: waiting on upstream fixes to the Cloudflare Pages OpenAPI schema")
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_pages_project." + rnd
 	projectName := resourcePrefix + rnd
@@ -556,7 +559,6 @@ func TestAccCloudflarePagesProject_EnvVarTypes(t *testing.T) {
 }
 
 func TestAccCloudflarePagesProject_PreviewDeploymentSettings(t *testing.T) {
-	t.Skip("FIXME: waiting on upstream fixes to the Cloudflare Pages OpenAPI schema")
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_pages_project." + rnd
 	projectName := resourcePrefix + rnd

--- a/internal/services/pages_project/testdata/pagesprojectdeploymentconfig.tf
+++ b/internal/services/pages_project/testdata/pagesprojectdeploymentconfig.tf
@@ -1,3 +1,8 @@
+resource "cloudflare_workers_kv_namespace" "%[1]s_kv_namespace" {
+  account_id = "%[2]s"
+  title = "tfacctest-pages-project-kv-namespace"
+}
+
 resource "cloudflare_pages_project" "%[1]s" {
   account_id        = "%[2]s"
   name              = "%[3]s"
@@ -16,7 +21,7 @@ resource "cloudflare_pages_project" "%[1]s" {
       }
       kv_namespaces = {
         KV_BINDING = {
-          namespace_id = "5eb63bbbe01eeed093cb22bb8f5acdc3"
+          namespace_id = cloudflare_workers_kv_namespace.%[1]s_kv_namespace.id
         }
       }
       durable_object_namespaces = {
@@ -66,10 +71,10 @@ resource "cloudflare_pages_project" "%[1]s" {
       }
       kv_namespaces = {
         KV_BINDING_1 = {
-          namespace_id = "5eb63bbbe01eeed093cb22bb8f5acdc3"
+          namespace_id = cloudflare_workers_kv_namespace.%[1]s_kv_namespace.id
         }
         KV_BINDING_2 = {
-          namespace_id = "3cdca5f8bb22bc390deee10ebbb36be5"
+          namespace_id = cloudflare_workers_kv_namespace.%[1]s_kv_namespace.id
         }
       }
       durable_object_namespaces = {

--- a/internal/services/pages_project/testdata/pagesprojectfullconfig.tf
+++ b/internal/services/pages_project/testdata/pagesprojectfullconfig.tf
@@ -1,3 +1,8 @@
+resource "cloudflare_workers_kv_namespace" "%[1]s_kv_namespace" {
+  account_id = "%[2]s"
+  title = "tfacctest-pages-project-kv-namespace"
+}
+
 resource "cloudflare_pages_project" "%[1]s" {
 	account_id = "%[2]s"
 	name = "%[3]s"
@@ -30,7 +35,7 @@ resource "cloudflare_pages_project" "%[1]s" {
 			
 			kv_namespaces = {
 				KV_PREVIEW = {
-					namespace_id = "preview-kv-namespace-id"
+					namespace_id = cloudflare_workers_kv_namespace.%[1]s_kv_namespace.id
 				}
 			}
 			
@@ -43,7 +48,7 @@ resource "cloudflare_pages_project" "%[1]s" {
 			r2_buckets = {
 				R2_PREVIEW = {
 					name = "preview-bucket"
-					jurisdiction = "us"
+					jurisdiction = "eu"
 				}
 			}
 			
@@ -113,7 +118,7 @@ resource "cloudflare_pages_project" "%[1]s" {
 			
 			kv_namespaces = {
 				KV_PROD = {
-					namespace_id = "prod-kv-namespace-id"
+					namespace_id = cloudflare_workers_kv_namespace.%[1]s_kv_namespace.id
 				}
 			}
 			

--- a/internal/services/pages_project/testdata/pagesprojectupdated.tf
+++ b/internal/services/pages_project/testdata/pagesprojectupdated.tf
@@ -4,7 +4,7 @@ resource "cloudflare_pages_project" "%[1]s" {
 	production_branch = "develop"
 	
 	build_config = {
-		build_caching = false
+		build_caching = true
 		build_command = "yarn build"
 		destination_dir = "build"
 		root_dir = "/"


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
This PR address some issues with the `cloudflare_pages_project` resource that resulted in constant resource state drift detection. In particular, secret values were not being handled correctly (as the API doesn't return their values). There are a few other attributes that weren't properly marked as computed. These acceptance tests also uncovered an API bug around setting R2 binding jurisdictions that we've now fixed.

~~Note: we're still waiting on some fixes to the JSON encoder (specifically, `apijson.MarshalForPatch()`) which will land once we re-enable the codegen pipeline. Once those lands, I'll update this PR to remove the last `t.Skip()` in the acceptance tests. Side note, those fixes should also take care of #5632.~~
EDIT: We'll address this in a follow up PR once the upstream fix has landed.

## Additional context & links
Follows #6318 

Fixes #5093 
Fixes #5773 