### PR TITLE
fix: add note to cloudflare_workers_script_subdomain about redundancy with cloudflare_worker

### DIFF
--- a/templates/resources/workers_script_subdomain.md.tmpl
+++ b/templates/resources/workers_script_subdomain.md.tmpl
@@ -1,0 +1,27 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.RenderedProviderName}}"
+subcategory: ""
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+-> This resource is redundant with `cloudflare_worker` and should not be used together. When using the `cloudflare_worker` resource, use the nested `subdomain` attribute to control subdomain settings instead.
+
+
+{{ if .HasExample -}}
+## Example Usage
+
+{{codefile "terraform" .ExampleFile}}
+{{- end }}
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+
+Import is supported using the following syntax:
+
+{{codefile "shell" .ImportFile}}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Add docs note for cloudflare_workers_script_subdomain resource

## Additional context & links

People using cloudflare_worker should not use cloudflare_workers_script_subdomain since cloudflare_worker already includes subdomain settings.