### PR TITLE
chore: cloudflare_certificate_pack docs show safe rotation instructions

### DIFF
--- a/docs/resources/certificate_pack.md
+++ b/docs/resources/certificate_pack.md
@@ -9,14 +9,11 @@ description: |-
 
 
 
-~> Certificate packs are not able to be updated in place and if
-you require a zero downtime rotation, you need to use Terraform's meta-arguments
-for [`lifecycle`](https://www.terraform.io/docs/configuration/resources.html#lifecycle-lifecycle-customizations) blocks.
-`create_before_destroy` should be suffice for most scenarios (exceptions are
-things like missing entitlements, high ranking domain). To completely
-de-risk rotations, use you can create multiple resources using a 2-phase change
-where you have both resources live at once and you remove the old one once
-you've confirmed the certificate is available.
+~> Certificate packs are not able to be updated in place. If
+you require a zero downtime rotation, you can create multiple
+resources using a 2-phase change where you have both resources
+live at once and you remove the old one once you've confirmed 
+the certificate is available.
 
 ## Example Usage
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
These instructions don't always result in a safe certificate pack rotation. There are external factors like Domain Control Validation, which takes a factor of minutes before a certificate pack is available for use for TLS termination.

## Additional context & links
