### PR TITLE
fix(zero_trust_dlp_custom_profile): fix read, refresh, import

### DIFF
--- a/internal/services/zero_trust_dlp_custom_profile/resource.go
+++ b/internal/services/zero_trust_dlp_custom_profile/resource.go
@@ -174,7 +174,7 @@ func (r *ZeroTrustDLPCustomProfileResource) Read(ctx context.Context, req resour
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
@@ -210,8 +210,6 @@ func (r *ZeroTrustDLPCustomProfileResource) Delete(ctx context.Context, req reso
 }
 
 func (r *ZeroTrustDLPCustomProfileResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	var data *ZeroTrustDLPCustomProfileModel = new(ZeroTrustDLPCustomProfileModel)
-
 	path_account_id := ""
 	path_profile_id := ""
 	diags := importpath.ParseImportID(
@@ -225,11 +223,8 @@ func (r *ZeroTrustDLPCustomProfileResource) ImportState(ctx context.Context, req
 		return
 	}
 
-	data.AccountID = types.StringValue(path_account_id)
-	data.ID = types.StringValue(path_profile_id)
-
 	res := new(http.Response)
-	env := ZeroTrustDLPCustomProfileResultEnvelope{*data}
+	env := ZeroTrustDLPCustomProfileResultEnvelope{}
 	_, err := r.client.ZeroTrust.DLP.Profiles.Custom.Get(
 		ctx,
 		path_profile_id,
@@ -249,7 +244,8 @@ func (r *ZeroTrustDLPCustomProfileResource) ImportState(ctx context.Context, req
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
 	}
-	data = &env.Result
+	data := &env.Result
+	data.AccountID = types.StringValue(path_account_id)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/zero_trust_dlp_custom_profile/resource_test.go
+++ b/internal/services/zero_trust_dlp_custom_profile/resource_test.go
@@ -87,7 +87,7 @@ func TestAccCloudflareZeroTrustDlpCustomProfile_Basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-				ImportStateVerifyIgnore: []string{"open_access", "created_at", "updated_at", "type", "context_awareness", "entries"},
+				ImportStateVerifyIgnore: []string{"open_access", "created_at", "updated_at", "type", "context_awareness", "entries", "ai_context_enabled"},
 			},
 		},
 	})
@@ -149,7 +149,7 @@ func TestAccCloudflareZeroTrustDlpCustomProfile_MinimalRequired(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-				ImportStateVerifyIgnore: []string{"open_access", "created_at", "updated_at", "type", "context_awareness", "entries"},
+				ImportStateVerifyIgnore: []string{"open_access", "created_at", "updated_at", "type", "context_awareness", "entries", "ai_context_enabled"},
 			},
 		},
 	})
@@ -181,7 +181,7 @@ func TestAccCloudflareZeroTrustDlpCustomProfile_AllSharedEntryTypes(t *testing.T
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-				ImportStateVerifyIgnore: []string{"open_access", "created_at", "updated_at", "type", "context_awareness", "entries"},
+				ImportStateVerifyIgnore: []string{"open_access", "created_at", "updated_at", "type", "context_awareness", "entries", "ai_context_enabled"},
 			},
 		},
 	})
@@ -237,7 +237,7 @@ func TestAccCloudflareZeroTrustDlpCustomProfile_DeprecatedAttributes(t *testing.
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-				ImportStateVerifyIgnore: []string{"open_access", "created_at", "updated_at", "type", "context_awareness", "entries"},
+				ImportStateVerifyIgnore: []string{"open_access", "created_at", "updated_at", "type", "context_awareness", "entries", "ai_context_enabled"},
 			},
 		},
 	})
@@ -285,7 +285,7 @@ func TestAccCloudflareZeroTrustDlpCustomProfile_BoundaryValues(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-				ImportStateVerifyIgnore: []string{"open_access", "created_at", "updated_at", "type", "context_awareness", "entries"},
+				ImportStateVerifyIgnore: []string{"open_access", "created_at", "updated_at", "type", "context_awareness", "entries", "ai_context_enabled"},
 			},
 		},
 	})

--- a/internal/services/zero_trust_dlp_custom_profile/schema.go
+++ b/internal/services/zero_trust_dlp_custom_profile/schema.go
@@ -146,17 +146,19 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Default:  booldefault.StaticBool(false),
 			},
 			"created_at": schema.StringAttribute{
-				Description: "When the profile was created.",
-				Computed:    true,
-				CustomType:  timetypes.RFC3339Type{},
+				Description:   "When the profile was created.",
+				Computed:      true,
+				CustomType:    timetypes.RFC3339Type{},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"open_access": schema.BoolAttribute{
 				Description: "Whether this profile can be accessed by anyone.",
 				Computed:    true,
 			},
 			"type": schema.StringAttribute{
-				Description: `Available values: "custom", "predefined", "integration".`,
-				Computed:    true,
+				Description:   `Available values: "custom", "predefined", "integration".`,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive(
 						"custom",


### PR DESCRIPTION
Acceptance tests were failing on a non-empty refresh plan.

```
=== RUN   TestAccCloudflareZeroTrustDlpCustomProfile_Basic
resource_test.go:46: Step 2/3 error: After applying this test step, the refresh plan was not empty.
    stdout

    Terraform used the selected providers to generate the following execution
    plan. Resource actions are indicated with the following symbols:
      ~ update in-place

    Terraform will perform the following actions:

      # cloudflare_zero_trust_dlp_custom_profile.garhxylojy will be updated in-place
      ~ resource "cloudflare_zero_trust_dlp_custom_profile" "garhxylojy" {
          ~ ai_context_enabled   = false -> true
          ~ created_at           = "2025-10-30T01:33:30Z" -> (known after apply)
            id                   = "15e4364d-3692-42f6-b8c9-ec7b8818a944"
            name                 = "garhxylojy-updated"
          + open_access          = (known after apply)
          ~ type                 = "custom" -> (known after apply)
          ~ updated_at           = "2025-10-30T01:33:34Z" -> (known after apply)
            # (5 unchanged attributes hidden)
        }

    Plan: 0 to add, 1 to change, 0 to destroy.
```
Fixes:
- updated the Read operation to use `apijson.UnmarshalComputed`; makes attributes like `ai_context_enabled` visible for state
- use `UseStateForUnknown` for `creted_at`
- use `ImportStateVerifyIgnore` to work around inconsistent CRUD

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
