### PR TITLE
cloudflare_list conditionally import nested items

### DIFF
--- a/examples/resources/cloudflare_list/import.sh
+++ b/examples/resources/cloudflare_list/import.sh
@@ -1,1 +1,2 @@
-$ terraform import cloudflare_list.example '<account_id>/<list_id>'
+$ terraform import cloudflare_list.example '<account_id>/<list_id>/items'
+$ terraform import cloudflare_list.example '<account_id>/<list_id>/no_items'

--- a/internal/services/list/resource_test.go
+++ b/internal/services/list/resource_test.go
@@ -150,7 +150,7 @@ func TestAccCloudflareList(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameIP,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/no_items", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
 				},
 				ImportStateVerify: true,
 			},
@@ -158,7 +158,7 @@ func TestAccCloudflareList(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameIP,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/no_items", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
 				},
 				ImportStateKind: resource.ImportBlockWithID,
 			},
@@ -207,7 +207,7 @@ func TestAccCloudflareList(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameRedirect,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameRedirect].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/items", accountID, s.RootModule().Resources[resourceNameRedirect].Primary.ID), nil
 				},
 				ImportStateVerify: true,
 			},
@@ -215,7 +215,7 @@ func TestAccCloudflareList(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameRedirect,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameRedirect].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/no_items", accountID, s.RootModule().Resources[resourceNameRedirect].Primary.ID), nil
 				},
 				ImportStateKind: resource.ImportBlockWithID,
 			},
@@ -264,7 +264,7 @@ func TestAccCloudflareList(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameASN,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameASN].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/no_items", accountID, s.RootModule().Resources[resourceNameASN].Primary.ID), nil
 				},
 				ImportStateVerify: true,
 			},
@@ -272,7 +272,7 @@ func TestAccCloudflareList(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameASN,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameASN].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/no_items", accountID, s.RootModule().Resources[resourceNameASN].Primary.ID), nil
 				},
 				ImportStateKind: resource.ImportBlockWithID,
 			},
@@ -321,7 +321,7 @@ func TestAccCloudflareList(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameHostname,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameHostname].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/no_items", accountID, s.RootModule().Resources[resourceNameHostname].Primary.ID), nil
 				},
 				ImportStateVerify: true,
 			},
@@ -329,7 +329,7 @@ func TestAccCloudflareList(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameHostname,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameHostname].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/no_items", accountID, s.RootModule().Resources[resourceNameHostname].Primary.ID), nil
 				},
 				ImportStateKind: resource.ImportBlockWithID,
 			},
@@ -397,7 +397,7 @@ func TestAccCloudflareListWithItems_IP(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameIP,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/items", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
 				},
 				ImportStateVerify: true,
 			},
@@ -405,7 +405,7 @@ func TestAccCloudflareListWithItems_IP(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameIP,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/items", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
 				},
 				ImportStateKind: resource.ImportBlockWithID,
 			},
@@ -420,7 +420,7 @@ func TestAccCloudflareListWithItems_IP(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameIP,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/no_items", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
 				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr(resourceNameIP, "items"),
@@ -491,7 +491,7 @@ func TestAccCloudflareListWithItems_Hostname(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameIP,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/items", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
 				},
 				ImportStateVerify: true,
 			},
@@ -499,7 +499,7 @@ func TestAccCloudflareListWithItems_Hostname(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameIP,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/items", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
 				},
 				ImportStateKind: resource.ImportBlockWithID,
 			},
@@ -567,7 +567,7 @@ func TestAccCloudflareListWithItems_Redirect(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameIP,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/items", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
 				},
 				ImportStateVerify: true,
 			},
@@ -575,9 +575,70 @@ func TestAccCloudflareListWithItems_Redirect(t *testing.T) {
 				ImportState:  true,
 				ResourceName: resourceNameIP,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return fmt.Sprintf("%s/%s", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
+					return fmt.Sprintf("%s/%s/items", accountID, s.RootModule().Resources[resourceNameIP].Primary.ID), nil
 				},
 				ImportStateKind: resource.ImportBlockWithID,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareList_ImportWithSeparateListItem(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
+	resourceNameList := fmt.Sprintf("cloudflare_list.%s", listName)
+	resourceNameItem := fmt.Sprintf("cloudflare_list_item.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	var listItemID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareListWithIpListItem(rnd, listName, rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameList, "account_id", accountID),
+					resource.TestCheckResourceAttr(resourceNameList, "name", listName),
+					resource.TestCheckResourceAttr(resourceNameList, "kind", "ip"),
+					resource.TestCheckNoResourceAttr(resourceNameList, "items"),
+					resource.TestCheckResourceAttr(resourceNameItem, "ip", "1.1.1.1"),
+					func(state *terraform.State) error {
+						listItemID = state.RootModule().Resources[resourceNameItem].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				ImportState:  true,
+				ResourceName: resourceNameList,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					return fmt.Sprintf("%s/%s/no_items", accountID, s.RootModule().Resources[resourceNameList].Primary.ID), nil
+				},
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"modified_on", "num_items"},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameList, "account_id", accountID),
+					resource.TestCheckResourceAttr(resourceNameList, "name", listName),
+					resource.TestCheckResourceAttr(resourceNameList, "kind", "ip"),
+
+					// Verify nested items are not populated during import
+					resource.TestCheckNoResourceAttr(resourceNameList, "items"),
+					// Verify the separate list item still exists
+					resource.TestCheckResourceAttr(resourceNameItem, "ip", "1.1.1.1"),
+					testAccCheckCloudflareListItemExists(resourceNameItem, accountID),
+					func(state *terraform.State) error {
+						id := state.RootModule().Resources[resourceNameItem].Primary.ID
+						if id != listItemID {
+							return errors.New("list item id does not match")
+						}
+						return nil
+					},
+				),
 			},
 		},
 	})
@@ -605,6 +666,39 @@ func testAccCheckCloudflareListWithRedirectItems(resourceName, listName, descrip
 
 func testAccCheckCloudflareListDataSource(resourceName, accountID, listName, description, kind string) string {
 	return acctest.LoadTestCase("listdatasource.tf", resourceName, accountID, listName, description, kind)
+}
+
+func testAccCheckCloudflareListWithIpListItem(resourceName, listName, description, accountID string) string {
+	return acctest.LoadTestCase("listwithiplistitem.tf", resourceName, listName, description, accountID)
+}
+
+func testAccCheckCloudflareListItemExists(resourceName, accountID string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("list item ID is not set")
+		}
+
+		listID := rs.Primary.Attributes["list_id"]
+		if listID == "" {
+			return fmt.Errorf("list ID is not set on list item")
+		}
+
+		client := acctest.SharedClient()
+		ctx := context.Background()
+
+		// Make direct API call to verify the list item exists
+		_, err := client.Rules.Lists.Items.Get(ctx, listID, rs.Primary.ID, rules.ListItemGetParams{AccountID: cloudflare.F(accountID)})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
 }
 
 func checkListAndPopulate(resourceName string, list *rules.ListsList) func(*terraform.State) error {

--- a/internal/services/list/testdata/listwithiplistitem.tf
+++ b/internal/services/list/testdata/listwithiplistitem.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_list" "%[2]s" {
+  account_id  = "%[4]s"
+  name        = "%[2]s"
+  kind        = "ip"
+}
+
+resource "cloudflare_list_item" "%[1]s" {
+  account_id = "%[4]s"
+  list_id    = cloudflare_list.%[2]s.id
+  ip         = "1.1.1.1"
+  comment    = "Test item for import test"
+}

--- a/templates/resources/list.md.tmpl
+++ b/templates/resources/list.md.tmpl
@@ -26,6 +26,10 @@ description: |-
 {{ if .HasImport -}}
 ## Import
 
+~> To import `cloudflare_list` resource with the nested `items` attribute, use the
+  `<account_id>/<list_id>/items` import id format. To import `cloudflare_list` resource for use with
+  `cloudflare_list_items`, use the `<account_id>/<list_id>/no_items` import id format.
+
 Import is supported using the following syntax:
 
 {{codefile "shell" .ImportFile}}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Currently we explicitly import any existing list items into the nested items property for cloudflare_list.

This causes the next Terraform plan, for a list with no items set, to think that cloudflare_list.items is going from a set containing items to a null set. Which will cause it to remove all existing items.

We want customers to decide whether they want to use the nested `cloudflare_list.items` or `cloudflare_list_item` to manage list items.

This PR updates the resource import id to add another path that can be used to specify if items should be imported or not.

`<account_id>/<list_id>/items` will import the nested items.

<img width="932" height="119" alt="image" src="https://github.com/user-attachments/assets/f2a0978a-eadd-4856-8e23-36fbefe61b20" />


`<account_id>/<list_id>/no_items` will not import the nested items. It expects `cloudflare_list.items` be unset and the user to use `cloudflare_list_item` instead.

<img width="1550" height="135" alt="image" src="https://github.com/user-attachments/assets/81b778b5-b860-4713-8aef-c8f4f3c06716" />



## Acceptance test run results

- [x] I have run acceptance tests for my changes and included the results below 

All passing for `cloudflare_list`.

## Additional context & links

Unfortunately the Terraform plugin framework doesn't not provide access to the Config or Plan while reading a resource so we cannot conditionally import `items` based on the configuration.

This causes the first plan/apply after an import to recreate the nested items. This causes no change to the resource but will make an actual API call.