### PR TITLE
Add migration test for logpull_retention

### DIFF
--- a/internal/services/logpull_retention/migrations_test.go
+++ b/internal/services/logpull_retention/migrations_test.go
@@ -50,7 +50,7 @@ resource "cloudflare_logpull_retention" "%[1]s" {
 				Config: v4Config,
 			},
 			// Step 2: Run migration and verify state transformation
-			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				// Verify resource exists and has correct type
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
@@ -93,7 +93,7 @@ resource "cloudflare_logpull_retention" "%[1]s" {
 				Config: v4Config,
 			},
 			// Step 2: Run migration and verify state transformation
-			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				// Verify resource exists and has correct type
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->
## Changes being requested

## Acceptance test run results

- [x] I have run acceptance tests for my changes and included the results below 
```
=== RUN   TestMigrateLogpullRetentionV4ToV5_Enabled
--- PASS: TestMigrateLogpullRetentionV4ToV5_Enabled (17.96s)
=== RUN   TestMigrateLogpullRetentionV4ToV5_Disabled
--- PASS: TestMigrateLogpullRetentionV4ToV5_Disabled (19.51s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/logpull_retention 38.965s
```
## Additional context & links
