### PR TITLE
chore(zone_settings): acceptance test to repro issue #6363

### DIFF
--- a/internal/services/zone_setting/resource_test.go
+++ b/internal/services/zone_setting/resource_test.go
@@ -236,6 +236,21 @@ func TestAccCloudflareZoneSetting_Ciphers(t *testing.T) {
 		CheckDestroy:             testAccCheckCloudflareZoneSettingDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testCloudflareZoneSettingConfigCiphersEmpty(rnd, zoneID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("setting_id"), knownvalue.StringExact("ciphers")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.ListSizeExact(0)),
+				},
+			},
+			// This will cause the panic due to #6363
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("%s/ciphers", zoneID),
+			},
+			{
 				Config: testCloudflareZoneSettingConfigCiphers(rnd, zoneID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
@@ -333,6 +348,10 @@ func testCloudflareZoneSettingConfigMinTLSVersion(resourceID, zoneID string) str
 
 func testCloudflareZoneSettingConfigCiphers(resourceID, zoneID string) string {
 	return acctest.LoadTestCase("ciphers.tf", resourceID, zoneID)
+}
+
+func testCloudflareZoneSettingConfigCiphersEmpty(resourceID, zoneID string) string {
+	return acctest.LoadTestCase("ciphers_empty.tf", resourceID, zoneID)
 }
 
 func testCloudflareZoneSettingEditableInconsistency(resourceID, zoneID, settingID, value string) string {

--- a/internal/services/zone_setting/testdata/ciphers_empty.tf
+++ b/internal/services/zone_setting/testdata/ciphers_empty.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_zone_setting" "%[1]s" {
+  zone_id = "%[2]s"
+  setting_id = "ciphers"
+  value = []
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results
```
~/c/github/terraform-provider-cloudflare vaishak/zone-settings-test *1 ❯ TF_ACC=1 go test -count 1 ./internal/services/zone_setting -run "TestAccCloudflareZoneSetting_Ciphers" -v
=== RUN   TestAccCloudflareZoneSetting_Ciphers
--- PASS: TestAccCloudflareZoneSetting_Ciphers (7.88s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zone_setting	9.135s
```
- [x] I have run acceptance tests for my changes and included the results below 

## Additional context & links
