### PR TITLE
feat: Add proxy_endpoint ZT Access Application

### DIFF
--- a/internal/services/zero_trust_access_application/plan_modifiers.go
+++ b/internal/services/zero_trust_access_application/plan_modifiers.go
@@ -18,7 +18,7 @@ var (
 	saasAppTypes                          = []string{"saas", "dash_sso"}
 	appLauncherVisibleAppTypes            = []string{"self_hosted", "ssh", "vnc", "rdp", "saas", "bookmark"}
 	targetCompatibleAppTypes              = []string{"rdp", "infrastructure"}
-	sessionDurationCompatibleAppTypes     = []string{"saas", "dash_sso", "self_hosted", "ssh", "vnc", "rdp", "app_launcher", "warp", "mcp_portal", "mcp"}
+	sessionDurationCompatibleAppTypes     = []string{"saas", "dash_sso", "self_hosted", "ssh", "vnc", "rdp", "app_launcher", "warp", "mcp_portal", "mcp", "proxy_endpoint"}
 	authenticateViaWarpCompatibleAppTypes = []string{"self_hosted", "ssh", "vnc", "rdp", "saas", "dash_sso"}
 	durationRegex                         = regexp.MustCompile(`^(?:0|[-+]?(\d+(?:\.\d*)?|\.\d+)(?:ns|us|µs|ms|s|m|h)(?:(\d+(?:\.\d*)?|\.\d+)(?:ns|us|µs|ms|s|m|h))*)$`)
 )

--- a/internal/services/zero_trust_access_application/resource_test.go
+++ b/internal/services/zero_trust_access_application/resource_test.go
@@ -2102,3 +2102,32 @@ func TestAccCloudflareAccessApplication_MCPSetup(t *testing.T) {
 func testAccCloudflareAccessApplicationMCPConfig(rnd, domain, accountID string) string {
 	return acctest.LoadTestCase("accessapplicationmcpconfig.tf", rnd, domain, accountID)
 }
+func TestAccCloudflareAccessApplication_ProxyEndpoint(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_zero_trust_access_application.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareAccessApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareAccessApplicationProxyEndpoint(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(name, "name", "Gateway Proxy"),
+					resource.TestCheckResourceAttr(name, "type", "proxy_endpoint"),
+					resource.TestCheckResourceAttr(name, "session_duration", "24h"),
+					resource.TestCheckResourceAttr(name, "policies.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareAccessApplicationProxyEndpoint(rnd, accID string) string {
+	return acctest.LoadTestCase("accessapplicationconfigproxyendpoint.tf", rnd, accID)
+}

--- a/internal/services/zero_trust_access_application/schema.go
+++ b/internal/services/zero_trust_access_application/schema.go
@@ -140,7 +140,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"type": schema.StringAttribute{
-				Description: "The application type.\nAvailable values: \"self_hosted\", \"saas\", \"ssh\", \"vnc\", \"app_launcher\", \"warp\", \"biso\", \"bookmark\", \"dash_sso\", \"infrastructure\", \"rdp\", \"mcp\", \"mcp_portal\".",
+				Description: "The application type.\nAvailable values: \"self_hosted\", \"saas\", \"ssh\", \"vnc\", \"app_launcher\", \"warp\", \"biso\", \"bookmark\", \"dash_sso\", \"infrastructure\", \"rdp\", \"mcp\", \"mcp_portal\", \"proxy_endpoint\".",
 				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive(
@@ -157,6 +157,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"rdp",
 						"mcp",
 						"mcp_portal",
+						"proxy_endpoint",
 					),
 				},
 			},

--- a/internal/services/zero_trust_access_application/testdata/accessapplicationconfigproxyendpoint.tf
+++ b/internal/services/zero_trust_access_application/testdata/accessapplicationconfigproxyendpoint.tf
@@ -1,0 +1,16 @@
+resource "cloudflare_zero_trust_access_application" "%[1]s" {
+  account_id       = "%[2]s"
+  name             = "Gateway Proxy"
+  type             = "proxy_endpoint"
+  domain           = "abcd123456.proxy.cloudflare-gateway.com"
+  session_duration = "24h"
+
+  policies = [{
+    decision   = "allow"
+    name       = "Allow all"
+    precedence = 1
+    include = [{
+      everyone = {}
+    }]
+  }]
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results
(omitting env vars)
```
go test internal/services/zero_trust_access_application/resource_test.go -v -count 1 -timeout 120m -parallel 1 -run "^TestAccCloudflareAccessApplication_ProxyEndpoint$"

=== RUN   TestAccCloudflareAccessApplication_ProxyEndpoint
--- PASS: TestAccCloudflareAccessApplication_ProxyEndpoint (3.53s)
PASS
ok      command-line-arguments  5.034s
```
- [x] I have run acceptance tests for my changes and included the results below 

## Additional context & links
