### PR TITLE
zt access: normalize IP addresses

### DIFF
--- a/internal/services/zero_trust_access_group/normalizations.go
+++ b/internal/services/zero_trust_access_group/normalizations.go
@@ -3,6 +3,7 @@ package zero_trust_access_group
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
@@ -26,6 +27,35 @@ func normalizeReadZeroTrustAccessGroupAPIData(ctx context.Context, data, sourceD
 	normalizeEmptyAndNullSlice(&data.Include, sourceData.Include)
 	normalizeEmptyAndNullSlice(&data.Require, sourceData.Require)
 	normalizeEmptyAndNullSlice(&data.Exclude, sourceData.Exclude)
+
+	// Normalize IP addresses in include/exclude/require rules to handle /32 and /128 CIDR notation
+	if data.Include != nil && sourceData.Include != nil {
+		for i := range *data.Include {
+			if i < len(*sourceData.Include) {
+				if (*data.Include)[i].IP != nil && (*sourceData.Include)[i].IP != nil {
+					utils.NormalizeIPStringWithCIDR(&(*data.Include)[i].IP.IP, (*sourceData.Include)[i].IP.IP)
+				}
+			}
+		}
+	}
+	if data.Exclude != nil && sourceData.Exclude != nil {
+		for i := range *data.Exclude {
+			if i < len(*sourceData.Exclude) {
+				if (*data.Exclude)[i].IP != nil && (*sourceData.Exclude)[i].IP != nil {
+					utils.NormalizeIPStringWithCIDR(&(*data.Exclude)[i].IP.IP, (*sourceData.Exclude)[i].IP.IP)
+				}
+			}
+		}
+	}
+	if data.Require != nil && sourceData.Require != nil {
+		for i := range *data.Require {
+			if i < len(*sourceData.Require) {
+				if (*data.Require)[i].IP != nil && (*sourceData.Require)[i].IP != nil {
+					utils.NormalizeIPStringWithCIDR(&(*data.Require)[i].IP.IP, (*sourceData.Require)[i].IP.IP)
+				}
+			}
+		}
+	}
 
 	return diags
 }

--- a/internal/services/zero_trust_access_group/schema.go
+++ b/internal/services/zero_trust_access_group/schema.go
@@ -6,11 +6,11 @@ import (
 	"context"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 var _ resource.ResourceWithConfigValidators = (*ZeroTrustAccessGroupResource)(nil)

--- a/internal/utils/ip_normalization.go
+++ b/internal/utils/ip_normalization.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"net"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// NormalizeIPStringWithCIDR normalizes IP addresses to handle /32 (IPv4) and /128 (IPv6)
+// CIDR notation equivalence. If the API value and config value are semantically equal
+// (same IP with or without CIDR notation), the config value is preserved to avoid drift.
+func NormalizeIPStringWithCIDR(apiValue *basetypes.StringValue, configValue basetypes.StringValue) {
+	if apiValue == nil || apiValue.IsNull() || apiValue.IsUnknown() || configValue.IsNull() || configValue.IsUnknown() {
+		return
+	}
+
+	apiStr := apiValue.ValueString()
+	configStr := configValue.ValueString()
+
+	// Normalize both to CIDR notation for comparison
+	normalizedAPI := NormalizeIPCIDR(apiStr)
+	normalizedConfig := NormalizeIPCIDR(configStr)
+
+	// If they match after normalization, preserve the config value
+	if normalizedAPI == normalizedConfig {
+		*apiValue = configValue
+	}
+}
+
+// NormalizeIPCIDR normalizes an IP address or CIDR to always include CIDR notation.
+// Single IPv4 addresses get /32, single IPv6 addresses get /128.
+// Addresses with existing CIDR notation are returned as-is.
+func NormalizeIPCIDR(ipStr string) string {
+	ipStr = strings.TrimSpace(ipStr)
+
+	if strings.Contains(ipStr, "/") {
+		return ipStr
+	}
+
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return ipStr
+	}
+
+	if ip.To4() != nil {
+		return ipStr + "/32"
+	}
+	return ipStr + "/128"
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #6059 API returns /32 and /128 onto IP addresses that did not include them. This PR normalizes to prevent terraform drift. 

## Acceptance test run results

I was not able to run acceptance tests for the zero_trust_access_policy resource - they fail in the terraform provider acceptance testing account (due to existing issues - not this PR). All other resources pass. 

- [x] I have run acceptance tests for my changes and included the results below 

## Additional context & links
