### PR TITLE
chore(zone): update migration tests

### DIFF
--- a/internal/services/zone/migrations_test.go
+++ b/internal/services/zone/migrations_test.go
@@ -51,7 +51,7 @@ resource "cloudflare_zone" "%[1]s" {
 				Config: v4Config,
 			},
 			// Step 2: Run migration and verify state
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(zoneName)),
 				// Verify v4 attributes are removed/transformed
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
@@ -102,7 +102,7 @@ resource "cloudflare_zone" "%[1]s" {
 				Config: v4Config,
 			},
 			// Step 2: Run migration and verify state
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				// Verify v4→v5 transformations
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(zoneName)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
@@ -150,7 +150,7 @@ resource "cloudflare_zone" "%[1]s" {
 				Config: v4Config,
 			},
 			// Step 2: Run migration and verify removed attributes
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(zoneName)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
 				// V5 has computed plan object instead of configurable string
@@ -194,7 +194,7 @@ resource "cloudflare_zone" "%[1]s" {
 				Config: v4Config,
 			},
 			// Step 2: Run migration and verify unicode handling
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(unicodeDomain)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("full")),
@@ -238,7 +238,7 @@ resource "cloudflare_zone" "%[1]s" {
 				Config: v4Config,
 			},
 			// Step 2: Run migration and verify secondary zone handling
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(zoneName)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("secondary")),
@@ -282,7 +282,7 @@ resource "cloudflare_zone" "%[1]s" {
 				Config: v4Config,
 			},
 			// Step 2: Run migration and verify meta structure
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(zoneName)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account").AtMapKey("id"), knownvalue.StringExact(accountID)),
 				// Verify meta is a structured object (v5 format)

--- a/internal/services/zone/resource_test.go
+++ b/internal/services/zone/resource_test.go
@@ -1,14 +1,103 @@
 package zone_test
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/zones"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func init() {
+	resource.AddTestSweepers("cloudflare_zone", &resource.Sweeper{
+		Name: "cloudflare_zone",
+		F:    testSweepCloudflareZone,
+	})
+}
+
+// testSweepCloudflareZone removes test zones created during acceptance tests.
+//
+// This sweeper:
+// - Lists all zones in the test account
+// - Filters for test zones (prefix: tf-acc-test-, tf-acctest-, test prefixes with terraform.cfapi.net)
+// - Deletes matching zones
+// - Continues on errors to sweep as many zones as possible
+//
+// Run with: go test ./internal/services/zone/ -v -sweep=all
+//
+// Requires:
+// - CLOUDFLARE_ACCOUNT_ID (for account-scoped zones)
+// - CLOUDFLARE_EMAIL + CLOUDFLARE_API_KEY or CLOUDFLARE_API_TOKEN
+func testSweepCloudflareZone(r string) error {
+	ctx := context.Background()
+	client := acctest.SharedClient()
+
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		return nil
+	}
+
+	// List all zones in the account
+	page, err := client.Zones.List(ctx, zones.ZoneListParams{
+		Account: cloudflare.F(zones.ZoneListParamsAccount{
+			ID: cloudflare.F(accountID),
+		}),
+	})
+	if err != nil {
+		log.Printf("[ERROR] Failed to fetch zones: %s", err)
+		return err
+	}
+
+	// Delete test zones only
+	for _, zone := range page.Result {
+		// Filter by test naming conventions
+		if !isTestZone(zone.Name) {
+			continue
+		}
+
+		log.Printf("[INFO] Deleting test zone: %s (%s)", zone.Name, zone.ID)
+		_, err := client.Zones.Delete(ctx, zones.ZoneDeleteParams{
+			ZoneID: cloudflare.F(zone.ID),
+		})
+		if err != nil {
+			log.Printf("[ERROR] Failed to delete zone %s (%s): %s", zone.Name, zone.ID, err)
+			// Continue sweeping other zones
+		}
+	}
+
+	return nil
+}
+
+// isTestZone checks if a zone name matches test naming patterns
+func isTestZone(name string) bool {
+	// Match common test prefixes
+	if strings.HasPrefix(name, "tf-acc-test-") ||
+		strings.HasPrefix(name, "tf-acctest-") {
+		return true
+	}
+
+	// Match terraform.cfapi.net test domains
+	if strings.HasSuffix(name, ".terraform.cfapi.net") ||
+		name == "terraform.cfapi.net" {
+		return true
+	}
+
+	// Match .cfapi.net domains (from acceptance tests)
+	if strings.HasSuffix(name, ".cfapi.net") &&
+		!strings.Contains(name, "production") &&
+		!strings.Contains(name, "prod-") {
+		return true
+	}
+
+	return false
+}
 
 func TestAccCloudflareZone_Basic(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()


### PR DESCRIPTION
Updates `cloudflare_zone` migration tests to use `tf-migrate` instead of `cmd/migrate`.

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have run acceptance tests for my changes and included the results below

```
mgirouard@sixteen:~/src/terraform-devstack/cloudflare-terraform-next$ TF_MIGRATE_BINARY_PATH=$HOME/src/terraform-devstack/tf-migrate/tf-migrate TF_ACC=1 go test -v ./internal/services/zone -run ^TestMigrate
=== RUN   TestMigrateZoneMigrationFromV4Basic
--- PASS: TestMigrateZoneMigrationFromV4Basic (17.05s)
=== RUN   TestMigrateZoneMigrationFromV4Complete
--- PASS: TestMigrateZoneMigrationFromV4Complete (17.34s)
=== RUN   TestMigrateZoneMigrationFromV4PlanFree
--- PASS: TestMigrateZoneMigrationFromV4PlanFree (13.75s)
=== RUN   TestMigrateZoneMigrationFromV4Unicode
--- PASS: TestMigrateZoneMigrationFromV4Unicode (15.19s)
=== RUN   TestMigrateZoneMigrationFromV4Secondary
    migrations_test.go:223: Step 1/2 error: Error running apply: exit status 1

        Error: error setting type on zone ID "6d4db077e36d864bb82381a210722601": Secondary zone signup not allowed (1111)

          with cloudflare_zone.obqcpolscn,
          on terraform_plugin_test.tf line 14, in resource "cloudflare_zone" "obqcpolscn":
          14: resource "cloudflare_zone" "obqcpolscn" {

--- FAIL: TestMigrateZoneMigrationFromV4Secondary (5.55s)
=== RUN   TestMigrateZoneMigrationFromV4MetaStructure
--- PASS: TestMigrateZoneMigrationFromV4MetaStructure (13.20s)
FAIL
FAIL    github.com/cloudflare/terraform-provider-cloudflare/internal/services/zone      82.099s
FAIL
```

## Additional context & links

Note that the test failure is because of my local configuration. The test should pass fine in 