### PR TITLE
chore(ci): drop migration tests from CI

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -67,13 +67,13 @@ jobs:
           TF_MIGRATE_BINARY_PATH: ${{ github.workspace }}/tf-migrate
         continue-on-error: true
 
-      - name: Run Magic Migration Tests
-        id: magic_migration_tests
-        run: ./scripts/run-ci-tests magic migration
-        env:
-          TF_ACC: 1
-          TF_MIGRATE_BINARY_PATH: ${{ github.workspace }}/tf-migrate
-        continue-on-error: true
+      # - name: Run Magic Migration Tests
+      #   id: magic_migration_tests
+      #   run: ./scripts/run-ci-tests magic migration
+      #   env:
+      #     TF_ACC: 1
+      #     TF_MIGRATE_BINARY_PATH: ${{ github.workspace }}/tf-migrate
+      #   continue-on-error: true
 
       ######## Organization Tests ########
       # These tests require a specific user with organization permissions
@@ -97,13 +97,13 @@ jobs:
           TF_MIGRATE_BINARY_PATH: ${{ github.workspace }}/tf-migrate
         continue-on-error: true
 
-      - name: Run Default Migration Tests
-        id: default_migration_tests
-        run: ./scripts/run-ci-tests default migration
-        env:
-          TF_ACC: 1
-          TF_MIGRATE_BINARY_PATH: ${{ github.workspace }}/tf-migrate
-        continue-on-error: true
+      # - name: Run Default Migration Tests
+      #   id: default_migration_tests
+      #   run: ./scripts/run-ci-tests default migration
+      #   env:
+      #     TF_ACC: 1
+      #     TF_MIGRATE_BINARY_PATH: ${{ github.workspace }}/tf-migrate
+      #   continue-on-error: true
 
       - name: Check Test Status
         if: ${{


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have run acceptance tests for my changes and included the results below 

## Additional context & links

We exhausted some resources during CI, which with migration tests, takes an extra 20-30 minutes to run. I'm dropping the migration tests from CI temporarily to make the iteration on tests a bit faster and less prone to timing out.