### PR TITLE
adding a simple CRUD test fo account tokens

### DIFF
--- a/internal/services/account_token/testdata/account_token-crud.tf
+++ b/internal/services/account_token/testdata/account_token-crud.tf
@@ -1,0 +1,31 @@
+data "cloudflare_account_api_token_permission_groups_list" "dns_read" {
+  account_id = "%[2]s"
+  name       = "DNS Read"
+  scope      = "com.cloudflare.api.account.zone"
+}
+
+resource "cloudflare_account_token" "crud_test" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+  expires_on = "%[3]s"
+
+  policies = [
+    {
+      effect = "allow"
+      permission_groups = [
+        { id = data.cloudflare_account_api_token_permission_groups_list.dns_read.result[0].id }
+      ]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" : {
+          "com.cloudflare.api.account.zone.*" = "*"
+        }
+      })
+    }
+  ]
+
+  condition = {
+    request_ip = {
+      in = ["%[4]s"]
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adding a basic CRUD test for account tokens.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
No special steps needed.

### Test output
```
TF_ACC=1 go test internal/services/account_token/resource_test.go --run TestAccAPIToken_CRUD
ok      command-line-arguments  17.659s
```

## Additional context & links
