### PR TITLE
fix(zero_trust_dlp_custom_profile): add sweepers for dlp_custom_profile

### DIFF
--- a/internal/services/zero_trust_dlp_custom_profile/resource_test.go
+++ b/internal/services/zero_trust_dlp_custom_profile/resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/cloudflare/cloudflare-go/v6"
@@ -23,6 +24,79 @@ import (
 const (
 	EnvTfAcc = "TF_ACC"
 )
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func init() {
+	resource.AddTestSweepers("cloudflare_zero_trust_dlp_custom_profile", &resource.Sweeper{
+		Name: "cloudflare_zero_trust_dlp_custom_profile",
+		F:    testSweepCloudflareZeroTrustDlpCustomProfile,
+	})
+}
+
+// testSweepCloudflareZeroTrustDlpCustomProfile removes test DLP custom profiles created during acceptance tests.
+//
+// This sweeper:
+// - Lists all DLP profiles in the test account
+// - Filters for custom profiles with test name prefixes (tf-acc-test-, tf-acctest-, tfmigrate-e2e-)
+// - Deletes matching custom profiles
+// - Continues on errors to sweep as many resources as possible
+//
+// Run with: go test ./internal/services/zero_trust_dlp_custom_profile/ -v -sweep=all
+//
+// Requires:
+// - CLOUDFLARE_ACCOUNT_ID (for account-scoped resources)
+// - CLOUDFLARE_EMAIL + CLOUDFLARE_API_KEY or CLOUDFLARE_API_TOKEN
+func testSweepCloudflareZeroTrustDlpCustomProfile(r string) error {
+	ctx := context.Background()
+	client := acctest.SharedClient()
+
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		return nil // Skip if no account ID set
+	}
+
+	// List all DLP profiles (both custom and predefined)
+	list, err := client.ZeroTrust.DLP.Profiles.List(ctx, zero_trust.DLPProfileListParams{
+		AccountID: cloudflare.F(accountID),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list DLP profiles: %w", err)
+	}
+
+	// Delete test custom profiles only
+	for _, profile := range list.Result {
+		// Only delete custom profiles (not predefined)
+		if profile.Type != "custom" {
+			continue
+		}
+
+		// Filter by test naming convention
+		if !isTestResource(profile.Name) {
+			continue
+		}
+
+		_, err := client.ZeroTrust.DLP.Profiles.Custom.Delete(ctx, profile.ID, zero_trust.DLPProfileCustomDeleteParams{
+			AccountID: cloudflare.F(accountID),
+		})
+		if err != nil {
+			// Log but don't fail - continue sweeping
+			fmt.Printf("Failed to delete DLP custom profile %s (%s): %v\n", profile.Name, profile.ID, err)
+		}
+	}
+
+	return nil
+}
+
+// isTestResource checks if a resource name matches test naming conventions
+func isTestResource(name string) bool {
+	return strings.HasPrefix(name, "tf-acc-test-") ||
+		strings.HasPrefix(name, "tf-acctest-") ||
+		strings.HasPrefix(name, "test-") ||
+		strings.HasPrefix(name, "tfmigrate-e2e-")
+}
 
 // setupDLPCustomProfileTest handles common test setup and TF_ACC environment check
 func setupDLPCustomProfileTest(t *testing.T) (string, string) {


### PR DESCRIPTION
## Changes being requested
This adds sweepers for zero_trust_dlp_custom_profile. The profiles were not being cleaned after progressive e2e test runs, requiring manual cleanup. 
- a concurrent change has been made in the tf-migrate repo to ensure all profiles use the `tfmigrate-e2e-` prefix

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below
```bash
=== RUN   TestMigrateZeroTrustDLPCustomProfile_V4ToV5_BasicProfile
--- PASS: TestMigrateZeroTrustDLPCustomProfile_V4ToV5_BasicProfile (23.30s)
=== RUN   TestMigrateZeroTrustDLPCustomProfile_V4ToV5_MultipleEntries
--- PASS: TestMigrateZeroTrustDLPCustomProfile_V4ToV5_MultipleEntries (20.06s)
=== RUN   TestMigrateZeroTrustDLPCustomProfile_V4ToV5_MinimalProfile
--- PASS: TestMigrateZeroTrustDLPCustomProfile_V4ToV5_MinimalProfile (20.27s)
=== RUN   TestMigrateZeroTrustDLPCustomProfile_V4ToV5_ComplexPatterns
--- PASS: TestMigrateZeroTrustDLPCustomProfile_V4ToV5_ComplexPatterns (20.20s)
=== RUN   TestMigrateZeroTrustDLPCustomProfile_V4ToV5_NoDescription
--- PASS: TestMigrateZeroTrustDLPCustomProfile_V4ToV5_NoDescription (22.18s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_dlp_custom_profile     107.237s
```

### Steps to run acceptance tests
```bash
TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/ssicard/workspace/terraform-devstack/tf-migrate/tf-migrate go test -v -run "TestMigrateZeroTrustDLPCustomProfile"
```

## Additional context & links
As this PR adds a sweeper, here are steps taken to test and run:

`TF_ACC=1 go test ./internal/services/zero_trust_dlp_custom_profile/ -v -sweep=all`

```bash
2025/11/26 11:30:45 [DEBUG] Running Sweepers for region (all):
2025/11/26 11:30:45 [DEBUG] Running Sweeper (cloudflare_zero_trust_dlp_custom_profile) in region (all)
2025/11/26 11:30:55 [DEBUG] Completed Sweeper (cloudflare_zero_trust_dlp_custom_profile) in region (all) in 10.816610458s
2025/11/26 11:30:55 Completed Sweepers for region (all) in 10.817893833s
2025/11/26 11:30:55 Sweeper Tests for region (all) ran successfully:
2025/11/26 11:30:55     - cloudflare_zero_trust_dlp_custom_profile
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_dlp_custom_profile     12.269s
```