### PR TITLE
CFSQL-1391 Only allow read_replication modification on update

### DIFF
--- a/internal/services/d1_database/model.go
+++ b/internal/services/d1_database/model.go
@@ -4,6 +4,7 @@ package d1_database
 
 import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -13,17 +14,17 @@ type D1DatabaseResultEnvelope struct {
 }
 
 type D1DatabaseModel struct {
-	ID                  types.String                    `tfsdk:"id" json:"-,computed"`
-	UUID                types.String                    `tfsdk:"uuid" json:"uuid,computed"`
-	AccountID           types.String                    `tfsdk:"account_id" path:"account_id,required"`
-	Name                types.String                    `tfsdk:"name" json:"name,required"`
-	Jurisdiction        types.String                    `tfsdk:"jurisdiction" json:"jurisdiction,optional,no_refresh"`
-	PrimaryLocationHint types.String                    `tfsdk:"primary_location_hint" json:"primary_location_hint,optional,no_refresh"`
-	ReadReplication     *D1DatabaseReadReplicationModel `tfsdk:"read_replication" json:"read_replication,optional"`
-	CreatedAt           timetypes.RFC3339               `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
-	FileSize            types.Float64                   `tfsdk:"file_size" json:"file_size,computed"`
-	NumTables           types.Float64                   `tfsdk:"num_tables" json:"num_tables,computed"`
-	Version             types.String                    `tfsdk:"version" json:"version,computed"`
+	ID                  types.String                                             `tfsdk:"id" json:"-,computed"`
+	UUID                types.String                                             `tfsdk:"uuid" json:"uuid,computed"`
+	AccountID           types.String                                             `tfsdk:"account_id" path:"account_id,required"`
+	Name                types.String                                             `tfsdk:"name" json:"name,required"`
+	Jurisdiction        types.String                                             `tfsdk:"jurisdiction" json:"jurisdiction,optional,no_refresh"`
+	PrimaryLocationHint types.String                                             `tfsdk:"primary_location_hint" json:"primary_location_hint,optional,no_refresh"`
+	ReadReplication     customfield.NestedObject[D1DatabaseReadReplicationModel] `tfsdk:"read_replication" json:"read_replication,optional"`
+	CreatedAt           timetypes.RFC3339                                        `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
+	FileSize            types.Float64                                            `tfsdk:"file_size" json:"file_size,computed"`
+	NumTables           types.Float64                                            `tfsdk:"num_tables" json:"num_tables,computed"`
+	Version             types.String                                             `tfsdk:"version" json:"version,computed"`
 }
 
 func (m D1DatabaseModel) MarshalJSON() (data []byte, err error) {
@@ -35,5 +36,5 @@ func (m D1DatabaseModel) MarshalJSONForUpdate(state D1DatabaseModel) (data []byt
 }
 
 type D1DatabaseReadReplicationModel struct {
-	Mode types.String `tfsdk:"mode" json:"mode,required"`
+	Mode types.String `tfsdk:"mode" json:"mode,optional"`
 }

--- a/internal/services/d1_database/plan_modifiers.go
+++ b/internal/services/d1_database/plan_modifiers.go
@@ -1,0 +1,43 @@
+package d1_database
+
+import (
+	"context"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func modifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
+	var plan, state *D1DatabaseModel
+	res.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	res.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if res.Diagnostics.HasError() || plan == nil {
+		return
+	}
+
+	// read_replication can only be set during updates, not during creation
+	// Only error if the user explicitly set it (not null and not unknown)
+	if state == nil && !plan.ReadReplication.IsNull() && !plan.ReadReplication.IsUnknown() {
+		res.Diagnostics.AddAttributeError(
+			path.Root("read_replication"),
+			"Invalid Attribute Configuration",
+			"read_replication can only be configured during updates, not during initial resource creation. Please remove this attribute from the initial configuration and add it in a subsequent update.",
+		)
+		return
+	}
+
+	// If this is an update and read_replication was removed from config (plan is null)
+	// but exists in state (state is not null), set it to disabled, we can revisit this to err if we want 
+	// the users to do this on another step instead
+	if state != nil && plan.ReadReplication.IsNull() && !state.ReadReplication.IsNull() {
+		plan.ReadReplication = customfield.NewObjectMust(
+			ctx,
+			&D1DatabaseReadReplicationModel{
+				Mode: types.StringValue("disabled"),
+			},
+		)
+		res.Diagnostics.Append(res.Plan.Set(ctx, &plan)...)
+	}
+}

--- a/internal/services/d1_database/resource.go
+++ b/internal/services/d1_database/resource.go
@@ -259,6 +259,6 @@ func (r *D1DatabaseResource) ImportState(ctx context.Context, req resource.Impor
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *D1DatabaseResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, _ *resource.ModifyPlanResponse) {
-
+func (r *D1DatabaseResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	modifyPlan(ctx, req, resp)
 }

--- a/internal/services/d1_database/schema.go
+++ b/internal/services/d1_database/schema.go
@@ -5,6 +5,7 @@ package d1_database
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -65,13 +66,13 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"read_replication": schema.SingleNestedAttribute{
 				Description: "Configuration for D1 read replication.",
 				Optional:    true,
+				Computed:    true,
+				CustomType:  customfield.NewNestedObjectType[D1DatabaseReadReplicationModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"mode": schema.StringAttribute{
 						Description: "The read replication mode for the database. Use 'auto' to create replicas and allow D1 automatically place them around the world, or 'disabled' to not use any database replicas (it can take a few hours for all replicas to be deleted).\nAvailable values: \"auto\", \"disabled\".",
-						Required:    true,
-						Validators: []validator.String{
-							stringvalidator.OneOfCaseInsensitive("auto", "disabled"),
-						},
+						Optional:    true,
+						Computed:    true,
 					},
 				},
 			},

--- a/internal/services/d1_database/testdata/d1databasebasicreadreplication.tf
+++ b/internal/services/d1_database/testdata/d1databasebasicreadreplication.tf
@@ -1,0 +1,8 @@
+
+  resource "cloudflare_d1_database" "%[1]s" {
+    account_id = "%[2]s"
+    name       = "%[1]s"
+    read_replication = {
+      mode = "auto"
+    }
+  }

--- a/internal/services/d1_database/testdata/d1databasewithreadreplication.tf
+++ b/internal/services/d1_database/testdata/d1databasewithreadreplication.tf
@@ -1,0 +1,8 @@
+
+  resource "cloudflare_d1_database" "%[1]s" {
+    account_id = "%[2]s"
+    name       = "%[1]s"
+    read_replication = {
+      mode = "auto"
+    }
+  }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

We want the below.

On creation:
- users cannot set read_replication mode, and we don't want terraform to implicitly sends null since our API will complain

On update:
- if we are enabling it (disabled -> auto) then the user should set this in configuration
- if they remove it from config, we can assume (?) they want to disable and we disable it for them (they can also send mode: disabled themselves, maybe we should err out and tell them to do that explicitly)
- If it is currently not set, and they don't include it in the resource, we omit it entirely and assume the read_replication mode is unchanged 

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
- Added a test to verify the user cannot send read_replication on creation and that terraform does not send null implicitly so that the API doesn't complain
- Added a test to verify that read_replication can be updated if provided on update only.  If it is not provided then we assume it is unchanged.

### Test output
<!-- Please paste the output of your acceptance test run below --> 
```
TF_ACC=1 CLOUDFLARE_API_TOKEN=<account_token> CLOUDFLARE_ACCOUNT_ID=<account_id> go test -v ./internal/services/d1_database -run TestAccCloudflareD1Database_ReadReplicationRejected -timeout 30m
=== RUN   TestAccCloudflareD1Database_ReadReplicationRejected
=== PAUSE TestAccCloudflareD1Database_ReadReplicationRejected
=== CONT  TestAccCloudflareD1Database_ReadReplicationRejected
--- PASS: TestAccCloudflareD1Database_ReadReplicationRejected (0.59s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/d1_database	2.286s

TF_ACC=1 CLOUDFLARE_API_TOKEN=<account_token> CLOUDFLARE_ACCOUNT_ID=<account_id> go test -v ./internal/services/d1_database -run TestAccCloudflareD1Database_Basic -timeout 30m
=== RUN   TestAccCloudflareD1Database_Basic
=== PAUSE TestAccCloudflareD1Database_Basic
=== CONT  TestAccCloudflareD1Database_Basic
--- PASS: TestAccCloudflareD1Database_Basic (4.67s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/d1_database	6.038s

TTF_ACC=1 CLOUDFLARE_API_TOKEN=<account_token> CLOUDFLARE_ACCOUNT_ID=<account_id> go test -v ./internal/services/d1_database -run TestAccCloudflareD1Database_ReadReplicationUpdate -timeout 30m
=== RUN   TestAccCloudflareD1Database_ReadReplicationUpdate
=== PAUSE TestAccCloudflareD1Database_ReadReplicationUpdate
=== CONT  TestAccCloudflareD1Database_ReadReplicationUpdate
--- PASS: TestAccCloudflareD1Database_ReadReplicationUpdate (8.01s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/d1_database	9.567s
```

## Additional context & links
https://jira.cfdata.org/browse/CFSQL-1391

Fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/6309