### PR TITLE
cloudflare_account_member refactor

### DIFF
--- a/internal/services/account_member/custom.go
+++ b/internal/services/account_member/custom.go
@@ -3,23 +3,46 @@ package account_member
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+type ConfiguredPermissionType int
+
+const (
+	Unknown ConfiguredPermissionType = iota
+	Policies
+	Roles
+)
+
+// Given a config value, determine which permission type is configured. This
+// should only be called with the config value, never the plan or state value.
+func checkConfiguredPermissionType(configuredModel *AccountMemberModel) ConfiguredPermissionType {
+	permissionType := Unknown
+
+	if !configuredModel.Roles.IsNull() && len(configuredModel.Roles.Elements()) > 0 {
+		permissionType = Roles
+	}
+	if !configuredModel.Policies.IsNull() && len(configuredModel.Policies.Elements()) > 0 {
+		if permissionType == Roles {
+			// if both are found, return Unknown
+			return Unknown
+		}
+		return Policies
+	}
+	return permissionType
+}
+
 func (m AccountMemberModel) marshalCustom() (data []byte, err error) {
 	return apijson.MarshalRoot(m)
 }
 
-func (m AccountMemberModel) marshalCustomForUpdate(state AccountMemberModel) (data []byte, err error) {
+func (m AccountMemberModel) marshalCustomForUpdate(state AccountMemberModel, configuredPermissionType ConfiguredPermissionType) (data []byte, err error) {
 	data, err = apijson.MarshalForUpdate(m, state)
 	if err != nil {
-		return
-	}
-
-	if m.Roles == nil || len(*m.Roles) == 0 {
 		return
 	}
 
@@ -28,18 +51,32 @@ func (m AccountMemberModel) marshalCustomForUpdate(state AccountMemberModel) (da
 		return
 	}
 
-	// Transform roles: ["role_id"] -> [{"id": "role_id"}]
-	roleObjects := make([]map[string]interface{}, 0, len(*m.Roles))
-	for _, role := range *m.Roles {
-		if !role.IsNull() && !role.IsUnknown() {
-			roleObjects = append(roleObjects, map[string]interface{}{
-				"id": role.ValueString(),
-			})
+	if configuredPermissionType == Roles {
+		delete(payload, "policies")
+
+		roles := m.Roles.Elements()
+
+		// Transform roles: ["role_id"] -> [{"id": "role_id"}]
+		roleObjects := make([]map[string]interface{}, 0, len(roles))
+		for _, role := range roles {
+			if !role.IsNull() && !role.IsUnknown() {
+				roleString, ok := role.(types.String)
+				if !ok {
+					return nil, fmt.Errorf("unexpected role type: %T", role)
+				}
+				roleObjects = append(roleObjects, map[string]interface{}{
+					"id": roleString.ValueString(),
+				})
+			}
+		}
+
+		if len(roleObjects) > 0 {
+			payload["roles"] = roleObjects
 		}
 	}
 
-	if len(roleObjects) > 0 {
-		payload["roles"] = roleObjects
+	if configuredPermissionType == Policies {
+		delete(payload, "roles")
 	}
 
 	// Ensure account_id is included for the API even though it's a path param
@@ -51,75 +88,74 @@ func (m AccountMemberModel) marshalCustomForUpdate(state AccountMemberModel) (da
 }
 
 func unmarshalCustom(data []byte, configuredModel *AccountMemberModel) (*AccountMemberModel, error) {
+	ctx := context.Background()
+	var env AccountMemberResultEnvelope
+	if err := apijson.Unmarshal(data, &env); err != nil {
+		return nil, err
+	}
+	result := &env.Result
+
+	result.AccountID = configuredModel.AccountID
+
+	return parsePoliciesAndRoles(ctx, data, result)
+}
+
+func unmarshalComputedCustom(data []byte, configuredModel *AccountMemberModel) (*AccountMemberModel, error) {
+	ctx := context.Background()
 	var env AccountMemberResultEnvelope
 	if err := apijson.UnmarshalComputed(data, &env); err != nil {
 		return nil, err
 	}
-
 	result := &env.Result
 
-	// Preserve required fields from configured model to avoid replacement
 	result.AccountID = configuredModel.AccountID
-	result.Email = configuredModel.Email
+	if result.Email.IsNull() && !configuredModel.Email.IsNull() {
+		// Preserve required fields from configured model to avoid replacement
+		result.Email = configuredModel.Email
+	}
 
 	// Only preserve status if it was explicitly configured
 	if !configuredModel.Status.IsNull() && !configuredModel.Status.IsUnknown() {
 		result.Status = configuredModel.Status
 	}
 
-	// Determine comparison strategy based on what's configured in Terraform
-	// as user can use roles or policies to configure the account member
-	configUsesRoles := configuredModel.Roles != nil && len(*configuredModel.Roles) > 0
-	configUsesPolicies := !configuredModel.Policies.IsNull() && !configuredModel.Policies.IsUnknown()
+	return parsePoliciesAndRoles(ctx, data, result)
+}
 
-	if configUsesRoles && !configUsesPolicies {
-		// User configured roles - preserve computed policies from API to prevent diffs
-		// Don't modify result.Policies - let it keep the computed values from API response
+func parsePoliciesAndRoles(ctx context.Context, data []byte, result *AccountMemberModel) (*AccountMemberModel, error) {
+	// Extract role IDs from GET response (roles come as objects with id field)
+	var fullResponse struct {
+		Result struct {
+			Policies []AccountMemberPoliciesModel `json:"policies"`
+			Roles    []struct {
+				ID types.String `json:"id"`
+			} `json:"roles"`
+		} `json:"result"`
+	}
 
-		// Extract role IDs from GET response (roles come as objects with id field)
-		var fullResponse struct {
-			Result struct {
-				Roles []struct {
-					ID string `json:"id"`
-				} `json:"roles"`
-			} `json:"result"`
-		}
+	err := apijson.Unmarshal(data, &fullResponse)
+	if err != nil {
+		return nil, err
+	}
 
-		if err := json.Unmarshal(data, &fullResponse); err == nil && len(fullResponse.Result.Roles) > 0 {
-			roleIDs := make([]types.String, 0, len(fullResponse.Result.Roles))
-			for _, role := range fullResponse.Result.Roles {
-				roleIDs = append(roleIDs, types.StringValue(role.ID))
-			}
-			result.Roles = &roleIDs
-		} else {
-			result.Roles = configuredModel.Roles
-		}
-	} else if configUsesPolicies && !configUsesRoles {
-		// User configured policies - ignore roles, set roles to nil to prevent diffs
-		result.Roles = nil
+	roleIDs := make([]types.String, 0, len(fullResponse.Result.Roles))
+	for _, role := range fullResponse.Result.Roles {
+		roleIDs = append(roleIDs, role.ID)
+	}
 
-		// Extract policies from the API response and ensure they match the configured structure
-		var fullResponse struct {
-			Result struct {
-				Policies []AccountMemberPoliciesModel `json:"policies"`
-			} `json:"result"`
-		}
-
-		if err := json.Unmarshal(data, &fullResponse); err == nil && len(fullResponse.Result.Policies) > 0 {
-			policies := append([]AccountMemberPoliciesModel(nil), fullResponse.Result.Policies...)
-			policiesList, diags := customfield.NewObjectSet(context.Background(), policies)
-			if !diags.HasError() {
-				result.Policies = policiesList
-			} else {
-				result.Policies = configuredModel.Policies
-			}
-		} else {
-			result.Policies = configuredModel.Policies
-		}
+	roleSet, diags := customfield.NewSet[types.String](ctx, roleIDs)
+	if !diags.HasError() {
+		result.Roles = roleSet
 	} else {
-		// Fallback: preserve configured values
-		result.Roles = configuredModel.Roles
-		result.Policies = configuredModel.Policies
+		return result, fmt.Errorf("failed to parse roles")
+	}
+
+	policies := append([]AccountMemberPoliciesModel(nil), fullResponse.Result.Policies...)
+	policiesSet, diags := customfield.NewObjectSet(ctx, policies)
+	if !diags.HasError() {
+		result.Policies = policiesSet
+	} else {
+		return result, fmt.Errorf("failed to parse policies")
 	}
 
 	return result, nil

--- a/internal/services/account_member/model.go
+++ b/internal/services/account_member/model.go
@@ -17,7 +17,7 @@ type AccountMemberModel struct {
 	AccountID types.String                                            `tfsdk:"account_id" path:"account_id,required"`
 	Email     types.String                                            `tfsdk:"email" json:"email,required"`
 	Status    types.String                                            `tfsdk:"status" json:"status,computed_optional"`
-	Roles     *[]types.String                                         `tfsdk:"roles" json:"roles,optional,no_refresh"`
+	Roles     customfield.Set[types.String]                           `tfsdk:"roles" json:"roles,computed_optional,no_refresh"`
 	Policies  customfield.NestedObjectSet[AccountMemberPoliciesModel] `tfsdk:"policies" json:"policies,computed_optional"`
 	User      customfield.NestedObject[AccountMemberUserModel]        `tfsdk:"user" json:"user,computed"`
 }

--- a/internal/services/account_member/testdata/cloudflare_account_member-roles-and-policies-invalid.tf
+++ b/internal/services/account_member/testdata/cloudflare_account_member-roles-and-policies-invalid.tf
@@ -1,0 +1,18 @@
+resource "cloudflare_account_member" "test_member" {
+  account_id = "%[1]s"
+  email      = "%[2]s"
+  status     = "pending"
+  roles = [
+    "doesn't matter"
+  ]
+  policies = [{
+    access = "allow"
+    resource_groups = [{
+      id : "doesn't matter"
+    }]
+    permission_groups = [{
+      id : "doesn't matter"
+    }]
+  }]
+}
+


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

This PR has a number of changes that are meant to address bugs with account_member Imports as well as drift issues around roles and policies.

### Resource Validation: ExactlyOneOf Roles or Policies

It is possible to pass both roles and policies to the API, but the API prefers policies and in that case will override the roles. This can cause unexpected errors if the API hands back roles different from what the user has configured. So, to reduce confusion we enforce one of either roles or policies, and error on both or neither.

### Changing resource Create function to perform POST + GET

There is a known bug in the POST endpoint for members whereby the response does not return roles. This causes part of our difficulties supporting roles, and some provider-side logic was attempting to fix this by simply preserving the state roles, which isn't great practice.

Roles may be removed in the future, and changing the endpoint is difficult. Instead, we can perform a second GET after the POST to retrieve the full correct state.

### Changing roles to a Set

Like other collection fields on policies, list order isn't guaranteed. To avoid unexpected drift, we can make roles into a set.

### Changing `ModifyPlan` to conditionally set Roles and Policies to "Unknown"

Roles vs Policies has been a problematic bit of the Members API. If the API caller provides roles, the server will hand back roles _and_ inferred policies. And If the API caller provides policies, the server will hand back policies _and_ roles. This is for backwards compatibility. But, the unknown response values can cause unintended drift or crashes in terraform.

Earlier fixes for this proved to be problematic. The new fix is to use the user's config to decide if they intend to change roles or policies, and if we can detect that change then we set the corresponding other collection to unknown (eg. if a user changes roles then the planned policies are set to unknown).

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
