### PR TITLE
chore(healthcheck): add test for expected_body default value

### DIFF
--- a/internal/services/healthcheck/testdata/http_no_expected_body.tf
+++ b/internal/services/healthcheck/testdata/http_no_expected_body.tf
@@ -1,0 +1,13 @@
+resource "cloudflare_healthcheck" "%[2]s" {
+  zone_id = "%[1]s"
+  name = "%[2]s"
+  address = "example.com"
+  type = "HTTP"
+  check_regions = ["WNAM"]
+  http_config = {
+    method = "GET"
+    path = "/"
+    port = 80
+    expected_codes = ["200"]
+  }
+}


### PR DESCRIPTION
Add acceptance test to verify that when expected_body is not specified in the config, the schema default of "" is used, matching the API response. This prevents plan drift for users who don't explicitly set expected_body.

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

1) Set environment variables:
- `CLOUDFLARE_ACCOUNT_ID=<insert_acc_id>`
- `CLOUDFLARE_ZONE_ID=<insert_zone_id>`
- `CLOUDFLARE_API_TOKEN=<insert_api_token>`
- `TC_ACC=1`

Ensure the API tokens as healthcheck edit permissions.

2) Run `go test ./internal/services/healthcheck -run "^TestAccCloudflareHealthcheck_ExpectedBodyDefaultNoDiff" -v -count 1`

### Test output

```
terraform-provider-cloudflare % ./run-tests.sh 
=== RUN   TestAccCloudflareHealthcheck_ExpectedBodyDefaultNoDiff
--- PASS: TestAccCloudflareHealthcheck_ExpectedBodyDefaultNoDiff (5.42s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/healthcheck       6.943s
```

## Additional context & links
