### PR TITLE
fix: update invalid codegen

### DIFF
--- a/internal/services/certificate_pack/resource.go
+++ b/internal/services/certificate_pack/resource.go
@@ -345,15 +345,19 @@ func (r *CertificatePackResource) ModifyPlan(ctx context.Context, req resource.M
 	// The API may:
 	// 1. Return hosts in a different order than submitted
 	// 2. Add additional hosts (e.g., cloudflaressl.com subdomain when cloudflare_branding=true)
-	if plan.Hosts != nil && state.Hosts != nil {
+	if !plan.Hosts.IsNull() && !state.Hosts.IsNull() {
 		planSet := make(map[string]bool)
 		stateSet := make(map[string]bool)
 
-		for _, h := range *plan.Hosts {
-			planSet[h.ValueString()] = true
+		for _, h := range plan.Hosts.Elements() {
+			if str, ok := h.(types.String); ok && !str.IsNull() {
+				planSet[str.ValueString()] = true
+			}
 		}
-		for _, h := range *state.Hosts {
-			stateSet[h.ValueString()] = true
+		for _, h := range state.Hosts.Elements() {
+			if str, ok := h.(types.String); ok && !str.IsNull() {
+				stateSet[str.ValueString()] = true
+			}
 		}
 
 		// Check if plan hosts are a subset of state hosts (API may have added extra hosts)

--- a/internal/services/certificate_pack/schema.go
+++ b/internal/services/certificate_pack/schema.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"


### PR DESCRIPTION
Unblocks acceptance tests by fixing some invalid code.

- adds missing import for `listplanmodifier`
- fixes bad `nil` checks for `plan.Hosts`
- fixes bad range over `plan.Hosts`

---

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [ ] ~~I have added or updated acceptance tests for my changes~~
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests


```bash
$ TF_ACC=1 go test ./internal/services/certificate_pack/... -v -count=1
```

### Test output


```
=== RUN   TestCertificatePackDataSourceModelSchemaParity
=== PAUSE TestCertificatePackDataSourceModelSchemaParity
=== RUN   TestCertificatePacksDataSourceModelSchemaParity
=== PAUSE TestCertificatePacksDataSourceModelSchemaParity
=== RUN   TestCertificatePackModelSchemaParity
=== PAUSE TestCertificatePackModelSchemaParity
=== RUN   TestAccCertificatePack_AdvancedLetsEncrypt
--- PASS: TestAccCertificatePack_AdvancedLetsEncrypt (5.49s)
=== RUN   TestAccCertificatePack_WaitForActive
--- PASS: TestAccCertificatePack_WaitForActive (5.88s)
=== RUN   TestAccCertificatePack_Basic
--- PASS: TestAccCertificatePack_Basic (5.37s)
=== RUN   TestAccCertificatePack_GoogleCA
--- PASS: TestAccCertificatePack_GoogleCA (5.04s)
=== RUN   TestAccCertificatePack_SSLComCA
--- PASS: TestAccCertificatePack_SSLComCA (4.03s)
=== RUN   TestAccCertificatePack_HttpValidation
--- PASS: TestAccCertificatePack_HttpValidation (4.59s)
=== RUN   TestAccCertificatePack_ValidityDays
=== RUN   TestAccCertificatePack_ValidityDays/14Days
=== RUN   TestAccCertificatePack_ValidityDays/30Days
=== RUN   TestAccCertificatePack_ValidityDays/365Days
--- PASS: TestAccCertificatePack_ValidityDays (12.68s)
    --- PASS: TestAccCertificatePack_ValidityDays/14Days (4.06s)
    --- PASS: TestAccCertificatePack_ValidityDays/30Days (4.43s)
    --- PASS: TestAccCertificatePack_ValidityDays/365Days (4.19s)
=== RUN   TestAccCertificatePack_CloudflareBranding
--- PASS: TestAccCertificatePack_CloudflareBranding (4.64s)
=== RUN   TestAccCertificatePack_ComputedFields
--- PASS: TestAccCertificatePack_ComputedFields (3.13s)
=== CONT  TestCertificatePackDataSourceModelSchemaParity
=== CONT  TestCertificatePackModelSchemaParity
=== CONT  TestCertificatePacksDataSourceModelSchemaParity
--- PASS: TestCertificatePackDataSourceModelSchemaParity (0.00s)
--- PASS: TestCertificatePackModelSchemaParity (0.00s)
--- PASS: TestCertificatePacksDataSourceModelSchemaParity (0.00s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/certificate_pack  50.863s
```

## Additional context & links
