### PR TITLE
chore: add acceptance tests for cloudflare_leaked_credential_check and cloudflare_leaked_credential_check_rule resources

### DIFF
--- a/internal/services/leaked_credential_check/resource_test.go
+++ b/internal/services/leaked_credential_check/resource_test.go
@@ -1,0 +1,90 @@
+package leaked_credential_check_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareLeakedCredentialsCheck_Basic(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_leaked_credential_check.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck_ZoneID(t)
+			acctest.TestAccPreCheck_Credentials(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create + Read
+			{
+				Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+				},
+			},
+			// Step 2: Update + Read
+			{
+				Config: testAccCloudflareLeakedCredentialsCheckDisabled(zoneID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(false)),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudflareLeakedCredentialsCheck_StateConsistency(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_leaked_credential_check.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck_ZoneID(t)
+			acctest.TestAccPreCheck_Credentials(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+				},
+			},
+		},
+	})
+}
+
+// Helper functions to load test case configurations
+func testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, name string) string {
+	return acctest.LoadTestCase("enabled.tf", zoneID, name)
+}
+
+func testAccCloudflareLeakedCredentialsCheckDisabled(zoneID, name string) string {
+	return acctest.LoadTestCase("disabled.tf", zoneID, name)
+}

--- a/internal/services/leaked_credential_check/testdata/disabled.tf
+++ b/internal/services/leaked_credential_check/testdata/disabled.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_leaked_credential_check" "%[2]s" {
+  zone_id = "%[1]s"
+  enabled = false
+}

--- a/internal/services/leaked_credential_check/testdata/enabled.tf
+++ b/internal/services/leaked_credential_check/testdata/enabled.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_leaked_credential_check" "%[2]s" {
+  zone_id = "%[1]s"
+  enabled = true
+}

--- a/internal/services/leaked_credential_check_rule/resource_test.go
+++ b/internal/services/leaked_credential_check_rule/resource_test.go
@@ -1,0 +1,98 @@
+package leaked_credential_check_rule_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareLeakedCredentialsCheckRule_Basic(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_leaked_credential_check_rule.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck_ZoneID(t)
+			acctest.TestAccPreCheck_Credentials(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create + Read
+			{
+				Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"username\")")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"pass\")")),
+				},
+			},
+			// Step 2: Update + Read
+			{
+				Config: testAccCloudflareLeakedCredentialsCheckModified(zoneID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"username_modified\")")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"pass_modified\")")),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudflareLeakedCredentialsCheckRule_StateConsistency(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_leaked_credential_check_rule.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck_ZoneID(t)
+			acctest.TestAccPreCheck_Credentials(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"username\")")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"pass\")")),
+				},
+			},
+			{
+				Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"username\")")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"pass\")")),
+				},
+			},
+		},
+	})
+}
+
+// Helper functions to load test case configurations
+func testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, name string) string {
+	return acctest.LoadTestCase("enabled.tf", zoneID, name)
+}
+
+func testAccCloudflareLeakedCredentialsCheckNotEnabled(zoneID, name string) string {
+	return acctest.LoadTestCase("not_enabled.tf", zoneID, name)
+}
+
+func testAccCloudflareLeakedCredentialsCheckModified(zoneID, name string) string {
+	return acctest.LoadTestCase("modified.tf", zoneID, name)
+}

--- a/internal/services/leaked_credential_check_rule/testdata/enabled.tf
+++ b/internal/services/leaked_credential_check_rule/testdata/enabled.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_leaked_credential_check" "%[2]s" {
+  zone_id = "%[1]s"
+  enabled = true
+}
+
+resource "cloudflare_leaked_credential_check_rule" "%[2]s" {
+  password = "lookup_json_string(http.request.body.raw, \"pass\")"
+  username = "lookup_json_string(http.request.body.raw, \"username\")"
+  zone_id  = "%[1]s"
+}

--- a/internal/services/leaked_credential_check_rule/testdata/modified.tf
+++ b/internal/services/leaked_credential_check_rule/testdata/modified.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_leaked_credential_check_rule" "%[2]s" {
+  password = "lookup_json_string(http.request.body.raw, \"pass_modified\")"
+  username = "lookup_json_string(http.request.body.raw, \"username_modified\")"
+  zone_id  = "%[1]s"
+}


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
- TF_ACC=1 go test ./internal/services/leaked_credential_check --count=1 
- TF_ACC=1 go test ./internal/services/leaked_credential_check_rule --count=1

### Test output
```
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/leaked_credential_check_rule	14.013s
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/leaked_credential_check	11.721s
```
## Additional context & links
