### PR TITLE
fix: cloudflare_worker can be cleanly imported

### DIFF
--- a/internal/services/worker/custom.go
+++ b/internal/services/worker/custom.go
@@ -32,3 +32,49 @@ func (m normalizeFloat64Modifier) PlanModifyFloat64(ctx context.Context, req pla
 	}
 	resp.PlanValue = types.Float64Value(req.PlanValue.ValueFloat64())
 }
+
+func DefaultSubdomainPreviewsEnabledToEnabled() planmodifier.Bool {
+	return defaultSubdomainPreviewsEnabledToEnabledModifier{}
+}
+
+type defaultSubdomainPreviewsEnabledToEnabledModifier struct{}
+
+func (m defaultSubdomainPreviewsEnabledToEnabledModifier) Description(_ context.Context) string {
+	return "Defaults subdomain.previews_enabled to the value of subdomain.enabled if subdomain.previews_enabled is not explicitly set"
+}
+
+func (m defaultSubdomainPreviewsEnabledToEnabledModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+// PlanModifyBool sets subdomain.previews_enabled to the value of
+// subdomain.enabled when subdomain.previews_enabled is null in the config.
+func (m defaultSubdomainPreviewsEnabledToEnabledModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	// If the config value is not null, the user has explicitly set it, so don't modify
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+
+	// If we're destroying, don't modify
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Get the sibling "enabled" attribute value
+	enabledPath := req.Path.ParentPath().AtName("enabled")
+	var enabled types.Bool
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, enabledPath, &enabled)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If subdomain.enabled is null or unknown, we can't use it as a default
+	if enabled.IsNull() || enabled.IsUnknown() {
+		// Fall back to false as the default
+		resp.PlanValue = types.BoolValue(false)
+		return
+	}
+
+	// Set subdomain.previews_enabled to the value of subdomain.enabled
+	resp.PlanValue = enabled
+}

--- a/internal/services/worker/resource.go
+++ b/internal/services/worker/resource.go
@@ -277,4 +277,5 @@ func (r *WorkerResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	// No changes to user-configurable attributes, so copy updated_on timestamp
 	// from state to avoid spurious changes.
 	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("updated_on"), state.UpdatedOn)...)
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("references"), state.References)...)
 }

--- a/internal/services/worker/schema.go
+++ b/internal/services/worker/schema.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -133,6 +134,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Description: "Whether [preview URLs](https://developers.cloudflare.com/workers/configuration/previews/) are enabled for the Worker.",
 						Computed:    true,
 						Optional:    true,
+						PlanModifiers: []planmodifier.Bool{
+							DefaultSubdomainPreviewsEnabledToEnabled(),
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 				Default: objectdefault.StaticValue(customfield.NewObjectMust(ctx, &WorkerSubdomainModel{

--- a/internal/services/worker/testdata/subdomain_enabled.tf
+++ b/internal/services/worker/testdata/subdomain_enabled.tf
@@ -1,0 +1,8 @@
+resource "cloudflare_worker" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[1]s"
+  
+  subdomain = {
+    enabled = true
+  }
+}

--- a/internal/services/worker/testdata/subdomain_explicit_previews.tf
+++ b/internal/services/worker/testdata/subdomain_explicit_previews.tf
@@ -1,0 +1,9 @@
+resource "cloudflare_worker" "%[1]s" {
+  account_id = "%[2]s"
+  name = "%[1]s"
+  
+  subdomain = {
+    enabled = true
+    previews_enabled = false
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Update cloudflare_worker to prevent update on import
- Mark references as known when they are the only change
- Update subdomain.previews_enabled to use dynamic default based on subdomain.enabled

This is a follow-up from #6357 that continues to work around an underlying floating point representation bug that we can't figure out. Terraform spuriously detects changes to the observability.head_sampling_rate property, marks the resource for update, and sets all computed properties to unknown. This change sets the computed subdomain.previews_enabled and references properties to known values in this case when there are no meaningful changes to the resource.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

```
$ CLOUDFLARE_ACCOUNT_ID=$CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_KEY=$CLOUDFLARE_API_KEY CLOUDFLARE_EMAIL=$CLOUDFLARE_EMAIL TF_ACC=1 go test ./internal/services/worker -run "^TestAccCloudflareWorker_Basic" -v -count 1
```
```
$ CLOUDFLARE_ACCOUNT_ID=$CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_KEY=$CLOUDFLARE_API_KEY CLOUDFLARE_EMAIL=$CLOUDFLARE_EMAIL TF_ACC=1 go test ./internal/services/worker -run "^TestAccCloudflareWorker_SubdomainDynamicDefault" -v -count 1
```

### Test output
<!-- Please paste the output of your acceptance test run below --> 

```
=== RUN   TestAccCloudflareWorker_Basic
--- PASS: TestAccCloudflareWorker_Basic (8.08s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/worker    8.110s
```

```
=== RUN   TestAccCloudflareWorker_SubdomainDynamicDefault
--- PASS: TestAccCloudflareWorker_SubdomainDynamicDefault (5.47s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/worker    5.490s
```

## Additional context & links

Closes ticket raised through internal support.