### PR TITLE
Add argo provider migration tests 

### DIFF
--- a/internal/services/argo_smart_routing/migrations_test.go
+++ b/internal/services/argo_smart_routing/migrations_test.go
@@ -1,0 +1,245 @@
+package argo_smart_routing_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestMigrateArgoSmartRoutingOnly tests migration from cloudflare_argo with only smart_routing attribute
+func TestMigrateArgoSmartRoutingOn(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_argo_smart_routing." + rnd
+	tmpDir := t.TempDir()
+
+	// V4 config - cloudflare_argo with smart_routing only
+	v4Config := fmt.Sprintf(`
+resource "cloudflare_argo" "%[1]s" {
+  zone_id       = "%[2]s"
+  smart_routing = "on"
+}`, rnd, zoneID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create with v4 provider
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			// Step 2: Run migration and verify state
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
+				// Verify resource migrated to cloudflare_argo_smart_routing
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.StringExact("on")),
+				// Verify computed fields are present
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("editable"), knownvalue.Bool(true)),
+			}),
+		},
+	})
+}
+
+// TestMigrateArgoSmartRoutingOff tests migration with smart_routing set to off
+func TestMigrateArgoSmartRoutingOff(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_argo_smart_routing." + rnd
+	tmpDir := t.TempDir()
+
+	// V4 config - cloudflare_argo with smart_routing off
+	v4Config := fmt.Sprintf(`
+resource "cloudflare_argo" "%[1]s" {
+  zone_id       = "%[2]s"
+  smart_routing = "off"
+}`, rnd, zoneID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create with v4 provider
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			// Step 2: Run migration and verify state
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.StringExact("off")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("editable"), knownvalue.Bool(true)),
+			}),
+		},
+	})
+}
+
+// TestMigrateArgoNeitherAttribute tests migration when neither attribute exists (defaults to smart_routing off)
+func TestMigrateArgoNeitherAttribute(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_argo_smart_routing." + rnd
+	tmpDir := t.TempDir()
+
+	// V4 config - cloudflare_argo with neither smart_routing nor tiered_caching
+	v4Config := fmt.Sprintf(`
+resource "cloudflare_argo" "%[1]s" {
+  zone_id = "%[2]s"
+}`, rnd, zoneID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create with v4 provider
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			// Step 2: Run migration and verify state
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
+				// Should default to smart_routing with value off
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.StringExact("off")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("editable"), knownvalue.Bool(true)),
+			}),
+		},
+	})
+}
+
+// TestMigrateArgoBothAttributes tests migration when both smart_routing and tiered_caching exist
+func TestMigrateArgoBothAttributes(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	smartRoutingResourceName := "cloudflare_argo_smart_routing." + rnd
+	tieredCachingResourceName := "cloudflare_argo_tiered_caching." + rnd + "_tiered"
+	tmpDir := t.TempDir()
+
+	// V4 config - cloudflare_argo with both attributes
+	v4Config := fmt.Sprintf(`
+resource "cloudflare_argo" "%[1]s" {
+  zone_id        = "%[2]s"
+  smart_routing  = "on"
+  tiered_caching = "on"
+}`, rnd, zoneID)
+
+	stateChecks := []statecheck.StateCheck{
+		// Verify smart_routing resource
+		statecheck.ExpectKnownValue(smartRoutingResourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+		statecheck.ExpectKnownValue(smartRoutingResourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+		statecheck.ExpectKnownValue(smartRoutingResourceName, tfjsonpath.New("value"), knownvalue.StringExact("on")),
+		statecheck.ExpectKnownValue(smartRoutingResourceName, tfjsonpath.New("editable"), knownvalue.Bool(true)),
+		// Verify tiered_caching resource with _tiered suffix
+		statecheck.ExpectKnownValue(tieredCachingResourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+		statecheck.ExpectKnownValue(tieredCachingResourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+		statecheck.ExpectKnownValue(tieredCachingResourceName, tfjsonpath.New("value"), knownvalue.StringExact("on")),
+		statecheck.ExpectKnownValue(tieredCachingResourceName, tfjsonpath.New("editable"), knownvalue.Bool(true)),
+	}
+
+	steps := []resource.TestStep{
+		{
+			// Step 1: Create with v4 provider
+			ExternalProviders: map[string]resource.ExternalProvider{
+				"cloudflare": {
+					Source:            "cloudflare/cloudflare",
+					VersionConstraint: "4.52.1",
+				},
+			},
+			Config: v4Config,
+		},
+	}
+
+	// Steps 2-3: Run migration and verify state (allows creates for split resources)
+	steps = append(steps, acctest.MigrationV2TestStepAllowCreate(t, v4Config, tmpDir, "4.52.1", "v4", "v5", stateChecks)...)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps:      steps,
+	})
+}
+
+// TestMigrateArgoWithVariables tests migration with variable references
+func TestMigrateArgoWithVariables(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_argo_smart_routing." + rnd
+	tmpDir := t.TempDir()
+
+	// V4 config with variable reference
+	v4Config := fmt.Sprintf(`
+variable "zone_id" {
+  type    = string
+  default = "%[2]s"
+}
+
+resource "cloudflare_argo" "%[1]s" {
+  zone_id       = var.zone_id
+  smart_routing = "on"
+}`, rnd, zoneID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create with v4 provider
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			// Step 2: Run migration and verify state
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.StringExact("on")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("editable"), knownvalue.Bool(true)),
+			}),
+		},
+	})
+}

--- a/internal/services/argo_tiered_caching/migrations_test.go
+++ b/internal/services/argo_tiered_caching/migrations_test.go
@@ -1,0 +1,149 @@
+package argo_tiered_caching_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestMigrateArgoTieredCachingOnly tests migration from cloudflare_argo with only tiered_caching attribute
+func TestMigrateArgoTieredCachingOnly(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_argo_tiered_caching." + rnd
+	tmpDir := t.TempDir()
+
+	// V4 config - cloudflare_argo with tiered_caching only
+	v4Config := fmt.Sprintf(`
+resource "cloudflare_argo" "%[1]s" {
+  zone_id        = "%[2]s"
+  tiered_caching = "on"
+}`, rnd, zoneID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create with v4 provider
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			// Step 2: Run migration and verify state
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
+				// Verify resource migrated to cloudflare_argo_tiered_caching
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.StringExact("on")),
+				// Verify computed fields are present
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("editable"), knownvalue.Bool(true)),
+			}),
+		},
+	})
+}
+
+// TestMigrateArgoTieredCachingOff tests migration with tiered_caching set to off
+func TestMigrateArgoTieredCachingOff(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_argo_tiered_caching." + rnd
+	tmpDir := t.TempDir()
+
+	// V4 config - cloudflare_argo with tiered_caching off
+	v4Config := fmt.Sprintf(`
+resource "cloudflare_argo" "%[1]s" {
+  zone_id        = "%[2]s"
+  tiered_caching = "off"
+}`, rnd, zoneID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create with v4 provider
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			// Step 2: Run migration and verify state
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.StringExact("off")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("editable"), knownvalue.Bool(true)),
+			}),
+		},
+	})
+}
+
+// TestMigrateArgoTieredCachingWithVariables tests migration with variable references
+func TestMigrateArgoTieredCachingWithVariables(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_argo_tiered_caching." + rnd
+	tmpDir := t.TempDir()
+
+	// V4 config with variable reference
+	v4Config := fmt.Sprintf(`
+variable "zone_id" {
+  type    = string
+  default = "%[2]s"
+}
+
+resource "cloudflare_argo" "%[1]s" {
+  zone_id        = var.zone_id
+  tiered_caching = "on"
+}`, rnd, zoneID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create with v4 provider
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			// Step 2: Run migration and verify state
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.StringExact("on")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("editable"), knownvalue.Bool(true)),
+			}),
+		},
+	})
+}
+


### PR DESCRIPTION
  ✅ argo_smart_routing - 5/5 tests PASSED (57.763s)                                                                   
                                                                                                                       
  === RUN   TestMigrateArgoSmartRoutingOn                                                                              
  --- PASS: TestMigrateArgoSmartRoutingOn (11.73s)                                                                     
  === RUN   TestMigrateArgoSmartRoutingOff                                                                             
  --- PASS: TestMigrateArgoSmartRoutingOff (10.51s)                                                                    
  === RUN   TestMigrateArgoNeitherAttribute                                                                            
  --- PASS: TestMigrateArgoNeitherAttribute (9.97s)                                                                    
  === RUN   TestMigrateArgoBothAttributes                                                                              
  --- PASS: TestMigrateArgoBothAttributes (13.62s)                                                                     
  === RUN   TestMigrateArgoWithVariables                                                                               
  --- PASS: TestMigrateArgoWithVariables (10.86s)                                                                      
  PASS                                                                                                                 
  ok    github.com/cloudflare/terraform-provider-cloudflare/internal/services/argo_smart_routing        57.763s        
                                                                                                                       
  ✅ argo_tiered_caching - 3/3 tests PASSED (35.508s)                                                                  
                                                                                                                       
  === RUN   TestMigrateArgoTieredCachingOnly                                                                           
  --- PASS: TestMigrateArgoTieredCachingOnly (11.36s)                                                                  
  === RUN   TestMigrateArgoTieredCachingOff                                                                            
  --- PASS: TestMigrateArgoTieredCachingOff (11.49s)                                                                   
  === RUN   TestMigrateArgoTieredCachingWithVariables                                                                  
  --- PASS: TestMigrateArgoTieredCachingWithVariables (10.84s)                                                         
  PASS                                                                                                                 
  ok    github.com/cloudflare/terraform-provider-cloudflare/internal/services/argo_tiered_caching       35.508s 