### PR TITLE
feat(spectrum_application): update migration tests

### DIFF
--- a/internal/services/spectrum_application/migrations_test.go
+++ b/internal/services/spectrum_application/migrations_test.go
@@ -41,7 +41,7 @@ func TestMigrateSpectrumApplication_Basic(t *testing.T) {
 				Config: v4Config,
 			},
 		}, // Step 2: Run migration and verify state
-			acctest.MigrationTestStepWithPlan(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStepWithPlan(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("protocol"), knownvalue.StringExact("tcp/22")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dns").AtMapKey("type"), knownvalue.StringExact("CNAME")),
@@ -77,7 +77,7 @@ func TestMigrateSpectrumApplication_OriginPortRange(t *testing.T) {
 				Config: v4Config,
 			},
 		}, // Step 2: Run migration and verify state
-			acctest.MigrationTestStepWithPlan(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStepWithPlan(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("protocol"), knownvalue.StringExact("tcp/3306")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dns").AtMapKey("type"), knownvalue.StringExact("CNAME")),
@@ -114,7 +114,7 @@ func TestMigrateSpectrumApplication_EdgeIPs(t *testing.T) {
 				Config: v4Config,
 			},
 		}, // Step 2: Run migration and verify state
-			acctest.MigrationTestStepWithPlan(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStepWithPlan(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("protocol"), knownvalue.StringExact("tcp/443")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dns").AtMapKey("type"), knownvalue.StringExact("CNAME")),
@@ -152,7 +152,7 @@ func TestMigrateSpectrumApplication_OriginDirect(t *testing.T) {
 				Config: v4Config,
 			},
 		}, // Step 2: Run migration and verify state
-			acctest.MigrationTestStepWithPlan(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStepWithPlan(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("protocol"), knownvalue.StringExact("tcp/3306")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dns").AtMapKey("type"), knownvalue.StringExact("CNAME")),
@@ -189,7 +189,7 @@ func TestMigrateSpectrumApplication_Complex(t *testing.T) {
 				Config: v4Config,
 			},
 		}, // Step 2: Run migration and verify state
-			acctest.MigrationTestStepWithPlan(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStepWithPlan(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("protocol"), knownvalue.StringExact("tcp/443")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dns").AtMapKey("type"), knownvalue.StringExact("CNAME")),


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
- updates the migration tests for spectrum_application to use the MigrateV2... method that uses the tf-migrate binary

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/ssicard/workspace/terraform-devstack/tf-migrate/tf-migrate go test -v -run "TestMigrate

### Test output
```
=== RUN   TestMigrateSpectrumApplication_Basic
--- PASS: TestMigrateSpectrumApplication_Basic (13.28s)
=== RUN   TestMigrateSpectrumApplication_OriginPortRange
--- PASS: TestMigrateSpectrumApplication_OriginPortRange (12.92s)
=== RUN   TestMigrateSpectrumApplication_EdgeIPs
--- PASS: TestMigrateSpectrumApplication_EdgeIPs (16.27s)
=== RUN   TestMigrateSpectrumApplication_OriginDirect
--- PASS: TestMigrateSpectrumApplication_OriginDirect (13.08s)
=== RUN   TestMigrateSpectrumApplication_Complex
--- PASS: TestMigrateSpectrumApplication_Complex (12.28s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/spectrum_application	69.264s
```

## Additional context & links
