### PR TITLE
update migration tests to v2 for tiered_cache resource

### DIFF
--- a/internal/services/tiered_cache/migrations_test.go
+++ b/internal/services/tiered_cache/migrations_test.go
@@ -51,7 +51,7 @@ resource "cloudflare_tiered_cache" "%[1]s" {
 				},
 			},
 			// Step 2: Run migration and verify state transformation
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.StringExact("on")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
@@ -100,7 +100,7 @@ resource "cloudflare_tiered_cache" "%[1]s" {
 			},
 			// Step 2: Run migration and verify state transformation
 			// After migration, the resource should be moved to cloudflare_argo_tiered_caching
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				// The resource should now exist as cloudflare_argo_tiered_caching with value="on"
 				statecheck.ExpectKnownValue(migratedResourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
 				statecheck.ExpectKnownValue(migratedResourceName, tfjsonpath.New("value"), knownvalue.StringExact("on")),
@@ -147,7 +147,7 @@ resource "cloudflare_tiered_cache" "%[1]s" {
 				},
 			},
 			// Step 2: Run migration and verify state transformation
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.StringExact("off")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
@@ -214,7 +214,7 @@ resource "cloudflare_tiered_cache" "%[1]s" {
 							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
 						},
 					},
-					acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+					acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.StringExact(tc.v5Value)),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),


### PR DESCRIPTION
=== RUN   TestMigrateTieredCache_Smart
--- PASS: TestMigrateTieredCache_Smart (16.35s)
=== RUN   TestMigrateTieredCache_Generic
--- PASS: TestMigrateTieredCache_Generic (13.56s)
=== RUN   TestMigrateTieredCache_Off
--- PASS: TestMigrateTieredCache_Off (13.38s)
=== RUN   TestMigrateTieredCache_AllValues
=== RUN   TestMigrateTieredCache_AllValues/Smart_To_On
=== RUN   TestMigrateTieredCache_AllValues/Off_To_Off
--- PASS: TestMigrateTieredCache_AllValues (30.44s)
    --- PASS: TestMigrateTieredCache_AllValues/Smart_To_On (15.16s)
    --- PASS: TestMigrateTieredCache_AllValues/Off_To_Off (15.28s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/tiered_cache      74.797s
