### PR TITLE
feat(zero_trust_access_identity_provider): update migrations test 

### DIFF
--- a/internal/services/zero_trust_access_identity_provider/migrations_test.go
+++ b/internal/services/zero_trust_access_identity_provider/migrations_test.go
@@ -57,7 +57,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 				Config: v4Config,
 			},
 			// Step 2: Run migration and verify state
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("onetimepin")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
@@ -110,7 +110,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 				},
 				Config: v4Config,
 			},
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("onetimepin")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
@@ -161,7 +161,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 				},
 				Config: v4Config,
 			},
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("github")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
@@ -226,7 +226,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 				},
 				Config: v4Config,
 			},
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("azureAD")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
@@ -370,7 +370,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 				},
 				Config: v4Config,
 			},
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("github")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
@@ -422,7 +422,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 				},
 				Config: v4Config,
 			},
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("linkedin")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
@@ -480,7 +480,7 @@ resource "cloudflare_access_identity_provider" "%[1]s" {
 				},
 				Config: v4Config,
 			},
-			acctest.MigrationTestStep(t, v4Config, tmpDir, "4.52.1", []statecheck.StateCheck{
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("azureAD")),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
- updates `zero_trust_access_identity_rule` to use MigrateV2.. for migrations_test to test against tf-migrate

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
`TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/ssicard/workspace/terraform-devstack/tf-migrate/tf-migrate go test -v -run "TestMigrate"`

### Test output
```
=== RUN   TestMigrateZeroTrustAccessIdentityProvider_OneTimePin_Basic
--- PASS: TestMigrateZeroTrustAccessIdentityProvider_OneTimePin_Basic (12.00s)
=== RUN   TestMigrateZeroTrustAccessIdentityProvider_OneTimePin_Zone
--- PASS: TestMigrateZeroTrustAccessIdentityProvider_OneTimePin_Zone (11.45s)
=== RUN   TestMigrateZeroTrustAccessIdentityProvider_OAuth_Comprehensive
--- PASS: TestMigrateZeroTrustAccessIdentityProvider_OAuth_Comprehensive (11.06s)
=== RUN   TestMigrateZeroTrustAccessIdentityProvider_AzureAD_Comprehensive
--- PASS: TestMigrateZeroTrustAccessIdentityProvider_AzureAD_Comprehensive (11.33s)
=== RUN   TestMigrateZeroTrustAccessIdentityProvider_SAML_Comprehensive
--- PASS: TestMigrateZeroTrustAccessIdentityProvider_SAML_Comprehensive (11.95s)
=== RUN   TestMigrateZeroTrustAccessIdentityProvider_GitHub
--- PASS: TestMigrateZeroTrustAccessIdentityProvider_GitHub (11.98s)
=== RUN   TestMigrateZeroTrustAccessIdentityProvider_GenericOAuth
--- PASS: TestMigrateZeroTrustAccessIdentityProvider_GenericOAuth (12.89s)
=== RUN   TestMigrateZeroTrustAccessIdentityProvider_SCIM_Secret_Enabled_After_Resource_Creation
--- PASS: TestMigrateZeroTrustAccessIdentityProvider_SCIM_Secret_Enabled_After_Resource_Creation (11.69s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_access_identity_provider	95.770s
```

## Additional context & links
