### PR TITLE
test(spectrum_application): remove BasicMinecraft test for deprecated…

### DIFF
--- a/internal/services/spectrum_application/resource_test.go
+++ b/internal/services/spectrum_application/resource_test.go
@@ -328,29 +328,6 @@ func TestAccCloudflareSpectrumApplication_BasicRDP(t *testing.T) {
 	})
 }
 
-func TestAccCloudflareSpectrumApplication_BasicMinecraft(t *testing.T) {
-	var spectrumApp cloudflare.SpectrumApplication
-	domain := os.Getenv("CLOUDFLARE_DOMAIN")
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
-	rnd := utils.GenerateRandomResourceName()
-	name := "cloudflare_spectrum_application." + rnd
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckCloudflareSpectrumApplicationConfigBasicTypes(zoneID, domain, rnd, "minecraft", 25565),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareSpectrumApplicationExists(name, &spectrumApp),
-					testAccCheckCloudflareSpectrumApplicationIDIsValid(name),
-					resource.TestCheckResourceAttr(name, "protocol", "minecraft"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccCloudflareSpectrumApplication_TLS(t *testing.T) {
 	var spectrumApp cloudflare.SpectrumApplication
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")


### PR DESCRIPTION
## Summary

  Removes the `TestAccCloudflareSpectrumApplication_BasicMinecraft` test which
  was failing due to Cloudflare deprecating the `minecraft` named protocol.

  ## Details

  - **Issue**: Test was failing with API error 13002: "The requested protocol is
  not available"
  - **Root cause**: Cloudflare removed support for the `minecraft` named protocol
   from their Spectrum API
  - **Solution**: Removed the test entirely since the feature it was testing (the
   minecraft protocol shortcut) no longer exists
  - **Note**: Other named protocols (`ssh`, `rdp`) still work and their tests
  continue to pass