### PR TITLE
fix(zero_trust_access_application): remove all conditions from sweeper

### DIFF
--- a/internal/services/zero_trust_access_application/resource_test.go
+++ b/internal/services/zero_trust_access_application/resource_test.go
@@ -57,11 +57,6 @@ func testSweepCloudflareAccessApplications(r string) error {
 	}
 
 	for _, accessApp := range zoneAccessApps {
-		// Use standard filtering helper
-		if !utils.ShouldSweepResource(accessApp.Name) {
-			continue
-		}
-
 		tflog.Info(ctx, fmt.Sprintf("Deleting zone-level Access Application: %s (%s)", accessApp.Name, accessApp.ID))
 		if err := client.DeleteAccessApplication(context.Background(), cloudflare.ZoneIdentifier(zoneID), accessApp.ID); err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to delete zone-level Access Application %s (%s): %s", accessApp.Name, accessApp.ID, err))
@@ -87,11 +82,6 @@ func testSweepCloudflareAccessApplications(r string) error {
 	}
 
 	for _, accessApp := range accountAccessApps {
-		// Use standard filtering helper
-		if !utils.ShouldSweepResource(accessApp.Name) {
-			continue
-		}
-
 		tflog.Info(ctx, fmt.Sprintf("Deleting account-level Access Application: %s (%s)", accessApp.Name, accessApp.ID))
 		if err := client.DeleteAccessApplication(context.Background(), cloudflare.AccountIdentifier(accountID), accessApp.ID); err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to delete account-level Access Application %s (%s): %s", accessApp.Name, accessApp.ID, err))


### PR DESCRIPTION
  The sweeper was using ShouldSweepResource to filter applications by name,
  but this caused issues with app_launcher applications which don't have names.

  Since Cloudflare only allows one app_launcher per account, and tests use
  isolated test accounts/zones, it's safe to unconditionally delete all
  access applications during sweeps.

  This ensures tests always start with a clean slate and prevents 409 Conflict
  errors when applications from previous test runs weren't properly cleaned up.

