### PR TITLE
fix(snippet): v4 to v5 migration acceptance tests

### DIFF
--- a/internal/services/snippet/migrations_test.go
+++ b/internal/services/snippet/migrations_test.go
@@ -68,8 +68,8 @@ func TestMigrateCloudflareSnippetBasic(t *testing.T) {
 					// Write out config
 					acctest.WriteOutConfig(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigBasic, rnd, zoneID), tmpDir)
 
-					// Run migration
-					acctest.RunMigrationCommand(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigBasic, rnd, zoneID), tmpDir)
+					// Run V2 migration
+					acctest.RunMigrationV2Command(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigBasic, rnd, zoneID), tmpDir, "v4", "v5")
 				},
 				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory(tmpDir),
@@ -126,8 +126,8 @@ func TestMigrateCloudflareSnippetMultipleFiles(t *testing.T) {
 					// Write out config
 					acctest.WriteOutConfig(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigMultipleFiles, rnd, zoneID), tmpDir)
 
-					// Run migration
-					acctest.RunMigrationCommand(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigMultipleFiles, rnd, zoneID), tmpDir)
+					// Run V2 migration
+					acctest.RunMigrationV2Command(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigMultipleFiles, rnd, zoneID), tmpDir, "v4", "v5")
 				},
 				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory(tmpDir),
@@ -191,8 +191,8 @@ func TestMigrateCloudflareSnippetComplexContent(t *testing.T) {
 					// Write out config
 					acctest.WriteOutConfig(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigComplexContent, rnd, zoneID), tmpDir)
 
-					// Run migration
-					acctest.RunMigrationCommand(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigComplexContent, rnd, zoneID), tmpDir)
+					// Run V2 migration
+					acctest.RunMigrationV2Command(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigComplexContent, rnd, zoneID), tmpDir, "v4", "v5")
 				},
 				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory(tmpDir),
@@ -248,8 +248,8 @@ func TestMigrateCloudflareSnippetWithImport(t *testing.T) {
 					// Write out config
 					acctest.WriteOutConfig(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigBasic, rnd, zoneID), tmpDir)
 
-					// Run migration
-					acctest.RunMigrationCommand(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigBasic, rnd, zoneID), tmpDir)
+					// Run V2 migration
+					acctest.RunMigrationV2Command(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigBasic, rnd, zoneID), tmpDir, "v4", "v5")
 				},
 				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory(tmpDir),
@@ -297,8 +297,8 @@ func TestMigrateCloudflareSnippetURLRewrite(t *testing.T) {
 					// Write out config
 					acctest.WriteOutConfig(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigURLRewrite, rnd, zoneID), tmpDir)
 
-					// Run migration
-					acctest.RunMigrationCommand(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigURLRewrite, rnd, zoneID), tmpDir)
+					// Run V2 migration
+					acctest.RunMigrationV2Command(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigURLRewrite, rnd, zoneID), tmpDir, "v4", "v5")
 				},
 				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory(tmpDir),
@@ -354,8 +354,8 @@ func TestMigrateCloudflareSnippetHeaderManipulation(t *testing.T) {
 					// Write out config
 					acctest.WriteOutConfig(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigHeaderManipulation, rnd, zoneID), tmpDir)
 
-					// Run migration
-					acctest.RunMigrationCommand(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigHeaderManipulation, rnd, zoneID), tmpDir)
+					// Run V2 migration
+					acctest.RunMigrationV2Command(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigHeaderManipulation, rnd, zoneID), tmpDir, "v4", "v5")
 				},
 				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory(tmpDir),
@@ -410,8 +410,8 @@ func TestMigrateCloudflareSnippetEdgeCases(t *testing.T) {
 					// Write out config
 					acctest.WriteOutConfig(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigEdgeCases, rnd, zoneID), tmpDir)
 
-					// Run migration
-					acctest.RunMigrationCommand(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigEdgeCases, rnd, zoneID), tmpDir)
+					// Run V2 migration
+					acctest.RunMigrationV2Command(t, fmt.Sprintf(testAccCloudflareSnippetMigrationConfigEdgeCases, rnd, zoneID), tmpDir, "v4", "v5")
 				},
 				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory(tmpDir),


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
TF_ACC=1 TF_MIGRATE_BINARY_PATH=~/cf-repos/terraform-devstack/tf-migrate/tf-migrate go test -v -run "TestMigrate" ./internal/services/snippet            

### Test output
=== RUN   TestMigrateCloudflareSnippetBasic
--- PASS: TestMigrateCloudflareSnippetBasic (9.67s)
=== RUN   TestMigrateCloudflareSnippetMultipleFiles
--- PASS: TestMigrateCloudflareSnippetMultipleFiles (10.81s)
=== RUN   TestMigrateCloudflareSnippetComplexContent
--- PASS: TestMigrateCloudflareSnippetComplexContent (8.82s)
=== RUN   TestMigrateCloudflareSnippetWithImport
--- PASS: TestMigrateCloudflareSnippetWithImport (10.13s)
=== RUN   TestMigrateCloudflareSnippetURLRewrite
--- PASS: TestMigrateCloudflareSnippetURLRewrite (10.43s)
=== RUN   TestMigrateCloudflareSnippetHeaderManipulation
--- PASS: TestMigrateCloudflareSnippetHeaderManipulation (10.34s)
=== RUN   TestMigrateCloudflareSnippetEdgeCases
--- PASS: TestMigrateCloudflareSnippetEdgeCases (9.44s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/snippet   71.332s
