### PR TITLE
ACCT-10961 account member status drift fix

### DIFF
--- a/internal/services/account_member/custom.go
+++ b/internal/services/account_member/custom.go
@@ -114,10 +114,13 @@ func unmarshalComputedCustom(data []byte, configuredModel *AccountMemberModel) (
 		result.Email = configuredModel.Email
 	}
 
-	// Only preserve status if it was explicitly configured
-	if !configuredModel.Status.IsNull() && !configuredModel.Status.IsUnknown() {
-		result.Status = configuredModel.Status
-	}
+	// Allow the status from the API to override the state,
+    // even if not explicitly set in the config.
+    if result.Status.IsNull() && !configuredModel.Status.IsNull() {
+        result.Status = configuredModel.Status
+    }
+    // If result.Status has a value from the API (e.g., "accepted"),
+    // we let it stay so it updates the Terraform state.
 
 	return parsePoliciesAndRoles(ctx, data, result)
 }

--- a/internal/services/account_member/schema.go
+++ b/internal/services/account_member/schema.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -47,7 +46,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					stringvalidator.OneOfCaseInsensitive("accepted", "pending"),
 				},
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIfConfigured()},
-				Default:       stringdefault.StaticString("pending"),
 			},
 			"roles": schema.SetAttribute{
 				Description: "Set of roles associated with this member.",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
This PR is aiming at solving status field caused drift issues around roles and policies updating.

## Root Cause
The status field drift occurred because the Terraform provider was strictly prioritizing the local configuration—which defaulted to pending—over the live API response. Even after a user accepted their invitation and the backend updated the database to accepted, the provider's unmarshal logic would "gatekeep" the state, forcing it back to pending during every refresh because the field wasn't explicitly set in the HCL. This state mismatch directly broke role and policy updates; when a user attempted to change permissions, the provider would either omit the status or send the incorrect pending value in the PUT request. The Cloudflare backend, which requires a valid current status to process membership modifications, would then silently reject the permission changes, leaving the Terraform state and the actual UI roles completely out of sync.

## Solution
Based on @steve-thousand branch: [steve-thousand:sconrad/account_member-refactor](https://github.com/steve-thousand/terraform-provider-cloudflare/tree/sconrad/account_member-refactor): 
 - Remove the default pending status for status
 - Allow the status from the API to override the state, even if not explicitly set in the config.

## Note
This branch have to be merged after this pr:  [cloudflare_account_member refactor #6520](https://github.com/cloudflare/terraform-provider-cloudflare/pull/6520/files#diff-d568d92b75f09a8b64bbafcd9f95ad490056972a84b0622f93efaf25fdd9f220R90) merged.

## Test
- Run this resource 
```javascript
resource "cloudflare_account_member" "test_member" { 
      account_id = <ACCOUNT_ID>
      email = <MEMBER_EMAIL>
      roles = [ <ROLE_1>] 
}
```

- New member accept the invite, and update roles to ROLE_2. After `terraform plan` should see return like blow
```
~ policies   = [
  - {
      - access            = "allow" -> null
      - permission_groups = [
          - {
              - id = "8e23b19e4e0d44c29d239c5688ba8cbb" -> null
            },
        ] -> null
      - resource_groups   = [
          - {
              - id = "ff5c503c062b427f994b76ce44ea152b" -> null
            },
        ] -> null
    },
] -> (known after apply)
~ roles      = [
    - "33666b9c79b9a5273fc7344ff42f953d",
    + "f2b20eaa1a5d4af42b53ac16238c99c7",
  ]
~ status     = "accepted" -> (known after apply)
```
Refresh the UI, should see the roles change. 

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
