### PR TITLE
ignore changes to r2_bucket location hint after bucket has been created

### DIFF
--- a/internal/services/r2_bucket/plan_modifiers.go
+++ b/internal/services/r2_bucket/plan_modifiers.go
@@ -2,7 +2,6 @@ package r2_bucket
 
 import (
 	"context"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -16,15 +15,9 @@ func modifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resour
 		return
 	}
 
-	// Handle case-insensitive location comparison
-	if stateApp != nil && !planApp.Location.IsNull() && !stateApp.Location.IsNull() &&
-		!planApp.Location.IsUnknown() && !stateApp.Location.IsUnknown() {
-		planAppLocation := planApp.Location.ValueString()
-		stateAppLocation := stateApp.Location.ValueString()
-		// If locations match case-insensitively, preserve the state's case
-		if strings.EqualFold(planAppLocation, stateAppLocation) {
-			res.Diagnostics.Append(res.Plan.SetAttribute(ctx, path.Root("location"), stateApp.Location)...)
-		}
+	// Location of a bucket cannot be changed after it is already created
+	if stateApp != nil && !stateApp.Location.IsNull() && !stateApp.Location.IsUnknown() {
+		res.Diagnostics.Append(res.Plan.SetAttribute(ctx, path.Root("location"), stateApp.Location)...)
 	}
 
 	if stateApp != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
TF_ACC=1 go test -v -run "^TestAcc" -count 1 ./internal/services/r2_bucket/

### Test output
<!-- Please paste the output of your acceptance test run below --> 
=== RUN   TestAccCloudflareR2Bucket_Basic
--- PASS: TestAccCloudflareR2Bucket_Basic (6.28s)
=== RUN   TestAccCloudflareR2Bucket_Minimum
--- PASS: TestAccCloudflareR2Bucket_Minimum (3.27s)
=== RUN   TestAccCloudflareR2Bucket_Jurisdiction
--- PASS: TestAccCloudflareR2Bucket_Jurisdiction (4.30s)
=== RUN   TestAccCloudflareR2Bucket_AllLocations
=== RUN   TestAccCloudflareR2Bucket_AllLocations/apac
=== RUN   TestAccCloudflareR2Bucket_AllLocations/eeur
=== RUN   TestAccCloudflareR2Bucket_AllLocations/enam
=== RUN   TestAccCloudflareR2Bucket_AllLocations/weur
=== RUN   TestAccCloudflareR2Bucket_AllLocations/wnam
=== RUN   TestAccCloudflareR2Bucket_AllLocations/oc
--- PASS: TestAccCloudflareR2Bucket_AllLocations (22.94s)
    --- PASS: TestAccCloudflareR2Bucket_AllLocations/apac (4.47s)
    --- PASS: TestAccCloudflareR2Bucket_AllLocations/eeur (4.17s)
    --- PASS: TestAccCloudflareR2Bucket_AllLocations/enam (3.06s)
    --- PASS: TestAccCloudflareR2Bucket_AllLocations/weur (3.93s)
    --- PASS: TestAccCloudflareR2Bucket_AllLocations/wnam (2.07s)
    --- PASS: TestAccCloudflareR2Bucket_AllLocations/oc (5.24s)
=== RUN   TestAccCloudflareR2Bucket_AllJurisdictions
=== RUN   TestAccCloudflareR2Bucket_AllJurisdictions/default
=== RUN   TestAccCloudflareR2Bucket_AllJurisdictions/fedramp
--- PASS: TestAccCloudflareR2Bucket_AllJurisdictions (4.82s)
    --- PASS: TestAccCloudflareR2Bucket_AllJurisdictions/default (2.25s)
    --- PASS: TestAccCloudflareR2Bucket_AllJurisdictions/fedramp (2.57s)
=== RUN   TestAccCloudflareR2Bucket_ComprehensiveConfiguration
--- PASS: TestAccCloudflareR2Bucket_ComprehensiveConfiguration (4.32s)
=== RUN   TestAccCloudflareR2Bucket_DefaultValues
--- PASS: TestAccCloudflareR2Bucket_DefaultValues (2.35s)
=== RUN   TestAccCloudflareR2Bucket_StorageClassUpdate
--- PASS: TestAccCloudflareR2Bucket_StorageClassUpdate (4.23s)
=== RUN   TestAccCloudflareR2Bucket_LocationCaseInsensitive
=== PAUSE TestAccCloudflareR2Bucket_LocationCaseInsensitive
=== RUN   TestAccCloudflareR2Bucket_LocationIgnoreChange
--- PASS: TestAccCloudflareR2Bucket_LocationIgnoreChange (5.44s)
=== CONT  TestAccCloudflareR2Bucket_LocationCaseInsensitive
--- PASS: TestAccCloudflareR2Bucket_LocationCaseInsensitive (7.45s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_bucket 67.452s

## Additional context & links
