### PR TITLE
fix(pages_project): add missing external link to docs

### DIFF
--- a/templates/resources/pages_project.md.tmpl
+++ b/templates/resources/pages_project.md.tmpl
@@ -11,7 +11,8 @@ description: |-
 
 -> If you are using a `source` block configuration, you must first have a
    connected GitHub or GitLab account connected to Cloudflare. See the
-   [Getting Started with Pages] documentation on how to link your accounts.
+   [Getting Started with Pages](https://developers.cloudflare.com/pages/get-started/git-integration/)
+   documentation on how to link your accounts.
 
 {{ if .HasExample -}}
 ## Example Usage


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adds missing link to the docs for the `pages_project` resource. The change is made to the template file.

Fixes #6606 
