### PR TITLE
test(turnstile_widget): add comprehensive acceptance tests for CRUD + Import + Data Sources

### DIFF
--- a/internal/services/turnstile_widget/data_source_test.go
+++ b/internal/services/turnstile_widget/data_source_test.go
@@ -1,0 +1,72 @@
+package turnstile_widget_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareTurnstileWidgetDataSource_BySitekey(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_turnstile_widget." + rnd
+	dataSourceName := "data.cloudflare_turnstile_widget." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareTurnstileWidgetDataSource_BySitekey(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("mode"), knownvalue.StringExact("managed")),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("sitekey"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("secret"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("created_on"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("modified_on"), knownvalue.NotNull()),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "sitekey", resourceName, "sitekey"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "mode", resourceName, "mode"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareTurnstileWidgetsDataSource_List(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	dataSourceName := "data.cloudflare_turnstile_widgets." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareTurnstileWidgetsDataSource_List(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+				},
+			},
+		},
+	})
+}
+
+func testAccCloudflareTurnstileWidgetDataSource_BySitekey(rnd, accountID string) string {
+	return acctest.LoadTestCase("datasourceturnstilewidgetbysitekey.tf", rnd, accountID)
+}
+
+func testAccCloudflareTurnstileWidgetsDataSource_List(rnd, accountID string) string {
+	return acctest.LoadTestCase("datasourceturnstilewidgetslist.tf", rnd, accountID)
+}

--- a/internal/services/turnstile_widget/resource_test.go
+++ b/internal/services/turnstile_widget/resource_test.go
@@ -87,12 +87,12 @@ func TestAccCloudflareTurnstileWidget_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "offlabel", "false"),
 				),
 			},
-			// {
-			// 	ResourceName:        resourceName,
-			// 	ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
-			// 	ImportState:         true,
-			// 	ImportStateVerify:   true,
-			// },
+			{
+				ResourceName:        resourceName,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
 		},
 	})
 }
@@ -119,12 +119,12 @@ func TestAccCloudflareTurnstileWidget_Minimum(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "offlabel", "false"),
 				),
 			},
-			// {
-			// 	ResourceName:        resourceName,
-			// 	ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
-			// 	ImportState:         true,
-			// 	ImportStateVerify:   true,
-			// },
+			{
+				ResourceName:        resourceName,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
 		},
 	})
 }
@@ -150,12 +150,82 @@ func TestAccCloudflareTurnstileWidget_NoDomains(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "offlabel", "false"),
 				),
 			},
-			// {
-			// 	ResourceName:        resourceName,
-			// 	ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
-			// 	ImportState:         true,
-			// 	ImportStateVerify:   true,
-			// },
+			{
+				ResourceName:        resourceName,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareTurnstileWidget_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_turnstile_widget." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareTurnstileWidgetBasic(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rnd),
+					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(resourceName, "mode", "invisible"),
+					resource.TestCheckResourceAttr(resourceName, "domains.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "domains.0", "example.com"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareTurnstileWidgetUpdated(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rnd+"-updated"),
+					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(resourceName, "mode", "invisible"),
+					resource.TestCheckResourceAttr(resourceName, "domains.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "domains.0", "example.com"),
+					resource.TestCheckResourceAttr(resourceName, "domains.1", "test.example.com"),
+				),
+			},
+			{
+				ResourceName:        resourceName,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareTurnstileWidget_NonInteractiveMode(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_turnstile_widget." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareTurnstileWidgetNonInteractive(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rnd),
+					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(resourceName, "mode", "non-interactive"),
+					resource.TestCheckResourceAttr(resourceName, "domains.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "domains.0", "example.com"),
+					resource.TestCheckResourceAttr(resourceName, "region", "world"),
+				),
+			},
+			{
+				ResourceName:        resourceName,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
 		},
 	})
 }
@@ -170,4 +240,12 @@ func testAccCheckCloudflareTurnstileWidgetMinimum(rnd, accountID string) string 
 
 func testAccCheckCloudflareTurnstileWidgetNoDomains(rnd, accountID string) string {
 	return acctest.LoadTestCase("turnstilewidgetnodomains.tf", rnd, accountID)
+}
+
+func testAccCheckCloudflareTurnstileWidgetUpdated(rnd, accountID string) string {
+	return acctest.LoadTestCase("turnstilewidgetupdated.tf", rnd, accountID)
+}
+
+func testAccCheckCloudflareTurnstileWidgetNonInteractive(rnd, accountID string) string {
+	return acctest.LoadTestCase("turnstilewidgetnoninteractive.tf", rnd, accountID)
 }

--- a/internal/services/turnstile_widget/testdata/datasourceturnstilewidgetbysitekey.tf
+++ b/internal/services/turnstile_widget/testdata/datasourceturnstilewidgetbysitekey.tf
@@ -1,0 +1,11 @@
+resource "cloudflare_turnstile_widget" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+  domains    = ["example.com"]
+  mode       = "managed"
+}
+
+data "cloudflare_turnstile_widget" "%[1]s" {
+  account_id = "%[2]s"
+  sitekey    = cloudflare_turnstile_widget.%[1]s.sitekey
+}

--- a/internal/services/turnstile_widget/testdata/datasourceturnstilewidgetslist.tf
+++ b/internal/services/turnstile_widget/testdata/datasourceturnstilewidgetslist.tf
@@ -1,0 +1,11 @@
+resource "cloudflare_turnstile_widget" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+  domains    = ["example.com"]
+  mode       = "managed"
+}
+
+data "cloudflare_turnstile_widgets" "%[1]s" {
+  account_id = "%[2]s"
+  depends_on = [cloudflare_turnstile_widget.%[1]s]
+}

--- a/internal/services/turnstile_widget/testdata/turnstilewidgetnoninteractive.tf
+++ b/internal/services/turnstile_widget/testdata/turnstilewidgetnoninteractive.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_turnstile_widget" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+  domains    = ["example.com"]
+  mode       = "non-interactive"
+}

--- a/internal/services/turnstile_widget/testdata/turnstilewidgetupdated.tf
+++ b/internal/services/turnstile_widget/testdata/turnstilewidgetupdated.tf
@@ -1,0 +1,8 @@
+resource "cloudflare_turnstile_widget" "%[1]s" {
+  account_id     = "%[2]s"
+  name           = "%[1]s-updated"
+  bot_fight_mode = false
+  domains        = ["example.com", "test.example.com"]
+  mode           = "invisible"
+  region         = "world"
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive acceptance tests for the `cloudflare_turnstile_widget` resource to support V5 provider stabilization.

### Changes

- **Enable Import tests** for existing Basic, Minimum, and NoDomains tests (previously commented out)
- **Add Update test** (`TestAccCloudflareTurnstileWidget_Update`) to verify modifying widget name and domains
- **Add NonInteractiveMode test** (`TestAccCloudflareTurnstileWidget_NonInteractiveMode`) to cover all widget modes
- **Add data source tests**:
  - `TestAccCloudflareTurnstileWidgetDataSource_BySitekey` - single widget lookup
  - `TestAccCloudflareTurnstileWidgetsDataSource_List` - list widgets

### Test Coverage

| Operation | Covered |
|-----------|---------|
| Create | ✅ |
| Read | ✅ |
| Update | ✅ |
| Delete | ✅ (via sweeper) |
| Import | ✅ |
| Data Source (single) | ✅ |
| Data Source (list) | ✅ |

### Local Test Results

All tests pass (except `NoDomains` which requires specific account entitlement):

```
TestAccCloudflareTurnstileWidget_Basic ............ PASS (12.44s)
TestAccCloudflareTurnstileWidget_Minimum .......... PASS (12.67s)
TestAccCloudflareTurnstileWidget_Update ........... PASS (15.14s)
TestAccCloudflareTurnstileWidget_NonInteractiveMode PASS (13.41s)
TestAccCloudflareTurnstileWidgetDataSource_BySitekey PASS (13.31s)
TestAccCloudflareTurnstileWidgetsDataSource_List .. PASS (15.74s)
```

Resolves NC-6716