### PR TITLE
fix(dns_record): don't double printf test data

### DIFF
--- a/internal/services/dns_record/resource_test.go
+++ b/internal/services/dns_record/resource_test.go
@@ -1196,7 +1196,7 @@ func testAccCheckCloudflareRecordConfigComprehensiveDrift(zoneID, rnd, domain st
 	if updated {
 		content = "192.168.1.2"
 	}
-	return fmt.Sprintf(acctest.LoadTestCase("dns_record_comprehensive_drift.tf", rnd, zoneID, domain, content))
+	return acctest.LoadTestCase("dns_record_comprehensive_drift.tf", rnd, zoneID, domain, content)
 }
 
 func testAccCheckCloudflareRecordRecreated(before, after *dns.RecordResponse) resource.TestCheckFunc {


### PR DESCRIPTION
Fixes a bug introduced in f289994d58 where we were double printf-ing the testdata. `accttest.LoadTestCase` already handles format args.

This was actually introduced back in November of last year, but go 1.23 had less strict checks for format strings. When we bumped to 1.24 this issue made itself knownt.

```bash
 mgirouard@sixteen:~/src/terraform-provider-cloudflare$ TF_MIGRATE_BINARY_PATH=/home/mgirouard/src/terraform-devstack/tf-migrate/bin/tf-migrate TF_ACC=1 go test ./internal/services/dns_record/... -v -count=1
 # github.com/cloudflare/terraform-provider-cloudflare/internal/services/dns_record_test
 # [github.com/cloudflare/terraform-provider-cloudflare/internal/services/dns_record_test]
 internal/services/dns_record/resource_test.go:1199:21: non-constant format string in call to fmt.Sprintf
 FAIL    github.com/cloudflare/terraform-provider-cloudflare/internal/services/dns_record [build failed]
 FAIL
```

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

<details><summary>See tests</summary>

```
mgirouard@sixteen:~/src/terraform-provider-cloudflare$ TF_MIGRATE_BINARY_PATH=/home/mgirouard/src/terraform-devstack/tf-migrate/bin/tf-migrate TF_ACC=1 go test ./internal/services/dns_record/... -v -count=1
=== RUN   TestDNSRecordDataSourceModelSchemaParity
=== PAUSE TestDNSRecordDataSourceModelSchemaParity
=== RUN   TestDNSRecordsDataSourceModelSchemaParity
=== PAUSE TestDNSRecordsDataSourceModelSchemaParity
=== RUN   TestMigrateDNSRecordBasicA
--- PASS: TestMigrateDNSRecordBasicA (17.27s)
=== RUN   TestMigrateDNSRecordCAARecord
--- PASS: TestMigrateDNSRecordCAARecord (19.86s)
=== RUN   TestMigrateDNSRecordMXRecord
--- PASS: TestMigrateDNSRecordMXRecord (16.39s)
=== RUN   TestMigrateDNSRecordSRVRecord
--- PASS: TestMigrateDNSRecordSRVRecord (16.70s)
=== RUN   TestMigrateDNSRecordTXTRecord
--- PASS: TestMigrateDNSRecordTXTRecord (14.79s)
=== RUN   TestMigrateDNSRecordCNAMERecord
--- PASS: TestMigrateDNSRecordCNAMERecord (15.06s)
=== RUN   TestMigrateDNSRecordWithAllowOverwrite
--- PASS: TestMigrateDNSRecordWithAllowOverwrite (16.62s)
=== RUN   TestMigrateDNSRecordMultipleRecords
--- PASS: TestMigrateDNSRecordMultipleRecords (18.95s)
=== RUN   TestMigrateDNSRecordAAAARecord
--- PASS: TestMigrateDNSRecordAAAARecord (14.74s)
=== RUN   TestMigrateDNSRecordNSRecord
--- PASS: TestMigrateDNSRecordNSRecord (15.46s)
=== RUN   TestMigrateDNSRecordWithTags
--- PASS: TestMigrateDNSRecordWithTags (15.26s)
=== RUN   TestMigrateDNSRecordPTRRecord
--- PASS: TestMigrateDNSRecordPTRRecord (15.14s)
=== RUN   TestMigrateDNSRecord_Issue6076
--- PASS: TestMigrateDNSRecord_Issue6076 (30.49s)
=== RUN   TestModifyPlan_ModifiedOnPreservation
=== RUN   TestModifyPlan_ModifiedOnPreservation/no_changes_preserves_modified_on
    resource_modifyplan_test.go:136: Test case: When no fields change, modified_on should be preserved from state
    resource_modifyplan_test.go:137: Expect preserve modified_on: true
=== RUN   TestModifyPlan_ModifiedOnPreservation/content_change_updates_modified_on
    resource_modifyplan_test.go:136: Test case: When content changes, modified_on should remain unknown for API to update
    resource_modifyplan_test.go:137: Expect preserve modified_on: false
=== RUN   TestModifyPlan_ModifiedOnPreservation/empty_settings_no_drift
    resource_modifyplan_test.go:136: Test case: Empty settings {} should not cause drift
    resource_modifyplan_test.go:137: Expect preserve modified_on: true
--- PASS: TestModifyPlan_ModifiedOnPreservation (0.00s)
    --- PASS: TestModifyPlan_ModifiedOnPreservation/no_changes_preserves_modified_on (0.00s)
    --- PASS: TestModifyPlan_ModifiedOnPreservation/content_change_updates_modified_on (0.00s)
    --- PASS: TestModifyPlan_ModifiedOnPreservation/empty_settings_no_drift (0.00s)
=== RUN   TestModifyPlan_SettingsEmptyObject
=== RUN   TestModifyPlan_SettingsEmptyObject/null_state_empty_plan_no_drift
    resource_modifyplan_test.go:184: State settings: <nil>
    resource_modifyplan_test.go:185: Plan settings: map[]
    resource_modifyplan_test.go:186: Expect drift: false
=== RUN   TestModifyPlan_SettingsEmptyObject/defaults_state_empty_plan_no_drift
    resource_modifyplan_test.go:184: State settings: map[flatten_cname:false ipv4_only:false ipv6_only:false]
    resource_modifyplan_test.go:185: Plan settings: map[]
    resource_modifyplan_test.go:186: Expect drift: false
=== RUN   TestModifyPlan_SettingsEmptyObject/actual_values_state_empty_plan_has_drift
    resource_modifyplan_test.go:184: State settings: map[flatten_cname:false ipv4_only:true ipv6_only:false]
    resource_modifyplan_test.go:185: Plan settings: map[]
    resource_modifyplan_test.go:186: Expect drift: true
--- PASS: TestModifyPlan_SettingsEmptyObject (0.00s)
    --- PASS: TestModifyPlan_SettingsEmptyObject/null_state_empty_plan_no_drift (0.00s)
    --- PASS: TestModifyPlan_SettingsEmptyObject/defaults_state_empty_plan_no_drift (0.00s)
    --- PASS: TestModifyPlan_SettingsEmptyObject/actual_values_state_empty_plan_has_drift (0.00s)
=== RUN   TestDNSRecordModelSchemaParity
=== PAUSE TestDNSRecordModelSchemaParity
=== RUN   TestAccCloudflareRecord_Basic
--- PASS: TestAccCloudflareRecord_Basic (2.85s)
=== RUN   TestAccCloudflareRecord_Apex
--- PASS: TestAccCloudflareRecord_Apex (3.54s)
=== RUN   TestAccCloudflareRecord_LOC
--- PASS: TestAccCloudflareRecord_LOC (3.21s)
=== RUN   TestAccCloudflareRecord_SRV
--- PASS: TestAccCloudflareRecord_SRV (3.02s)
=== RUN   TestAccCloudflareRecord_CAA
--- PASS: TestAccCloudflareRecord_CAA (5.33s)
=== RUN   TestAccCloudflareRecord_Proxied
--- PASS: TestAccCloudflareRecord_Proxied (3.14s)
=== RUN   TestAccCloudflareRecord_Updated
--- PASS: TestAccCloudflareRecord_Updated (4.72s)
=== RUN   TestAccCloudflareRecord_typeForceNewRecord
--- PASS: TestAccCloudflareRecord_typeForceNewRecord (5.75s)
=== RUN   TestAccCloudflareRecord_TtlValidation
--- PASS: TestAccCloudflareRecord_TtlValidation (0.63s)
=== RUN   TestAccCloudflareRecord_ExplicitProxiedFalse
--- PASS: TestAccCloudflareRecord_ExplicitProxiedFalse (7.81s)
=== RUN   TestAccCloudflareRecord_MXWithPriorityZero
--- PASS: TestAccCloudflareRecord_MXWithPriorityZero (3.33s)
=== RUN   TestAccCloudflareRecord_HTTPS
--- PASS: TestAccCloudflareRecord_HTTPS (3.04s)
=== RUN   TestAccCloudflareRecord_SVCB
--- PASS: TestAccCloudflareRecord_SVCB (3.14s)
=== RUN   TestAccCloudflareRecord_MXNull
=== PAUSE TestAccCloudflareRecord_MXNull
=== RUN   TestAccCloudflareRecord_DNSKEY
    acctest.go:217: Skipping acceptance test for default zone (0da42c8d2132a9ddaf714f9e7c920711). Pending automating setup from https://developers.cloudflare.com/dns/dnssec/multi-signer-dnssec/.
--- SKIP: TestAccCloudflareRecord_DNSKEY (0.00s)
=== RUN   TestAccCloudflareRecord_ClearTags
--- PASS: TestAccCloudflareRecord_ClearTags (4.85s)
=== RUN   TestSuppressTrailingDots
=== PAUSE TestSuppressTrailingDots
=== RUN   TestAccCloudflareRecord_TagsDrift
--- PASS: TestAccCloudflareRecord_TagsDrift (8.23s)
=== RUN   TestAccCloudflareRecord_ComputedFieldsDrift
--- PASS: TestAccCloudflareRecord_ComputedFieldsDrift (7.72s)
=== RUN   TestAccCloudflareRecord_DriftIssue5517
--- PASS: TestAccCloudflareRecord_DriftIssue5517 (6.24s)
=== RUN   TestAccCloudflareRecord_ModifiedOnDrift6438
--- PASS: TestAccCloudflareRecord_ModifiedOnDrift6438 (8.39s)
=== RUN   TestAccCloudflareRecord_SettingsDrift
--- PASS: TestAccCloudflareRecord_SettingsDrift (7.29s)
=== RUN   TestAccCloudflareRecord_ComprehensiveDriftPrevention
--- PASS: TestAccCloudflareRecord_ComprehensiveDriftPrevention (28.59s)
=== RUN   TestAccCloudflareRecord_SimpleDrift
--- PASS: TestAccCloudflareRecord_SimpleDrift (3.80s)
=== RUN   TestAccCloudflareRecord_CNAMECase
--- PASS: TestAccCloudflareRecord_CNAMECase (3.50s)
=== RUN   TestAccCloudflareRecord_CommentModifiedOn
--- PASS: TestAccCloudflareRecord_CommentModifiedOn (5.08s)
=== RUN   TestAccCloudflareRecord_FQDNNormalize
--- PASS: TestAccCloudflareRecord_FQDNNormalize (5.43s)
=== RUN   TestAccCloudflareRecord_ModifiedOnDrift
--- PASS: TestAccCloudflareRecord_ModifiedOnDrift (7.24s)
=== RUN   TestAccCloudflareRecord_ModifiedOnConsistency
--- PASS: TestAccCloudflareRecord_ModifiedOnConsistency (13.71s)
=== CONT  TestDNSRecordDataSourceModelSchemaParity
=== CONT  TestSuppressTrailingDots
--- PASS: TestSuppressTrailingDots (0.00s)
=== CONT  TestDNSRecordModelSchemaParity
=== CONT  TestAccCloudflareRecord_MXNull
=== CONT  TestDNSRecordsDataSourceModelSchemaParity
--- PASS: TestDNSRecordModelSchemaParity (0.00s)
--- PASS: TestDNSRecordDataSourceModelSchemaParity (0.00s)
--- PASS: TestDNSRecordsDataSourceModelSchemaParity (0.00s)
--- PASS: TestAccCloudflareRecord_MXNull (3.61s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/dns_record        389.935s
```

</details>

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
