### PR TITLE
support new fields for Magic WAN tunnels

### DIFF
--- a/internal/services/magic_wan_gre_tunnel/custom_model.go
+++ b/internal/services/magic_wan_gre_tunnel/custom_model.go
@@ -13,19 +13,22 @@ type CustomMagicWANGRETunnelResultEnvelope struct {
 }
 
 type CustomMagicWANGRETunnelModel struct {
-	ID                    types.String                                                `tfsdk:"id" json:"id,computed"`
-	AccountID             types.String                                                `tfsdk:"account_id" path:"account_id,required"`
-	CloudflareGREEndpoint types.String                                                `tfsdk:"cloudflare_gre_endpoint" json:"cloudflare_gre_endpoint,required"`
-	CustomerGREEndpoint   types.String                                                `tfsdk:"customer_gre_endpoint" json:"customer_gre_endpoint,required"`
-	InterfaceAddress      types.String                                                `tfsdk:"interface_address" json:"interface_address,required"`
-	Name                  types.String                                                `tfsdk:"name" json:"name,required"`
-	Description           types.String                                                `tfsdk:"description" json:"description,optional"`
-	InterfaceAddress6     types.String                                                `tfsdk:"interface_address6" json:"interface_address6,optional"`
-	Mtu                   types.Int64                                                 `tfsdk:"mtu" json:"mtu,computed_optional"`
-	TTL                   types.Int64                                                 `tfsdk:"ttl" json:"ttl,computed_optional"`
-	HealthCheck           customfield.NestedObject[MagicWANGRETunnelHealthCheckModel] `tfsdk:"health_check" json:"health_check,computed_optional"`
-	CreatedOn             timetypes.RFC3339                                           `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
-	ModifiedOn            timetypes.RFC3339                                           `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
+	ID                     types.String                                                `tfsdk:"id" json:"id,computed"`
+	AccountID              types.String                                                `tfsdk:"account_id" path:"account_id,required"`
+	BGP                    *MagicWANGRETunnelBGPModel                                  `tfsdk:"bgp" json:"bgp,optional"`
+	CloudflareGREEndpoint  types.String                                                `tfsdk:"cloudflare_gre_endpoint" json:"cloudflare_gre_endpoint,required"`
+	CustomerGREEndpoint    types.String                                                `tfsdk:"customer_gre_endpoint" json:"customer_gre_endpoint,required"`
+	InterfaceAddress       types.String                                                `tfsdk:"interface_address" json:"interface_address,required"`
+	Name                   types.String                                                `tfsdk:"name" json:"name,required"`
+	Description            types.String                                                `tfsdk:"description" json:"description,optional"`
+	InterfaceAddress6      types.String                                                `tfsdk:"interface_address6" json:"interface_address6,optional"`
+	AutomaticReturnRouting types.Bool                                                  `tfsdk:"automatic_return_routing" json:"automatic_return_routing,computed_optional"`
+	Mtu                    types.Int64                                                 `tfsdk:"mtu" json:"mtu,computed_optional"`
+	TTL                    types.Int64                                                 `tfsdk:"ttl" json:"ttl,computed_optional"`
+	HealthCheck            customfield.NestedObject[MagicWANGRETunnelHealthCheckModel] `tfsdk:"health_check" json:"health_check,computed_optional"`
+	CreatedOn              timetypes.RFC3339                                           `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
+	ModifiedOn             timetypes.RFC3339                                           `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
+	BGPStatus              customfield.NestedObject[MagicWANGRETunnelBGPStatusModel]   `tfsdk:"bgp_status" json:"bgp_status,computed"`
 }
 
 func (m CustomMagicWANGRETunnelModel) MarshalJSON() (data []byte, err error) {

--- a/internal/services/magic_wan_gre_tunnel/custom_schema.go
+++ b/internal/services/magic_wan_gre_tunnel/custom_schema.go
@@ -5,15 +5,20 @@ import (
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var _ resource.ResourceWithConfigValidators = (*MagicWANGRETunnelResource)(nil)
@@ -30,6 +35,29 @@ func customResourceSchema(ctx context.Context) schema.Schema {
 				Description:   "Identifier",
 				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"bgp": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"customer_asn": schema.Int64Attribute{
+						Description: "ASN used on the customer end of the BGP session",
+						Required:    true,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
+					},
+					"extra_prefixes": schema.ListAttribute{
+						Description: "Prefixes in this list will be advertised to the customer device, in addition to the routes in the Magic routing table.",
+						Optional:    true,
+						Computed:    true,
+						ElementType: types.StringType,
+						Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
+					},
+					"md5_key": schema.StringAttribute{
+						Description: "MD5 key to use for session authentication.\n\nNote that *this is not a security measure*. MD5 is not a valid security mechanism, and the\nkey is not treated as a secret value. This is *only* supported for preventing\nmisconfiguration, not for defending against malicious attacks.\n\nThe MD5 key, if set, must be of non-zero length and consist only of the following types of\ncharacter:\n\n* ASCII alphanumerics: `[a-zA-Z0-9]`\n* Special characters in the set `'!@#$%^&*()+[]{}<>/.,;:_-~`= \\|`\n\nIn other words, MD5 keys may contain any printable ASCII character aside from newline (0x0A),\nquotation mark (`\"`), vertical tab (0x0B), carriage return (0x0D), tab (0x09), form feed\n(0x0C), and the question mark (`?`). Requests specifying an MD5 key with one or more of\nthese disallowed characters will be rejected.",
+						Optional:    true,
+					},
+				},
 			},
 			"cloudflare_gre_endpoint": schema.StringAttribute{
 				Description: "The IP address assigned to the Cloudflare side of the GRE tunnel.",
@@ -54,6 +82,12 @@ func customResourceSchema(ctx context.Context) schema.Schema {
 			"interface_address6": schema.StringAttribute{
 				Description: "A 127 bit IPV6 prefix from within the virtual_subnet6 prefix space with the address being the first IP of the subnet and not same as the address of virtual_subnet6. Eg if virtual_subnet6 is 2606:54c1:7:0:a9fe:12d2::/127 , interface_address6 could be 2606:54c1:7:0:a9fe:12d2:1:200/127",
 				Optional:    true,
+			},
+			"automatic_return_routing": schema.BoolAttribute{
+				Description: "True if automatic stateful return routing should be enabled for a tunnel, false otherwise.",
+				Computed:    true,
+				Optional:    true,
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"mtu": schema.Int64Attribute{
 				Description: "Maximum Transmission Unit (MTU) in bytes for the GRE tunnel. The minimum value is 576.",
@@ -136,6 +170,51 @@ func customResourceSchema(ctx context.Context) schema.Schema {
 				Description: "The date and time the tunnel was last modified.",
 				Computed:    true,
 				CustomType:  timetypes.RFC3339Type{},
+			},
+			"bgp_status": schema.SingleNestedAttribute{
+				Computed:   true,
+				CustomType: customfield.NewNestedObjectType[MagicWANGRETunnelBGPStatusModel](ctx),
+				Attributes: map[string]schema.Attribute{
+					"state": schema.StringAttribute{
+						Description: `Available values: "BGP_DOWN", "BGP_UP", "BGP_ESTABLISHING".`,
+						Computed:    true,
+						Validators: []validator.String{
+							stringvalidator.OneOfCaseInsensitive(
+								"BGP_DOWN",
+								"BGP_UP",
+								"BGP_ESTABLISHING",
+							),
+						},
+					},
+					"tcp_established": schema.BoolAttribute{
+						Computed: true,
+					},
+					"updated_at": schema.StringAttribute{
+						Computed:   true,
+						CustomType: timetypes.RFC3339Type{},
+					},
+					"bgp_state": schema.StringAttribute{
+						Computed: true,
+					},
+					"cf_speaker_ip": schema.StringAttribute{
+						Computed: true,
+					},
+					"cf_speaker_port": schema.Int64Attribute{
+						Computed: true,
+						Validators: []validator.Int64{
+							int64validator.Between(1, 65535),
+						},
+					},
+					"customer_speaker_ip": schema.StringAttribute{
+						Computed: true,
+					},
+					"customer_speaker_port": schema.Int64Attribute{
+						Computed: true,
+						Validators: []validator.Int64{
+							int64validator.Between(1, 65535),
+						},
+					},
+				},
 			},
 		},
 	}

--- a/internal/services/magic_wan_gre_tunnel/resource.go
+++ b/internal/services/magic_wan_gre_tunnel/resource.go
@@ -182,6 +182,12 @@ func (r *MagicWANGRETunnelResource) Read(ctx context.Context, req resource.ReadR
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
 	}
+
+	// avoid unnecessary diff
+	if env.Result.AutomaticReturnRouting.IsNull() {
+		env.Result.AutomaticReturnRouting = types.BoolValue(false)
+	}
+
 	data = &env.Result
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/services/magic_wan_gre_tunnel/resource_test.go
+++ b/internal/services/magic_wan_gre_tunnel/resource_test.go
@@ -107,6 +107,8 @@ func TestAccCloudflareGRETunnelExists(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "cloudflare_gre_endpoint", cfIP),
 					resource.TestCheckResourceAttr(name, "interface_address", "10.213.0.20/31"),
 					resource.TestCheckResourceAttr(name, "health_check.target.effective", "203.0.113.10"),
+					resource.TestCheckResourceAttr(name, "automatic_return_routing", "true"),
+					resource.TestCheckResourceAttr(name, "bgp.customer_asn", "65002"),
 				),
 			},
 			{

--- a/internal/services/magic_wan_gre_tunnel/testdata/gretunnelsimple.tf
+++ b/internal/services/magic_wan_gre_tunnel/testdata/gretunnelsimple.tf
@@ -6,4 +6,8 @@
 	cloudflare_gre_endpoint = "%[5]s"
 	interface_address = "%[7]s"
 	description = "%[3]s"
+	automatic_return_routing = true
+	bgp = {
+		customer_asn = 65002
+	}
   }

--- a/internal/services/magic_wan_ipsec_tunnel/custom_model.go
+++ b/internal/services/magic_wan_ipsec_tunnel/custom_model.go
@@ -13,21 +13,25 @@ type CustomMagicWANIPSECTunnelResultEnvelope struct {
 }
 
 type CustomMagicWANIPSECTunnelModel struct {
-	ID                 types.String                                                  `tfsdk:"id" json:"id,computed"`
-	AccountID          types.String                                                  `tfsdk:"account_id" path:"account_id,required"`
-	CloudflareEndpoint types.String                                                  `tfsdk:"cloudflare_endpoint" json:"cloudflare_endpoint,required"`
-	InterfaceAddress   types.String                                                  `tfsdk:"interface_address" json:"interface_address,required"`
-	Name               types.String                                                  `tfsdk:"name" json:"name,required"`
-	CustomerEndpoint   types.String                                                  `tfsdk:"customer_endpoint" json:"customer_endpoint,optional"`
-	Description        types.String                                                  `tfsdk:"description" json:"description,optional"`
-	InterfaceAddress6  types.String                                                  `tfsdk:"interface_address6" json:"interface_address6,optional"`
-	PSK                types.String                                                  `tfsdk:"psk" json:"psk,optional,no_refresh"`
-	ReplayProtection   types.Bool                                                    `tfsdk:"replay_protection" json:"replay_protection,computed_optional"`
-	HealthCheck        customfield.NestedObject[MagicWANIPSECTunnelHealthCheckModel] `tfsdk:"health_check" json:"health_check,computed_optional"`
-	AllowNullCipher    types.Bool                                                    `tfsdk:"allow_null_cipher" json:"allow_null_cipher,computed_optional,no_refresh"`
-	CreatedOn          timetypes.RFC3339                                             `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
-	ModifiedOn         timetypes.RFC3339                                             `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
-	PSKMetadata        customfield.NestedObject[MagicWANIPSECTunnelPSKMetadataModel] `tfsdk:"psk_metadata" json:"psk_metadata,computed_optional"`
+	ID                     types.String                                                             `tfsdk:"id" json:"id,computed"`
+	AccountID              types.String                                                             `tfsdk:"account_id" path:"account_id,required"`
+	CloudflareEndpoint     types.String                                                             `tfsdk:"cloudflare_endpoint" json:"cloudflare_endpoint,required"`
+	InterfaceAddress       types.String                                                             `tfsdk:"interface_address" json:"interface_address,required"`
+	Name                   types.String                                                             `tfsdk:"name" json:"name,required"`
+	CustomerEndpoint       types.String                                                             `tfsdk:"customer_endpoint" json:"customer_endpoint,optional"`
+	Description            types.String                                                             `tfsdk:"description" json:"description,optional"`
+	InterfaceAddress6      types.String                                                             `tfsdk:"interface_address6" json:"interface_address6,optional"`
+	PSK                    types.String                                                             `tfsdk:"psk" json:"psk,optional,no_refresh"`
+	BGP                    *MagicWANIPSECTunnelBGPModel                                             `tfsdk:"bgp" json:"bgp,optional"`
+	AutomaticReturnRouting types.Bool                                                               `tfsdk:"automatic_return_routing" json:"automatic_return_routing,computed_optional"`
+	ReplayProtection       types.Bool                                                               `tfsdk:"replay_protection" json:"replay_protection,computed_optional"`
+	HealthCheck            customfield.NestedObject[MagicWANIPSECTunnelHealthCheckModel]            `tfsdk:"health_check" json:"health_check,computed_optional"`
+	AllowNullCipher        types.Bool                                                               `tfsdk:"allow_null_cipher" json:"allow_null_cipher,computed_optional,no_refresh"`
+	CreatedOn              timetypes.RFC3339                                                        `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
+	ModifiedOn             timetypes.RFC3339                                                        `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
+	BGPStatus              customfield.NestedObject[MagicWANIPSECTunnelBGPStatusModel]              `tfsdk:"bgp_status" json:"bgp_status,computed"`
+	CustomRemoteIdentities *MagicWANIPSECTunnelCustomRemoteIdentitiesModel                          `tfsdk:"custom_remote_identities" json:"custom_remote_identities,optional"`
+	PSKMetadata            customfield.NestedObject[MagicWANIPSECTunnelPSKMetadataModel]            `tfsdk:"psk_metadata" json:"psk_metadata,computed_optional"`
 }
 
 func (m CustomMagicWANIPSECTunnelModel) MarshalJSON() (data []byte, err error) {

--- a/internal/services/magic_wan_ipsec_tunnel/resource.go
+++ b/internal/services/magic_wan_ipsec_tunnel/resource.go
@@ -187,6 +187,10 @@ func (r *MagicWANIPSECTunnelResource) Read(ctx context.Context, req resource.Rea
 	if env.Result.ReplayProtection.IsNull() {
 		env.Result.ReplayProtection = types.BoolValue(false)
 	}
+	if env.Result.AutomaticReturnRouting.IsNull() {
+		env.Result.AutomaticReturnRouting = types.BoolValue(false)
+	}
+
 	data = &env.Result
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/services/magic_wan_ipsec_tunnel/resource_test.go
+++ b/internal/services/magic_wan_ipsec_tunnel/resource_test.go
@@ -112,6 +112,8 @@ func TestAccCloudflareIPsecTunnelExists(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "health_check.rate", "low"),
 					resource.TestCheckResourceAttr(name, "psk", "asdf1234"),
 					resource.TestCheckResourceAttr(name, "replay_protection", "true"),
+					resource.TestCheckResourceAttr(name, "automatic_return_routing", "true"),
+					resource.TestCheckResourceAttr(name, "bgp.customer_asn", "65001"),
 				),
 			},
 			{

--- a/internal/services/magic_wan_ipsec_tunnel/testdata/ipsectunnelsimple.tf
+++ b/internal/services/magic_wan_ipsec_tunnel/testdata/ipsectunnelsimple.tf
@@ -14,4 +14,8 @@
 	}
 	psk = "%[4]s"
 	replay_protection = true
+	automatic_return_routing = true
+	bgp = {
+		customer_asn = 65001
+	}
   }


### PR DESCRIPTION
new fields

magic_wan_ipsec_tunnel:
    - automatic_return_routing
    - custom_remote_identities
    - bgp

magic_wan_gre_tunnel:
    - automatic_return_routing
    - bgp

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
```
% TF_ACC=1 go test -parallel=1 -p=1 -count=1 ./internal/services/{magic_wan_ipsec_tunnel,magic_wan_gre_tunnel,magic_wan_static_route} -run "^TestAcc"
```

### Test output
<!-- Please paste the output of your acceptance test run below --> 

```
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/magic_wan_ipsec_tunnel    42.718s
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/magic_wan_gre_tunnel      43.441s
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/magic_wan_static_route    48.826s
```


## Additional context & links
