### PR TITLE
feat(argo): add migration tests

### DIFF
--- a/internal/services/argo_tiered_caching/migrations_test.go
+++ b/internal/services/argo_tiered_caching/migrations_test.go
@@ -147,3 +147,49 @@ resource "cloudflare_argo" "%[1]s" {
 	})
 }
 
+// TestMigrateArgoTieredCachingWithLifecycle tests migration with lifecycle meta-argument
+func TestMigrateArgoTieredCachingWithLifecycle(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_argo_tiered_caching." + rnd
+	tmpDir := t.TempDir()
+
+	// V4 config with lifecycle block to test preservation
+	v4Config := fmt.Sprintf(`
+resource "cloudflare_argo" "%[1]s" {
+  zone_id        = "%[2]s"
+  tiered_caching = "on"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}`, rnd, zoneID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create with v4 provider
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			// Step 2: Run migration and verify state
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("value"), knownvalue.StringExact("on")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("editable"), knownvalue.Bool(true)),
+			}),
+		},
+	})
+}
+


### PR DESCRIPTION
```
TF_MIGRATE_BINARY_PATH=/Users/tjozsa/cf-repos/sdks/migration-work/agent-a/tf-migrate/bin/tf-migrate TF_ACC=1 go test ./internal/services/argo_smart_routing -v -run TestMigrate
=== RUN   TestMigrateArgoSmartRoutingOn
--- PASS: TestMigrateArgoSmartRoutingOn (19.48s)
=== RUN   TestMigrateArgoSmartRoutingOff
--- PASS: TestMigrateArgoSmartRoutingOff (17.03s)
=== RUN   TestMigrateArgoNeitherAttribute
--- PASS: TestMigrateArgoNeitherAttribute (13.95s)
=== RUN   TestMigrateArgoBothAttributes
--- PASS: TestMigrateArgoBothAttributes (25.66s)
=== RUN   TestMigrateArgoWithVariables
--- PASS: TestMigrateArgoWithVariables (19.37s)
=== RUN   TestMigrateArgoWithDependsOn
--- PASS: TestMigrateArgoWithDependsOn (18.11s)
=== RUN   TestMigrateArgoWithLifecycle
--- PASS: TestMigrateArgoWithLifecycle (17.63s)
=== RUN   TestMigrateArgoWithConditional
--- PASS: TestMigrateArgoWithConditional (18.88s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/argo_smart_routing	151.979s
```