### PR TITLE
add default to description in zero_trust_device_custom_profile

### DIFF
--- a/internal/services/zero_trust_device_custom_profile/model.go
+++ b/internal/services/zero_trust_device_custom_profile/model.go
@@ -19,7 +19,7 @@ type ZeroTrustDeviceCustomProfileModel struct {
 	Match                      types.String                                                                   `tfsdk:"match" json:"match,required"`
 	Name                       types.String                                                                   `tfsdk:"name" json:"name,required"`
 	Precedence                 types.Float64                                                                  `tfsdk:"precedence" json:"precedence,computed_optional"`
-	Description                types.String                                                                   `tfsdk:"description" json:"description,optional"`
+	Description                types.String                                                                   `tfsdk:"description" json:"description,computed_optional"`
 	LANAllowMinutes            types.Float64                                                                  `tfsdk:"lan_allow_minutes" json:"lan_allow_minutes,optional"`
 	LANAllowSubnetSize         types.Float64                                                                  `tfsdk:"lan_allow_subnet_size" json:"lan_allow_subnet_size,optional"`
 	Exclude                    customfield.NestedObjectList[ZeroTrustDeviceCustomProfileExcludeModel]         `tfsdk:"exclude" json:"exclude,computed_optional"`

--- a/internal/services/zero_trust_device_custom_profile/schema.go
+++ b/internal/services/zero_trust_device_custom_profile/schema.go
@@ -56,6 +56,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"description": schema.StringAttribute{
 				Description: "A description of the policy.",
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"lan_allow_minutes": schema.Float64Attribute{
 				Description: "The amount of time in minutes a user is allowed access to their LAN. A value of 0 will allow LAN access until the next WARP reconnection, such as a reboot or a laptop waking from sleep. Note that this field is omitted from the response if null or unset.",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
This adds the `Default` and `Computed` attribute to the description field of zero_trust_device_custom_profiles

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links

Closes #6189 