### PR TITLE
test(zone_subscription): prevent plan overwrites on primary testing zone

### DIFF
--- a/internal/services/zone_subscription/resource_test.go
+++ b/internal/services/zone_subscription/resource_test.go
@@ -38,7 +38,7 @@ func testSweepCloudflareZoneSubscription(r string) error {
 
 func TestAccCloudflareZoneSubscription_Basic(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneID := os.Getenv("CLOUDFLARE_ALT_ZONE_ID")
 	resourceName := "cloudflare_zone_subscription." + rnd
 
 	resource.Test(t, resource.TestCase{
@@ -86,7 +86,7 @@ func TestAccCloudflareZoneSubscription_Basic(t *testing.T) {
 
 func TestAccCloudflareZoneSubscriptionResource_WithPlanChange(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneID := os.Getenv("CLOUDFLARE_ALT_ZONE_ID")
 	resourceName := "cloudflare_zone_subscription." + rnd
 
 	resource.Test(t, resource.TestCase{
@@ -186,7 +186,7 @@ func TestAccCloudflareZoneSubscriptionResource_CreateZoneWithPlan_CUSTESC_57375(
 // Tests that importing a zone subscription with frequency="not-applicable" doesn't cause drift
 func TestAccCloudflareZoneSubscriptionResource_ImportNoChanges_BILLSUB_247(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneID := os.Getenv("CLOUDFLARE_ALT_ZONE_ID")
 	resourceName := "cloudflare_zone_subscription." + rnd
 
 	resource.Test(t, resource.TestCase{
@@ -233,7 +233,7 @@ func TestAccCloudflareZoneSubscriptionResource_ImportNoChanges_BILLSUB_247(t *te
 // The API accepts the value during create/update but returns "not-applicable" on read, causing drift
 func TestAccCloudflareZoneSubscriptionResource_FrequencyNotSupported(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
-	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneID := os.Getenv("CLOUDFLARE_ALT_ZONE_ID")
 	resourceName := "cloudflare_zone_subscription." + rnd
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Use alternate zone for testing `zone_subscription` resource to prevent entitlements changes from interfering with other acceptance tests.

## Acceptance test run results

- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
`TF_ACC=1 go test ./internal/services/zone_subscription -run 'TestAccCloudflare' -count=1 -v`

### Test output
<!-- Please paste the output of your acceptance test run below --> 
```
=== RUN   TestAccCloudflareZoneSubscriptionDataSource_Basic
--- PASS: TestAccCloudflareZoneSubscriptionDataSource_Basic (5.37s)
=== RUN   TestAccCloudflareZoneSubscription_Basic
--- PASS: TestAccCloudflareZoneSubscription_Basic (11.48s)
=== RUN   TestAccCloudflareZoneSubscriptionResource_WithPlanChange
--- PASS: TestAccCloudflareZoneSubscriptionResource_WithPlanChange (12.29s)
=== RUN   TestAccCloudflareZoneSubscriptionResource_CreateZoneWithPlan_CUSTESC_57375
--- PASS: TestAccCloudflareZoneSubscriptionResource_CreateZoneWithPlan_CUSTESC_57375 (15.58s)
=== RUN   TestAccCloudflareZoneSubscriptionResource_ImportNoChanges_BILLSUB_247
--- PASS: TestAccCloudflareZoneSubscriptionResource_ImportNoChanges_BILLSUB_247 (8.13s)
=== RUN   TestAccCloudflareZoneSubscriptionResource_FrequencyNotSupported
=== PAUSE TestAccCloudflareZoneSubscriptionResource_FrequencyNotSupported
=== RUN   TestAccCloudflareZoneSubscriptionResource_PartnersEnt
=== PAUSE TestAccCloudflareZoneSubscriptionResource_PartnersEnt
=== CONT  TestAccCloudflareZoneSubscriptionResource_FrequencyNotSupported
=== CONT  TestAccCloudflareZoneSubscriptionResource_PartnersEnt
--- PASS: TestAccCloudflareZoneSubscriptionResource_FrequencyNotSupported (4.14s)
--- PASS: TestAccCloudflareZoneSubscriptionResource_PartnersEnt (7.37s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zone_subscription	62.250s
```