### PR TITLE
feat(custom_hostname_fallback_origin): add comprehensive lifecycle test

### DIFF
--- a/internal/services/custom_hostname_fallback_origin/resource_test.go
+++ b/internal/services/custom_hostname_fallback_origin/resource_test.go
@@ -6,12 +6,18 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/custom_hostnames"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestMain(m *testing.M) {
@@ -34,7 +40,47 @@ func testSweepCloudflareCustomHostnameFallbackOrigin(r string) error {
 	return nil
 }
 
-func TestAccCloudflareCustomHostnameFallbackOrigin(t *testing.T) {
+func testAccCheckCloudflareCustomHostnameFallbackOrigin(zoneID, rnd, subdomain, domain string) string {
+	return acctest.LoadTestCase("customhostnamefallbackorigin.tf", zoneID, rnd, subdomain, domain)
+}
+
+func testAccCheckCloudflareCustomHostnameFallbackOriginUpdated(zoneID, rnd, subdomain, domain string) string {
+	return acctest.LoadTestCase("customhostnamefallbackorigin_updated.tf", zoneID, rnd, subdomain, domain)
+}
+
+func testAccCheckCloudflareCustomHostnameFallbackOriginDestroy(s *terraform.State) error {
+	client := acctest.SharedClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_custom_hostname_fallback_origin" {
+			continue
+		}
+
+		zoneID := rs.Primary.Attributes[consts.ZoneIDSchemaKey]
+		fallbackOrigin, err := client.CustomHostnames.FallbackOrigin.Get(
+			context.Background(),
+			custom_hostnames.FallbackOriginGetParams{
+				ZoneID: cloudflare.F(zoneID),
+			},
+		)
+
+		// If error, resource is gone - that's expected
+		if err != nil {
+			continue
+		}
+
+		// If pending_deletion, that's acceptable (API will clean up)
+		if fallbackOrigin.Status == "pending_deletion" {
+			continue
+		}
+
+		return fmt.Errorf("Fallback Origin still exists with status: %s", fallbackOrigin.Status)
+	}
+
+	return nil
+}
+
+func TestAccCloudflareCustomHostnameFallbackOrigin_FullLifecycle(t *testing.T) {
 	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the custom hostname
 	// fallback endpoint does not yet support the API tokens for updates and it
 	// results in state error messages.
@@ -46,84 +92,67 @@ func TestAccCloudflareCustomHostnameFallbackOrigin(t *testing.T) {
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_custom_hostname_fallback_origin." + rnd
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareCustomHostnameFallbackOriginDestroy,
 		Steps: []resource.TestStep{
+			// Step 1: Create
 			{
 				Config: testAccCheckCloudflareCustomHostnameFallbackOrigin(zoneID, rnd, rnd, domain),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
-					resource.TestCheckResourceAttr(resourceName, "origin", fmt.Sprintf("fallback-origin.%s.%s", rnd, domain)),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Required attributes
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("origin"), knownvalue.StringExact(fmt.Sprintf("fallback-origin.%s.%s", rnd, domain))),
+					// Computed attributes
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+				},
+			},
+			// Step 2: Drift check - same config, expect empty plan
+			{
+				Config: testAccCheckCloudflareCustomHostnameFallbackOrigin(zoneID, rnd, rnd, domain),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 3: Update origin
+			{
+				Config: testAccCheckCloudflareCustomHostnameFallbackOriginUpdated(zoneID, rnd, rnd, domain),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("origin"), knownvalue.StringExact(fmt.Sprintf("fallback-origin-updated.%s.%s", rnd, domain))),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Required attributes
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("origin"), knownvalue.StringExact(fmt.Sprintf("fallback-origin-updated.%s.%s", rnd, domain))),
+					// Computed attributes
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+				},
+			},
+			// Step 4: Drift check after update
+			{
+				Config: testAccCheckCloudflareCustomHostnameFallbackOriginUpdated(zoneID, rnd, rnd, domain),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 5: Import
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"created_at", "updated_at"},
 			},
 		},
 	})
-}
-
-func testAccCheckCloudflareCustomHostnameFallbackOrigin(zoneID, rnd, subdomain, domain string) string {
-	return acctest.LoadTestCase("customhostnamefallbackorigin.tf", zoneID, rnd, subdomain, domain)
-}
-
-// This test is flaky due to the short time in between test steps that causes the resource
-// to still be in a 'pending deletion' state. The v4 provider had custom logic to add wait
-// times to the underlying API calls for this resource.
-//
-// func TestAccCloudflareCustomHostnameFallbackOriginUpdate(t *testing.T) {
-// 	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the custom hostname
-// 	// fallback endpoint does not yet support the API tokens for updates and it
-// 	// results in state error messages.
-// 	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-// 		t.Setenv("CLOUDFLARE_API_TOKEN", "")
-// 	}
-//
-// 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
-// 	domain := os.Getenv("CLOUDFLARE_DOMAIN")
-// 	rnd := utils.GenerateRandomResourceName()
-// 	rndUpdate := rnd + "-updated"
-// 	resourceName := "cloudflare_custom_hostname_fallback_origin." + rnd
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-// 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-// 		CheckDestroy:             testAccCheckCloudflareCustomHostnameFallbackOriginDestroy,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccCheckCloudflareCustomHostnameFallbackOrigin(zoneID, rnd, rnd, domain),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
-// 					resource.TestCheckResourceAttr(resourceName, "origin", fmt.Sprintf("fallback-origin.%s.%s", rnd, domain)),
-// 				),
-// 			},
-// 			{
-// 				Config: testAccCheckCloudflareCustomHostnameFallbackOrigin(zoneID, rnd, rndUpdate, domain),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
-// 					resource.TestCheckResourceAttr(resourceName, "origin", fmt.Sprintf("fallback-origin.%s.%s", rndUpdate, domain)),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
-
-func testAccCheckCloudflareCustomHostnameFallbackOriginDestroy(s *terraform.State) error {
-	client, clientErr := acctest.SharedV1Client() // TODO(terraform): replace with SharedV2Clent
-	if clientErr != nil {
-		tflog.Error(context.TODO(), fmt.Sprintf("failed to create Cloudflare client: %s", clientErr))
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "cloudflare_custom_hostname_fallback_origin" {
-			continue
-		}
-
-		fallbackOrigin, err := client.CustomHostnameFallbackOrigin(context.Background(), rs.Primary.Attributes[consts.ZoneIDSchemaKey])
-
-		// If the fallback origin is in the process of being deleted, that's fine to
-		// say it's been deleted as the remote API will take care of it.
-		if fallbackOrigin.Status != "pending_deletion" && err == nil {
-			return fmt.Errorf("Fallback Origin still exists")
-		}
-	}
-
-	return nil
 }

--- a/internal/services/custom_hostname_fallback_origin/testdata/customhostnamefallbackorigin_updated.tf
+++ b/internal/services/custom_hostname_fallback_origin/testdata/customhostnamefallbackorigin_updated.tf
@@ -1,0 +1,25 @@
+
+resource "cloudflare_custom_hostname_fallback_origin" "%[2]s" {
+  zone_id = "%[1]s"
+  origin = "fallback-origin-updated.%[3]s.%[4]s"
+}
+
+resource "cloudflare_dns_record" "%[2]s" {
+  zone_id = "%[1]s"
+  name    = "fallback-origin.%[2]s.%[4]s"
+  content   = "example.com"
+  type    = "CNAME"
+  proxied = true
+  ttl     = 1
+  depends_on = [cloudflare_custom_hostname_fallback_origin.%[2]s]
+}
+
+resource "cloudflare_dns_record" "%[2]s_updated" {
+  zone_id = "%[1]s"
+  name    = "fallback-origin-updated.%[2]s.%[4]s"
+  content   = "example.com"
+  type    = "CNAME"
+  proxied = true
+  ttl     = 1
+  depends_on = [cloudflare_custom_hostname_fallback_origin.%[2]s]
+}


### PR DESCRIPTION
SECENG-12969

- Replace basic single-step test with full lifecycle test covering Create, Drift check, Update, Drift check, and Import
- Upgrade CheckDestroy from v1 to v6 client
- Use statecheck pattern instead of TestCheckFunc
- Add ImportState testing
- Remove commented-out flaky update test (now covered by lifecycle test)

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Add comprehensive lifecycle test for `custom_hostname_fallback_origin` resource
- Modernize test patterns to match current codebase standards

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

```bash
export TF_ACC=1
export CLOUDFLARE_API_KEY="<your-api-key>"
export CLOUDFLARE_EMAIL="<your-email>"
export CLOUDFLARE_ZONE_ID="<your-zone-id>"
export CLOUDFLARE_DOMAIN="<your-domain>"
go test -v -timeout=30m ./internal/services/custom_hostname_fallback_origin/... -run TestAccCloudflareCustomHostnameFallbackOrigin_FullLifecycle
```

### Test output

```
=== RUN   TestAccCloudflareCustomHostnameFallbackOrigin_FullLifecycle
--- PASS: TestAccCloudflareCustomHostnameFallbackOrigin_FullLifecycle (12.77s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/custom_hostname_fallback_origin    14.100s
```

## Additional context & links
