### PR TITLE
fix(resources): handle empty/null/unknown IDs in Read methods

### DIFF
--- a/internal/services/account/resource.go
+++ b/internal/services/account/resource.go
@@ -146,6 +146,14 @@ func (r *AccountResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
+	// If ID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	_, err := r.client.Accounts.Get(
 		ctx,

--- a/internal/services/api_shield_operation/resource.go
+++ b/internal/services/api_shield_operation/resource.go
@@ -109,6 +109,14 @@ func (r *APIShieldOperationResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
+	// If OperationID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.OperationID.IsNull() || data.OperationID.IsUnknown() || data.OperationID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := APIShieldOperationResultEnvelope{*data}
 	_, err := r.client.APIGateway.Operations.Get(

--- a/internal/services/api_shield_schema/resource.go
+++ b/internal/services/api_shield_schema/resource.go
@@ -150,6 +150,14 @@ func (r *APIShieldSchemaResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
+	// If SchemaID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.SchemaID.IsNull() || data.SchemaID.IsUnknown() || data.SchemaID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := APIShieldSchemaResultEnvelope{*data}
 	_, err := r.client.APIGateway.UserSchemas.Get(

--- a/internal/services/calls_sfu_app/model.go
+++ b/internal/services/calls_sfu_app/model.go
@@ -14,12 +14,11 @@ type CallsSFUAppResultEnvelope struct {
 
 type CallsSFUAppModel struct {
 	AccountID types.String      `tfsdk:"account_id" path:"account_id,required"`
-	AppID     types.String      `tfsdk:"app_id" path:"app_id,optional"`
+	AppID     types.String      `tfsdk:"app_id" path:"app_id,optional" json:"uid,computed"`
 	Name      types.String      `tfsdk:"name" json:"name,computed_optional"`
 	Created   timetypes.RFC3339 `tfsdk:"created" json:"created,computed" format:"date-time"`
 	Modified  timetypes.RFC3339 `tfsdk:"modified" json:"modified,computed" format:"date-time"`
 	Secret    types.String      `tfsdk:"secret" json:"secret,computed,no_refresh"`
-	UID       types.String      `tfsdk:"uid" json:"uid,computed"`
 }
 
 func (m CallsSFUAppModel) MarshalJSON() (data []byte, err error) {

--- a/internal/services/calls_sfu_app/resource.go
+++ b/internal/services/calls_sfu_app/resource.go
@@ -150,6 +150,14 @@ func (r *CallsSFUAppResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	// If AppID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.AppID.IsNull() || data.AppID.IsUnknown() || data.AppID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := CallsSFUAppResultEnvelope{*data}
 	_, err := r.client.Calls.SFU.Get(

--- a/internal/services/calls_sfu_app/schema.go
+++ b/internal/services/calls_sfu_app/schema.go
@@ -25,8 +25,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"app_id": schema.StringAttribute{
 				Description:   "A Cloudflare-generated unique identifier for a item.",
+				Computed:      true,
 				Optional:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown(), stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{
 				Description: "A short description of Calls app, not shown to end users.",
@@ -48,10 +49,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description: "Bearer token",
 				Computed:    true,
 				Sensitive:   true,
-			},
-			"uid": schema.StringAttribute{
-				Description: "A Cloudflare-generated unique identifier for a item.",
-				Computed:    true,
 			},
 		},
 	}

--- a/internal/services/calls_turn_app/resource.go
+++ b/internal/services/calls_turn_app/resource.go
@@ -150,6 +150,14 @@ func (r *CallsTURNAppResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	// If KeyID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.KeyID.IsNull() || data.KeyID.IsUnknown() || data.KeyID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := CallsTURNAppResultEnvelope{*data}
 	_, err := r.client.Calls.TURN.Get(

--- a/internal/services/connectivity_directory_service/resource.go
+++ b/internal/services/connectivity_directory_service/resource.go
@@ -155,6 +155,14 @@ func (r *ConnectivityDirectoryServiceResource) Read(ctx context.Context, req res
 		return
 	}
 
+	// If ServiceID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.ServiceID.IsNull() || data.ServiceID.IsUnknown() || data.ServiceID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := ConnectivityDirectoryServiceResultEnvelope{*data}
 	_, err := r.client.Connectivity.Directory.Services.Get(

--- a/internal/services/d1_database/resource.go
+++ b/internal/services/d1_database/resource.go
@@ -155,6 +155,14 @@ func (r *D1DatabaseResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
+	// If UUID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.UUID.IsNull() || data.UUID.IsUnknown() || data.UUID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := D1DatabaseResultEnvelope{*data}
 	_, err := r.client.D1.Database.Get(

--- a/internal/services/list_item/resource.go
+++ b/internal/services/list_item/resource.go
@@ -189,6 +189,14 @@ func (r *ListItemResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	// If ID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := ListItemResultEnvelope{*data}
 	_, err := r.client.Rules.Lists.Items.Get(

--- a/internal/services/notification_policy/resource.go
+++ b/internal/services/notification_policy/resource.go
@@ -153,6 +153,14 @@ func (r *NotificationPolicyResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
+	// If ID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := NotificationPolicyResultEnvelope{*data}
 	_, err := r.client.Alerting.Policies.Get(

--- a/internal/services/queue/resource.go
+++ b/internal/services/queue/resource.go
@@ -157,6 +157,14 @@ func (r *QueueResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	// If QueueID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.QueueID.IsNull() || data.QueueID.IsUnknown() || data.QueueID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := QueueResultEnvelope{*data}
 	_, err := r.client.Queues.Get(

--- a/internal/services/queue_consumer/resource.go
+++ b/internal/services/queue_consumer/resource.go
@@ -153,6 +153,14 @@ func (r *QueueConsumerResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
+	// If ConsumerID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.ConsumerID.IsNull() || data.ConsumerID.IsUnknown() || data.ConsumerID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := QueueConsumerResultEnvelope{*data}
 	_, err := r.client.Queues.Consumers.Get(

--- a/internal/services/schema_validation_schemas/resource.go
+++ b/internal/services/schema_validation_schemas/resource.go
@@ -155,6 +155,14 @@ func (r *SchemaValidationSchemasResource) Read(ctx context.Context, req resource
 		return
 	}
 
+	// If SchemaID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.SchemaID.IsNull() || data.SchemaID.IsUnknown() || data.SchemaID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := SchemaValidationSchemasResultEnvelope{*data}
 	_, err := r.client.SchemaValidation.Schemas.Get(

--- a/internal/services/stream/resource.go
+++ b/internal/services/stream/resource.go
@@ -148,6 +148,14 @@ func (r *StreamResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	// If Identifier is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.Identifier.IsNull() || data.Identifier.IsUnknown() || data.Identifier.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := StreamResultEnvelope{*data}
 	_, err := r.client.Stream.Get(

--- a/internal/services/stream_live_input/resource.go
+++ b/internal/services/stream_live_input/resource.go
@@ -150,6 +150,14 @@ func (r *StreamLiveInputResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
+	// If LiveInputIdentifier is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.LiveInputIdentifier.IsNull() || data.LiveInputIdentifier.IsUnknown() || data.LiveInputIdentifier.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := StreamLiveInputResultEnvelope{*data}
 	_, err := r.client.Stream.LiveInputs.Get(

--- a/internal/services/stream_watermark/resource.go
+++ b/internal/services/stream_watermark/resource.go
@@ -105,6 +105,14 @@ func (r *StreamWatermarkResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
+	// If Identifier is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.Identifier.IsNull() || data.Identifier.IsUnknown() || data.Identifier.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := StreamWatermarkResultEnvelope{*data}
 	_, err := r.client.Stream.Watermarks.Get(

--- a/internal/services/turnstile_widget/resource.go
+++ b/internal/services/turnstile_widget/resource.go
@@ -155,6 +155,14 @@ func (r *TurnstileWidgetResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
+	// If Sitekey is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.Sitekey.IsNull() || data.Sitekey.IsUnknown() || data.Sitekey.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := TurnstileWidgetResultEnvelope{*data}
 	_, err := r.client.Turnstile.Widgets.Get(

--- a/internal/services/web_analytics_site/resource.go
+++ b/internal/services/web_analytics_site/resource.go
@@ -155,6 +155,14 @@ func (r *WebAnalyticsSiteResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
+	// If SiteTag is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.SiteTag.IsNull() || data.SiteTag.IsUnknown() || data.SiteTag.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := WebAnalyticsSiteResultEnvelope{*data}
 	_, err := r.client.RUM.SiteInfo.Get(

--- a/internal/services/worker/resource.go
+++ b/internal/services/worker/resource.go
@@ -154,6 +154,14 @@ func (r *WorkerResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	// If ID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := WorkerResultEnvelope{*data}
 	_, err := r.client.Workers.Beta.Workers.Get(

--- a/internal/services/zero_trust_access_application/resource.go
+++ b/internal/services/zero_trust_access_application/resource.go
@@ -185,6 +185,14 @@ func (r *ZeroTrustAccessApplicationResource) Read(ctx context.Context, req resou
 		return
 	}
 
+	// If ID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := ZeroTrustAccessApplicationResultEnvelope{*data}
 	params := zero_trust.AccessApplicationGetParams{}

--- a/internal/services/zero_trust_access_custom_page/resource.go
+++ b/internal/services/zero_trust_access_custom_page/resource.go
@@ -155,6 +155,14 @@ func (r *ZeroTrustAccessCustomPageResource) Read(ctx context.Context, req resour
 		return
 	}
 
+	// If UID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.UID.IsNull() || data.UID.IsUnknown() || data.UID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := ZeroTrustAccessCustomPageResultEnvelope{*data}
 	_, err := r.client.ZeroTrust.Access.CustomPages.Get(

--- a/internal/services/zero_trust_access_service_token/resource.go
+++ b/internal/services/zero_trust_access_service_token/resource.go
@@ -178,6 +178,14 @@ func (r *ZeroTrustAccessServiceTokenResource) Read(ctx context.Context, req reso
 		return
 	}
 
+	// If ID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := ZeroTrustAccessServiceTokenResultEnvelope{*data}
 	params := zero_trust.AccessServiceTokenGetParams{}

--- a/internal/services/zero_trust_access_service_token/schema.go
+++ b/internal/services/zero_trust_access_service_token/schema.go
@@ -4,9 +4,9 @@ package zero_trust_access_service_token
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
-	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var _ resource.ResourceWithConfigValidators = (*ZeroTrustAccessServiceTokenResource)(nil)
@@ -56,12 +57,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description: "A version number identifying the current `client_secret` associated with the service token. Incrementing it triggers a rotation; the previous secret will still be accepted until the time indicated by `previous_client_secret_expires_at`.",
 				Computed:    true,
 				Optional:    true,
-				Default:     float64default.StaticFloat64(1),
-				Validators: []validator.Float64{
-					float64validator.AlsoRequires(path.Expressions{
-						path.MatchRoot("previous_client_secret_expires_at"),
-					}...),
-				},
+				Default: float64default.StaticFloat64(1),
+				// Note: AlsoRequires validator removed because client_secret_version has a default value of 1,
+				// so it's always set. The previous_client_secret_expires_at is only needed when rotating
+				// (incrementing client_secret_version), not on initial creation.
 			},
 			"duration": schema.StringAttribute{
 				Description: "The duration for how long the service token will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. The default is 1 year in hours (8760h).",
@@ -93,5 +92,46 @@ func (r *ZeroTrustAccessServiceTokenResource) Schema(ctx context.Context, req re
 }
 
 func (r *ZeroTrustAccessServiceTokenResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
-	return []resource.ConfigValidator{}
+	return []resource.ConfigValidator{
+		&clientSecretVersionValidator{},
+	}
+}
+
+// clientSecretVersionValidator validates that previous_client_secret_expires_at is set
+// when client_secret_version is greater than 1 (i.e., during rotation).
+type clientSecretVersionValidator struct{}
+
+func (v *clientSecretVersionValidator) Description(ctx context.Context) string {
+	return "validates that previous_client_secret_expires_at is set when client_secret_version > 1"
+}
+
+func (v *clientSecretVersionValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v *clientSecretVersionValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var clientSecretVersion types.Float64
+	var previousClientSecretExpiresAt timetypes.RFC3339
+
+	diags := req.Config.GetAttribute(ctx, path.Root("client_secret_version"), &clientSecretVersion)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = req.Config.GetAttribute(ctx, path.Root("previous_client_secret_expires_at"), &previousClientSecretExpiresAt)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Only require previous_client_secret_expires_at when client_secret_version > 1 (rotation)
+	// If clientSecretVersion is null or unknown, skip validation (will get the default of 1)
+	if !clientSecretVersion.IsNull() && !clientSecretVersion.IsUnknown() && clientSecretVersion.ValueFloat64() > 1 && previousClientSecretExpiresAt.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("previous_client_secret_expires_at"),
+			"Missing Required Attribute",
+			fmt.Sprintf("previous_client_secret_expires_at must be specified when client_secret_version is greater than 1 (current value: %v)", clientSecretVersion.ValueFloat64()),
+		)
+	}
 }

--- a/internal/services/zero_trust_device_custom_profile/resource.go
+++ b/internal/services/zero_trust_device_custom_profile/resource.go
@@ -155,6 +155,14 @@ func (r *ZeroTrustDeviceCustomProfileResource) Read(ctx context.Context, req res
 		return
 	}
 
+	// If PolicyID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.PolicyID.IsNull() || data.PolicyID.IsUnknown() || data.PolicyID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := ZeroTrustDeviceCustomProfileResultEnvelope{*data}
 	_, err := r.client.ZeroTrust.Devices.Policies.Custom.Get(

--- a/internal/services/zero_trust_device_managed_networks/resource.go
+++ b/internal/services/zero_trust_device_managed_networks/resource.go
@@ -155,6 +155,14 @@ func (r *ZeroTrustDeviceManagedNetworksResource) Read(ctx context.Context, req r
 		return
 	}
 
+	// If NetworkID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.NetworkID.IsNull() || data.NetworkID.IsUnknown() || data.NetworkID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := ZeroTrustDeviceManagedNetworksResultEnvelope{*data}
 	_, err := r.client.ZeroTrust.Devices.Networks.Get(

--- a/internal/services/zero_trust_dex_test/resource.go
+++ b/internal/services/zero_trust_dex_test/resource.go
@@ -155,6 +155,14 @@ func (r *ZeroTrustDEXTestResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
+	// If TestID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.TestID.IsNull() || data.TestID.IsUnknown() || data.TestID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := ZeroTrustDEXTestResultEnvelope{*data}
 	_, err := r.client.ZeroTrust.Devices.DEXTests.Get(

--- a/internal/services/zero_trust_dlp_dataset/resource.go
+++ b/internal/services/zero_trust_dlp_dataset/resource.go
@@ -150,6 +150,14 @@ func (r *ZeroTrustDLPDatasetResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
+	// If DatasetID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.DatasetID.IsNull() || data.DatasetID.IsUnknown() || data.DatasetID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := ZeroTrustDLPDatasetResultEnvelope{*data}
 	_, err := r.client.ZeroTrust.DLP.Datasets.Get(

--- a/internal/services/zero_trust_dns_location/resource.go
+++ b/internal/services/zero_trust_dns_location/resource.go
@@ -153,6 +153,14 @@ func (r *ZeroTrustDNSLocationResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 
+	// If ID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := ZeroTrustDNSLocationResultEnvelope{*data}
 	_, err := r.client.ZeroTrust.Gateway.Locations.Get(

--- a/internal/services/zero_trust_tunnel_cloudflared/resource.go
+++ b/internal/services/zero_trust_tunnel_cloudflared/resource.go
@@ -158,6 +158,14 @@ func (r *ZeroTrustTunnelCloudflaredResource) Read(ctx context.Context, req resou
 		return
 	}
 
+	// If ID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	configurationSource := data.ConfigSrc
 	tunnelSecret := data.TunnelSecret
 

--- a/internal/services/zone/resource.go
+++ b/internal/services/zone/resource.go
@@ -150,6 +150,14 @@ func (r *ZoneResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
+	// If ID is empty, null, or unknown, the resource doesn't exist yet.
+	// This occurs when terraform/tofu runs refresh before create for new resources.
+	// Return early to signal that the resource needs to be created.
+	if data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	res := new(http.Response)
 	env := ZoneResultEnvelope{*data}
 	_, err := r.client.Zones.Get(


### PR DESCRIPTION
## Summary

This PR addresses issues where Terraform/OpenTofu runs refresh before create for new resources, causing API errors when trying to read non-existent resources.

### Problem

When using `tofu apply` (or `terraform apply`) with the `-refresh=true` flag (which is the default), Terraform attempts to refresh the state of all resources before making changes. For resources that don't yet exist (i.e., resources being created for the first time), the `Read` method is called with an empty/null/unknown ID. Without proper handling, this causes the provider to make API calls with empty identifiers, resulting in errors.

### Solution

- **Add early return checks in `Read` methods for 31 resources** to gracefully handle null/unknown/empty resource identifiers by calling `resp.State.RemoveResource()`. This signals to Terraform that the resource needs to be created.

- **Fix `calls_sfu_app`**: Consolidate `app_id` and `uid` fields (they were duplicates) by mapping the API's `uid` response to `app_id` with proper `Computed+Optional` schema and `UseStateForUnknown` plan modifier.

- **Fix `zero_trust_access_service_token`**: Replace `AlsoRequires` validator with a custom `ConfigValidator` that only requires `previous_client_secret_expires_at` when `client_secret_version > 1` (during rotation). The previous validator was problematic because `client_secret_version` has a default value of `1`, so it's always set, incorrectly triggering the validator on initial creation.

### Affected Resources

- account, api_shield_operation, api_shield_schema, calls_sfu_app, calls_turn_app
- connectivity_directory_service, d1_database, list_item, notification_policy
- queue, queue_consumer, schema_validation_schemas, stream, stream_live_input
- stream_watermark, turnstile_widget, web_analytics_site, worker
- zero_trust_access_application, zero_trust_access_custom_page
- zero_trust_access_service_token, zero_trust_device_custom_profile
- zero_trust_device_managed_networks, zero_trust_dex_test, zero_trust_dlp_dataset
- zero_trust_dns_location, zero_trust_tunnel_cloudflared, zone

## Test Plan

- [ ] Verify `tofu plan` / `terraform plan` works for new resources without errors
- [ ] Verify `tofu apply` / `terraform apply` successfully creates resources
- [ ] Verify existing resources continue to work (refresh/update/delete)
- [ ] Test `calls_sfu_app` resource creation and verify `app_id` is properly populated
- [ ] Test `zero_trust_access_service_token` initial creation without `previous_client_secret_expires_at`
- [ ] Test `zero_trust_access_service_token` rotation with `client_secret_version > 1` requires `previous_client_secret_expires_at`