### PR TITLE
test(authenticated_origin_pulls_settings): add comprehensive lifecycle test

### DIFF
--- a/internal/services/authenticated_origin_pulls_settings/resource_test.go
+++ b/internal/services/authenticated_origin_pulls_settings/resource_test.go
@@ -1,0 +1,113 @@
+package authenticated_origin_pulls_settings_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func init() {
+	resource.AddTestSweepers("cloudflare_authenticated_origin_pulls_settings", &resource.Sweeper{
+		Name: "cloudflare_authenticated_origin_pulls_settings",
+		F:    testSweepCloudflareAuthenticatedOriginPullsSettings,
+	})
+}
+
+func testSweepCloudflareAuthenticatedOriginPullsSettings(r string) error {
+	ctx := context.Background()
+	// Authenticated Origin Pulls Settings is a zone-level configuration setting.
+	// It's a singleton setting per zone, not something that accumulates.
+	// No sweeping required.
+	tflog.Info(ctx, "Authenticated Origin Pulls Settings doesn't require sweeping (zone setting)")
+	return nil
+}
+
+func testAccAuthenticatedOriginPullsSettingsEnabled(zoneID, rnd string) string {
+	return acctest.LoadTestCase("authenticatedoriginpullssettings.tf", rnd, zoneID)
+}
+
+func testAccAuthenticatedOriginPullsSettingsDisabled(zoneID, rnd string) string {
+	return acctest.LoadTestCase("authenticatedoriginpullssettings_disabled.tf", rnd, zoneID)
+}
+
+func TestAccAuthenticatedOriginPullsSettings_FullLifecycle(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_authenticated_origin_pulls_settings." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck_ZoneID(t)
+			acctest.TestAccPreCheck_Credentials(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with enabled = true
+			{
+				Config: testAccAuthenticatedOriginPullsSettingsEnabled(zoneID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+				},
+			},
+			// Step 2: Drift check - same config, expect empty plan
+			{
+				Config: testAccAuthenticatedOriginPullsSettingsEnabled(zoneID, rnd),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 3: Update to enabled = false
+			{
+				Config: testAccAuthenticatedOriginPullsSettingsDisabled(zoneID, rnd),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(false)),
+				},
+			},
+			// Step 4: Drift check after update
+			{
+				Config: testAccAuthenticatedOriginPullsSettingsDisabled(zoneID, rnd),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 5: Update back to enabled = true (confirms toggle works both ways)
+			{
+				Config: testAccAuthenticatedOriginPullsSettingsEnabled(zoneID, rnd),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/authenticated_origin_pulls_settings/testdata/authenticatedoriginpullssettings.tf
+++ b/internal/services/authenticated_origin_pulls_settings/testdata/authenticatedoriginpullssettings.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_authenticated_origin_pulls_settings" "%[1]s" {
+  zone_id = "%[2]s"
+  enabled = true
+}

--- a/internal/services/authenticated_origin_pulls_settings/testdata/authenticatedoriginpullssettings_disabled.tf
+++ b/internal/services/authenticated_origin_pulls_settings/testdata/authenticatedoriginpullssettings_disabled.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_authenticated_origin_pulls_settings" "%[1]s" {
+  zone_id = "%[2]s"
+  enabled = false
+}


### PR DESCRIPTION
SECENG-13299

- Add full lifecycle test covering Create, Drift check, Update, Drift check, and Toggle back
- Use modern testing patterns (statecheck, plancheck, knownvalue)
- Add testdata files for enabled and disabled configurations
- Add sweeper (no-op for zone-level singleton setting)

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Add comprehensive lifecycle test for `authenticated_origin_pulls_settings` resource
- Modernize test patterns to match current codebase standards

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

```bash
export TF_ACC=1
export CLOUDFLARE_API_KEY="<your-api-key>"
export CLOUDFLARE_EMAIL="<your-email>"
export CLOUDFLARE_ZONE_ID="<your-zone-id>"
go test -v -timeout=30m ./internal/services/authenticated_origin_pulls_settings/... -run TestAccAuthenticatedOriginPullsSettings_FullLifecycle
```

### Test output

```
=== RUN   TestAccAuthenticatedOriginPullsSettings_FullLifecycle
--- PASS: TestAccAuthenticatedOriginPullsSettings_FullLifecycle (21.67s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/authenticated_origin_pulls_settings    23.104s
```

## Additional context & links

This resource is a zone-level singleton boolean setting that enables/disables zone-level authenticated origin pulls. Key characteristics:
- No `id` attribute (uses `zone_id` as identifier)
- No ImportState implemented
- Delete is a no-op (setting persists in API)