### PR TITLE
feat(authenticated_origin_pulls_settings): v4 to v5 migration

### DIFF
--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/migrations_test.go
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/migrations_test.go
@@ -1,0 +1,254 @@
+package v500_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+var (
+	currentProviderVersion = internal.PackageVersion // Current v5 release
+)
+
+// Migration Test Configuration
+//
+// Version is read from LAST_V4_VERSION environment variable (set in .github/workflows/migration-tests.yml)
+// - Last stable v4 release: default 4.52.5
+// - Current v5 release: auto-updates with releases (internal.PackageVersion)
+//
+// Based on breaking changes analysis:
+// - Resource renamed: cloudflare_authenticated_origin_pulls → cloudflare_authenticated_origin_pulls_settings
+// - Fields removed in v5: hostname, authenticated_origin_pulls_certificate
+// - Fields kept: zone_id, enabled, id
+
+// Embed migration test configuration files
+//
+//go:embed testdata/v4_zone_wide.tf
+var v4ZoneWideConfig string
+
+//go:embed testdata/v5_zone_wide.tf
+var v5ZoneWideConfig string
+
+//go:embed testdata/v4_with_hostname.tf
+var v4WithHostnameConfig string
+
+//go:embed testdata/v4_with_certificate.tf
+var v4WithCertificateConfig string
+
+//go:embed testdata/v4_disabled.tf
+var v4DisabledConfig string
+
+//go:embed testdata/v5_disabled.tf
+var v5DisabledConfig string
+
+// aopMigrationTestStep creates a test step for authenticated_origin_pulls_settings migration
+func aopMigrationTestStep(t *testing.T, testConfig string, tmpDir string, exactVersion string, sourceVersion string, targetVersion string, expectNonEmptyPlan bool, stateChecks []statecheck.StateCheck) resource.TestStep {
+	return resource.TestStep{
+		PreConfig: func() {
+			acctest.WriteOutConfig(t, testConfig, tmpDir)
+			acctest.RunMigrationV2Command(t, testConfig, tmpDir, sourceVersion, targetVersion)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		ConfigDirectory:          config.StaticDirectory(tmpDir),
+		ExpectNonEmptyPlan:       expectNonEmptyPlan,
+		ConfigPlanChecks: resource.ConfigPlanChecks{
+			PreApply: []plancheck.PlanCheck{
+				acctest.DebugNonEmptyPlan,
+			},
+		},
+		ConfigStateChecks: stateChecks,
+	}
+}
+
+// TestMigrateAuthenticatedOriginPullsSettingsBasic tests migration of basic zone-wide AOP from v4 to v5
+func TestMigrateAuthenticatedOriginPullsSettingsBasic(t *testing.T) {
+	testCases := []struct {
+		name               string
+		version            string
+		configFn           func(rnd, zoneID string) string
+		expectNonEmptyPlan bool
+	}{
+		{
+			name:     "from_v4_latest",
+			version:  os.Getenv("LAST_V4_VERSION"),
+			configFn: func(rnd, zoneID string) string { return fmt.Sprintf(v4ZoneWideConfig, rnd, zoneID) },
+		},
+		{
+			name:     "from_v5",
+			version:  currentProviderVersion,
+			configFn: func(rnd, zoneID string) string { return fmt.Sprintf(v5ZoneWideConfig, rnd, zoneID) },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						// Step 1: Create with specific version
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					// Step 2: Run migration and verify state
+					aopMigrationTestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, tc.expectNonEmptyPlan, []statecheck.StateCheck{
+						// Resource should be renamed to cloudflare_authenticated_origin_pulls_settings
+						statecheck.ExpectKnownValue("cloudflare_authenticated_origin_pulls_settings."+rnd, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+						statecheck.ExpectKnownValue("cloudflare_authenticated_origin_pulls_settings."+rnd, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+					}),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateAuthenticatedOriginPullsSettingsDisabled tests migration of disabled AOP from v4 to v5
+func TestMigrateAuthenticatedOriginPullsSettingsDisabled(t *testing.T) {
+	testCases := []struct {
+		name               string
+		version            string
+		configFn           func(rnd, zoneID string) string
+		expectNonEmptyPlan bool
+	}{
+		{
+			name:     "from_v4_latest",
+			version:  os.Getenv("LAST_V4_VERSION"),
+			configFn: func(rnd, zoneID string) string { return fmt.Sprintf(v4DisabledConfig, rnd, zoneID) },
+		},
+		{
+			name:     "from_v5",
+			version:  currentProviderVersion,
+			configFn: func(rnd, zoneID string) string { return fmt.Sprintf(v5DisabledConfig, rnd, zoneID) },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						// Step 1: Create with specific version
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					// Step 2: Run migration and verify state
+					aopMigrationTestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, tc.expectNonEmptyPlan, []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("cloudflare_authenticated_origin_pulls_settings."+rnd, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+						statecheck.ExpectKnownValue("cloudflare_authenticated_origin_pulls_settings."+rnd, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+					}),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateAuthenticatedOriginPullsSettingsWithHostname tests migration with v4-only hostname field
+// The hostname field should be removed in the v5 state
+func TestMigrateAuthenticatedOriginPullsSettingsWithHostname(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	tmpDir := t.TempDir()
+
+	// V4 config with hostname (should be removed in v5)
+	v4Config := fmt.Sprintf(v4WithHostnameConfig, rnd, zoneID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: os.Getenv("LAST_V4_VERSION"),
+					},
+				},
+				Config: v4Config,
+			},
+			aopMigrationTestStep(t, v4Config, tmpDir, os.Getenv("LAST_V4_VERSION"), "v4", "v5", false, []statecheck.StateCheck{
+				statecheck.ExpectKnownValue("cloudflare_authenticated_origin_pulls_settings."+rnd, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+				// hostname should not exist in v5 state
+			}),
+		},
+	})
+}
+
+// TestMigrateAuthenticatedOriginPullsSettingsWithCertificate tests migration with v4-only certificate field
+// The authenticated_origin_pulls_certificate field should be removed in the v5 state
+func TestMigrateAuthenticatedOriginPullsSettingsWithCertificate(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	tmpDir := t.TempDir()
+
+	// V4 config with certificate reference (should be removed in v5)
+	v4Config := fmt.Sprintf(v4WithCertificateConfig, rnd, zoneID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: os.Getenv("LAST_V4_VERSION"),
+					},
+				},
+				Config: v4Config,
+			},
+			aopMigrationTestStep(t, v4Config, tmpDir, os.Getenv("LAST_V4_VERSION"), "v4", "v5", false, []statecheck.StateCheck{
+				statecheck.ExpectKnownValue("cloudflare_authenticated_origin_pulls_settings."+rnd, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+				// authenticated_origin_pulls_certificate should not exist in v5 state
+			}),
+		},
+	})
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/model.go
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/model.go
@@ -1,0 +1,40 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ============================================================================
+// Source Models (Legacy Provider - v4.x)
+// ============================================================================
+
+// SourceCloudflareAuthenticatedOriginPullsModel represents the legacy resource state from v4.x provider.
+// Schema version: 0 (actual v4 schema version)
+// Resource type: cloudflare_authenticated_origin_pulls
+//
+// This model includes ALL v4 fields, including ones that will be removed in v5:
+// - hostname: Per-hostname AOP configuration (removed in v5)
+// - authenticated_origin_pulls_certificate: Certificate ID for AOP (removed in v5)
+type SourceCloudflareAuthenticatedOriginPullsModel struct {
+	ID                                   types.String `tfsdk:"id"`
+	ZoneID                              types.String `tfsdk:"zone_id"`
+	Hostname                            types.String `tfsdk:"hostname"`
+	AuthenticatedOriginPullsCertificate types.String `tfsdk:"authenticated_origin_pulls_certificate"`
+	Enabled                             types.Bool   `tfsdk:"enabled"`
+}
+
+// ============================================================================
+// Target Models (Current Provider - v5.x+)
+// ============================================================================
+
+// TargetAuthenticatedOriginPullsSettingsModel represents the current resource state from v5.x+ provider.
+// Schema version: 500
+// Resource type: cloudflare_authenticated_origin_pulls_settings
+//
+// Note: This matches the model in the parent package's model.go file.
+// The v5 model is simplified - it only supports zone-wide AOP settings.
+type TargetAuthenticatedOriginPullsSettingsModel struct {
+	ID      types.String `tfsdk:"id"`
+	ZoneID  types.String `tfsdk:"zone_id"`
+	Enabled types.Bool   `tfsdk:"enabled"`
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/move.go
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/move.go
@@ -1,0 +1,43 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// MoveState handles moving state from legacy resource to current resource.
+// This is triggered by Terraform 1.8+ when it encounters a `moved` block:
+//
+//   moved {
+//     from = cloudflare_authenticated_origin_pulls.example
+//     to   = cloudflare_authenticated_origin_pulls_settings.example
+//   }
+//
+// For Terraform < 1.8, users must manually run:
+//   terraform state mv cloudflare_authenticated_origin_pulls.example cloudflare_authenticated_origin_pulls_settings.example
+//
+// which will preserve the source schema_version and trigger UpgradeFromLegacyV0 instead.
+func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+	tflog.Info(ctx, "Moving state from legacy cloudflare_authenticated_origin_pulls to cloudflare_authenticated_origin_pulls_settings")
+
+	// Parse the source state (legacy v4 format)
+	var sourceState SourceCloudflareAuthenticatedOriginPullsModel
+	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform to target (current v5 format)
+	targetState, diags := Transform(ctx, sourceState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Set the moved state
+	resp.Diagnostics.Append(resp.TargetState.Set(ctx, targetState)...)
+
+	tflog.Info(ctx, "State move from legacy cloudflare_authenticated_origin_pulls completed successfully")
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/schema.go
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/schema.go
@@ -1,0 +1,35 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// SourceCloudflareAuthenticatedOriginPullsSchema returns the source schema for legacy resource.
+// Schema version: 0 (v4 schema version)
+// Resource type: cloudflare_authenticated_origin_pulls
+//
+// This minimal schema is used only for reading v4 state during migration.
+// It includes only the properties needed for state parsing (Required, Optional, Computed).
+// Validators, PlanModifiers, and Descriptions are intentionally omitted.
+func SourceCloudflareAuthenticatedOriginPullsSchema() schema.Schema {
+	return schema.Schema{
+		Version: 0, // v4 schema version
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"zone_id": schema.StringAttribute{
+				Required: true,
+			},
+			"hostname": schema.StringAttribute{
+				Optional: true,
+			},
+			"authenticated_origin_pulls_certificate": schema.StringAttribute{
+				Optional: true,
+			},
+			"enabled": schema.BoolAttribute{
+				Required: true,
+			},
+		},
+	}
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/testdata/v4_disabled.tf
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/testdata/v4_disabled.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_authenticated_origin_pulls" "%[1]s" {
+  zone_id = "%[2]s"
+  enabled = false
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/testdata/v4_with_certificate.tf
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/testdata/v4_with_certificate.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_authenticated_origin_pulls" "%[1]s" {
+  zone_id                                = "%[2]s"
+  authenticated_origin_pulls_certificate = "cert-123"
+  enabled                                = true
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/testdata/v4_with_hostname.tf
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/testdata/v4_with_hostname.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_authenticated_origin_pulls" "%[1]s" {
+  zone_id  = "%[2]s"
+  hostname = "example.com"
+  enabled  = true
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/testdata/v4_zone_wide.tf
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/testdata/v4_zone_wide.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_authenticated_origin_pulls" "%[1]s" {
+  zone_id = "%[2]s"
+  enabled = true
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/testdata/v5_disabled.tf
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/testdata/v5_disabled.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_authenticated_origin_pulls_settings" "%[1]s" {
+  zone_id = "%[2]s"
+  enabled = false
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/testdata/v5_zone_wide.tf
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/testdata/v5_zone_wide.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_authenticated_origin_pulls_settings" "%[1]s" {
+  zone_id = "%[2]s"
+  enabled = true
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/transform.go
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/transform.go
@@ -1,0 +1,29 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// Transform converts legacy v4 state to current v5 state.
+// This function is used by both MoveState and UpgradeState.
+//
+// Transformation logic:
+// - Copy: id, zone_id, enabled
+// - Drop: hostname, authenticated_origin_pulls_certificate (removed in v5)
+func Transform(ctx context.Context, source SourceCloudflareAuthenticatedOriginPullsModel) (TargetAuthenticatedOriginPullsSettingsModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var target TargetAuthenticatedOriginPullsSettingsModel
+
+	// Direct field mappings (no transformation needed)
+	target.ID = source.ID
+	target.ZoneID = source.ZoneID
+	target.Enabled = source.Enabled
+
+	// Fields removed in v5 (no action needed):
+	// - hostname
+	// - authenticated_origin_pulls_certificate
+
+	return target, diags
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/transform_test.go
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/transform_test.go
@@ -1,0 +1,125 @@
+package v500_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/authenticated_origin_pulls_settings/migration/v500"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransform(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		source         v500.SourceCloudflareAuthenticatedOriginPullsModel
+		expectedTarget v500.TargetAuthenticatedOriginPullsSettingsModel
+		expectError    bool
+	}{
+		{
+			name: "basic transformation - all fields present",
+			source: v500.SourceCloudflareAuthenticatedOriginPullsModel{
+				ID:                                   types.StringValue("zone-123"),
+				ZoneID:                              types.StringValue("zone-123"),
+				Hostname:                            types.StringValue("example.com"),
+				AuthenticatedOriginPullsCertificate: types.StringValue("cert-123"),
+				Enabled:                             types.BoolValue(true),
+			},
+			expectedTarget: v500.TargetAuthenticatedOriginPullsSettingsModel{
+				ID:      types.StringValue("zone-123"),
+				ZoneID:  types.StringValue("zone-123"),
+				Enabled: types.BoolValue(true),
+			},
+			expectError: false,
+		},
+		{
+			name: "disabled state",
+			source: v500.SourceCloudflareAuthenticatedOriginPullsModel{
+				ID:                                   types.StringValue("zone-456"),
+				ZoneID:                              types.StringValue("zone-456"),
+				Hostname:                            types.StringValue("test.example.com"),
+				AuthenticatedOriginPullsCertificate: types.StringValue("cert-456"),
+				Enabled:                             types.BoolValue(false),
+			},
+			expectedTarget: v500.TargetAuthenticatedOriginPullsSettingsModel{
+				ID:      types.StringValue("zone-456"),
+				ZoneID:  types.StringValue("zone-456"),
+				Enabled: types.BoolValue(false),
+			},
+			expectError: false,
+		},
+		{
+			name: "null optional fields",
+			source: v500.SourceCloudflareAuthenticatedOriginPullsModel{
+				ID:                                   types.StringValue("zone-789"),
+				ZoneID:                              types.StringValue("zone-789"),
+				Hostname:                            types.StringNull(),
+				AuthenticatedOriginPullsCertificate: types.StringNull(),
+				Enabled:                             types.BoolValue(true),
+			},
+			expectedTarget: v500.TargetAuthenticatedOriginPullsSettingsModel{
+				ID:      types.StringValue("zone-789"),
+				ZoneID:  types.StringValue("zone-789"),
+				Enabled: types.BoolValue(true),
+			},
+			expectError: false,
+		},
+		{
+			name: "unknown values",
+			source: v500.SourceCloudflareAuthenticatedOriginPullsModel{
+				ID:                                   types.StringUnknown(),
+				ZoneID:                              types.StringValue("zone-999"),
+				Hostname:                            types.StringUnknown(),
+				AuthenticatedOriginPullsCertificate: types.StringUnknown(),
+				Enabled:                             types.BoolUnknown(),
+			},
+			expectedTarget: v500.TargetAuthenticatedOriginPullsSettingsModel{
+				ID:      types.StringUnknown(),
+				ZoneID:  types.StringValue("zone-999"),
+				Enabled: types.BoolUnknown(),
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target, diags := v500.Transform(ctx, tt.source)
+
+			if tt.expectError {
+				require.True(t, diags.HasError(), "Expected error but got none")
+			} else {
+				require.False(t, diags.HasError(), "Unexpected error: %v", diags)
+
+				// Verify all fields are correctly mapped
+				assert.Equal(t, tt.expectedTarget.ID, target.ID, "ID mismatch")
+				assert.Equal(t, tt.expectedTarget.ZoneID, target.ZoneID, "ZoneID mismatch")
+				assert.Equal(t, tt.expectedTarget.Enabled, target.Enabled, "Enabled mismatch")
+			}
+		})
+	}
+}
+
+func TestTransform_FieldsDropped(t *testing.T) {
+	ctx := context.Background()
+
+	source := v500.SourceCloudflareAuthenticatedOriginPullsModel{
+		ID:                                   types.StringValue("zone-123"),
+		ZoneID:                              types.StringValue("zone-123"),
+		Hostname:                            types.StringValue("should-be-dropped.example.com"),
+		AuthenticatedOriginPullsCertificate: types.StringValue("cert-should-be-dropped"),
+		Enabled:                             types.BoolValue(true),
+	}
+
+	target, diags := v500.Transform(ctx, source)
+	require.False(t, diags.HasError())
+
+	// Verify that hostname and authenticated_origin_pulls_certificate are not in target
+	// (They should not exist in the target model at all - this is validated by the type system)
+	assert.Equal(t, types.StringValue("zone-123"), target.ID)
+	assert.Equal(t, types.StringValue("zone-123"), target.ZoneID)
+	assert.Equal(t, types.BoolValue(true), target.Enabled)
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/upgrade.go
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/upgrade.go
@@ -1,0 +1,61 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// UpgradeFromLegacyV0 handles state upgrade from legacy v4 (schema version 0) to v5 (schema version 500).
+//
+// This upgrader is triggered when:
+// - User has v4 state (schema_version: 0)
+// - User runs `terraform state mv` to rename from cloudflare_authenticated_origin_pulls to cloudflare_authenticated_origin_pulls_settings
+// - Terraform detects schema version mismatch and calls this upgrader
+//
+// Note: For Terraform 1.8+, MoveState will be triggered instead via `moved` blocks.
+func UpgradeFromLegacyV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading authenticated_origin_pulls_settings state from legacy v0 to v500")
+
+	// Parse the source state (legacy v4 format with schema version 0)
+	var sourceState SourceCloudflareAuthenticatedOriginPullsModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &sourceState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform to target (current v5 format)
+	targetState, diags := Transform(ctx, sourceState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Set the upgraded state
+	resp.Diagnostics.Append(resp.State.Set(ctx, targetState)...)
+
+	tflog.Info(ctx, "State upgrade from v0 to v500 completed successfully")
+}
+
+// UpgradeFromV1 handles state upgrade from v5 (schema version 1) to v5 (schema version 500).
+//
+// This is a no-op upgrader that exists solely to support the schema version rollout mechanism:
+// - When TF_MIG_TEST is unset (production): schema version = 1
+// - When TF_MIG_TEST is set (testing): schema version = 500
+//
+// This upgrader ensures users with schema version 1 can seamlessly upgrade to version 500
+// when the version is increased during testing, without any actual state transformation.
+func UpgradeFromV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Debug(ctx, "No-op state upgrade from v1 to v500 (schema versions are compatible)")
+
+	// This is a no-op: v1 and v500 have identical schemas.
+	// We just need to parse and re-set the state to update the schema version metadata.
+	var state TargetAuthenticatedOriginPullsSettingsModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/upgrade_test.go
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/upgrade_test.go
@@ -1,0 +1,244 @@
+package v500_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/authenticated_origin_pulls_settings/migration/v500"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeFromLegacyV0(t *testing.T) {
+	ctx := context.Background()
+	sourceSchema := v500.SourceCloudflareAuthenticatedOriginPullsSchema()
+
+	tests := []struct {
+		name           string
+		sourceState    map[string]interface{}
+		expectedTarget v500.TargetAuthenticatedOriginPullsSettingsModel
+		expectError    bool
+	}{
+		{
+			name: "upgrade with all fields",
+			sourceState: map[string]interface{}{
+				"id":                                     "zone-123",
+				"zone_id":                                "zone-123",
+				"hostname":                               "example.com",
+				"authenticated_origin_pulls_certificate": "cert-123",
+				"enabled":                                true,
+			},
+			expectedTarget: v500.TargetAuthenticatedOriginPullsSettingsModel{
+				ID:      types.StringValue("zone-123"),
+				ZoneID:  types.StringValue("zone-123"),
+				Enabled: types.BoolValue(true),
+			},
+			expectError: false,
+		},
+		{
+			name: "upgrade with disabled state",
+			sourceState: map[string]interface{}{
+				"id":                                     "zone-456",
+				"zone_id":                                "zone-456",
+				"hostname":                               "test.example.com",
+				"authenticated_origin_pulls_certificate": "cert-456",
+				"enabled":                                false,
+			},
+			expectedTarget: v500.TargetAuthenticatedOriginPullsSettingsModel{
+				ID:      types.StringValue("zone-456"),
+				ZoneID:  types.StringValue("zone-456"),
+				Enabled: types.BoolValue(false),
+			},
+			expectError: false,
+		},
+		{
+			name: "upgrade with null optional fields",
+			sourceState: map[string]interface{}{
+				"id":                                     "zone-789",
+				"zone_id":                                "zone-789",
+				"hostname":                               nil,
+				"authenticated_origin_pulls_certificate": nil,
+				"enabled":                                true,
+			},
+			expectedTarget: v500.TargetAuthenticatedOriginPullsSettingsModel{
+				ID:      types.StringValue("zone-789"),
+				ZoneID:  types.StringValue("zone-789"),
+				Enabled: types.BoolValue(true),
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create source state
+			sourceStateValue := createTerraformValue(t, sourceSchema, tt.sourceState)
+			sourceState := tfsdk.State{
+				Raw:    sourceStateValue,
+				Schema: sourceSchema,
+			}
+
+			// Create request and response
+			req := resource.UpgradeStateRequest{
+				State: &sourceState,
+			}
+			resp := &resource.UpgradeStateResponse{
+				State: tfsdk.State{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"id": schema.StringAttribute{
+								Computed: true,
+							},
+							"zone_id": schema.StringAttribute{
+								Required: true,
+							},
+							"enabled": schema.BoolAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+			}
+
+			// Run upgrade
+			v500.UpgradeFromLegacyV0(ctx, req, resp)
+
+			if tt.expectError {
+				require.True(t, resp.Diagnostics.HasError(), "Expected error but got none")
+			} else {
+				require.False(t, resp.Diagnostics.HasError(), "Unexpected error: %v", resp.Diagnostics)
+
+				// Extract upgraded state
+				var upgradedState v500.TargetAuthenticatedOriginPullsSettingsModel
+				diags := resp.State.Get(ctx, &upgradedState)
+				require.False(t, diags.HasError(), "Failed to extract upgraded state: %v", diags)
+
+				// Verify fields
+				assert.Equal(t, tt.expectedTarget.ID, upgradedState.ID, "ID mismatch")
+				assert.Equal(t, tt.expectedTarget.ZoneID, upgradedState.ZoneID, "ZoneID mismatch")
+				assert.Equal(t, tt.expectedTarget.Enabled, upgradedState.Enabled, "Enabled mismatch")
+			}
+		})
+	}
+}
+
+func TestUpgradeFromV1(t *testing.T) {
+	ctx := context.Background()
+
+	// V1 and V500 have identical schemas, so this is a no-op
+	targetSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"zone_id": schema.StringAttribute{
+				Required: true,
+			},
+			"enabled": schema.BoolAttribute{
+				Required: true,
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		sourceState map[string]interface{}
+		expectError bool
+	}{
+		{
+			name: "no-op upgrade preserves state",
+			sourceState: map[string]interface{}{
+				"id":      "zone-123",
+				"zone_id": "zone-123",
+				"enabled": true,
+			},
+			expectError: false,
+		},
+		{
+			name: "no-op upgrade with disabled state",
+			sourceState: map[string]interface{}{
+				"id":      "zone-456",
+				"zone_id": "zone-456",
+				"enabled": false,
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create source state
+			sourceStateValue := createTerraformValue(t, targetSchema, tt.sourceState)
+			sourceState := tfsdk.State{
+				Raw:    sourceStateValue,
+				Schema: targetSchema,
+			}
+
+			// Create request and response
+			req := resource.UpgradeStateRequest{
+				State: &sourceState,
+			}
+			resp := &resource.UpgradeStateResponse{
+				State: tfsdk.State{
+					Schema: targetSchema,
+				},
+			}
+
+			// Run upgrade
+			v500.UpgradeFromV1(ctx, req, resp)
+
+			if tt.expectError {
+				require.True(t, resp.Diagnostics.HasError(), "Expected error but got none")
+			} else {
+				require.False(t, resp.Diagnostics.HasError(), "Unexpected error: %v", resp.Diagnostics)
+
+				// Extract upgraded state
+				var upgradedState v500.TargetAuthenticatedOriginPullsSettingsModel
+				diags := resp.State.Get(ctx, &upgradedState)
+				require.False(t, diags.HasError(), "Failed to extract upgraded state: %v", diags)
+
+				// Verify state unchanged (no-op)
+				assert.Equal(t, types.StringValue(tt.sourceState["id"].(string)), upgradedState.ID)
+				assert.Equal(t, types.StringValue(tt.sourceState["zone_id"].(string)), upgradedState.ZoneID)
+				assert.Equal(t, types.BoolValue(tt.sourceState["enabled"].(bool)), upgradedState.Enabled)
+			}
+		})
+	}
+}
+
+// createTerraformValue creates a tftypes.Value from a schema and map of values
+func createTerraformValue(t *testing.T, s schema.Schema, values map[string]interface{}) tftypes.Value {
+	t.Helper()
+
+	// Build the tftypes.Type from schema
+	attrTypes := make(map[string]tftypes.Type)
+	for name := range s.Attributes {
+		switch s.Attributes[name].(type) {
+		case schema.StringAttribute:
+			attrTypes[name] = tftypes.String
+		case schema.BoolAttribute:
+			attrTypes[name] = tftypes.Bool
+		default:
+			t.Fatalf("Unsupported attribute type for %s", name)
+		}
+	}
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	// Build the value map
+	valueMap := make(map[string]tftypes.Value)
+	for name, val := range values {
+		if val == nil {
+			valueMap[name] = tftypes.NewValue(attrTypes[name], nil)
+		} else {
+			valueMap[name] = tftypes.NewValue(attrTypes[name], val)
+		}
+	}
+
+	return tftypes.NewValue(objectType, valueMap)
+}

--- a/internal/services/authenticated_origin_pulls_settings/migrations.go
+++ b/internal/services/authenticated_origin_pulls_settings/migrations.go
@@ -5,11 +5,41 @@ package authenticated_origin_pulls_settings
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/authenticated_origin_pulls_settings/migration/v500"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+// Interface assertions
 var _ resource.ResourceWithUpgradeState = (*AuthenticatedOriginPullsSettingsResource)(nil)
+var _ resource.ResourceWithMoveState = (*AuthenticatedOriginPullsSettingsResource)(nil)
 
+// MoveState registers state movers for resource renames.
+// This enables Terraform 1.8+ `moved` blocks to automatically trigger state migration.
+func (r *AuthenticatedOriginPullsSettingsResource) MoveState(ctx context.Context) []resource.StateMover {
+	sourceSchema := v500.SourceCloudflareAuthenticatedOriginPullsSchema()
+
+	return []resource.StateMover{
+		{
+			SourceSchema: &sourceSchema,
+			StateMover:   v500.MoveState,
+		},
+	}
+}
+
+// UpgradeState registers state upgraders for schema version changes.
 func (r *AuthenticatedOriginPullsSettingsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	sourceSchema := v500.SourceCloudflareAuthenticatedOriginPullsSchema()
+
+	return map[int64]resource.StateUpgrader{
+		// Upgrade from v4 (schema version 0) to v5 (schema version 500)
+		0: {
+			PriorSchema:   &sourceSchema,
+			StateUpgrader: v500.UpgradeFromLegacyV0,
+		},
+		// Upgrade from v5 (schema version 1) to v5 (schema version 500)
+		// This is a no-op upgrade to support TF_MIG_TEST rollout mechanism
+		1: {
+			StateUpgrader: v500.UpgradeFromV1,
+		},
+	}
 }

--- a/internal/services/authenticated_origin_pulls_settings/schema.go
+++ b/internal/services/authenticated_origin_pulls_settings/schema.go
@@ -5,6 +5,7 @@ package authenticated_origin_pulls_settings
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -15,6 +16,7 @@ var _ resource.ResourceWithConfigValidators = (*AuthenticatedOriginPullsSettings
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: migrations.GetSchemaVersion(1, 500),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",


### PR DESCRIPTION
```
TF_MIG_TEST=true TF_MIGRATE_BINARY_PATH=/Users/tjozsa/cf-repos/sdks/migration-work/agent-c/tf-migrate/bin/tf-migrate TF_ACC=1 go test ./internal/services/authenticated_origin_pulls_settings/migration/... -v -run TestMigrate
=== RUN   TestMigrateAuthenticatedOriginPullsSettingsBasic
=== RUN   TestMigrateAuthenticatedOriginPullsSettingsBasic/from_v4_latest
=== RUN   TestMigrateAuthenticatedOriginPullsSettingsBasic/from_v5
--- PASS: TestMigrateAuthenticatedOriginPullsSettingsBasic (37.46s)
    --- PASS: TestMigrateAuthenticatedOriginPullsSettingsBasic/from_v4_latest (23.31s)
    --- PASS: TestMigrateAuthenticatedOriginPullsSettingsBasic/from_v5 (14.14s)
=== RUN   TestMigrateAuthenticatedOriginPullsSettingsDisabled
=== RUN   TestMigrateAuthenticatedOriginPullsSettingsDisabled/from_v4_latest
=== RUN   TestMigrateAuthenticatedOriginPullsSettingsDisabled/from_v5
--- PASS: TestMigrateAuthenticatedOriginPullsSettingsDisabled (34.47s)
    --- PASS: TestMigrateAuthenticatedOriginPullsSettingsDisabled/from_v4_latest (20.53s)
    --- PASS: TestMigrateAuthenticatedOriginPullsSettingsDisabled/from_v5 (13.95s)
=== RUN   TestMigrateAuthenticatedOriginPullsSettingsWithHostname
--- PASS: TestMigrateAuthenticatedOriginPullsSettingsWithHostname (19.11s)
=== RUN   TestMigrateAuthenticatedOriginPullsSettingsWithCertificate
--- PASS: TestMigrateAuthenticatedOriginPullsSettingsWithCertificate (19.84s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/authenticated_origin_pulls_settings/migration/v500	(cached)
```