### PR TITLE
fix(page_rule): use local provider in v5 migration tests

### DIFF
--- a/internal/services/page_rule/migration/v500/migrations_test.go
+++ b/internal/services/page_rule/migration/v500/migrations_test.go
@@ -69,19 +69,31 @@ func TestMigratePageRule_V4ToV5_Basic(t *testing.T) {
 			testConfig := tc.configFn(rnd, zoneID, target)
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
+			// For v5 tests, use local provider; for v4 tests, use external provider
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				// Use local v5 provider (has GetSchemaVersion, will create version=1 state)
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				// Use external v4 provider (will create version=0 state)
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config: testConfig,
+				}
+			}
+
 			resource.Test(t, resource.TestCase{
 				WorkingDir: tmpDir,
 				Steps: []resource.TestStep{
-					{
-						// Step 1: Create with specific provider version
-						ExternalProviders: map[string]resource.ExternalProvider{
-							"cloudflare": {
-								Source:            "cloudflare/cloudflare",
-								VersionConstraint: tc.version,
-							},
-						},
-						Config: testConfig,
-					},
+					firstStep,
 					// Step 2: Run migration and verify state
 					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
 						[]statecheck.StateCheck{
@@ -154,18 +166,31 @@ func TestMigratePageRule_V4ToV5_CacheKeyFields(t *testing.T) {
 			testConfig := tc.configFn(rnd, zoneID, target)
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
+			// For v5 tests, use local provider; for v4 tests, use external provider
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				// Use local v5 provider (has GetSchemaVersion, will create version=1 state)
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				// Use external v4 provider (will create version=0 state)
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config: testConfig,
+				}
+			}
+
 			resource.Test(t, resource.TestCase{
 				WorkingDir: tmpDir,
 				Steps: []resource.TestStep{
-					{
-						ExternalProviders: map[string]resource.ExternalProvider{
-							"cloudflare": {
-								Source:            "cloudflare/cloudflare",
-								VersionConstraint: tc.version,
-							},
-						},
-						Config: testConfig,
-					},
+					firstStep,
 					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
 						[]statecheck.StateCheck{
 							// Verify cache_key_fields.host.resolved

--- a/internal/services/page_rule/migrations.go
+++ b/internal/services/page_rule/migrations.go
@@ -15,29 +15,30 @@ var _ resource.ResourceWithUpgradeState = (*PageRuleResource)(nil)
 // UpgradeState registers state upgraders for schema version changes.
 //
 // This handles two upgrade paths:
-// 1. v4 state (schema_version=0) → v5 (version=500): Full transformation
-// 2. v5 state (version=1) → v5 (version=500): No-op upgrade (when TF_MIG_TEST=1)
+// 1. version=0 (v4 SDKv2) → v5 (version=500): Full transformation
+// 2. version=1 (v5 Plugin Framework) → v5 (version=500): No-op upgrade (when TF_MIG_TEST=1)
 //
-// The separation of schema versions (v4=0, v5=1/500) eliminates the need for
-// dual-format detection that was required in earlier implementations.
+// Clear schema version separation:
+// - v4 SDKv2 provider: schema_version=0, actions as array
+// - v5 Plugin Framework provider: version=1 (production) or version=500 (test)
 func (r *PageRuleResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	// v4 schema for version=0 upgrader
 	v4Schema := v500.SourceV4PageRuleSchema()
 
-	// For version 1 upgrader, use the current v5 schema but override version to 1
-	// This is necessary because GetSchemaVersion returns 500 when TF_MIG_TEST=1,
-	// but we need PriorSchema to match the state version being upgraded (version 1)
+	// v5 schema for version=1 upgrader (override version to match production state)
 	v5SchemaVersion1 := ResourceSchema(ctx)
 	v5SchemaVersion1.Version = 1
 
 	return map[int64]resource.StateUpgrader{
 		// Handle state from v4 SDKv2 provider (schema_version=0)
+		// Uses v4 PriorSchema to parse, then transforms to v5
 		0: {
 			PriorSchema:   &v4Schema,
 			StateUpgrader: v500.UpgradeFromV4,
 		},
 
-		// Handle state from v5 Plugin Framework provider with version=1
-		// This is a no-op upgrade that just bumps the version to 500
+		// Handle state from v5 Plugin Framework provider (version=1)
+		// Uses v5 PriorSchema, no-op version bump to 500
 		1: {
 			PriorSchema:   &v5SchemaVersion1,
 			StateUpgrader: v500.UpgradeFromV5,


### PR DESCRIPTION
```
TF_MIG_TEST=true TF_MIGRATE_BINARY_PATH=/Users/tjozsa/cf-repos/sdks/migration-work/agent-a/tf-migrate/bin/tf-migrate TF_ACC=1 go test ./internal/services/page_rule/migration/... -v -run TestMigrate
=== RUN   TestMigratePageRule_V4ToV5_Basic
=== RUN   TestMigratePageRule_V4ToV5_Basic/from_v4_latest
=== RUN   TestMigratePageRule_V4ToV5_Basic/from_v5
--- PASS: TestMigratePageRule_V4ToV5_Basic (70.51s)
    --- PASS: TestMigratePageRule_V4ToV5_Basic/from_v4_latest (65.75s)
    --- PASS: TestMigratePageRule_V4ToV5_Basic/from_v5 (4.76s)
=== RUN   TestMigratePageRule_V4ToV5_CacheKeyFields
=== RUN   TestMigratePageRule_V4ToV5_CacheKeyFields/from_v4_latest
=== RUN   TestMigratePageRule_V4ToV5_CacheKeyFields/from_v5
--- PASS: TestMigratePageRule_V4ToV5_CacheKeyFields (66.21s)
    --- PASS: TestMigratePageRule_V4ToV5_CacheKeyFields/from_v4_latest (61.16s)
    --- PASS: TestMigratePageRule_V4ToV5_CacheKeyFields/from_v5 (5.05s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/page_rule/migration/v500	139.096s
```