### PR TITLE
fix: handle nil NumberValue in accessors to prevent crash

### DIFF
--- a/internal/types/accessors.go
+++ b/internal/types/accessors.go
@@ -18,7 +18,10 @@ func floatValue(value attr.Value) (bool, *big.Float) {
 	case basetypes.Float64Value:
 		return true, big.NewFloat(v.ValueFloat64())
 	case basetypes.NumberValue:
-		return true, v.ValueBigFloat()
+		if f := v.ValueBigFloat(); f != nil {
+			return true, f
+		}
+		return false, nil
 	default:
 		return false, nil
 	}
@@ -35,8 +38,10 @@ func intValue(value attr.Value) (bool, *big.Int) {
 	case basetypes.Int64Value:
 		return true, big.NewInt((v.ValueInt64()))
 	case basetypes.NumberValue:
-		if i, a := v.ValueBigFloat().Int(nil); a == big.Exact {
-			return true, i
+		if f := v.ValueBigFloat(); f != nil {
+			if i, a := f.Int(nil); a == big.Exact {
+				return true, i
+			}
 		}
 		return false, nil
 	default:

--- a/internal/types/accessors_test.go
+++ b/internal/types/accessors_test.go
@@ -1,0 +1,104 @@
+package types
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestIntValue_NullNumber reproduces the crash in CUSTESC-56992
+// When a NumberValue is null/unknown, ValueBigFloat() returns nil, and calling
+// .Int(nil) on it causes a nil pointer dereference (segfault).
+func TestIntValue_NullNumber(t *testing.T) {
+	// Create a null NumberValue - this is what happens when a dynamic attribute
+	// is null during semantic equality checks
+	nullNumber := types.NumberNull()
+
+	// This should NOT crash - but it does in the buggy version
+	ok, val := IntValue(nullNumber)
+
+	// With the fix, this should return false, nil
+	if ok {
+		t.Errorf("expected ok=false for null NumberValue, got ok=true with val=%v", val)
+	}
+	if val != nil {
+		t.Errorf("expected val=nil for null NumberValue, got %v", val)
+	}
+}
+
+// TestIntValue_UnknownNumber tests that unknown NumberValue also doesn't crash
+func TestIntValue_UnknownNumber(t *testing.T) {
+	unknownNumber := types.NumberUnknown()
+
+	ok, val := IntValue(unknownNumber)
+
+	if ok {
+		t.Errorf("expected ok=false for unknown NumberValue, got ok=true with val=%v", val)
+	}
+	if val != nil {
+		t.Errorf("expected val=nil for unknown NumberValue, got %v", val)
+	}
+}
+
+// TestFloatValue_NullNumber tests the same bug in floatValue()
+func TestFloatValue_NullNumber(t *testing.T) {
+	nullNumber := types.NumberNull()
+
+	ok, val := FloatValue(nullNumber)
+
+	if ok {
+		t.Errorf("expected ok=false for null NumberValue, got ok=true with val=%v", val)
+	}
+	if val != nil {
+		t.Errorf("expected val=nil for null NumberValue, got %v", val)
+	}
+}
+
+// TestFloatValue_UnknownNumber tests that unknown NumberValue also doesn't crash
+func TestFloatValue_UnknownNumber(t *testing.T) {
+	unknownNumber := types.NumberUnknown()
+
+	ok, val := FloatValue(unknownNumber)
+
+	if ok {
+		t.Errorf("expected ok=false for unknown NumberValue, got ok=true with val=%v", val)
+	}
+	if val != nil {
+		t.Errorf("expected val=nil for unknown NumberValue, got %v", val)
+	}
+}
+
+// TestIntValue_ValidNumber ensures normal NumberValue still works
+func TestIntValue_ValidNumber(t *testing.T) {
+	validNumber := types.NumberValue(big.NewFloat(42))
+
+	ok, val := IntValue(validNumber)
+
+	if !ok {
+		t.Errorf("expected ok=true for valid NumberValue, got ok=false")
+	}
+	if val == nil || val.Int64() != 42 {
+		t.Errorf("expected val=42 for valid NumberValue, got %v", val)
+	}
+}
+
+// TestFloatValue_ValidNumber ensures normal NumberValue still works
+func TestFloatValue_ValidNumber(t *testing.T) {
+	validNumber := types.NumberValue(big.NewFloat(3.14))
+
+	ok, val := FloatValue(validNumber)
+
+	if !ok {
+		t.Errorf("expected ok=true for valid NumberValue, got ok=false")
+	}
+	if val == nil {
+		t.Errorf("expected non-nil val for valid NumberValue")
+	}
+	// Check approximately equal (floating point)
+	expected := 3.14
+	actual, _ := val.Float64()
+	if actual < expected-0.001 || actual > expected+0.001 {
+		t.Errorf("expected val≈3.14 for valid NumberValue, got %v", actual)
+	}
+}


### PR DESCRIPTION
When a NumberValue is null or unknown, ValueBigFloat() returns nil.
The intValue() and floatValue() functions did not check for this,
causing a nil pointer dereference during semantic equality checks
on dynamic attributes.

This attempts to fix the issue identified here:
https://github.com/cloudflare/terraform-provider-cloudflare/issues/6306

This does seem to fix to eliminate the panic however as to how this customer got into this state, I'm unsure. 

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
=== RUN   TestIntValue_NullNumber
--- PASS: TestIntValue_NullNumber (0.00s)
=== RUN   TestIntValue_UnknownNumber
--- PASS: TestIntValue_UnknownNumber (0.00s)
=== RUN   TestFloatValue_NullNumber
--- PASS: TestFloatValue_NullNumber (0.00s)
=== RUN   TestFloatValue_UnknownNumber
--- PASS: TestFloatValue_UnknownNumber (0.00s)
=== RUN   TestIntValue_ValidNumber
--- PASS: TestIntValue_ValidNumber (0.00s)

## Additional context & links
