### PR TITLE
chore: fix model/schema parity

### DIFF
--- a/internal/services/pages_project/model.go
+++ b/internal/services/pages_project/model.go
@@ -157,7 +157,7 @@ type PagesProjectDeploymentConfigsPreviewR2BucketsModel struct {
 type PagesProjectDeploymentConfigsPreviewServicesModel struct {
 	Service     types.String `tfsdk:"service" json:"service,required"`
 	Entrypoint  types.String `tfsdk:"entrypoint" json:"entrypoint,optional"`
-	Environment types.String `tfsdk:"environment" json:"environment,optional"`
+	Environment types.String `tfsdk:"environment" json:"environment,computed_optional"`
 }
 
 type PagesProjectDeploymentConfigsPreviewVectorizeBindingsModel struct {
@@ -245,7 +245,7 @@ type PagesProjectDeploymentConfigsProductionR2BucketsModel struct {
 type PagesProjectDeploymentConfigsProductionServicesModel struct {
 	Service     types.String `tfsdk:"service" json:"service,required"`
 	Entrypoint  types.String `tfsdk:"entrypoint" json:"entrypoint,optional"`
-	Environment types.String `tfsdk:"environment" json:"environment,optional"`
+	Environment types.String `tfsdk:"environment" json:"environment,computed_optional"`
 }
 
 type PagesProjectDeploymentConfigsProductionVectorizeBindingsModel struct {

--- a/internal/services/zero_trust_device_default_profile/model.go
+++ b/internal/services/zero_trust_device_default_profile/model.go
@@ -31,7 +31,7 @@ type ZeroTrustDeviceDefaultProfileModel struct {
 	TunnelProtocol             types.String                                                                    `tfsdk:"tunnel_protocol" json:"tunnel_protocol,computed_optional"`
 	Exclude                    customfield.NestedObjectList[ZeroTrustDeviceDefaultProfileExcludeModel]         `tfsdk:"exclude" json:"exclude,computed_optional"`
 	Include                    customfield.NestedObjectList[ZeroTrustDeviceDefaultProfileIncludeModel]         `tfsdk:"include" json:"include,computed_optional"`
-	ServiceModeV2              customfield.NestedObject[ZeroTrustDeviceDefaultProfileServiceModeV2Model]       `tfsdk:"service_mode_v2" json:"service_mode_v2,computed_optional"`
+	ServiceModeV2              customfield.NestedObject[ZeroTrustDeviceDefaultProfileServiceModeV2Model]       `tfsdk:"service_mode_v2" json:"service_mode_v2,optional"`
 	Default                    types.Bool                                                                      `tfsdk:"default" json:"default,computed"`
 	Enabled                    types.Bool                                                                      `tfsdk:"enabled" json:"enabled,computed"`
 	GatewayUniqueID            types.String                                                                    `tfsdk:"gateway_unique_id" json:"gateway_unique_id,computed"`
@@ -47,20 +47,20 @@ func (m ZeroTrustDeviceDefaultProfileModel) MarshalJSONForUpdate(state ZeroTrust
 }
 
 type ZeroTrustDeviceDefaultProfileExcludeModel struct {
-	Address     types.String `tfsdk:"address" json:"address,computed_optional"`
-	Description types.String `tfsdk:"description" json:"description,computed_optional"`
-	Host        types.String `tfsdk:"host" json:"host,computed_optional"`
+	Address     types.String `tfsdk:"address" json:"address,optional"`
+	Description types.String `tfsdk:"description" json:"description,optional"`
+	Host        types.String `tfsdk:"host" json:"host,optional"`
 }
 
 type ZeroTrustDeviceDefaultProfileIncludeModel struct {
-	Address     types.String `tfsdk:"address" json:"address,computed_optional"`
-	Description types.String `tfsdk:"description" json:"description,computed_optional"`
-	Host        types.String `tfsdk:"host" json:"host,computed_optional"`
+	Address     types.String `tfsdk:"address" json:"address,optional"`
+	Description types.String `tfsdk:"description" json:"description,optional"`
+	Host        types.String `tfsdk:"host" json:"host,optional"`
 }
 
 type ZeroTrustDeviceDefaultProfileServiceModeV2Model struct {
-	Mode types.String  `tfsdk:"mode" json:"mode,computed_optional"`
-	Port types.Float64 `tfsdk:"port" json:"port,computed_optional"`
+	Mode types.String  `tfsdk:"mode" json:"mode,optional"`
+	Port types.Float64 `tfsdk:"port" json:"port,optional"`
 }
 
 type ZeroTrustDeviceDefaultProfileFallbackDomainsModel struct {

--- a/internal/services/zero_trust_dex_test/model.go
+++ b/internal/services/zero_trust_dex_test/model.go
@@ -34,8 +34,8 @@ func (m ZeroTrustDEXTestModel) MarshalJSONForUpdate(state ZeroTrustDEXTestModel)
 }
 
 type ZeroTrustDEXTestDataModel struct {
-	Host   types.String `tfsdk:"host" json:"host,required"`
-	Kind   types.String `tfsdk:"kind" json:"kind,required"`
+	Host   types.String `tfsdk:"host" json:"host,optional"`
+	Kind   types.String `tfsdk:"kind" json:"kind,optional"`
 	Method types.String `tfsdk:"method" json:"method,optional"`
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixing failing tests for the v5.17.0 release.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

```bash
go test -v \
  -run 'TestPagesProjectModelSchemaParity|TestZeroTrustDeviceDefaultProfileModelSchemaParity|TestZeroTrustDEXTestModelSchemaParity' \
    ./internal/services/pages_project/... \
    ./internal/services/zero_trust_device_default_profile/... \
    ./internal/services/zero_trust_dex_test/...
```

### Test output
<!-- Please paste the output of your acceptance test run below --> 

```
=== RUN   TestPagesProjectModelSchemaParity
=== PAUSE TestPagesProjectModelSchemaParity
=== CONT  TestPagesProjectModelSchemaParity
--- PASS: TestPagesProjectModelSchemaParity (0.00s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/pages_project     0.015s
testing: warning: no tests to run
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/pages_project/migration/v500      0.011s [no tests to run]
=== RUN   TestZeroTrustDeviceDefaultProfileModelSchemaParity
=== PAUSE TestZeroTrustDeviceDefaultProfileModelSchemaParity
=== CONT  TestZeroTrustDeviceDefaultProfileModelSchemaParity
--- PASS: TestZeroTrustDeviceDefaultProfileModelSchemaParity (0.00s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_device_default_profile 0.011s
=== RUN   TestZeroTrustDEXTestModelSchemaParity
=== PAUSE TestZeroTrustDEXTestModelSchemaParity
=== CONT  TestZeroTrustDEXTestModelSchemaParity
--- PASS: TestZeroTrustDEXTestModelSchemaParity (0.00s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_dex_test       0.011s
```

## Additional context & links
