### PR TITLE
test(dcv_delegation): add data source test

### DIFF
--- a/internal/services/dcv_delegation/data_source_test.go
+++ b/internal/services/dcv_delegation/data_source_test.go
@@ -1,0 +1,42 @@
+package dcv_delegation_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccCloudflareDCVDelegationDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("data.cloudflare_dcv_delegation.%s", rnd)
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("datasource_basic.tf", rnd, zoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
+					resource.TestCheckResourceAttrSet(name, "uuid"),
+					resource.TestCheckResourceAttrWith(name, "uuid", func(value string) error {
+						matched, _ := regexp.MatchString("^[a-f0-9]{16}$", value)
+						if !matched {
+							return fmt.Errorf("expected 16-character hex UUID, got: %s", value)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}

--- a/internal/services/dcv_delegation/testdata/datasource_basic.tf
+++ b/internal/services/dcv_delegation/testdata/datasource_basic.tf
@@ -1,0 +1,4 @@
+data "cloudflare_dcv_delegation" "%[1]s" {
+  zone_id = "%[2]s"
+}
+


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Add test for dcv_delegation data source. This is read only.
## Acceptance test run results

- [X] I have added or updated acceptance tests for my changes
- [X] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
TF_ACC=1 go test ./internal/services/dcv_delegation -v -run TestAccCloudflareDCVDelegationDataSource_Basic


### Test output
<!-- Please paste the output of your acceptance test run below --> 
=== RUN   TestAccCloudflareDCVDelegationDataSource_Basic
--- PASS: TestAccCloudflareDCVDelegationDataSource_Basic (2.34s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/dcv_delegation	4.188s

## Additional context & links
