### PR TITLE
feat(logpull_retention): support state upgrader

### DIFF
--- a/internal/services/logpull_retention/migration/v500/handler.go
+++ b/internal/services/logpull_retention/migration/v500/handler.go
@@ -1,0 +1,48 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// UpgradeFromV4 handles state upgrades from v4 SDKv2 provider (schema_version=0) to v5 (version=500).
+//
+// This performs a full transformation from v4 → v5 format.
+// The v4 state has schema_version=0 (SDKv2 default), and we transform it to v5 format.
+func UpgradeFromV4(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading logpull_retention state from v4 SDKv2 provider (schema_version=0)")
+
+	// Parse v4 state using v4 model
+	var v4State SourceCloudflareLogpullRetentionModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &v4State)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform v4 → v5
+	v5State, diags := Transform(ctx, v4State)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Write transformed state
+	resp.Diagnostics.Append(resp.State.Set(ctx, v5State)...)
+	tflog.Info(ctx, "State upgrade from v4 to v5 completed successfully")
+}
+
+// UpgradeFromV5 handles state upgrades from v5 Plugin Framework provider (version=1) to v5 (version=500).
+//
+// This is a no-op upgrade since the schema is compatible - just bumps the version.
+// This handler is only triggered when TF_MIG_TEST=1 (GetSchemaVersion returns 500).
+func UpgradeFromV5(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading logpull_retention state from version=1 to version=500 (no-op)")
+
+	// CRITICAL: For no-op upgrades, copy raw state directly
+	// This preserves all state data without any transformation
+	resp.State.Raw = req.State.Raw
+
+	tflog.Info(ctx, "State version bump from 1 to 500 completed")
+}

--- a/internal/services/logpull_retention/migration/v500/migrations_test.go
+++ b/internal/services/logpull_retention/migration/v500/migrations_test.go
@@ -1,0 +1,176 @@
+package v500_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+var (
+	currentProviderVersion = internal.PackageVersion // Current v5 release
+)
+
+// Embed test configs
+//
+//go:embed testdata/v4_enabled_true.tf
+var v4EnabledTrueConfig string
+
+//go:embed testdata/v5_enabled_true.tf
+var v5EnabledTrueConfig string
+
+//go:embed testdata/v4_enabled_false.tf
+var v4EnabledFalseConfig string
+
+//go:embed testdata/v5_enabled_false.tf
+var v5EnabledFalseConfig string
+
+// TestMigrateLogpullRetention_V4ToV5_EnabledTrue tests migration with enabled=true → flag=true.
+// This test validates:
+// - Field rename: enabled → flag
+// - Boolean value preservation: true → true
+func TestMigrateLogpullRetention_V4ToV5_EnabledTrue(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID string) string
+	}{
+		{
+			name:    "from_v4_latest", // Tests legacy v4 → current v5
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v4EnabledTrueConfig, rnd, zoneID)
+			},
+		},
+		{
+			name:    "from_v5", // Tests within v5 (version bump)
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v5EnabledTrueConfig, rnd, zoneID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test setup
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						// Step 1: Create with specific provider version
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					// Step 2: Run migration and verify state
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							// Verify zone_id preserved
+							statecheck.ExpectKnownValue(
+								"cloudflare_logpull_retention."+rnd,
+								tfjsonpath.New("zone_id"),
+								knownvalue.StringExact(zoneID),
+							),
+							// CRITICAL: Verify enabled → flag rename with value preserved (true)
+							statecheck.ExpectKnownValue(
+								"cloudflare_logpull_retention."+rnd,
+								tfjsonpath.New("flag"),
+								knownvalue.Bool(true),
+							),
+						},
+					),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateLogpullRetention_V4ToV5_EnabledFalse tests migration with enabled=false → flag=false.
+// This test validates:
+// - Field rename: enabled → flag
+// - Boolean value preservation: false → false
+func TestMigrateLogpullRetention_V4ToV5_EnabledFalse(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID string) string
+	}{
+		{
+			name:    "from_v4_latest", // Tests legacy v4 → current v5
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v4EnabledFalseConfig, rnd, zoneID)
+			},
+		},
+		{
+			name:    "from_v5", // Tests within v5 (version bump)
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v5EnabledFalseConfig, rnd, zoneID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test setup
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						// Step 1: Create with specific provider version
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					// Step 2: Run migration and verify state
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							// Verify zone_id preserved
+							statecheck.ExpectKnownValue(
+								"cloudflare_logpull_retention."+rnd,
+								tfjsonpath.New("zone_id"),
+								knownvalue.StringExact(zoneID),
+							),
+							// CRITICAL: Verify enabled → flag rename with value preserved (false)
+							statecheck.ExpectKnownValue(
+								"cloudflare_logpull_retention."+rnd,
+								tfjsonpath.New("flag"),
+								knownvalue.Bool(false),
+							),
+						},
+					),
+				},
+			})
+		})
+	}
+}

--- a/internal/services/logpull_retention/migration/v500/model.go
+++ b/internal/services/logpull_retention/migration/v500/model.go
@@ -1,0 +1,31 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ============================================================================
+// Source Models (Legacy Provider - v4.x)
+// ============================================================================
+
+// SourceCloudflareLogpullRetentionModel represents the source cloudflare_logpull_retention state structure.
+// This corresponds to the legacy (SDKv2) cloudflare provider v4.x.
+// Used by UpgradeState to parse legacy state and transform to v5 structure.
+type SourceCloudflareLogpullRetentionModel struct {
+	ID      types.String `tfsdk:"id"`
+	ZoneID  types.String `tfsdk:"zone_id"`
+	Enabled types.Bool   `tfsdk:"enabled"` // Renamed to "flag" in v5
+}
+
+// ============================================================================
+// Target Models (Current Provider - v5.x+)
+// ============================================================================
+
+// TargetLogpullRetentionModel represents the current cloudflare_logpull_retention state structure.
+// This corresponds to schema version 500 in the v5.x+ provider.
+// This model should match the LogpullRetentionModel in the parent package's model.go file.
+type TargetLogpullRetentionModel struct {
+	ID     types.String `tfsdk:"id"`
+	ZoneID types.String `tfsdk:"zone_id"`
+	Flag   types.Bool   `tfsdk:"flag"` // Renamed from "enabled" in v4
+}

--- a/internal/services/logpull_retention/migration/v500/schema.go
+++ b/internal/services/logpull_retention/migration/v500/schema.go
@@ -1,0 +1,30 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// SourceCloudflareLogpullRetentionSchema returns the legacy cloudflare_logpull_retention schema.
+// This is used by UpgradeState to parse state from the legacy SDKv2 provider (v4.x).
+// Reference: https://github.com/cloudflare/terraform-provider-cloudflare/blob/v4/internal/sdkv2provider/schema_cloudflare_logpull_retention.go
+//
+// This minimal schema includes only the properties needed for state parsing:
+// - Required, Optional, Computed flags
+// - ElementType for collections
+// Validators, PlanModifiers, and Descriptions are intentionally omitted.
+func SourceCloudflareLogpullRetentionSchema() schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"zone_id": schema.StringAttribute{
+				Required: true,
+			},
+			// Source v4 field: "enabled" (will be renamed to "flag" in v5)
+			"enabled": schema.BoolAttribute{
+				Required: true,
+			},
+		},
+	}
+}

--- a/internal/services/logpull_retention/migration/v500/testdata/v4_enabled_false.tf
+++ b/internal/services/logpull_retention/migration/v500/testdata/v4_enabled_false.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_logpull_retention" "%s" {
+  zone_id = "%s"
+  enabled = false
+}

--- a/internal/services/logpull_retention/migration/v500/testdata/v4_enabled_true.tf
+++ b/internal/services/logpull_retention/migration/v500/testdata/v4_enabled_true.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_logpull_retention" "%s" {
+  zone_id = "%s"
+  enabled = true
+}

--- a/internal/services/logpull_retention/migration/v500/testdata/v5_enabled_false.tf
+++ b/internal/services/logpull_retention/migration/v500/testdata/v5_enabled_false.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_logpull_retention" "%s" {
+  zone_id = "%s"
+  flag    = false
+}

--- a/internal/services/logpull_retention/migration/v500/testdata/v5_enabled_true.tf
+++ b/internal/services/logpull_retention/migration/v500/testdata/v5_enabled_true.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_logpull_retention" "%s" {
+  zone_id = "%s"
+  flag    = true
+}

--- a/internal/services/logpull_retention/migration/v500/transform.go
+++ b/internal/services/logpull_retention/migration/v500/transform.go
@@ -1,0 +1,31 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// Transform converts source (legacy v4 SDKv2) state to target (current v5 Plugin Framework) state.
+// This function handles the field rename from "enabled" to "flag".
+func Transform(ctx context.Context, source SourceCloudflareLogpullRetentionModel) (*TargetLogpullRetentionModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Step 1: Validate required fields
+	if source.ZoneID.IsNull() || source.ZoneID.IsUnknown() {
+		diags.AddError(
+			"Missing required field",
+			"zone_id is required for logpull_retention migration. The source state is missing this field, which indicates corrupted state.",
+		)
+		return nil, diags
+	}
+
+	// Step 2: Initialize target with direct copies and field rename
+	target := &TargetLogpullRetentionModel{
+		ID:     source.ID,
+		ZoneID: source.ZoneID,
+		Flag:   source.Enabled, // Rename: enabled → flag
+	}
+
+	return target, diags
+}

--- a/internal/services/logpull_retention/migrations.go
+++ b/internal/services/logpull_retention/migrations.go
@@ -4,20 +4,58 @@ package logpull_retention
 
 import (
 	"context"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/logpull_retention/migration/v500"
 )
 
 var _ resource.ResourceWithUpgradeState = (*LogpullRetentionResource)(nil)
 
+// UpgradeState registers state upgraders for schema version changes.
+//
+// This handles two upgrade paths:
+// 1. v4 state (schema_version=0) → v5 (version=500): Full transformation
+// 2. v5 state (version=1) → v5 (version=500): No-op upgrade (when TF_MIG_TEST=1)
+//
+// In production (no TF_MIG_TEST), only a no-op upgrader is registered at slot 0
+// to safely bump existing v5 users from version 0 to 1 without triggering the
+// v4→v5 transformation (which would fail on v5-format state).
 func (r *LogpullRetentionResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	targetSchema := ResourceSchema(ctx)
-	return map[int64]resource.StateUpgrader{
-		0: {
-			PriorSchema: &targetSchema,
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				resp.State.Raw = req.State.Raw
+
+	if os.Getenv("TF_MIG_TEST") == "" {
+		return map[int64]resource.StateUpgrader{
+			0: {
+				PriorSchema: &targetSchema,
+				StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+					resp.State.Raw = req.State.Raw
+				},
 			},
+		}
+	}
+
+	v4Schema := v500.SourceCloudflareLogpullRetentionSchema()
+
+	// For version 1 upgrader, use the current v5 schema but override version to 1
+	// This is necessary because GetSchemaVersion returns 500 when TF_MIG_TEST=1,
+	// but we need PriorSchema to match the state version being upgraded (version 1)
+	v5SchemaVersion1 := ResourceSchema(ctx)
+	v5SchemaVersion1.Version = 1
+
+	return map[int64]resource.StateUpgrader{
+		// Handle state from v4 SDKv2 provider (schema_version=0)
+		0: {
+			PriorSchema:   &v4Schema,
+			StateUpgrader: v500.UpgradeFromV4,
+		},
+
+		// Handle state from v5 Plugin Framework provider with version=1
+		// This is a no-op upgrade that just bumps the version to 500
+		1: {
+			PriorSchema:   &v5SchemaVersion1,
+			StateUpgrader: v500.UpgradeFromV5,
 		},
 	}
 }

--- a/internal/services/logpull_retention/schema.go
+++ b/internal/services/logpull_retention/schema.go
@@ -5,6 +5,7 @@ package logpull_retention
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
@@ -16,7 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*LogpullRetentionResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
-		Version: 1,
+		Version: migrations.GetSchemaVersion(1, 500),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Support state upgraders for `cloudflare_logpull_retention`

## Acceptance test run results

- [X] I have added or updated acceptance tests for my changes
- [X] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
`TF_MIG_TEST=1 TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/ssicard/workspace/terraform-devstack/tf-migrate/tf-migrate go test -v -timeout 20m -run TestMigrate github.com/cloudflare/terraform-provider-cloudflare/internal/services/logpull_retention/migration/v500`

### Test output
```
=== RUN   TestMigrateLogpullRetention_V4ToV5_EnabledTrue
=== RUN   TestMigrateLogpullRetention_V4ToV5_EnabledTrue/from_v4_latest
=== RUN   TestMigrateLogpullRetention_V4ToV5_EnabledTrue/from_v5
--- PASS: TestMigrateLogpullRetention_V4ToV5_EnabledTrue (28.07s)
    --- PASS: TestMigrateLogpullRetention_V4ToV5_EnabledTrue/from_v4_latest (16.89s)
    --- PASS: TestMigrateLogpullRetention_V4ToV5_EnabledTrue/from_v5 (11.18s)
=== RUN   TestMigrateLogpullRetention_V4ToV5_EnabledFalse
=== RUN   TestMigrateLogpullRetention_V4ToV5_EnabledFalse/from_v4_latest
=== RUN   TestMigrateLogpullRetention_V4ToV5_EnabledFalse/from_v5
--- PASS: TestMigrateLogpullRetention_V4ToV5_EnabledFalse (26.80s)
    --- PASS: TestMigrateLogpullRetention_V4ToV5_EnabledFalse/from_v4_latest (13.94s)
    --- PASS: TestMigrateLogpullRetention_V4ToV5_EnabledFalse/from_v5 (12.85s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/logpull_retention/migration/v500	56.260s
```
