### PR TITLE
fix(zero_trust_device_default_profile): add UseStateForUnknown

### DIFF
--- a/internal/services/zero_trust_device_default_profile/model.go
+++ b/internal/services/zero_trust_device_default_profile/model.go
@@ -31,7 +31,7 @@ type ZeroTrustDeviceDefaultProfileModel struct {
 	TunnelProtocol             types.String                                                                    `tfsdk:"tunnel_protocol" json:"tunnel_protocol,computed_optional"`
 	Exclude                    customfield.NestedObjectList[ZeroTrustDeviceDefaultProfileExcludeModel]         `tfsdk:"exclude" json:"exclude,computed_optional"`
 	Include                    customfield.NestedObjectList[ZeroTrustDeviceDefaultProfileIncludeModel]         `tfsdk:"include" json:"include,computed_optional"`
-	ServiceModeV2              customfield.NestedObject[ZeroTrustDeviceDefaultProfileServiceModeV2Model]       `tfsdk:"service_mode_v2" json:"service_mode_v2,optional"`
+	ServiceModeV2              customfield.NestedObject[ZeroTrustDeviceDefaultProfileServiceModeV2Model]       `tfsdk:"service_mode_v2" json:"service_mode_v2,computed_optional"`
 	Default                    types.Bool                                                                      `tfsdk:"default" json:"default,computed"`
 	Enabled                    types.Bool                                                                      `tfsdk:"enabled" json:"enabled,computed"`
 	GatewayUniqueID            types.String                                                                    `tfsdk:"gateway_unique_id" json:"gateway_unique_id,computed"`

--- a/internal/services/zero_trust_device_default_profile/resource_test.go
+++ b/internal/services/zero_trust_device_default_profile/resource_test.go
@@ -292,3 +292,107 @@ func TestAccUpgradeZeroTrustDeviceDefaultProfile_FromPublishedV5(t *testing.T) {
 		},
 	})
 }
+
+func TestAccCloudflareZeroTrustDeviceDefaultProfile_ServiceModeProxy(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_device_default_profile.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareZeroTrustDeviceDefaultProfileServiceModeProxy(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service_mode_v2").AtMapKey("mode"), knownvalue.StringExact("proxy")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service_mode_v2").AtMapKey("port"), knownvalue.Float64Exact(8080)),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"exclude", "include", "fallback_domains", "default", "gateway_unique_id", "service_mode_v2"},
+				ImportStateId:           accountID,
+			},
+			{
+				Config:   testAccCloudflareZeroTrustDeviceDefaultProfileServiceModeProxy(accountID, rnd),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareZeroTrustDeviceDefaultProfile_UnsetOptionals(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_device_default_profile.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareZeroTrustDeviceDefaultProfileWithOptionals(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("allow_mode_switch"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("allow_updates"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("allowed_to_leave"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("auto_connect"), knownvalue.Float64Exact(60)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("captive_portal"), knownvalue.Float64Exact(300)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("disable_auto_fallback"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("exclude_office_ips"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("register_interface_ip_with_dns"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("sccm_vpn_boundary_support"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("switch_locked"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tunnel_protocol"), knownvalue.StringExact("wireguard")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("support_url"), knownvalue.StringExact("https://support.example.com")),
+				},
+			},
+			{
+				Config: testAccCloudflareZeroTrustDeviceDefaultProfileWithoutOptionals(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("allow_mode_switch"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("allow_updates"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("allowed_to_leave"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("auto_connect"), knownvalue.Float64Exact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("captive_portal"), knownvalue.Float64Exact(180)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("disable_auto_fallback"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("exclude_office_ips"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("register_interface_ip_with_dns"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("sccm_vpn_boundary_support"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("switch_locked"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tunnel_protocol"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("support_url"), knownvalue.StringExact("")),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"exclude", "include", "fallback_domains", "default", "gateway_unique_id", "service_mode_v2"},
+				ImportStateId:           accountID,
+			},
+			{
+				Config:   testAccCloudflareZeroTrustDeviceDefaultProfileWithoutOptionals(accountID, rnd),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccCloudflareZeroTrustDeviceDefaultProfileServiceModeProxy(accountID, rnd string) string {
+	return acctest.LoadTestCase("devicedefaultprofileservicemodeproxy.tf", rnd, accountID)
+}
+
+func testAccCloudflareZeroTrustDeviceDefaultProfileWithOptionals(accountID, rnd string) string {
+	return acctest.LoadTestCase("devicedefaultprofilewithoptionals.tf", rnd, accountID)
+}
+
+func testAccCloudflareZeroTrustDeviceDefaultProfileWithoutOptionals(accountID, rnd string) string {
+	return acctest.LoadTestCase("devicedefaultprofilewithoutoptionals.tf", rnd, accountID)
+}

--- a/internal/services/zero_trust_device_default_profile/schema.go
+++ b/internal/services/zero_trust_device_default_profile/schema.go
@@ -11,8 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -95,8 +97,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"service_mode_v2": schema.SingleNestedAttribute{
-				Optional:   true,
-				CustomType: customfield.NewNestedObjectType[ZeroTrustDeviceDefaultProfileServiceModeV2Model](ctx),
+				Computed:      true,
+				Optional:      true,
+				CustomType:    customfield.NewNestedObjectType[ZeroTrustDeviceDefaultProfileServiceModeV2Model](ctx),
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 				Attributes: map[string]schema.Attribute{
 					"mode": schema.StringAttribute{
 						Description: "The mode to run the WARP client under.",
@@ -181,8 +185,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Default:     stringdefault.StaticString(""),
 			},
 			"default": schema.BoolAttribute{
-				Description: "Whether the policy will be applied to matching devices.",
-				Computed:    true,
+				Description:   "Whether the policy will be applied to matching devices.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"enabled": schema.BoolAttribute{
 				Description: "Whether the policy will be applied to matching devices.",
@@ -190,11 +195,13 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Default:     booldefault.StaticBool(true),
 			},
 			"gateway_unique_id": schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"fallback_domains": schema.ListNestedAttribute{
-				Computed:   true,
-				CustomType: customfield.NewNestedObjectListType[ZeroTrustDeviceDefaultProfileFallbackDomainsModel](ctx),
+				Computed:      true,
+				PlanModifiers: []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+				CustomType:    customfield.NewNestedObjectListType[ZeroTrustDeviceDefaultProfileFallbackDomainsModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"suffix": schema.StringAttribute{

--- a/internal/services/zero_trust_device_default_profile/testdata/devicedefaultprofileservicemodeproxy.tf
+++ b/internal/services/zero_trust_device_default_profile/testdata/devicedefaultprofileservicemodeproxy.tf
@@ -1,0 +1,9 @@
+resource "cloudflare_zero_trust_device_default_profile" "%[1]s" {
+  account_id = "%[2]s"
+  exclude    = []
+
+  service_mode_v2 = {
+    mode = "proxy"
+    port = 8080
+  }
+}

--- a/internal/services/zero_trust_device_default_profile/testdata/devicedefaultprofilewithoptionals.tf
+++ b/internal/services/zero_trust_device_default_profile/testdata/devicedefaultprofilewithoptionals.tf
@@ -1,0 +1,20 @@
+resource "cloudflare_zero_trust_device_default_profile" "%[1]s" {
+  account_id                     = "%[2]s"
+  allow_mode_switch              = true
+  allow_updates                  = true
+  allowed_to_leave               = false
+  auto_connect                   = 60
+  captive_portal                 = 300
+  disable_auto_fallback          = true
+  exclude_office_ips             = true
+  register_interface_ip_with_dns = false
+  sccm_vpn_boundary_support      = true
+  switch_locked                  = true
+  tunnel_protocol                = "wireguard"
+  support_url                    = "https://support.example.com"
+  exclude                        = []
+
+  service_mode_v2 = {
+    mode = "warp"
+  }
+}

--- a/internal/services/zero_trust_device_default_profile/testdata/devicedefaultprofilewithoutoptionals.tf
+++ b/internal/services/zero_trust_device_default_profile/testdata/devicedefaultprofilewithoutoptionals.tf
@@ -1,0 +1,8 @@
+resource "cloudflare_zero_trust_device_default_profile" "%[1]s" {
+  account_id = "%[2]s"
+  exclude    = []
+
+  service_mode_v2 = {
+    mode = "warp"
+  }
+}

--- a/internal/services/zero_trust_device_default_profile_local_domain_fallback/resource_test.go
+++ b/internal/services/zero_trust_device_default_profile_local_domain_fallback/resource_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
@@ -63,10 +63,14 @@ func TestAccCloudflareFallbackDomain_Basic(t *testing.T) {
 				Config: testAccCloudflareDefaultFallbackDomain(rnd, accountID, "example domain", "example.com", "1.0.0.1"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.ListSizeExact(1)),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains").AtSliceIndex(0).AtMapKey("description"), knownvalue.StringExact("example domain")),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains").AtSliceIndex(0).AtMapKey("suffix"), knownvalue.StringExact("example.com")),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains").AtSliceIndex(0).AtMapKey("dns_server").AtSliceIndex(0), knownvalue.StringExact("1.0.0.1")),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"description": knownvalue.StringExact("example domain"),
+							"suffix":      knownvalue.StringExact("example.com"),
+							"dns_server":  knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("1.0.0.1")}),
+						}),
+					})),
 				},
 			},
 			{
@@ -108,10 +112,14 @@ func TestAccCloudflareFallbackDomain_DefaultPolicy(t *testing.T) {
 				Config: testAccCloudflareDefaultFallbackDomain(rnd, accountID, "second example domain", "example.net", "1.1.1.1"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.ListSizeExact(1)),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains").AtSliceIndex(0).AtMapKey("description"), knownvalue.StringExact("second example domain")),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains").AtSliceIndex(0).AtMapKey("suffix"), knownvalue.StringExact("example.net")),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains").AtSliceIndex(0).AtMapKey("dns_server").AtSliceIndex(0), knownvalue.StringExact("1.1.1.1")),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"description": knownvalue.StringExact("second example domain"),
+							"suffix":      knownvalue.StringExact("example.net"),
+							"dns_server":  knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("1.1.1.1")}),
+						}),
+					})),
 				},
 			},
 			{
@@ -153,7 +161,7 @@ func TestAccCloudflareFallbackDomain_MultipleDomains(t *testing.T) {
 				Config: testAccCloudflareDefaultFallbackDomain_MultipleDomains(rnd, accountID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.ListSizeExact(4)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.SetSizeExact(4)),
 				},
 			},
 			{
@@ -174,7 +182,7 @@ func TestAccCloudflareFallbackDomain_MultipleDomains(t *testing.T) {
 				Config: testAccCloudflareDefaultFallbackDomain_MultipleDomainsUpdated(rnd, accountID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
-					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.ListSizeExact(3)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.SetSizeExact(3)),
 				},
 			},
 			{
@@ -228,4 +236,122 @@ func TestAccUpgradeZeroTrustDeviceDefaultProfileLocalDomainFallback_FromPublishe
 			},
 		},
 	})
+}
+
+func TestAccCloudflareFallbackDomain_MultipleDnsServers(t *testing.T) {
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_zero_trust_device_default_profile_local_domain_fallback.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareDefaultFallbackDomain_MultipleDnsServers(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"suffix":      knownvalue.StringExact("corp.example.com"),
+							"description": knownvalue.StringExact("Corporate domain with multiple DNS servers"),
+							"dns_server": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.StringExact("10.0.0.1"),
+								knownvalue.StringExact("10.0.0.2"),
+								knownvalue.StringExact("10.0.0.3"),
+							}),
+						}),
+					})),
+				},
+			},
+			{
+				Config:   testAccCloudflareDefaultFallbackDomain_MultipleDnsServers(rnd, accountID),
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     accountID,
+			},
+			{
+				Config:   testAccCloudflareDefaultFallbackDomain_MultipleDnsServers(rnd, accountID),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareFallbackDomain_UpdateDomainAttributes(t *testing.T) {
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_zero_trust_device_default_profile_local_domain_fallback.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareDefaultFallbackDomain_UpdateAttrs(rnd, accountID, "Initial description", "192.168.1.1"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"suffix":      knownvalue.StringExact("test.local"),
+							"description": knownvalue.StringExact("Initial description"),
+							"dns_server":  knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("192.168.1.1")}),
+						}),
+					})),
+				},
+			},
+			{
+				Config: testAccCloudflareDefaultFallbackDomain_UpdateAttrs(rnd, accountID, "Updated description", "10.10.10.10"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("domains"), knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"suffix":      knownvalue.StringExact("test.local"),
+							"description": knownvalue.StringExact("Updated description"),
+							"dns_server":  knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("10.10.10.10")}),
+						}),
+					})),
+				},
+			},
+			{
+				Config:   testAccCloudflareDefaultFallbackDomain_UpdateAttrs(rnd, accountID, "Updated description", "10.10.10.10"),
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     accountID,
+			},
+			{
+				Config:   testAccCloudflareDefaultFallbackDomain_UpdateAttrs(rnd, accountID, "Updated description", "10.10.10.10"),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccCloudflareDefaultFallbackDomain_MultipleDnsServers(rnd, accountID string) string {
+	return acctest.LoadTestCase("defaultfallbackdomain_multiple-dns-servers.tf", rnd, accountID)
+}
+
+func testAccCloudflareDefaultFallbackDomain_UpdateAttrs(rnd, accountID, description, dnsServer string) string {
+	return acctest.LoadTestCase("defaultfallbackdomain_update-attrs.tf", rnd, accountID, description, dnsServer)
 }

--- a/internal/services/zero_trust_device_default_profile_local_domain_fallback/schema.go
+++ b/internal/services/zero_trust_device_default_profile_local_domain_fallback/schema.go
@@ -26,7 +26,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown(), stringplanmodifier.RequiresReplace()},
 			},
-			"domains": schema.ListNestedAttribute{
+			"domains": schema.SetNestedAttribute{
 				Required: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/services/zero_trust_device_default_profile_local_domain_fallback/testdata/defaultfallbackdomain_multiple-dns-servers.tf
+++ b/internal/services/zero_trust_device_default_profile_local_domain_fallback/testdata/defaultfallbackdomain_multiple-dns-servers.tf
@@ -1,0 +1,8 @@
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "%[1]s" {
+  account_id = "%[2]s"
+  domains = [{
+    suffix      = "corp.example.com"
+    description = "Corporate domain with multiple DNS servers"
+    dns_server  = ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+  }]
+}

--- a/internal/services/zero_trust_device_default_profile_local_domain_fallback/testdata/defaultfallbackdomain_update-attrs.tf
+++ b/internal/services/zero_trust_device_default_profile_local_domain_fallback/testdata/defaultfallbackdomain_update-attrs.tf
@@ -1,0 +1,8 @@
+resource "cloudflare_zero_trust_device_default_profile_local_domain_fallback" "%[1]s" {
+  account_id = "%[2]s"
+  domains = [{
+    suffix      = "test.local"
+    description = "%[3]s"
+    dns_server  = ["%[4]s"]
+  }]
+}


### PR DESCRIPTION
…ero_trust_device_default_profile_local_domain_fallback to nested set

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

We're simply adding `UseStateUnknown` to fields in zero_trust_device_default_profile as well as changing zero_trust_device_default_profile_local_domain_fallback to a nested set instead of list to prevent drift issues.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
jlu@M6YD7V50CG terraform-provider-cloudflare % TF_ACC=1 go test -v ./internal/services/zero_trust_device_default_profile/... -run 'TestAcc'
=== RUN   TestAccCloudflareZeroTrustDeviceDefaultProfile_Basic
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_Basic (5.47s)
=== RUN   TestAccCloudflareZeroTrustDeviceDefaultProfile_Update
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_Update (5.24s)
=== RUN   TestAccCloudflareZeroTrustDeviceDefaultProfile_Complete
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_Complete (3.17s)
=== RUN   TestAccCloudflareZeroTrustDeviceDefaultProfile_WithExclude
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_WithExclude (2.90s)
=== RUN   TestAccCloudflareZeroTrustDeviceDefaultProfile_WithInclude
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_WithInclude (3.88s)
=== RUN   TestAccUpgradeZeroTrustDeviceDefaultProfile_FromPublishedV5
--- PASS: TestAccUpgradeZeroTrustDeviceDefaultProfile_FromPublishedV5 (17.81s)
=== RUN   TestAccCloudflareZeroTrustDeviceDefaultProfile_ServiceModeProxy
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_ServiceModeProxy (3.52s)
=== RUN   TestAccCloudflareZeroTrustDeviceDefaultProfile_UnsetOptionals
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_UnsetOptionals (4.40s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_device_default_profile 48.151s

jlu@M6YD7V50CG terraform-provider-cloudflare % TF_ACC=1 go test -v ./internal/services/zero_trust_device_default_profile_local_domain_fallback/... -run 'TestAcc'
=== RUN   TestAccCloudflareFallbackDomain_Basic
--- PASS: TestAccCloudflareFallbackDomain_Basic (9.92s)
=== RUN   TestAccCloudflareFallbackDomain_DefaultPolicy
--- PASS: TestAccCloudflareFallbackDomain_DefaultPolicy (3.51s)
=== RUN   TestAccCloudflareFallbackDomain_MultipleDomains
--- PASS: TestAccCloudflareFallbackDomain_MultipleDomains (6.56s)
=== RUN   TestAccUpgradeZeroTrustDeviceDefaultProfileLocalDomainFallback_FromPublishedV5
--- PASS: TestAccUpgradeZeroTrustDeviceDefaultProfileLocalDomainFallback_FromPublishedV5 (15.58s)
=== RUN   TestAccCloudflareFallbackDomain_MultipleDnsServers
--- PASS: TestAccCloudflareFallbackDomain_MultipleDnsServers (3.98s)
=== RUN   TestAccCloudflareFallbackDomain_UpdateDomainAttributes
--- PASS: TestAccCloudflareFallbackDomain_UpdateDomainAttributes (5.09s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_device_default_profile_local_domain_fallback46.490s
## Additional context & links
