### PR TITLE
feat(bot_management): state upgrader

### DIFF
--- a/internal/services/bot_management/migration/v500/handler.go
+++ b/internal/services/bot_management/migration/v500/handler.go
@@ -1,0 +1,48 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// UpgradeFromV4 handles state upgrades from v4 SDKv2 provider (schema_version=0) to v5 (version=500).
+//
+// This performs a full transformation from v4 -> v5 format.
+// The v4 state has schema_version=0 (SDKv2 default), and we transform it to v5 format.
+func UpgradeFromV4(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading bot_management state from v4 SDKv2 provider (schema_version=0)")
+
+	// Parse v4 state using v4 model
+	var v4State SourceCloudflareBotManagementModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &v4State)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform v4 -> v5
+	v5State, diags := Transform(ctx, v4State)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Write transformed state
+	resp.Diagnostics.Append(resp.State.Set(ctx, v5State)...)
+	tflog.Info(ctx, "State upgrade from v4 to v5 completed successfully")
+}
+
+// UpgradeFromV5 handles state upgrades from v5 Plugin Framework provider (version=1) to v5 (version=500).
+//
+// This is a no-op upgrade since the schema is compatible - just bumps the version.
+// This handler is only triggered when TF_MIG_TEST=1 (GetSchemaVersion returns 500).
+func UpgradeFromV5(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading bot_management state from version=1 to version=500 (no-op)")
+
+	// For no-op upgrades, copy raw state directly.
+	// This preserves all state data without any transformation.
+	resp.State.Raw = req.State.Raw
+
+	tflog.Info(ctx, "State version bump from 1 to 500 completed")
+}

--- a/internal/services/bot_management/migration/v500/migrations_test.go
+++ b/internal/services/bot_management/migration/v500/migrations_test.go
@@ -1,0 +1,228 @@
+package v500_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+var (
+	currentProviderVersion = internal.PackageVersion // Current v5 release
+)
+
+// Embed test configs
+//
+//go:embed testdata/v4_basic.tf
+var v4BasicConfig string
+
+//go:embed testdata/v5_basic.tf
+var v5BasicConfig string
+
+//go:embed testdata/v4_ai_bots_protection.tf
+var v4AIBotsProtectionConfig string
+
+//go:embed testdata/v5_ai_bots_protection.tf
+var v5AIBotsProtectionConfig string
+
+//go:embed testdata/v4_multiple_fields.tf
+var v4MultipleFieldsConfig string
+
+//go:embed testdata/v5_multiple_fields.tf
+var v5MultipleFieldsConfig string
+
+// TestMigrateBotManagement_V4ToV5_Basic tests basic bot management migration with minimal fields
+func TestMigrateBotManagement_V4ToV5_Basic(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v4BasicConfig, rnd, zoneID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v5BasicConfig, rnd, zoneID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			resourceName := "cloudflare_bot_management." + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enable_js"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("auto_update_model"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+						},
+					),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateBotManagement_V4ToV5_AIBotsProtection tests migration with AI bots protection
+func TestMigrateBotManagement_V4ToV5_AIBotsProtection(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v4AIBotsProtectionConfig, rnd, zoneID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v5AIBotsProtectionConfig, rnd, zoneID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			resourceName := "cloudflare_bot_management." + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ai_bots_protection"), knownvalue.StringExact("block")),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enable_js"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("auto_update_model"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("suppress_session_score"), knownvalue.Bool(false)),
+						},
+					),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateBotManagement_V4ToV5_MultipleFields tests migration with multiple fields
+func TestMigrateBotManagement_V4ToV5_MultipleFields(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v4MultipleFieldsConfig, rnd, zoneID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v5MultipleFieldsConfig, rnd, zoneID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			resourceName := "cloudflare_bot_management." + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enable_js"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("auto_update_model"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("suppress_session_score"), knownvalue.Bool(false)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ai_bots_protection"), knownvalue.StringExact("block")),
+						},
+					),
+				},
+			})
+		})
+	}
+}

--- a/internal/services/bot_management/migration/v500/model.go
+++ b/internal/services/bot_management/migration/v500/model.go
@@ -1,0 +1,68 @@
+package v500
+
+import (
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ============================================================================
+// Source Models (Legacy Provider - v4.x)
+// ============================================================================
+
+// SourceCloudflareBotManagementModel represents the legacy cloudflare_bot_management resource state from v4.x provider.
+// Schema version: 0 (SDKv2 provider)
+// Resource type: cloudflare_bot_management
+type SourceCloudflareBotManagementModel struct {
+	ID                           types.String `tfsdk:"id"`
+	ZoneID                       types.String `tfsdk:"zone_id"`
+	AIBotsProtection             types.String `tfsdk:"ai_bots_protection"`
+	AutoUpdateModel              types.Bool   `tfsdk:"auto_update_model"`
+	EnableJS                     types.Bool   `tfsdk:"enable_js"`
+	FightMode                    types.Bool   `tfsdk:"fight_mode"`
+	OptimizeWordpress            types.Bool   `tfsdk:"optimize_wordpress"`
+	SBFMDefinitelyAutomated      types.String `tfsdk:"sbfm_definitely_automated"`
+	SBFMLikelyAutomated          types.String `tfsdk:"sbfm_likely_automated"`
+	SBFMStaticResourceProtection types.Bool   `tfsdk:"sbfm_static_resource_protection"`
+	SBFMVerifiedBots             types.String `tfsdk:"sbfm_verified_bots"`
+	SuppressSessionScore         types.Bool   `tfsdk:"suppress_session_score"`
+	UsingLatestModel             types.Bool   `tfsdk:"using_latest_model"`
+}
+
+// ============================================================================
+// Target Models (Current Provider - v5.x+)
+// ============================================================================
+
+// TargetBotManagementModel represents the current cloudflare_bot_management resource state from v5.x+ provider.
+// Schema version: 500
+// Resource type: cloudflare_bot_management
+type TargetBotManagementModel struct {
+	ID                           types.String                                                       `tfsdk:"id"`
+	ZoneID                       types.String                                                       `tfsdk:"zone_id"`
+	AIBotsProtection             types.String                                                       `tfsdk:"ai_bots_protection"`
+	AutoUpdateModel              types.Bool                                                         `tfsdk:"auto_update_model"`
+	BmCookieEnabled              types.Bool                                                         `tfsdk:"bm_cookie_enabled"`
+	CfRobotsVariant              types.String                                                       `tfsdk:"cf_robots_variant"`
+	CrawlerProtection            types.String                                                       `tfsdk:"crawler_protection"`
+	EnableJS                     types.Bool                                                         `tfsdk:"enable_js"`
+	FightMode                    types.Bool                                                         `tfsdk:"fight_mode"`
+	IsRobotsTXTManaged           types.Bool                                                         `tfsdk:"is_robots_txt_managed"`
+	OptimizeWordpress            types.Bool                                                         `tfsdk:"optimize_wordpress"`
+	SBFMDefinitelyAutomated      types.String                                                       `tfsdk:"sbfm_definitely_automated"`
+	SBFMLikelyAutomated          types.String                                                       `tfsdk:"sbfm_likely_automated"`
+	SBFMStaticResourceProtection types.Bool                                                         `tfsdk:"sbfm_static_resource_protection"`
+	SBFMVerifiedBots             types.String                                                       `tfsdk:"sbfm_verified_bots"`
+	SuppressSessionScore         types.Bool                                                         `tfsdk:"suppress_session_score"`
+	UsingLatestModel             types.Bool                                                         `tfsdk:"using_latest_model"`
+	StaleZoneConfiguration       customfield.NestedObject[TargetBotManagementStaleZoneConfigModel]  `tfsdk:"stale_zone_configuration"`
+}
+
+// TargetBotManagementStaleZoneConfigModel represents the nested stale_zone_configuration in v5.
+type TargetBotManagementStaleZoneConfigModel struct {
+	OptimizeWordpress            types.Bool   `tfsdk:"optimize_wordpress"`
+	SBFMDefinitelyAutomated      types.String `tfsdk:"sbfm_definitely_automated"`
+	SBFMLikelyAutomated          types.String `tfsdk:"sbfm_likely_automated"`
+	SBFMStaticResourceProtection types.String `tfsdk:"sbfm_static_resource_protection"`
+	SBFMVerifiedBots             types.String `tfsdk:"sbfm_verified_bots"`
+	SuppressSessionScore         types.Bool   `tfsdk:"suppress_session_score"`
+	FightMode                    types.Bool   `tfsdk:"fight_mode"`
+}

--- a/internal/services/bot_management/migration/v500/schema.go
+++ b/internal/services/bot_management/migration/v500/schema.go
@@ -1,0 +1,67 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// SourceCloudflareBotManagementSchema returns the source schema for legacy cloudflare_bot_management resource.
+// Schema version: 0 (SDKv2 provider - v4.x)
+//
+// This minimal schema is used only for reading v4 state during migration.
+// It includes only the properties needed for state parsing (Required, Optional, Computed).
+// Validators, PlanModifiers, and Descriptions are intentionally omitted.
+func SourceCloudflareBotManagementSchema() schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"zone_id": schema.StringAttribute{
+				Required: true,
+			},
+			"ai_bots_protection": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"auto_update_model": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"enable_js": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"fight_mode": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"optimize_wordpress": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"sbfm_definitely_automated": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"sbfm_likely_automated": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"sbfm_static_resource_protection": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"sbfm_verified_bots": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"suppress_session_score": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"using_latest_model": schema.BoolAttribute{
+				Computed: true,
+			},
+		},
+	}
+}

--- a/internal/services/bot_management/migration/v500/testdata/v4_ai_bots_protection.tf
+++ b/internal/services/bot_management/migration/v500/testdata/v4_ai_bots_protection.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_bot_management" "%s" {
+  zone_id               = "%s"
+  enable_js             = true
+  auto_update_model     = true
+  ai_bots_protection    = "block"
+  suppress_session_score = false
+}

--- a/internal/services/bot_management/migration/v500/testdata/v4_basic.tf
+++ b/internal/services/bot_management/migration/v500/testdata/v4_basic.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_bot_management" "%s" {
+  zone_id           = "%s"
+  enable_js         = true
+  auto_update_model = true
+}

--- a/internal/services/bot_management/migration/v500/testdata/v4_multiple_fields.tf
+++ b/internal/services/bot_management/migration/v500/testdata/v4_multiple_fields.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_bot_management" "%s" {
+  zone_id                = "%s"
+  enable_js              = true
+  auto_update_model      = true
+  suppress_session_score = false
+  ai_bots_protection     = "block"
+}

--- a/internal/services/bot_management/migration/v500/testdata/v5_ai_bots_protection.tf
+++ b/internal/services/bot_management/migration/v500/testdata/v5_ai_bots_protection.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_bot_management" "%s" {
+  zone_id               = "%s"
+  enable_js             = true
+  auto_update_model     = true
+  ai_bots_protection    = "block"
+  suppress_session_score = false
+}

--- a/internal/services/bot_management/migration/v500/testdata/v5_basic.tf
+++ b/internal/services/bot_management/migration/v500/testdata/v5_basic.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_bot_management" "%s" {
+  zone_id           = "%s"
+  enable_js         = true
+  auto_update_model = true
+}

--- a/internal/services/bot_management/migration/v500/testdata/v5_multiple_fields.tf
+++ b/internal/services/bot_management/migration/v500/testdata/v5_multiple_fields.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_bot_management" "%s" {
+  zone_id                = "%s"
+  enable_js              = true
+  auto_update_model      = true
+  suppress_session_score = false
+  ai_bots_protection     = "block"
+}

--- a/internal/services/bot_management/migration/v500/transform.go
+++ b/internal/services/bot_management/migration/v500/transform.go
@@ -1,0 +1,52 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Transform converts source (legacy v4) state to target (current v5) state.
+//
+// For bot_management, v4 and v5 share the same field names and types for all v4 fields.
+// The transformation is a direct copy of all v4 fields, with new v5-only fields set to null.
+func Transform(ctx context.Context, source SourceCloudflareBotManagementModel) (*TargetBotManagementModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Validate required fields
+	if source.ZoneID.IsNull() || source.ZoneID.IsUnknown() {
+		diags.AddError(
+			"Missing required field",
+			"zone_id is required for bot_management migration. The source state is missing this field, which indicates corrupted state.",
+		)
+		return nil, diags
+	}
+
+	// Direct copy of all v4 fields (same names and types in v5)
+	target := &TargetBotManagementModel{
+		ID:                           source.ID,
+		ZoneID:                       source.ZoneID,
+		AIBotsProtection:             source.AIBotsProtection,
+		AutoUpdateModel:              source.AutoUpdateModel,
+		EnableJS:                     source.EnableJS,
+		FightMode:                    source.FightMode,
+		OptimizeWordpress:            source.OptimizeWordpress,
+		SBFMDefinitelyAutomated:      source.SBFMDefinitelyAutomated,
+		SBFMLikelyAutomated:          source.SBFMLikelyAutomated,
+		SBFMStaticResourceProtection: source.SBFMStaticResourceProtection,
+		SBFMVerifiedBots:             source.SBFMVerifiedBots,
+		SuppressSessionScore:         source.SuppressSessionScore,
+		UsingLatestModel:             source.UsingLatestModel,
+	}
+
+	// New v5-only fields: set to null (will be refreshed from API on next read)
+	target.BmCookieEnabled = types.BoolNull()
+	target.CfRobotsVariant = types.StringNull()
+	target.CrawlerProtection = types.StringNull()
+	target.IsRobotsTXTManaged = types.BoolNull()
+	target.StaleZoneConfiguration = customfield.NullObject[TargetBotManagementStaleZoneConfigModel](ctx)
+
+	return target, diags
+}

--- a/internal/services/bot_management/migrations.go
+++ b/internal/services/bot_management/migrations.go
@@ -1,15 +1,39 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 package bot_management
 
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/bot_management/migration/v500"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 var _ resource.ResourceWithUpgradeState = (*BotManagementResource)(nil)
 
+// UpgradeState registers state upgraders for schema version changes.
+//
+// This handles two upgrade paths:
+// 1. v4 state (schema_version=0) -> v5 (version=500): Full transformation
+//   - Copies all v4 fields directly (same names and types)
+//   - Sets new v5-only fields to null (bm_cookie_enabled, cf_robots_variant, etc.)
+//   - Sets stale_zone_configuration to null
+//
+// 2. v5 state (version=1) -> v5 (version=500): No-op upgrade (when TF_MIG_TEST=1)
+//   - Just bumps the version number, no data transformation
 func (r *BotManagementResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	sourceSchema := v500.SourceCloudflareBotManagementSchema()
+	targetSchema := ResourceSchema(ctx)
+
+	return map[int64]resource.StateUpgrader{
+		// Handle state from v4 SDKv2 provider (schema_version=0)
+		0: {
+			PriorSchema:   &sourceSchema,
+			StateUpgrader: v500.UpgradeFromV4,
+		},
+		// Handle state from v5 Plugin Framework provider with version=1
+		// This is a no-op upgrade that just bumps the version to 500
+		1: {
+			PriorSchema:   &targetSchema,
+			StateUpgrader: v500.UpgradeFromV5,
+		},
+	}
 }

--- a/internal/services/bot_management/schema.go
+++ b/internal/services/bot_management/schema.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -19,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*BotManagementResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: migrations.GetSchemaVersion(1, 500),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
```
TF_MIG_TEST=true TF_ACC=1 go test -p 1  ./internal/services/bot_management/migration/v500/  -run "TestMi" -v
```

### Test output
```
~/c/github/provider-copy/terraform-provider-cloudflare-bot-mgmt vaishak/bot-mgmt ❯ TF_MIG_TEST=true TF_ACC=1 go test -p 1  ./internal/services/bot_management/migration/v500/  -run "TestMi" -v
=== RUN   TestMigrateBotManagement_V4ToV5_Basic
=== RUN   TestMigrateBotManagement_V4ToV5_Basic/from_v4_latest
=== RUN   TestMigrateBotManagement_V4ToV5_Basic/from_v5
--- PASS: TestMigrateBotManagement_V4ToV5_Basic (30.03s)
    --- PASS: TestMigrateBotManagement_V4ToV5_Basic/from_v4_latest (17.45s)
    --- PASS: TestMigrateBotManagement_V4ToV5_Basic/from_v5 (12.58s)
=== RUN   TestMigrateBotManagement_V4ToV5_AIBotsProtection
=== RUN   TestMigrateBotManagement_V4ToV5_AIBotsProtection/from_v4_latest
=== RUN   TestMigrateBotManagement_V4ToV5_AIBotsProtection/from_v5
--- PASS: TestMigrateBotManagement_V4ToV5_AIBotsProtection (29.86s)
    --- PASS: TestMigrateBotManagement_V4ToV5_AIBotsProtection/from_v4_latest (16.69s)
    --- PASS: TestMigrateBotManagement_V4ToV5_AIBotsProtection/from_v5 (13.17s)
=== RUN   TestMigrateBotManagement_V4ToV5_MultipleFields
=== RUN   TestMigrateBotManagement_V4ToV5_MultipleFields/from_v4_latest
=== RUN   TestMigrateBotManagement_V4ToV5_MultipleFields/from_v5
--- PASS: TestMigrateBotManagement_V4ToV5_MultipleFields (30.36s)
    --- PASS: TestMigrateBotManagement_V4ToV5_MultipleFields/from_v4_latest (16.97s)
    --- PASS: TestMigrateBotManagement_V4ToV5_MultipleFields/from_v5 (13.39s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/bot_management/migration/v500	91.926s

```

## Additional context & links
