### PR TITLE
fix(docs): v5 migration for authenticated_origin_pulls (zone and host…

### DIFF
--- a/docs/guides/version-5-upgrade.md
+++ b/docs/guides/version-5-upgrade.md
@@ -438,6 +438,291 @@ resource "cloudflare_api_token" "example" {
 }
 ```
 
+## cloudflare_authenticated_origin_pulls
+
+In version 4, `cloudflare_authenticated_origin_pulls` was a single polymorphic resource that handled three different modes of Authenticated Origin Pulls (AOP) based on which optional attributes were set. In version 5, this has been split into separate resources that map to distinct API endpoints.
+
+**Migration Note:** After importing resources, you may see computed fields (like `id`, `status`, `expires_on`) refresh on the first `terraform plan`. This is expected behavior as Terraform populates these values from the API. Additionally, certificate resources require a `terraform apply` after import to sync the `private_key` attribute, since the API doesn't return private keys for security reasons.
+
+**Migration paths by mode:**
+
+### Global AOP (zone-level toggle only)
+
+If your v4 resource only had `zone_id` and `enabled` (no certificate or hostname), migrate to `cloudflare_authenticated_origin_pulls_settings`.
+
+Before
+
+```hcl
+resource "cloudflare_authenticated_origin_pulls" "example" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+}
+```
+
+After
+
+```hcl
+resource "cloudflare_authenticated_origin_pulls_settings" "example" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+}
+```
+
+State migration:
+
+```sh
+terraform state rm cloudflare_authenticated_origin_pulls.example
+terraform import cloudflare_authenticated_origin_pulls_settings.example 0da42c8d2132a9ddaf714f9e7c920711
+```
+
+### Per-Zone AOP (zone-level with custom certificate)
+
+If your v4 resource had `zone_id`, `enabled`, and `authenticated_origin_pulls_certificate` (but no `hostname`), the association resource changes name in v5. **Important:** Per-zone AOP requires TWO resources in both v4 and v5 - one for the certificate and one for the settings.
+
+Before
+
+```hcl
+# V4: Certificate resource
+resource "cloudflare_authenticated_origin_pulls_certificate" "my_cert" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  type        = "per-zone"
+  certificate = file("cert.pem")
+  private_key = file("key.pem")
+}
+
+# V4: Association/settings resource
+resource "cloudflare_authenticated_origin_pulls" "my_zone" {
+  zone_id                               = "0da42c8d2132a9ddaf714f9e7c920711"
+  authenticated_origin_pulls_certificate = cloudflare_authenticated_origin_pulls_certificate.my_cert.id
+  enabled                               = true
+}
+```
+
+After
+
+```hcl
+# V5: Certificate resource (same name, drop 'type' attribute)
+resource "cloudflare_authenticated_origin_pulls_certificate" "my_cert" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  certificate = file("cert.pem")
+  private_key = file("key.pem")
+}
+
+# V5: Settings resource (RENAMED from cloudflare_authenticated_origin_pulls)
+resource "cloudflare_authenticated_origin_pulls_settings" "my_zone" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+}
+```
+
+Key changes:
+- Certificate resource: Remove the `type` attribute (see `cloudflare_authenticated_origin_pulls_certificate` section below for details)
+- Association resource: Rename to `cloudflare_authenticated_origin_pulls_settings` and remove the `authenticated_origin_pulls_certificate` reference (the certificate is now implicitly used when uploaded)
+
+State migration:
+
+```sh
+# Remove the v4 association resource
+terraform state rm cloudflare_authenticated_origin_pulls.my_zone
+
+# Import into v5 settings resource
+terraform import cloudflare_authenticated_origin_pulls_settings.my_zone 0da42c8d2132a9ddaf714f9e7c920711
+
+# Certificate resource state migration is covered in the cloudflare_authenticated_origin_pulls_certificate section below
+
+# After importing the certificate, sync the private_key attribute
+terraform apply -target=cloudflare_authenticated_origin_pulls_certificate.my_cert
+
+# Verify no drift remains
+terraform plan
+# Expected: "No changes. Your infrastructure matches the configuration."
+```
+
+### Per-Hostname AOP (hostname-specific configuration)
+
+If your v4 resource had all four attributes (`zone_id`, `enabled`, `authenticated_origin_pulls_certificate`, and `hostname`), **both the certificate and association resources change** in v5. Per-hostname AOP requires TWO resources in both v4 and v5.
+
+Before
+
+```hcl
+# V4: Certificate resource with type="per-hostname"
+resource "cloudflare_authenticated_origin_pulls_certificate" "my_cert" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  type        = "per-hostname"
+  certificate = file("cert.pem")
+  private_key = file("key.pem")
+}
+
+# V4: Hostname association resource
+resource "cloudflare_authenticated_origin_pulls" "my_hostname" {
+  zone_id                               = "0da42c8d2132a9ddaf714f9e7c920711"
+  authenticated_origin_pulls_certificate = cloudflare_authenticated_origin_pulls_certificate.my_cert.id
+  hostname                              = "app.example.com"
+  enabled                               = true
+}
+```
+
+After
+
+```hcl
+# V5: Certificate resource (RENAMED and type removed)
+resource "cloudflare_authenticated_origin_pulls_hostname_certificate" "my_cert" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  certificate = file("cert.pem")
+  private_key = file("key.pem")
+}
+
+# V5: Hostname association resource (RESTRUCTURED schema)
+resource "cloudflare_authenticated_origin_pulls" "my_hostname" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  config = [{
+    hostname = "app.example.com"
+    cert_id  = cloudflare_authenticated_origin_pulls_hostname_certificate.my_cert.id
+    enabled  = true
+  }]
+}
+```
+
+Key changes:
+- Certificate resource: Rename to `cloudflare_authenticated_origin_pulls_hostname_certificate` and remove `type` attribute (see certificate section below)
+- Association resource: Restructure flat attributes into a nested `config` list; rename `authenticated_origin_pulls_certificate` to `cert_id`
+- The `config` list must contain exactly one item per resource instance
+
+State migration:
+
+```sh
+# Certificate resource - see cloudflare_authenticated_origin_pulls_certificate section below for detailed steps
+terraform state rm cloudflare_authenticated_origin_pulls_certificate.my_cert
+terraform import cloudflare_authenticated_origin_pulls_hostname_certificate.my_cert 0da42c8d2132a9ddaf714f9e7c920711/<certificate_id>
+
+# Association resource
+terraform state rm cloudflare_authenticated_origin_pulls.my_hostname
+terraform import cloudflare_authenticated_origin_pulls.my_hostname 0da42c8d2132a9ddaf714f9e7c920711/app.example.com
+
+# After importing the certificate, sync the private_key attribute
+terraform apply -target=cloudflare_authenticated_origin_pulls_hostname_certificate.my_cert
+
+# Verify no drift remains
+terraform plan
+# Expected: "No changes. Your infrastructure matches the configuration."
+```
+
+**Troubleshooting Import Issues**
+
+If you encounter `Error: Attempt to index null value` during import:
+
+**Cause:** Outputs or other resource references try to access nested attributes (`config[0].enabled`) before the resource is fully populated from the API.
+
+**Solution A - Use defensive output syntax (Recommended):**
+```hcl
+output "hostname_aop_enabled" {
+  value       = try(cloudflare_authenticated_origin_pulls.my_hostname.config[0].enabled, null)
+  description = "Whether hostname-level AOP is enabled (null during import, populated after plan/apply)"
+}
+```
+The `try()` function returns `null` if `config` is null during import, then populates with the actual value after `terraform plan` or `terraform apply`.
+
+**Solution B - Comment out outputs temporarily:**
+Comment out nested attribute references during import, then uncomment after running `terraform plan`.
+
+**Solution C - Remove outputs during migration:**
+Delete outputs entirely during migration, add them back after verification is complete.
+
+## cloudflare_authenticated_origin_pulls_certificate
+
+In version 4, this resource had a `type` attribute with values `"per-zone"` or `"per-hostname"` to differentiate between zone-level and hostname-level certificates. In version 5, these are now separate resources.
+
+### Per-Zone Certificate
+
+If your v4 certificate had `type = "per-zone"`, the resource name stays the same but the `type` attribute is removed. **Note:** You must also use `cloudflare_authenticated_origin_pulls_settings` to enable zone-level AOP (see the `cloudflare_authenticated_origin_pulls` section above).
+
+Before
+
+```hcl
+resource "cloudflare_authenticated_origin_pulls_certificate" "example" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  type        = "per-zone"
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIGAjCCA+qgAwIBAgIJAI7kymlF7CWT...
+-----END CERTIFICATE-----
+EOT
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASC...
+-----END PRIVATE KEY-----
+EOT
+}
+```
+
+After
+
+```hcl
+resource "cloudflare_authenticated_origin_pulls_certificate" "example" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIGAjCCA+qgAwIBAgIJAI7kymlF7CWT...
+-----END CERTIFICATE-----
+EOT
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASC...
+-----END PRIVATE KEY-----
+EOT
+}
+```
+
+State migration is not required for per-zone certificates; simply remove the `type` attribute from your configuration.
+
+### Per-Hostname Certificate
+
+If your v4 certificate had `type = "per-hostname"`, migrate to the new `cloudflare_authenticated_origin_pulls_hostname_certificate` resource and remove the `type` attribute. **Note:** You must also update your hostname association resources (see the per-hostname section in `cloudflare_authenticated_origin_pulls` above).
+
+Before
+
+```hcl
+resource "cloudflare_authenticated_origin_pulls_certificate" "example" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  type        = "per-hostname"
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIGAjCCA+qgAwIBAgIJAI7kymlF7CWT...
+-----END CERTIFICATE-----
+EOT
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASC...
+-----END PRIVATE KEY-----
+EOT
+}
+```
+
+After
+
+```hcl
+resource "cloudflare_authenticated_origin_pulls_hostname_certificate" "example" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIGAjCCA+qgAwIBAgIJAI7kymlF7CWT...
+-----END CERTIFICATE-----
+EOT
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASC...
+-----END PRIVATE KEY-----
+EOT
+}
+```
+
+State migration:
+
+```sh
+terraform state rm cloudflare_authenticated_origin_pulls_certificate.example
+terraform import cloudflare_authenticated_origin_pulls_hostname_certificate.example 0da42c8d2132a9ddaf714f9e7c920711/<certificate_id>
+```
+
 ## cloudflare_hostname_tls_setting
 
 - `setting` is now `setting_id`.

--- a/templates/guides/version-5-upgrade.md
+++ b/templates/guides/version-5-upgrade.md
@@ -438,6 +438,291 @@ resource "cloudflare_api_token" "example" {
 }
 ```
 
+## cloudflare_authenticated_origin_pulls
+
+In version 4, `cloudflare_authenticated_origin_pulls` was a single polymorphic resource that handled three different modes of Authenticated Origin Pulls (AOP) based on which optional attributes were set. In version 5, this has been split into separate resources that map to distinct API endpoints.
+
+**Migration Note:** After importing resources, you may see computed fields (like `id`, `status`, `expires_on`) refresh on the first `terraform plan`. This is expected behavior as Terraform populates these values from the API. Additionally, certificate resources require a `terraform apply` after import to sync the `private_key` attribute, since the API doesn't return private keys for security reasons.
+
+**Migration paths by mode:**
+
+### Global AOP (zone-level toggle only)
+
+If your v4 resource only had `zone_id` and `enabled` (no certificate or hostname), migrate to `cloudflare_authenticated_origin_pulls_settings`.
+
+Before
+
+```hcl
+resource "cloudflare_authenticated_origin_pulls" "example" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+}
+```
+
+After
+
+```hcl
+resource "cloudflare_authenticated_origin_pulls_settings" "example" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+}
+```
+
+State migration:
+
+```sh
+terraform state rm cloudflare_authenticated_origin_pulls.example
+terraform import cloudflare_authenticated_origin_pulls_settings.example 0da42c8d2132a9ddaf714f9e7c920711
+```
+
+### Per-Zone AOP (zone-level with custom certificate)
+
+If your v4 resource had `zone_id`, `enabled`, and `authenticated_origin_pulls_certificate` (but no `hostname`), the association resource changes name in v5. **Important:** Per-zone AOP requires TWO resources in both v4 and v5 - one for the certificate and one for the settings.
+
+Before
+
+```hcl
+# V4: Certificate resource
+resource "cloudflare_authenticated_origin_pulls_certificate" "my_cert" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  type        = "per-zone"
+  certificate = file("cert.pem")
+  private_key = file("key.pem")
+}
+
+# V4: Association/settings resource
+resource "cloudflare_authenticated_origin_pulls" "my_zone" {
+  zone_id                               = "0da42c8d2132a9ddaf714f9e7c920711"
+  authenticated_origin_pulls_certificate = cloudflare_authenticated_origin_pulls_certificate.my_cert.id
+  enabled                               = true
+}
+```
+
+After
+
+```hcl
+# V5: Certificate resource (same name, drop 'type' attribute)
+resource "cloudflare_authenticated_origin_pulls_certificate" "my_cert" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  certificate = file("cert.pem")
+  private_key = file("key.pem")
+}
+
+# V5: Settings resource (RENAMED from cloudflare_authenticated_origin_pulls)
+resource "cloudflare_authenticated_origin_pulls_settings" "my_zone" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  enabled = true
+}
+```
+
+Key changes:
+- Certificate resource: Remove the `type` attribute (see `cloudflare_authenticated_origin_pulls_certificate` section below for details)
+- Association resource: Rename to `cloudflare_authenticated_origin_pulls_settings` and remove the `authenticated_origin_pulls_certificate` reference (the certificate is now implicitly used when uploaded)
+
+State migration:
+
+```sh
+# Remove the v4 association resource
+terraform state rm cloudflare_authenticated_origin_pulls.my_zone
+
+# Import into v5 settings resource
+terraform import cloudflare_authenticated_origin_pulls_settings.my_zone 0da42c8d2132a9ddaf714f9e7c920711
+
+# Certificate resource state migration is covered in the cloudflare_authenticated_origin_pulls_certificate section below
+
+# After importing the certificate, sync the private_key attribute
+terraform apply -target=cloudflare_authenticated_origin_pulls_certificate.my_cert
+
+# Verify no drift remains
+terraform plan
+# Expected: "No changes. Your infrastructure matches the configuration."
+```
+
+### Per-Hostname AOP (hostname-specific configuration)
+
+If your v4 resource had all four attributes (`zone_id`, `enabled`, `authenticated_origin_pulls_certificate`, and `hostname`), **both the certificate and association resources change** in v5. Per-hostname AOP requires TWO resources in both v4 and v5.
+
+Before
+
+```hcl
+# V4: Certificate resource with type="per-hostname"
+resource "cloudflare_authenticated_origin_pulls_certificate" "my_cert" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  type        = "per-hostname"
+  certificate = file("cert.pem")
+  private_key = file("key.pem")
+}
+
+# V4: Hostname association resource
+resource "cloudflare_authenticated_origin_pulls" "my_hostname" {
+  zone_id                               = "0da42c8d2132a9ddaf714f9e7c920711"
+  authenticated_origin_pulls_certificate = cloudflare_authenticated_origin_pulls_certificate.my_cert.id
+  hostname                              = "app.example.com"
+  enabled                               = true
+}
+```
+
+After
+
+```hcl
+# V5: Certificate resource (RENAMED and type removed)
+resource "cloudflare_authenticated_origin_pulls_hostname_certificate" "my_cert" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  certificate = file("cert.pem")
+  private_key = file("key.pem")
+}
+
+# V5: Hostname association resource (RESTRUCTURED schema)
+resource "cloudflare_authenticated_origin_pulls" "my_hostname" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  config = [{
+    hostname = "app.example.com"
+    cert_id  = cloudflare_authenticated_origin_pulls_hostname_certificate.my_cert.id
+    enabled  = true
+  }]
+}
+```
+
+Key changes:
+- Certificate resource: Rename to `cloudflare_authenticated_origin_pulls_hostname_certificate` and remove `type` attribute (see certificate section below)
+- Association resource: Restructure flat attributes into a nested `config` list; rename `authenticated_origin_pulls_certificate` to `cert_id`
+- The `config` list must contain exactly one item per resource instance
+
+State migration:
+
+```sh
+# Certificate resource - see cloudflare_authenticated_origin_pulls_certificate section below for detailed steps
+terraform state rm cloudflare_authenticated_origin_pulls_certificate.my_cert
+terraform import cloudflare_authenticated_origin_pulls_hostname_certificate.my_cert 0da42c8d2132a9ddaf714f9e7c920711/<certificate_id>
+
+# Association resource
+terraform state rm cloudflare_authenticated_origin_pulls.my_hostname
+terraform import cloudflare_authenticated_origin_pulls.my_hostname 0da42c8d2132a9ddaf714f9e7c920711/app.example.com
+
+# After importing the certificate, sync the private_key attribute
+terraform apply -target=cloudflare_authenticated_origin_pulls_hostname_certificate.my_cert
+
+# Verify no drift remains
+terraform plan
+# Expected: "No changes. Your infrastructure matches the configuration."
+```
+
+**Troubleshooting Import Issues**
+
+If you encounter `Error: Attempt to index null value` during import:
+
+**Cause:** Outputs or other resource references try to access nested attributes (`config[0].enabled`) before the resource is fully populated from the API.
+
+**Solution A - Use defensive output syntax (Recommended):**
+```hcl
+output "hostname_aop_enabled" {
+  value       = try(cloudflare_authenticated_origin_pulls.my_hostname.config[0].enabled, null)
+  description = "Whether hostname-level AOP is enabled (null during import, populated after plan/apply)"
+}
+```
+The `try()` function returns `null` if `config` is null during import, then populates with the actual value after `terraform plan` or `terraform apply`.
+
+**Solution B - Comment out outputs temporarily:**
+Comment out nested attribute references during import, then uncomment after running `terraform plan`.
+
+**Solution C - Remove outputs during migration:**
+Delete outputs entirely during migration, add them back after verification is complete.
+
+## cloudflare_authenticated_origin_pulls_certificate
+
+In version 4, this resource had a `type` attribute with values `"per-zone"` or `"per-hostname"` to differentiate between zone-level and hostname-level certificates. In version 5, these are now separate resources.
+
+### Per-Zone Certificate
+
+If your v4 certificate had `type = "per-zone"`, the resource name stays the same but the `type` attribute is removed. **Note:** You must also use `cloudflare_authenticated_origin_pulls_settings` to enable zone-level AOP (see the `cloudflare_authenticated_origin_pulls` section above).
+
+Before
+
+```hcl
+resource "cloudflare_authenticated_origin_pulls_certificate" "example" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  type        = "per-zone"
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIGAjCCA+qgAwIBAgIJAI7kymlF7CWT...
+-----END CERTIFICATE-----
+EOT
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASC...
+-----END PRIVATE KEY-----
+EOT
+}
+```
+
+After
+
+```hcl
+resource "cloudflare_authenticated_origin_pulls_certificate" "example" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIGAjCCA+qgAwIBAgIJAI7kymlF7CWT...
+-----END CERTIFICATE-----
+EOT
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASC...
+-----END PRIVATE KEY-----
+EOT
+}
+```
+
+State migration is not required for per-zone certificates; simply remove the `type` attribute from your configuration.
+
+### Per-Hostname Certificate
+
+If your v4 certificate had `type = "per-hostname"`, migrate to the new `cloudflare_authenticated_origin_pulls_hostname_certificate` resource and remove the `type` attribute. **Note:** You must also update your hostname association resources (see the per-hostname section in `cloudflare_authenticated_origin_pulls` above).
+
+Before
+
+```hcl
+resource "cloudflare_authenticated_origin_pulls_certificate" "example" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  type        = "per-hostname"
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIGAjCCA+qgAwIBAgIJAI7kymlF7CWT...
+-----END CERTIFICATE-----
+EOT
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASC...
+-----END PRIVATE KEY-----
+EOT
+}
+```
+
+After
+
+```hcl
+resource "cloudflare_authenticated_origin_pulls_hostname_certificate" "example" {
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIGAjCCA+qgAwIBAgIJAI7kymlF7CWT...
+-----END CERTIFICATE-----
+EOT
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASC...
+-----END PRIVATE KEY-----
+EOT
+}
+```
+
+State migration:
+
+```sh
+terraform state rm cloudflare_authenticated_origin_pulls_certificate.example
+terraform import cloudflare_authenticated_origin_pulls_hostname_certificate.example 0da42c8d2132a9ddaf714f9e7c920711/<certificate_id>
+```
+
 ## cloudflare_hostname_tls_setting
 
 - `setting` is now `setting_id`.


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Manual migration is needed since automated migration tooling will not be able to handle this change. The v4 cloudflare_authenticated_origin_pulls resource was polymorphic - it handled 3 different modes determined by which optional attributes were set. 

- Global AOP: Only zone_id + enabled
- Per-Zone AOP: authenticated_origin_pulls_certificate attribute
- Per-Hostname AOP: hostname attribute

In v5, these split into separate resource:
- Global/Per-Zone settings → cloudflare_authenticated_origin_pulls_settings
- Per-Zone certificate  → cloudflare_authenticated_origin_pulls_certificate
- Per-Hostname association and enable settings → cloudflare_authenticated_origin_pulls
- Per-Hostname certificate → cloudflare_authenticated_origin_pulls_hostname_certificate

Changes:
1. **zone aop cert**: cloudflare_authenticated_origin_pulls_certificate → cloudflare_authenticated_origin_pulls_certificate (remove type field)
2. **hostname aop cert**: cloudflare_authenticated_origin_pulls_certificate → cloudflare_authenticated_origin_pulls_hostname_certificate (new resource + remove type).
3. **Zone AOP cert association + enable settings**:  cloudflare_authenticated_origin_pulls → cloudflare_authenticated_origin_pulls_settings (no longer need to include zone aop cert)
4. **Hostname AOP cert association + enable setting**: cloudflare_authenticated_origin_pulls → cloudflare_authenticated_origin_pulls (but structure is different)

## Acceptance test run results

Tested with provider v4.52.5 to v5.17.0

- [X] I have added or updated acceptance tests for my changes
- [X] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
Manual migration

### Test output
<!-- Please paste the output of your acceptance test run below --> 
[scenario-1-global-aop.log](https://github.com/user-attachments/files/25274336/scenario-1-global-aop.log)
[scenario-2-per-zone-COMPLETE.log](https://github.com/user-attachments/files/25274337/scenario-2-per-zone-COMPLETE.log)
[scenario-3-per-hostname-COMPLETE-retest.log](https://github.com/user-attachments/files/25274338/scenario-3-per-hostname-COMPLETE-retest.log)