### PR TITLE
feat(healthcheck): state upgrader

### DIFF
--- a/internal/services/healthcheck/migration/v500/handler.go
+++ b/internal/services/healthcheck/migration/v500/handler.go
@@ -1,0 +1,62 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// UpgradeFromV4 handles state upgrades from v4 SDKv2 provider (schema_version=0) to v5 (version=500).
+//
+// This performs a full transformation from v4 flat structure to v5 nested structure.
+// The v4 state has schema_version=0 (SDKv2 default), and we transform it to v5 format with
+// http_config or tcp_config nested objects based on the healthcheck type.
+func UpgradeFromV4(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading healthcheck state from v4 SDKv2 provider (schema_version=0)")
+
+	// Parse v4 state using v4 model (flat structure)
+	var v4State SourceHealthcheckModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &v4State)...)
+	if resp.Diagnostics.HasError() {
+		tflog.Error(ctx, "Failed to parse v4 healthcheck state")
+		return
+	}
+
+	tflog.Debug(ctx, "Parsed v4 state", map[string]interface{}{
+		"zone_id": v4State.ZoneID.ValueString(),
+		"name":    v4State.Name.ValueString(),
+		"type":    v4State.Type.ValueString(),
+	})
+
+	// Transform v4 → v5
+	v5State, diags := Transform(ctx, v4State)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		tflog.Error(ctx, "Failed to transform v4 healthcheck state to v5 format")
+		return
+	}
+
+	// Write transformed state
+	resp.Diagnostics.Append(resp.State.Set(ctx, v5State)...)
+	if resp.Diagnostics.HasError() {
+		tflog.Error(ctx, "Failed to write v5 healthcheck state")
+		return
+	}
+
+	tflog.Info(ctx, "State upgrade from v4 to v5 completed successfully")
+}
+
+// UpgradeFromV5 handles state upgrades from v5 Plugin Framework provider (version=1) to v5 (version=500).
+//
+// This is a no-op upgrade since the schema is compatible - just bumps the version.
+// This handler is only triggered when TF_MIG_TEST=1 (GetSchemaVersion returns 500).
+func UpgradeFromV5(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading healthcheck state from version=1 to version=500 (no-op)")
+
+	// CRITICAL: For no-op upgrades, copy raw state directly
+	// This preserves all state data without any transformation
+	resp.State.Raw = req.State.Raw
+
+	tflog.Info(ctx, "State version bump from 1 to 500 completed")
+}

--- a/internal/services/healthcheck/migration/v500/migrations_test.go
+++ b/internal/services/healthcheck/migration/v500/migrations_test.go
@@ -1,0 +1,654 @@
+package v500_test
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+var (
+	currentProviderVersion = internal.PackageVersion // Current v5 release
+)
+
+// Embed test configs - HTTP Basic
+//
+//go:embed testdata/v4_http_basic.tf
+var v4HTTPBasicConfig string
+
+//go:embed testdata/v5_http_basic.tf
+var v5HTTPBasicConfig string
+
+// Embed test configs - HTTP with Headers
+//
+//go:embed testdata/v4_http_headers.tf
+var v4HTTPHeadersConfig string
+
+//go:embed testdata/v5_http_headers.tf
+var v5HTTPHeadersConfig string
+
+// Embed test configs - TCP
+//
+//go:embed testdata/v4_tcp.tf
+var v4TCPConfig string
+
+//go:embed testdata/v5_tcp.tf
+var v5TCPConfig string
+
+// Embed test configs - HTTPS Full
+//
+//go:embed testdata/v4_https_full.tf
+var v4HTTPSFullConfig string
+
+//go:embed testdata/v5_https_full.tf
+var v5HTTPSFullConfig string
+
+// Custom plan check for healthcheck that allows only tcp_config/http_config computed drift
+type expectEmptyPlanExceptHealthcheckConfigDrift struct{}
+
+func (e expectEmptyPlanExceptHealthcheckConfigDrift) CheckPlan(ctx context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+	for _, rc := range req.Plan.ResourceChanges {
+		// Skip no-op and read actions
+		if rc.Change.Actions[0] == "no-op" || rc.Change.Actions[0] == "read" {
+			continue
+		}
+
+		// Check if this is an update action
+		if rc.Change.Actions[0] != "update" {
+			resp.Error = fmt.Errorf("expected empty plan, but %s has planned action(s): %v", rc.Address, rc.Change.Actions)
+			return
+		}
+
+		// For updates, check each attribute change
+		beforeMap, beforeOk := rc.Change.Before.(map[string]interface{})
+		afterMap, afterOk := rc.Change.After.(map[string]interface{})
+
+		if !beforeOk || !afterOk {
+			resp.Error = fmt.Errorf("expected empty plan, but %s has non-map changes", rc.Address)
+			return
+		}
+
+		// Check each attribute that's different
+		for key, afterValue := range afterMap {
+			beforeValue, _ := beforeMap[key]
+
+			// Skip if values are the same
+			if reflect.DeepEqual(beforeValue, afterValue) {
+				continue
+			}
+
+			// Allow changes from falsey to null
+			if afterValue == nil {
+				if isFalseyValue(beforeValue) {
+					continue // This change is allowed
+				}
+			}
+
+			// Healthcheck specific: Allow tcp_config/http_config computed field drift
+			// The unused config (tcp_config for HTTP type, http_config for TCP type) is marked as
+			// Computed:true in the schema and will show as "(known after apply)" on refresh
+			if key == "tcp_config" || key == "http_config" {
+				if beforeValue == nil {
+					continue // This change is allowed - computed field drift
+				}
+			}
+
+			// If we get here, it's a disallowed change
+			resp.Error = fmt.Errorf("expected empty plan except for healthcheck config drift, but %s.%s has change from %v to %v",
+				rc.Address, key, beforeValue, afterValue)
+			return
+		}
+	}
+}
+
+// isFalseyValue checks if a value is "falsey" (false, 0, "", empty slice/map)
+func isFalseyValue(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	switch val := v.(type) {
+	case bool:
+		return !val
+	case string:
+		return val == ""
+	case float64:
+		return val == 0
+	case int:
+		return val == 0
+	case []interface{}:
+		return len(val) == 0
+	case map[string]interface{}:
+		return len(val) == 0
+	default:
+		return false
+	}
+}
+
+var ExpectEmptyPlanExceptHealthcheckConfigDrift = expectEmptyPlanExceptHealthcheckConfigDrift{}
+
+// TestMigrateHealthcheck_V4ToV5_HTTPBasic tests basic HTTP healthcheck migration
+// with flat → nested http_config transformation
+func TestMigrateHealthcheck_V4ToV5_HTTPBasic(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID, name string) string
+	}{
+		{
+			name:    "from_v4_latest", // Tests legacy v4 → current v5
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID, name string) string {
+				return fmt.Sprintf(v4HTTPBasicConfig, rnd, zoneID, name)
+			},
+		},
+		{
+			name:    "from_v5", // Tests within v5 (version bump)
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID, name string) string {
+				return fmt.Sprintf(v5HTTPBasicConfig, rnd, zoneID, name)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			name := "tf-test-" + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID, name)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			// Build Step 1
+			step1 := resource.TestStep{
+				// Step 1: Create with specific provider version
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: tc.version,
+					},
+				},
+				Config: testConfig,
+			}
+			// For from_v5 test case, v5 provider has computed field drift even on initial create
+			if tc.version == currentProviderVersion {
+				step1.ExpectNonEmptyPlan = true
+			}
+
+			resource.Test(t, resource.TestCase{
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					step1,
+					// Step 2: Run migration and verify state with custom plan check
+					// Note: Persistent drift is expected for tcp_config/http_config computed fields.
+					// Our custom plan check only allows the tcp_config/http_config drift as acceptable,
+					// failing on anything else.
+					{
+						PreConfig: func() {
+							acctest.WriteOutConfig(t, testConfig, tmpDir)
+							acctest.RunMigrationV2Command(t, testConfig, tmpDir, sourceVer, targetVer)
+						},
+						ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+						ConfigDirectory:          config.StaticDirectory(tmpDir),
+						ExpectNonEmptyPlan:       true, // Allow drift, validated by custom checks below
+						ConfigPlanChecks: resource.ConfigPlanChecks{
+							PreApply: []plancheck.PlanCheck{
+								acctest.DebugNonEmptyPlan,
+								// Only allow tcp_config/http_config drift, fail on other changes
+								ExpectEmptyPlanExceptHealthcheckConfigDrift,
+							},
+							PostApplyPostRefresh: []plancheck.PlanCheck{
+								acctest.DebugNonEmptyPlan,
+								// Only allow tcp_config/http_config drift, fail on other changes
+								ExpectEmptyPlanExceptHealthcheckConfigDrift,
+							},
+						},
+						ConfigStateChecks: []statecheck.StateCheck{
+							// Verify core fields
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("zone_id"),
+								knownvalue.StringExact(zoneID),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("name"),
+								knownvalue.StringExact(name),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("address"),
+								knownvalue.StringExact("example.com"),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("type"),
+								knownvalue.StringExact("HTTP"),
+							),
+
+							// Verify HTTP config nested object exists
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config"),
+								knownvalue.NotNull(),
+							),
+
+							// Verify HTTP config fields (flat → nested transformation)
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("method"),
+								knownvalue.StringExact("GET"),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("port"),
+								knownvalue.Int64Exact(80),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("path"),
+								knownvalue.StringExact("/health"),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("expected_body"),
+								knownvalue.StringExact("OK"),
+							),
+
+							// Note: No need to verify flat fields are null at root -
+							// v5 schema doesn't have method/port/path at root level, they only exist in http_config
+
+							// Verify TCP config doesn't exist (HTTP type)
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("tcp_config"),
+								knownvalue.Null(),
+							),
+						},
+					},
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateHealthcheck_V4ToV5_HTTPHeaders tests header Set → Map transformation
+func TestMigrateHealthcheck_V4ToV5_HTTPHeaders(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID, name string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID, name string) string {
+				return fmt.Sprintf(v4HTTPHeadersConfig, rnd, zoneID, name)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID, name string) string {
+				return fmt.Sprintf(v5HTTPHeadersConfig, rnd, zoneID, name)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			name := "tf-test-" + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID, name)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			// Build Step 1
+			step1 := resource.TestStep{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: tc.version,
+					},
+				},
+				Config: testConfig,
+			}
+			// For from_v5 test case, v5 provider has computed field drift even on initial create
+			if tc.version == currentProviderVersion {
+				step1.ExpectNonEmptyPlan = true
+			}
+
+			resource.Test(t, resource.TestCase{
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					step1,
+					// Step 2: Run migration and verify state with custom plan check
+					// Note: Persistent drift is expected for tcp_config/http_config computed fields.
+					// Our custom plan check only allows the tcp_config/http_config drift as acceptable,
+					// failing on anything else.
+					{
+						PreConfig: func() {
+							acctest.WriteOutConfig(t, testConfig, tmpDir)
+							acctest.RunMigrationV2Command(t, testConfig, tmpDir, sourceVer, targetVer)
+						},
+						ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+						ConfigDirectory:          config.StaticDirectory(tmpDir),
+						ExpectNonEmptyPlan:       true, // Allow drift, validated by custom checks below
+						ConfigPlanChecks: resource.ConfigPlanChecks{
+							PreApply: []plancheck.PlanCheck{
+								acctest.DebugNonEmptyPlan,
+								// Only allow tcp_config/http_config drift, fail on other changes
+								ExpectEmptyPlanExceptHealthcheckConfigDrift,
+							},
+							PostApplyPostRefresh: []plancheck.PlanCheck{
+								acctest.DebugNonEmptyPlan,
+								// Only allow tcp_config/http_config drift, fail on other changes
+								ExpectEmptyPlanExceptHealthcheckConfigDrift,
+							},
+						},
+						ConfigStateChecks: []statecheck.StateCheck{
+							// Verify http_config.header exists as map
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("header"),
+								knownvalue.NotNull(),
+							),
+
+							// Verify header map contains transformed values
+							// v4: header { header = "Host" values = ["example.com"] }
+							// v5: header = { "Host" = ["example.com"] }
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("header").AtMapKey("Host"),
+								knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.StringExact("example.com"),
+								}),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("header").AtMapKey("User-Agent"),
+								knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.StringExact("Cloudflare-Healthcheck/1.0"),
+								}),
+							),
+
+							// Note: No need to verify flat header field is null at root -
+							// v5 schema doesn't have header at root level, it only exists in http_config
+						},
+					},
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateHealthcheck_V4ToV5_TCP tests TCP config transformation
+func TestMigrateHealthcheck_V4ToV5_TCP(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID, name string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID, name string) string {
+				return fmt.Sprintf(v4TCPConfig, rnd, zoneID, name)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID, name string) string {
+				return fmt.Sprintf(v5TCPConfig, rnd, zoneID, name)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			name := "tf-test-" + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID, name)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			// Build Step 1
+			step1 := resource.TestStep{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: tc.version,
+					},
+				},
+				Config: testConfig,
+			}
+			// For from_v5 test case, v5 provider has computed field drift even on initial create
+			if tc.version == currentProviderVersion {
+				step1.ExpectNonEmptyPlan = true
+			}
+
+			resource.Test(t, resource.TestCase{
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					step1,
+					// Step 2: Run migration and verify state with custom plan check
+					// Note: Persistent drift is expected for tcp_config/http_config computed fields.
+					// Our custom plan check only allows the tcp_config/http_config drift as acceptable,
+					// failing on anything else.
+					{
+						PreConfig: func() {
+							acctest.WriteOutConfig(t, testConfig, tmpDir)
+							acctest.RunMigrationV2Command(t, testConfig, tmpDir, sourceVer, targetVer)
+						},
+						ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+						ConfigDirectory:          config.StaticDirectory(tmpDir),
+						ExpectNonEmptyPlan:       true, // Allow drift, validated by custom checks below
+						ConfigPlanChecks: resource.ConfigPlanChecks{
+							PreApply: []plancheck.PlanCheck{
+								acctest.DebugNonEmptyPlan,
+								// Only allow tcp_config/http_config drift, fail on other changes
+								ExpectEmptyPlanExceptHealthcheckConfigDrift,
+							},
+							PostApplyPostRefresh: []plancheck.PlanCheck{
+								acctest.DebugNonEmptyPlan,
+								// Only allow tcp_config/http_config drift, fail on other changes
+								ExpectEmptyPlanExceptHealthcheckConfigDrift,
+							},
+						},
+						ConfigStateChecks: []statecheck.StateCheck{
+							// Verify type is TCP
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("type"),
+								knownvalue.StringExact("TCP"),
+							),
+
+							// Verify tcp_config nested object exists
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("tcp_config"),
+								knownvalue.NotNull(),
+							),
+
+							// Verify TCP config fields (flat → nested transformation)
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("tcp_config").AtMapKey("method"),
+								knownvalue.StringExact("connection_established"),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("tcp_config").AtMapKey("port"),
+								knownvalue.Int64Exact(443),
+							),
+
+							// Note: No need to verify flat fields are null at root -
+							// v5 schema doesn't have method/port at root level, they only exist in tcp_config
+
+							// Verify HTTP config doesn't exist (TCP type)
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config"),
+								knownvalue.Null(),
+							),
+						},
+					},
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateHealthcheck_V4ToV5_HTTPSFull tests full HTTPS healthcheck with all options
+func TestMigrateHealthcheck_V4ToV5_HTTPSFull(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID, name string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID, name string) string {
+				return fmt.Sprintf(v4HTTPSFullConfig, rnd, zoneID, name)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID, name string) string {
+				return fmt.Sprintf(v5HTTPSFullConfig, rnd, zoneID, name)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			name := "tf-test-" + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID, name)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							// Verify core fields
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("type"),
+								knownvalue.StringExact("HTTPS"),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("description"),
+								knownvalue.StringExact("Full HTTPS healthcheck"),
+							),
+
+							// Verify check_regions (List conversion)
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("check_regions"),
+								knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.StringExact("WNAM"),
+									knownvalue.StringExact("ENAM"),
+								}),
+							),
+
+							// Verify http_config with all HTTPS fields
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("method"),
+								knownvalue.StringExact("GET"),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("port"),
+								knownvalue.Int64Exact(443),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("path"),
+								knownvalue.StringExact("/api/health"),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("expected_body"),
+								knownvalue.StringExact("healthy"),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("follow_redirects"),
+								knownvalue.Bool(true),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("http_config").AtMapKey("allow_insecure"),
+								knownvalue.Bool(true),
+							),
+
+							// Verify config values
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("interval"),
+								knownvalue.Int64Exact(60),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("retries"),
+								knownvalue.Int64Exact(2),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("timeout"),
+								knownvalue.Int64Exact(10),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("consecutive_fails"),
+								knownvalue.Int64Exact(2),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("consecutive_successes"),
+								knownvalue.Int64Exact(2),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_healthcheck."+rnd,
+								tfjsonpath.New("suspended"),
+								knownvalue.Bool(false),
+							),
+						},
+					),
+				},
+			})
+		})
+	}
+}

--- a/internal/services/healthcheck/migration/v500/model.go
+++ b/internal/services/healthcheck/migration/v500/model.go
@@ -1,0 +1,111 @@
+package v500
+
+import (
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ============================================================================
+// Source Models (Legacy Provider - v4.x - SDKv2)
+// ============================================================================
+
+// SourceHealthcheckModel represents the legacy healthcheck state from v4.x provider.
+// Schema version: 0 (implicit in v4)
+// Resource type: cloudflare_healthcheck
+//
+// IMPORTANT: v4 has FLAT structure - all HTTP/TCP fields are at root level.
+// The v5 structure nests these into http_config or tcp_config based on type.
+type SourceHealthcheckModel struct {
+	// Core fields (stay at root in both v4 and v5)
+	ID                   types.String `tfsdk:"id"`
+	ZoneID               types.String `tfsdk:"zone_id"`
+	Name                 types.String `tfsdk:"name"`
+	Description          types.String `tfsdk:"description"`
+	Address              types.String `tfsdk:"address"`
+	Type                 types.String `tfsdk:"type"`
+	CheckRegions         types.List   `tfsdk:"check_regions"` // List of strings
+	Suspended            types.Bool   `tfsdk:"suspended"`
+	ConsecutiveFails     types.Int64  `tfsdk:"consecutive_fails"`
+	ConsecutiveSuccesses types.Int64  `tfsdk:"consecutive_successes"`
+	Interval             types.Int64  `tfsdk:"interval"`
+	Retries              types.Int64  `tfsdk:"retries"`
+	Timeout              types.Int64  `tfsdk:"timeout"`
+	CreatedOn            types.String `tfsdk:"created_on"`
+	ModifiedOn           types.String `tfsdk:"modified_on"`
+
+	// FLAT HTTP/TCP fields (at root in v4, will move to nested config in v5)
+	// These fields exist at root level in v4 and need to be moved into
+	// http_config or tcp_config based on the type field value.
+	Method          types.String `tfsdk:"method"`           // → http_config.method OR tcp_config.method
+	Port            types.Int64  `tfsdk:"port"`             // → http_config.port OR tcp_config.port
+	Path            types.String `tfsdk:"path"`             // → http_config.path (HTTP only)
+	ExpectedCodes   types.List   `tfsdk:"expected_codes"`   // → http_config.expected_codes (HTTP only)
+	ExpectedBody    types.String `tfsdk:"expected_body"`    // → http_config.expected_body (HTTP only)
+	FollowRedirects types.Bool   `tfsdk:"follow_redirects"` // → http_config.follow_redirects (HTTP only)
+	AllowInsecure   types.Bool   `tfsdk:"allow_insecure"`   // → http_config.allow_insecure (HTTP only)
+
+	// Header as Set (v4 format) - will convert to Map in v5
+	// v4: Set of objects with {header: string, values: []string}
+	// v5: Map[string][]string
+	Header types.Set `tfsdk:"header"` // → http_config.header (as Map)
+}
+
+// SourceHeaderModel represents a single header entry in the v4 Set structure.
+// v4 stores headers as a Set of objects with "header" and "values" fields.
+// v5 converts this to a Map[string][]string.
+type SourceHeaderModel struct {
+	Header types.String `tfsdk:"header"` // Header name (e.g., "Host")
+	Values types.Set    `tfsdk:"values"` // Set of string values
+}
+
+// ============================================================================
+// Target Models (Current Provider - v5.x+ - Framework)
+// ============================================================================
+
+// TargetHealthcheckModel represents the current healthcheck state from v5.x+ provider.
+// Schema version: 500
+// Resource type: cloudflare_healthcheck
+//
+// This matches the HealthcheckModel in internal/services/healthcheck/model.go
+type TargetHealthcheckModel struct {
+	ID                   types.String                                         `tfsdk:"id"`
+	ZoneID               types.String                                         `tfsdk:"zone_id"`
+	Address              types.String                                         `tfsdk:"address"`
+	Name                 types.String                                         `tfsdk:"name"`
+	Description          types.String                                         `tfsdk:"description"`
+	CheckRegions         *[]types.String                                      `tfsdk:"check_regions"`
+	ConsecutiveFails     types.Int64                                          `tfsdk:"consecutive_fails"`
+	ConsecutiveSuccesses types.Int64                                          `tfsdk:"consecutive_successes"`
+	Interval             types.Int64                                          `tfsdk:"interval"`
+	Retries              types.Int64                                          `tfsdk:"retries"`
+	Suspended            types.Bool                                           `tfsdk:"suspended"`
+	Timeout              types.Int64                                          `tfsdk:"timeout"`
+	Type                 types.String                                         `tfsdk:"type"`
+	HTTPConfig           customfield.NestedObject[TargetHTTPConfigModel]      `tfsdk:"http_config"`
+	TCPConfig            customfield.NestedObject[TargetTCPConfigModel]       `tfsdk:"tcp_config"`
+	CreatedOn            timetypes.RFC3339                                    `tfsdk:"created_on"`
+	FailureReason        types.String                                         `tfsdk:"failure_reason"`
+	ModifiedOn           timetypes.RFC3339                                    `tfsdk:"modified_on"`
+	Status               types.String                                         `tfsdk:"status"`
+}
+
+// TargetHTTPConfigModel represents the http_config nested object in v5.
+// This matches HealthcheckHTTPConfigModel in internal/services/healthcheck/model.go
+type TargetHTTPConfigModel struct {
+	AllowInsecure   types.Bool                  `tfsdk:"allow_insecure"`
+	ExpectedBody    types.String                `tfsdk:"expected_body"`
+	ExpectedCodes   *[]types.String             `tfsdk:"expected_codes"`
+	FollowRedirects types.Bool                  `tfsdk:"follow_redirects"`
+	Header          *map[string]*[]types.String `tfsdk:"header"` // Map format in v5
+	Method          types.String                `tfsdk:"method"`
+	Path            types.String                `tfsdk:"path"`
+	Port            types.Int64                 `tfsdk:"port"`
+}
+
+// TargetTCPConfigModel represents the tcp_config nested object in v5.
+// This matches HealthcheckTCPConfigModel in internal/services/healthcheck/model.go
+type TargetTCPConfigModel struct {
+	Method types.String `tfsdk:"method"`
+	Port   types.Int64  `tfsdk:"port"`
+}

--- a/internal/services/healthcheck/migration/v500/schema.go
+++ b/internal/services/healthcheck/migration/v500/schema.go
@@ -1,0 +1,123 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// SourceHealthcheckSchema returns the source schema for legacy healthcheck resource.
+// Schema version: 0 (implicit in v4 - no Version field specified)
+// Resource type: cloudflare_healthcheck
+//
+// IMPORTANT: This schema represents the v4 FLAT structure.
+// All HTTP/TCP-specific fields (method, port, path, etc.) are at the ROOT level in v4.
+// The v5 schema nests these into http_config or tcp_config objects.
+//
+// This minimal schema is used only for reading v4 state during migration.
+// It includes only the properties needed for state parsing (Required, Optional, Computed, ElementType).
+// Validators, PlanModifiers, and Descriptions are intentionally omitted.
+func SourceHealthcheckSchema() schema.Schema {
+	return schema.Schema{
+		Version: 0, // v4 schema has no explicit Version field (defaults to 0)
+		Attributes: map[string]schema.Attribute{
+			// Core identity fields
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"zone_id": schema.StringAttribute{
+				Required: true,
+			},
+
+			// Required fields
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"address": schema.StringAttribute{
+				Required: true,
+			},
+			"type": schema.StringAttribute{
+				Required: true,
+			},
+
+			// Optional configuration fields
+			"description": schema.StringAttribute{
+				Optional: true,
+			},
+			"check_regions": schema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Computed:    true,
+			},
+			"suspended": schema.BoolAttribute{
+				Optional: true,
+			},
+			"consecutive_fails": schema.Int64Attribute{
+				Optional: true,
+			},
+			"consecutive_successes": schema.Int64Attribute{
+				Optional: true,
+			},
+			"interval": schema.Int64Attribute{
+				Optional: true,
+			},
+			"retries": schema.Int64Attribute{
+				Optional: true,
+			},
+			"timeout": schema.Int64Attribute{
+				Optional: true,
+			},
+
+			// FLAT HTTP/TCP fields at ROOT level (v4 structure)
+			// These will move into http_config or tcp_config in v5
+			"method": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"port": schema.Int64Attribute{
+				Optional: true,
+			},
+			"path": schema.StringAttribute{
+				Optional: true,
+			},
+			"expected_codes": schema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"expected_body": schema.StringAttribute{
+				Optional: true,
+			},
+			"follow_redirects": schema.BoolAttribute{
+				Optional: true,
+			},
+			"allow_insecure": schema.BoolAttribute{
+				Optional: true,
+			},
+
+			// Header as Set of nested objects (v4 format)
+			// v4: Set of {header: string, values: []string}
+			// v5: Map[string][]string
+			"header": schema.SetNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"header": schema.StringAttribute{
+							Required: true,
+						},
+						"values": schema.SetAttribute{
+							ElementType: types.StringType,
+							Required:    true,
+						},
+					},
+				},
+			},
+
+			// Computed/output fields
+			"created_on": schema.StringAttribute{
+				Computed: true,
+			},
+			"modified_on": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}

--- a/internal/services/healthcheck/migration/v500/testdata/v4_http_basic.tf
+++ b/internal/services/healthcheck/migration/v500/testdata/v4_http_basic.tf
@@ -1,0 +1,24 @@
+resource "cloudflare_healthcheck" "%s" {
+  zone_id = "%s"
+  name    = "%s"
+  address = "example.com"
+  type    = "HTTP"
+
+  # Flat structure in v4 - all fields at root level
+  method          = "GET"
+  port            = 80
+  path            = "/health"
+  expected_codes  = ["200", "201"]
+  expected_body   = "OK"
+  follow_redirects = false
+  allow_insecure  = false
+
+  # Specify check_regions explicitly to avoid API default drift
+  check_regions = ["WNAM"]
+
+  interval             = 60
+  retries              = 2
+  timeout              = 5
+  consecutive_fails    = 1
+  consecutive_successes = 1
+}

--- a/internal/services/healthcheck/migration/v500/testdata/v4_http_headers.tf
+++ b/internal/services/healthcheck/migration/v500/testdata/v4_http_headers.tf
@@ -1,0 +1,25 @@
+resource "cloudflare_healthcheck" "%s" {
+  zone_id = "%s"
+  name    = "%s"
+  address = "example.com"
+  type    = "HTTP"
+
+  method = "GET"
+  port   = 80
+  path   = "/health"
+  expected_codes = ["200"]
+
+  # Specify check_regions explicitly to avoid API default drift
+  check_regions = ["WNAM"]
+
+  # v4 format: header blocks (Set of nested objects)
+  header {
+    header = "Host"
+    values = ["example.com"]
+  }
+
+  header {
+    header = "User-Agent"
+    values = ["Cloudflare-Healthcheck/1.0"]
+  }
+}

--- a/internal/services/healthcheck/migration/v500/testdata/v4_https_full.tf
+++ b/internal/services/healthcheck/migration/v500/testdata/v4_https_full.tf
@@ -1,0 +1,24 @@
+resource "cloudflare_healthcheck" "%s" {
+  zone_id     = "%s"
+  name        = "%s"
+  address     = "example.com"
+  type        = "HTTPS"
+  description = "Full HTTPS healthcheck"
+
+  # v4 flat structure - all HTTPS fields at root
+  method           = "GET"
+  port             = 443
+  path             = "/api/health"
+  expected_codes   = ["200", "201", "202"]
+  expected_body    = "healthy"
+  follow_redirects = true
+  allow_insecure   = true
+
+  check_regions         = ["WNAM", "ENAM"]
+  interval              = 60
+  retries               = 2
+  timeout               = 10
+  consecutive_fails     = 2
+  consecutive_successes = 2
+  suspended             = false
+}

--- a/internal/services/healthcheck/migration/v500/testdata/v4_tcp.tf
+++ b/internal/services/healthcheck/migration/v500/testdata/v4_tcp.tf
@@ -1,0 +1,19 @@
+resource "cloudflare_healthcheck" "%s" {
+  zone_id = "%s"
+  name    = "%s"
+  address = "example.com"
+  type    = "TCP"
+
+  # v4 flat structure - TCP fields at root level
+  method = "connection_established"
+  port   = 443
+
+  # Specify check_regions explicitly to avoid API default drift
+  check_regions = ["WNAM"]
+
+  interval             = 60
+  retries              = 2
+  timeout              = 5
+  consecutive_fails    = 1
+  consecutive_successes = 1
+}

--- a/internal/services/healthcheck/migration/v500/testdata/v5_http_basic.tf
+++ b/internal/services/healthcheck/migration/v500/testdata/v5_http_basic.tf
@@ -1,0 +1,26 @@
+resource "cloudflare_healthcheck" "%s" {
+  zone_id = "%s"
+  name    = "%s"
+  address = "example.com"
+  type    = "HTTP"
+
+  # Nested structure in v5 - HTTP fields in http_config
+  http_config = {
+    method           = "GET"
+    port             = 80
+    path             = "/health"
+    expected_codes   = ["200", "201"]
+    expected_body    = "OK"
+    follow_redirects = false
+    allow_insecure   = false
+  }
+
+  # Specify check_regions explicitly to avoid API default drift
+  check_regions = ["WNAM"]
+
+  interval              = 60
+  retries               = 2
+  timeout               = 5
+  consecutive_fails     = 1
+  consecutive_successes = 1
+}

--- a/internal/services/healthcheck/migration/v500/testdata/v5_http_headers.tf
+++ b/internal/services/healthcheck/migration/v500/testdata/v5_http_headers.tf
@@ -1,0 +1,23 @@
+resource "cloudflare_healthcheck" "%s" {
+  zone_id = "%s"
+  name    = "%s"
+  address = "example.com"
+  type    = "HTTP"
+
+  # Specify check_regions explicitly to avoid API default drift
+  check_regions = ["WNAM"]
+
+  # v5 format: nested http_config with header map
+  http_config = {
+    method         = "GET"
+    port           = 80
+    path           = "/health"
+    expected_codes = ["200"]
+
+    # v5 format: header as map
+    header = {
+      "Host"       = ["example.com"]
+      "User-Agent" = ["Cloudflare-Healthcheck/1.0"]
+    }
+  }
+}

--- a/internal/services/healthcheck/migration/v500/testdata/v5_https_full.tf
+++ b/internal/services/healthcheck/migration/v500/testdata/v5_https_full.tf
@@ -1,0 +1,26 @@
+resource "cloudflare_healthcheck" "%s" {
+  zone_id     = "%s"
+  name        = "%s"
+  address     = "example.com"
+  type        = "HTTPS"
+  description = "Full HTTPS healthcheck"
+
+  # v5 nested structure - HTTPS fields in http_config
+  http_config = {
+    method           = "GET"
+    port             = 443
+    path             = "/api/health"
+    expected_codes   = ["200", "201", "202"]
+    expected_body    = "healthy"
+    follow_redirects = true
+    allow_insecure   = true
+  }
+
+  check_regions         = ["WNAM", "ENAM"]
+  interval              = 60
+  retries               = 2
+  timeout               = 10
+  consecutive_fails     = 2
+  consecutive_successes = 2
+  suspended             = false
+}

--- a/internal/services/healthcheck/migration/v500/testdata/v5_tcp.tf
+++ b/internal/services/healthcheck/migration/v500/testdata/v5_tcp.tf
@@ -1,0 +1,21 @@
+resource "cloudflare_healthcheck" "%s" {
+  zone_id = "%s"
+  name    = "%s"
+  address = "example.com"
+  type    = "TCP"
+
+  # v5 nested structure - TCP fields in tcp_config
+  tcp_config = {
+    method = "connection_established"
+    port   = 443
+  }
+
+  # Specify check_regions explicitly to avoid API default drift
+  check_regions = ["WNAM"]
+
+  interval              = 60
+  retries               = 2
+  timeout               = 5
+  consecutive_fails     = 1
+  consecutive_successes = 1
+}

--- a/internal/services/healthcheck/migration/v500/transform.go
+++ b/internal/services/healthcheck/migration/v500/transform.go
@@ -1,0 +1,281 @@
+package v500
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Transform converts source (v4 flat structure) state to target (v5 nested structure) state.
+//
+// Major transformations:
+// - Flat HTTP/TCP fields → nested http_config or tcp_config based on type
+// - Header Set of objects → Map
+// - CheckRegions List → *[]types.String
+//
+// This function is called by UpgradeFromV4 handler.
+func Transform(ctx context.Context, source SourceHealthcheckModel) (*TargetHealthcheckModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Step 1: Validate required fields
+	if source.ZoneID.IsNull() || source.ZoneID.IsUnknown() {
+		diags.AddError(
+			"Missing required field",
+			"zone_id is required for healthcheck migration. The source state is missing this field, which indicates corrupted state.",
+		)
+		return nil, diags
+	}
+	if source.Name.IsNull() || source.Name.IsUnknown() {
+		diags.AddError(
+			"Missing required field",
+			"name is required for healthcheck migration. The source state is missing this field, which indicates corrupted state.",
+		)
+		return nil, diags
+	}
+	if source.Address.IsNull() || source.Address.IsUnknown() {
+		diags.AddError(
+			"Missing required field",
+			"address is required for healthcheck migration. The source state is missing this field, which indicates corrupted state.",
+		)
+		return nil, diags
+	}
+
+	// Step 2: Initialize target with direct copies
+	target := &TargetHealthcheckModel{
+		ID:                   source.ID,
+		ZoneID:               source.ZoneID,
+		Name:                 source.Name,
+		Description:          source.Description,
+		Address:              source.Address,
+		Type:                 source.Type,
+		Suspended:            source.Suspended,
+		ConsecutiveFails:     source.ConsecutiveFails,
+		ConsecutiveSuccesses: source.ConsecutiveSuccesses,
+		Interval:             source.Interval,
+		Retries:              source.Retries,
+		Timeout:              source.Timeout,
+	}
+
+	// Convert CheckRegions from List to *[]types.String
+	if !source.CheckRegions.IsNull() && !source.CheckRegions.IsUnknown() {
+		var regions []types.String
+		diags.Append(source.CheckRegions.ElementsAs(ctx, &regions, false)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		target.CheckRegions = &regions
+	}
+
+	// Convert timestamps (String → RFC3339)
+	// The framework handles the conversion automatically via the timetypes.RFC3339 type
+	if !source.CreatedOn.IsNull() && !source.CreatedOn.IsUnknown() {
+		createdOn, parseDiags := timetypes.NewRFC3339Value(source.CreatedOn.ValueString())
+		diags.Append(parseDiags...)
+		if !parseDiags.HasError() {
+			target.CreatedOn = createdOn
+		}
+	}
+	if !source.ModifiedOn.IsNull() && !source.ModifiedOn.IsUnknown() {
+		modifiedOn, parseDiags := timetypes.NewRFC3339Value(source.ModifiedOn.ValueString())
+		diags.Append(parseDiags...)
+		if !parseDiags.HasError() {
+			target.ModifiedOn = modifiedOn
+		}
+	}
+
+	// Step 3: Determine healthcheck type and create appropriate config
+	healthcheckType := "HTTP" // Default if not specified
+	if !source.Type.IsNull() && !source.Type.IsUnknown() {
+		healthcheckType = strings.ToUpper(source.Type.ValueString())
+	}
+
+	tflog.Debug(ctx, "Transforming healthcheck config", map[string]interface{}{
+		"type": healthcheckType,
+	})
+
+	// Branch based on type
+	if healthcheckType == "TCP" {
+		// Create TCP config
+		tcpConfig, tcpDiags := transformTCPConfig(ctx, source)
+		diags.Append(tcpDiags...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		target.TCPConfig = tcpConfig
+
+		tflog.Debug(ctx, "Created tcp_config", map[string]interface{}{
+			"has_method": !source.Method.IsNull(),
+			"has_port":   !source.Port.IsNull(),
+		})
+	} else {
+		// Create HTTP config (for HTTP and HTTPS types)
+		httpConfig, httpDiags := transformHTTPConfig(ctx, source)
+		diags.Append(httpDiags...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		target.HTTPConfig = httpConfig
+
+		tflog.Debug(ctx, "Created http_config", map[string]interface{}{
+			"has_method":   !source.Method.IsNull(),
+			"has_port":     !source.Port.IsNull(),
+			"has_path":     !source.Path.IsNull(),
+			"has_headers":  !source.Header.IsNull(),
+		})
+	}
+
+	return target, diags
+}
+
+// transformHTTPConfig creates http_config nested object from flat v4 fields.
+//
+// Moves these fields from root to http_config:
+// - method, port, path, expected_codes, expected_body
+// - follow_redirects, allow_insecure
+// - header (Set → Map transformation)
+func transformHTTPConfig(ctx context.Context, source SourceHealthcheckModel) (customfield.NestedObject[TargetHTTPConfigModel], diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Create HTTP config model with values from source
+	httpConfig := TargetHTTPConfigModel{
+		Method:          source.Method,
+		Port:            source.Port,
+		Path:            source.Path,
+		ExpectedBody:    source.ExpectedBody,
+		FollowRedirects: source.FollowRedirects,
+		AllowInsecure:   source.AllowInsecure,
+	}
+
+	// Convert ExpectedCodes List to *[]types.String
+	if !source.ExpectedCodes.IsNull() && !source.ExpectedCodes.IsUnknown() {
+		var codes []types.String
+		diags.Append(source.ExpectedCodes.ElementsAs(ctx, &codes, false)...)
+		if diags.HasError() {
+			return customfield.NullObject[TargetHTTPConfigModel](ctx), diags
+		}
+		httpConfig.ExpectedCodes = &codes
+	}
+
+	// Transform header Set → Map
+	headerMap, headerDiags := transformHeaderSetToMap(ctx, source.Header)
+	diags.Append(headerDiags...)
+	if diags.HasError() {
+		return customfield.NullObject[TargetHTTPConfigModel](ctx), diags
+	}
+	httpConfig.Header = headerMap
+
+	// Wrap in customfield.NestedObject
+	nestedObj, nestedDiags := customfield.NewObject(ctx, &httpConfig)
+	diags.Append(nestedDiags...)
+	if diags.HasError() {
+		return customfield.NullObject[TargetHTTPConfigModel](ctx), diags
+	}
+
+	return nestedObj, diags
+}
+
+// transformTCPConfig creates tcp_config nested object from flat v4 fields.
+//
+// Moves these fields from root to tcp_config:
+// - method, port
+func transformTCPConfig(ctx context.Context, source SourceHealthcheckModel) (customfield.NestedObject[TargetTCPConfigModel], diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Create TCP config model with values from source
+	tcpConfig := TargetTCPConfigModel{
+		Method: source.Method,
+		Port:   source.Port,
+	}
+
+	// Wrap in customfield.NestedObject
+	nestedObj, nestedDiags := customfield.NewObject(ctx, &tcpConfig)
+	diags.Append(nestedDiags...)
+	if diags.HasError() {
+		return customfield.NullObject[TargetTCPConfigModel](ctx), diags
+	}
+
+	return nestedObj, diags
+}
+
+// transformHeaderSetToMap converts v4 header Set structure to v5 Map structure.
+//
+// v4 format (Set of objects):
+//   [{header: "Host", values: ["example.com"]}, {header: "User-Agent", values: ["Bot"]}]
+//
+// v5 format (Map):
+//   {"Host": ["example.com"], "User-Agent": ["Bot"]}
+//
+// Returns nil if source header Set is null/empty.
+func transformHeaderSetToMap(ctx context.Context, headerSet types.Set) (*map[string]*[]types.String, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// If header Set is null or unknown, return nil
+	if headerSet.IsNull() || headerSet.IsUnknown() {
+		return nil, diags
+	}
+
+	// Extract header items from Set
+	var headerItems []SourceHeaderModel
+	diags.Append(headerSet.ElementsAs(ctx, &headerItems, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// If no headers, return nil
+	if len(headerItems) == 0 {
+		return nil, diags
+	}
+
+	// Convert to map
+	headerMap := make(map[string]*[]types.String)
+
+	for _, item := range headerItems {
+		// Skip if header name is missing
+		if item.Header.IsNull() || item.Header.IsUnknown() {
+			tflog.Warn(ctx, "Skipping header with missing name")
+			continue
+		}
+
+		headerName := item.Header.ValueString()
+
+		// Skip if values are missing
+		if item.Values.IsNull() || item.Values.IsUnknown() {
+			tflog.Warn(ctx, "Skipping header with missing values", map[string]interface{}{
+				"header": headerName,
+			})
+			continue
+		}
+
+		// Extract values from Set to []types.String
+		var values []types.String
+		valuesDiags := item.Values.ElementsAs(ctx, &values, false)
+		if valuesDiags.HasError() {
+			// Log warning but continue processing other headers
+			tflog.Warn(ctx, "Failed to extract values for header, skipping", map[string]interface{}{
+				"header": headerName,
+				"error":  valuesDiags.Errors()[0].Summary(),
+			})
+			continue
+		}
+
+		// Add to map
+		headerMap[headerName] = &values
+
+		tflog.Debug(ctx, "Transformed header", map[string]interface{}{
+			"name":        headerName,
+			"value_count": len(values),
+		})
+	}
+
+	// If we ended up with no valid headers, return nil
+	if len(headerMap) == 0 {
+		return nil, diags
+	}
+
+	return &headerMap, diags
+}

--- a/internal/services/healthcheck/migrations.go
+++ b/internal/services/healthcheck/migrations.go
@@ -5,19 +5,41 @@ package healthcheck
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/healthcheck/migration/v500"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 var _ resource.ResourceWithUpgradeState = (*HealthcheckResource)(nil)
 
+// UpgradeState registers state upgraders for schema version changes.
+//
+// This handles two upgrade paths:
+// 1. v4 state (schema_version=0) → v5 (version=500): Full transformation
+//    - Flat structure → Nested http_config/tcp_config based on type
+//    - Header Set → Map transformation
+// 2. v5 state (version=1) → v5 (version=500): No-op upgrade (when TF_MIG_TEST=1)
+//    - Just version bump, no transformation
+//
+// The separation of schema versions (v4=0, v5=1/500) eliminates the need for
+// dual-format detection that was required in earlier implementations.
 func (r *HealthcheckResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	sourceSchema := v500.SourceHealthcheckSchema()
 	targetSchema := ResourceSchema(ctx)
+
 	return map[int64]resource.StateUpgrader{
+		// Handle state from v4 SDKv2 provider (schema_version=0)
+		// Full transformation: flat fields → nested http_config/tcp_config
 		0: {
-			PriorSchema: &targetSchema,
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				resp.State.Raw = req.State.Raw
-			},
+			PriorSchema:   &sourceSchema,
+			StateUpgrader: v500.UpgradeFromV4,
+		},
+
+		// Handle state from v5 Plugin Framework provider with version=1
+		// This is a no-op upgrade that just bumps the version to 500
+		// Only triggered when TF_MIG_TEST=1 (GetSchemaVersion returns 500)
+		1: {
+			PriorSchema:   &targetSchema,
+			StateUpgrader: v500.UpgradeFromV5,
 		},
 	}
 }

--- a/internal/services/healthcheck/schema.go
+++ b/internal/services/healthcheck/schema.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -24,7 +25,7 @@ var _ resource.ResourceWithConfigValidators = (*HealthcheckResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
-		Version: 1,
+		Version: migrations.GetSchemaVersion(1, 500),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier",


### PR DESCRIPTION
```
=== RUN   TestMigrateHealthcheck_V4ToV5_HTTPBasic
=== RUN   TestMigrateHealthcheck_V4ToV5_HTTPBasic/from_v4_latest
=== RUN   TestMigrateHealthcheck_V4ToV5_HTTPBasic/from_v5
--- PASS: TestMigrateHealthcheck_V4ToV5_HTTPBasic (23.31s)
    --- PASS: TestMigrateHealthcheck_V4ToV5_HTTPBasic/from_v4_latest (12.82s)
    --- PASS: TestMigrateHealthcheck_V4ToV5_HTTPBasic/from_v5 (10.48s)
=== RUN   TestMigrateHealthcheck_V4ToV5_HTTPHeaders
=== RUN   TestMigrateHealthcheck_V4ToV5_HTTPHeaders/from_v4_latest
=== RUN   TestMigrateHealthcheck_V4ToV5_HTTPHeaders/from_v5
--- PASS: TestMigrateHealthcheck_V4ToV5_HTTPHeaders (23.10s)
    --- PASS: TestMigrateHealthcheck_V4ToV5_HTTPHeaders/from_v4_latest (11.58s)
    --- PASS: TestMigrateHealthcheck_V4ToV5_HTTPHeaders/from_v5 (11.52s)
=== RUN   TestMigrateHealthcheck_V4ToV5_TCP
=== RUN   TestMigrateHealthcheck_V4ToV5_TCP/from_v4_latest
=== RUN   TestMigrateHealthcheck_V4ToV5_TCP/from_v5
--- PASS: TestMigrateHealthcheck_V4ToV5_TCP (22.39s)
    --- PASS: TestMigrateHealthcheck_V4ToV5_TCP/from_v4_latest (11.49s)
    --- PASS: TestMigrateHealthcheck_V4ToV5_TCP/from_v5 (10.90s)
=== RUN   TestMigrateHealthcheck_V4ToV5_HTTPSFull
=== RUN   TestMigrateHealthcheck_V4ToV5_HTTPSFull/from_v4_latest
=== RUN   TestMigrateHealthcheck_V4ToV5_HTTPSFull/from_v5
--- PASS: TestMigrateHealthcheck_V4ToV5_HTTPSFull (21.85s)
    --- PASS: TestMigrateHealthcheck_V4ToV5_HTTPSFull/from_v4_latest (11.64s)
    --- PASS: TestMigrateHealthcheck_V4ToV5_HTTPSFull/from_v5 (10.21s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/healthcheck/migration/v500        92.103s
```