### PR TITLE
fix: authenticated_origin_pulls_certificate and authenticated_origin_…

### DIFF
--- a/internal/services/authenticated_origin_pulls_certificate/data_source_model.go
+++ b/internal/services/authenticated_origin_pulls_certificate/data_source_model.go
@@ -21,10 +21,9 @@ type AuthenticatedOriginPullsCertificateDataSourceModel struct {
 	CertificateID types.String      `tfsdk:"certificate_id" path:"certificate_id,required"`
 	ZoneID        types.String      `tfsdk:"zone_id" path:"zone_id,required"`
 	Certificate   types.String      `tfsdk:"certificate" json:"certificate,computed"`
-	Enabled       types.Bool        `tfsdk:"enabled" json:"enabled,computed"`
 	ExpiresOn     timetypes.RFC3339 `tfsdk:"expires_on" json:"expires_on,computed" format:"date-time"`
 	Issuer        types.String      `tfsdk:"issuer" json:"issuer,computed"`
-	PrivateKey    types.String      `tfsdk:"private_key" json:"private_key,computed"`
+	SerialNumber  types.String      `tfsdk:"serial_number" json:"serial_number,computed"`
 	Signature     types.String      `tfsdk:"signature" json:"signature,computed"`
 	Status        types.String      `tfsdk:"status" json:"status,computed"`
 	UploadedOn    timetypes.RFC3339 `tfsdk:"uploaded_on" json:"uploaded_on,computed" format:"date-time"`

--- a/internal/services/authenticated_origin_pulls_certificate/data_source_schema.go
+++ b/internal/services/authenticated_origin_pulls_certificate/data_source_schema.go
@@ -33,10 +33,6 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				Description: "The zone's leaf certificate.",
 				Computed:    true,
 			},
-			"enabled": schema.BoolAttribute{
-				Description: "Indicates whether zone-level authenticated origin pulls is enabled.",
-				Computed:    true,
-			},
 			"expires_on": schema.StringAttribute{
 				Description: "When the certificate from the authority expires.",
 				Computed:    true,
@@ -46,10 +42,9 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				Description: "The certificate authority that issued the certificate.",
 				Computed:    true,
 			},
-			"private_key": schema.StringAttribute{
-				Description: "The zone's private key.",
+			"serial_number": schema.StringAttribute{
+				Description: "The serial number on the uploaded certificate.",
 				Computed:    true,
-				Sensitive:   true,
 			},
 			"signature": schema.StringAttribute{
 				Description: "The type of hash used for the certificate.",

--- a/internal/services/authenticated_origin_pulls_certificate/list_data_source_model.go
+++ b/internal/services/authenticated_origin_pulls_certificate/list_data_source_model.go
@@ -32,13 +32,12 @@ func (m *AuthenticatedOriginPullsCertificatesDataSourceModel) toListParams(_ con
 }
 
 type AuthenticatedOriginPullsCertificatesResultDataSourceModel struct {
-	ID          types.String      `tfsdk:"id" json:"id,computed"`
-	Certificate types.String      `tfsdk:"certificate" json:"certificate,computed"`
-	ExpiresOn   timetypes.RFC3339 `tfsdk:"expires_on" json:"expires_on,computed" format:"date-time"`
-	Issuer      types.String      `tfsdk:"issuer" json:"issuer,computed"`
-	Signature   types.String      `tfsdk:"signature" json:"signature,computed"`
-	Status      types.String      `tfsdk:"status" json:"status,computed"`
-	UploadedOn  timetypes.RFC3339 `tfsdk:"uploaded_on" json:"uploaded_on,computed" format:"date-time"`
-	Enabled     types.Bool        `tfsdk:"enabled" json:"enabled,computed"`
-	PrivateKey  types.String      `tfsdk:"private_key" json:"private_key,computed"`
+	ID           types.String      `tfsdk:"id" json:"id,computed"`
+	Certificate  types.String      `tfsdk:"certificate" json:"certificate,computed"`
+	ExpiresOn    timetypes.RFC3339 `tfsdk:"expires_on" json:"expires_on,computed" format:"date-time"`
+	Issuer       types.String      `tfsdk:"issuer" json:"issuer,computed"`
+	SerialNumber types.String      `tfsdk:"serial_number" json:"serial_number,computed"`
+	Signature    types.String      `tfsdk:"signature" json:"signature,computed"`
+	Status       types.String      `tfsdk:"status" json:"status,computed"`
+	UploadedOn   timetypes.RFC3339 `tfsdk:"uploaded_on" json:"uploaded_on,computed" format:"date-time"`
 }

--- a/internal/services/authenticated_origin_pulls_certificate/list_data_source_schema.go
+++ b/internal/services/authenticated_origin_pulls_certificate/list_data_source_schema.go
@@ -53,6 +53,10 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 							Description: "The certificate authority that issued the certificate.",
 							Computed:    true,
 						},
+						"serial_number": schema.StringAttribute{
+							Description: "The serial number on the uploaded certificate.",
+							Computed:    true,
+						},
 						"signature": schema.StringAttribute{
 							Description: "The type of hash used for the certificate.",
 							Computed:    true,
@@ -76,15 +80,6 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 							Description: "This is the time the certificate was uploaded.",
 							Computed:    true,
 							CustomType:  timetypes.RFC3339Type{},
-						},
-						"enabled": schema.BoolAttribute{
-							Description: "Indicates whether zone-level authenticated origin pulls is enabled.",
-							Computed:    true,
-						},
-						"private_key": schema.StringAttribute{
-							Description: "The zone's private key.",
-							Computed:    true,
-							Sensitive:   true,
 						},
 					},
 				},

--- a/internal/services/authenticated_origin_pulls_certificate/model.go
+++ b/internal/services/authenticated_origin_pulls_certificate/model.go
@@ -21,6 +21,7 @@ type AuthenticatedOriginPullsCertificateModel struct {
 	ExpiresOn     timetypes.RFC3339 `tfsdk:"expires_on" json:"expires_on,computed" format:"date-time"`
 	ID            types.String      `tfsdk:"id" json:"id,computed"`
 	Issuer        types.String      `tfsdk:"issuer" json:"issuer,computed"`
+	SerialNumber  types.String      `tfsdk:"serial_number" json:"serial_number,computed"`
 	Signature     types.String      `tfsdk:"signature" json:"signature,computed"`
 	Status        types.String      `tfsdk:"status" json:"status,computed"`
 	UploadedOn    timetypes.RFC3339 `tfsdk:"uploaded_on" json:"uploaded_on,computed" format:"date-time"`

--- a/internal/services/authenticated_origin_pulls_certificate/resource_test.go
+++ b/internal/services/authenticated_origin_pulls_certificate/resource_test.go
@@ -154,6 +154,7 @@ func TestAccAuthenticatedOriginPullsCertificate_FullLifecycle(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("expires_on"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("uploaded_on"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("signature"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("serial_number"), knownvalue.NotNull()),
 				},
 			},
 			// Step 2: Import

--- a/internal/services/authenticated_origin_pulls_certificate/schema.go
+++ b/internal/services/authenticated_origin_pulls_certificate/schema.go
@@ -59,6 +59,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description: "The certificate authority that issued the certificate.",
 				Computed:    true,
 			},
+			"serial_number": schema.StringAttribute{
+				Description: "The serial number on the uploaded certificate.",
+				Computed:    true,
+			},
 			"signature": schema.StringAttribute{
 				Description: "The type of hash used for the certificate.",
 				Computed:    true,

--- a/internal/services/authenticated_origin_pulls_hostname_certificate/list_data_source_model.go
+++ b/internal/services/authenticated_origin_pulls_hostname_certificate/list_data_source_model.go
@@ -32,20 +32,12 @@ func (m *AuthenticatedOriginPullsHostnameCertificatesDataSourceModel) toListPara
 }
 
 type AuthenticatedOriginPullsHostnameCertificatesResultDataSourceModel struct {
-	CERTID         types.String      `tfsdk:"cert_id" json:"cert_id,computed"`
-	CERTStatus     types.String      `tfsdk:"cert_status" json:"cert_status,computed"`
-	CERTUpdatedAt  timetypes.RFC3339 `tfsdk:"cert_updated_at" json:"cert_updated_at,computed" format:"date-time"`
-	CERTUploadedOn timetypes.RFC3339 `tfsdk:"cert_uploaded_on" json:"cert_uploaded_on,computed" format:"date-time"`
-	Certificate    types.String      `tfsdk:"certificate" json:"certificate,computed"`
-	CreatedAt      timetypes.RFC3339 `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
-	Enabled        types.Bool        `tfsdk:"enabled" json:"enabled,computed"`
-	ExpiresOn      timetypes.RFC3339 `tfsdk:"expires_on" json:"expires_on,computed" format:"date-time"`
-	Hostname       types.String      `tfsdk:"hostname" json:"hostname,computed"`
-	Issuer         types.String      `tfsdk:"issuer" json:"issuer,computed"`
-	SerialNumber   types.String      `tfsdk:"serial_number" json:"serial_number,computed"`
-	Signature      types.String      `tfsdk:"signature" json:"signature,computed"`
-	Status         types.String      `tfsdk:"status" json:"status,computed"`
-	UpdatedAt      timetypes.RFC3339 `tfsdk:"updated_at" json:"updated_at,computed" format:"date-time"`
-	ID             types.String      `tfsdk:"id" json:"id,computed"`
-	PrivateKey     types.String      `tfsdk:"private_key" json:"private_key,computed"`
+	ID           types.String      `tfsdk:"id" json:"id,computed"`
+	Certificate  types.String      `tfsdk:"certificate" json:"certificate,computed"`
+	ExpiresOn    timetypes.RFC3339 `tfsdk:"expires_on" json:"expires_on,computed" format:"date-time"`
+	Issuer       types.String      `tfsdk:"issuer" json:"issuer,computed"`
+	SerialNumber types.String      `tfsdk:"serial_number" json:"serial_number,computed"`
+	Signature    types.String      `tfsdk:"signature" json:"signature,computed"`
+	Status       types.String      `tfsdk:"status" json:"status,computed"`
+	UploadedOn   timetypes.RFC3339 `tfsdk:"uploaded_on" json:"uploaded_on,computed" format:"date-time"`
 }

--- a/internal/services/authenticated_origin_pulls_hostname_certificate/list_data_source_schema.go
+++ b/internal/services/authenticated_origin_pulls_hostname_certificate/list_data_source_schema.go
@@ -36,56 +36,18 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 				CustomType:  customfield.NewNestedObjectListType[AuthenticatedOriginPullsHostnameCertificatesResultDataSourceModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"cert_id": schema.StringAttribute{
+						"id": schema.StringAttribute{
 							Description: "Identifier.",
 							Computed:    true,
 						},
-						"cert_status": schema.StringAttribute{
-							Description: "Status of the certificate or the association.\nAvailable values: \"initializing\", \"pending_deployment\", \"pending_deletion\", \"active\", \"deleted\", \"deployment_timed_out\", \"deletion_timed_out\".",
-							Computed:    true,
-							Validators: []validator.String{
-								stringvalidator.OneOfCaseInsensitive(
-									"initializing",
-									"pending_deployment",
-									"pending_deletion",
-									"active",
-									"deleted",
-									"deployment_timed_out",
-									"deletion_timed_out",
-								),
-							},
-						},
-						"cert_updated_at": schema.StringAttribute{
-							Description: "The time when the certificate was updated.",
-							Computed:    true,
-							CustomType:  timetypes.RFC3339Type{},
-						},
-						"cert_uploaded_on": schema.StringAttribute{
-							Description: "The time when the certificate was uploaded.",
-							Computed:    true,
-							CustomType:  timetypes.RFC3339Type{},
-						},
 						"certificate": schema.StringAttribute{
 							Description: "The hostname certificate.",
-							Computed:    true,
-						},
-						"created_at": schema.StringAttribute{
-							Description: "The time when the certificate was created.",
-							Computed:    true,
-							CustomType:  timetypes.RFC3339Type{},
-						},
-						"enabled": schema.BoolAttribute{
-							Description: "Indicates whether hostname-level authenticated origin pulls is enabled. A null value voids the association.",
 							Computed:    true,
 						},
 						"expires_on": schema.StringAttribute{
 							Description: "The date when the certificate expires.",
 							Computed:    true,
 							CustomType:  timetypes.RFC3339Type{},
-						},
-						"hostname": schema.StringAttribute{
-							Description: "The hostname on the origin for which the client certificate uploaded will be used.",
-							Computed:    true,
 						},
 						"issuer": schema.StringAttribute{
 							Description: "The certificate authority that issued the certificate.",
@@ -114,19 +76,10 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 								),
 							},
 						},
-						"updated_at": schema.StringAttribute{
-							Description: "The time when the certificate was updated.",
+						"uploaded_on": schema.StringAttribute{
+							Description: "The time when the certificate was uploaded.",
 							Computed:    true,
 							CustomType:  timetypes.RFC3339Type{},
-						},
-						"id": schema.StringAttribute{
-							Description: "Identifier.",
-							Computed:    true,
-						},
-						"private_key": schema.StringAttribute{
-							Description: "The hostname certificate's private key.",
-							Computed:    true,
-							Sensitive:   true,
 						},
 					},
 				},

--- a/internal/services/authenticated_origin_pulls_hostname_certificate/resource_test.go
+++ b/internal/services/authenticated_origin_pulls_hostname_certificate/resource_test.go
@@ -137,6 +137,7 @@ func TestAccAuthenticatedOriginPullsHostnameCertificate_FullLifecycle(t *testing
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("uploaded_on"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("serial_number"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("signature"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("serial_number"), knownvalue.NotNull()),
 				},
 			},
 			// Step 2: Import


### PR DESCRIPTION
…pulls_hostname_certificate model and schema

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
1. Add missing Serial Number to get response for Zone and Hostname AOP cert
2. Remove Enabled and Private Key from get response for Zone AOP cert
3. Fix get response for Hostname AOP cert

## Acceptance test run results

- [X] I have added or updated acceptance tests for my changes
- [X] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
**Zone AOP**
TF_LOG=DEBUG go test ./internal/services/authenticated_origin_pulls_certificate -v -run TestAuthenticatedOriginPullsCertificateDataSourceModelSchemaParity

TF_LOG=DEBUG TF_ACC=1 go test ./internal/services/authenticated_origin_pulls_certificate -v -run TestAccAuthenticatedOriginPullsCertificate_FullLifecycle

**Hostname AOP**
TF_LOG=DEBUG go test ./internal/services/authenticated_origin_pulls_hostname_certificate -v -run TestAuthenticatedOriginPullsHostnameCertificateDataSourceModelSchemaParity

TF_LOG=DEBUG TF_ACC=1 go test ./internal/services/authenticated_origin_pulls_hostname_certificate -v -run TestAccAuthenticatedOriginPullsHostnameCertificate_FullLifecycle

### Test output
<!-- Please paste the output of your acceptance test run below --> 
**Zone AOP**
TF_LOG=DEBUG go test ./internal/services/authenticated_origin_pulls_certificate -v -run TestAuthenticatedOriginPullsCertificateDataSourceModelSchemaParity
=== RUN   TestAuthenticatedOriginPullsCertificateDataSourceModelSchemaParity
=== PAUSE TestAuthenticatedOriginPullsCertificateDataSourceModelSchemaParity
=== CONT  TestAuthenticatedOriginPullsCertificateDataSourceModelSchemaParity
--- PASS: TestAuthenticatedOriginPullsCertificateDataSourceModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/authenticated_origin_pulls_certificate	1.608s


TF_LOG=DEBUG TF_ACC=1 go test ./internal/services/authenticated_origin_pulls_certificate -v -run TestAccAuthenticatedOriginPullsCertificate_FullLifecycle
=== RUN   TestAccAuthenticatedOriginPullsCertificate_FullLifecycle
--- PASS: TestAccAuthenticatedOriginPullsCertificate_FullLifecycle (5.72s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/authenticated_origin_pulls_certificate	7.325s

**Hostname AOP**
TF_LOG=DEBUG go test ./internal/services/authenticated_origin_pulls_hostname_certificate -v -run TestAuthenticatedOriginPullsHostnameCertificateDataSourceModelSchemaParity
=== RUN   TestAuthenticatedOriginPullsHostnameCertificateDataSourceModelSchemaParity
=== PAUSE TestAuthenticatedOriginPullsHostnameCertificateDataSourceModelSchemaParity
=== CONT  TestAuthenticatedOriginPullsHostnameCertificateDataSourceModelSchemaParity
--- PASS: TestAuthenticatedOriginPullsHostnameCertificateDataSourceModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/authenticated_origin_pulls_hostname_certificate	1.665s

TF_LOG=DEBUG TF_ACC=1 go test ./internal/services/authenticated_origin_pulls_hostname_certificate -v -run TestAccAuthenticatedOriginPullsHostnameCertificate_FullLifecycle
=== RUN   TestAccAuthenticatedOriginPullsHostnameCertificate_FullLifecycle
--- PASS: TestAccAuthenticatedOriginPullsHostnameCertificate_FullLifecycle (9.58s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/authenticated_origin_pulls_hostname_certificate	11.137s

## Additional context & links
**Zone AOP Cert Get List**
curl --request GET \
  --url "https://api.cloudflare.com/client/v4/zones/$P_ZONE/origin_tls_client_auth" \
  --header 'Content-Type: application/json' \
  --header 'Cache-Control: no-cache' \
  --header "Authorization: Bearer $P_AOT" | jq
{
  "success": true,
  "errors": [],
  "messages": [],
  "result": [
    {
      "id": "uuid here,
      "status": "active",
      "issuer": "...",
      "signature": "SHA256-RSA",
      "serial_number": "...l",
      "certificate": "...",
      "uploaded_on": "2024-10-16T03:36:59.864715Z",
      "expires_on": "2034-10-13T22:33:09Z"
    }..]...}

**Zone AOP Cert Get**
curl --request GET \
  --url "https://api.cloudflare.com/client/v4/zones/$P_ZONE/origin_tls_client_auth/dcf2537e-4d8b-4cbb-9f66-8c0704ed5073" \
  --header 'Content-Type: application/json' \
  --header 'Cache-Control: no-cache' \
  --header "Authorization: Bearer $P_AOT" | jq
{
  "success": true,
  "errors": [],
  "messages": [],
  "result": {
    "id": "dcf2537e-4d8b-4cbb-9f66-8c0704ed5073",
    "status": "active",
    "issuer": "....",
    "signature": "SHA256-RSA",
    "serial_number": "....",
    "certificate": "...",
    "uploaded_on": "2026-02-12T20:15:08.811785Z",
    "expires_on": "2027-02-12T20:08:40Z"
  }
}

**Hostname AOP Cert Get List**
 --request GET \
  --url "https://api.cloudflare.com/client/v4/zones/$P_ZONE/origin_tls_client_auth/hostnames/certificates" \
  --header 'Content-Type: application/json' \
  --header 'Cache-Control: no-cache' \
  --header "Authorization: Bearer $P_AOT" | jq
{
  "success": true,
  "errors": [],
  "messages": [],
  "result": [
    {
      "id": "8a9b449e-ac59-4e5f-becd-7abacd932c70",
      "status": "active",
      "issuer": "CN=fed.ltz.life,O=Internet Widgits Pty Ltd,L=San Francisco,ST=California,C=US",
      "signature": "SHA256-RSA",
      "serial_number": "534133105815536154000508520383906056536607471646",
      "certificate": "...",
      "uploaded_on": "2025-04-28T20:15:49.771971Z",
      "expires_on": "2027-04-28T20:12:46Z"
    },..].."

**Hostname AOP Cert Get**
curl --request GET \
  --url "https://api.cloudflare.com/client/v4/zones/$P_ZONE/origin_tls_client_auth/hostnames/certificates/c41cd5e6-e76c-44a0-9178-5d9c800a978b" \
  --header 'Content-Type: application/json' \
  --header 'Cache-Control: no-cache' \
  --header "Authorization: Bearer $P_AOT" | jq
{
  "success": true,
  "errors": [],
  "messages": [],
  "result": {
    "id": "c41cd5e6-e76c-44a0-9178-5d9c800a978b",
    "status": "active",
    "issuer": "...",
    "signature": "SHA256-RSA",
    "serial_number": "...",
    "certificate": "...",
    "uploaded_on": "2025-06-09T20:09:35.43196Z",
    "expires_on": "2027-04-28T20:45:06Z"
  }
}
