### PR TITLE
chore(zone_setting): support v4 to v5 state upgraders

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -912,10 +912,12 @@ func WriteOutConfig(t *testing.T, v4Config string, tmpDir string) {
 
 }
 
-// dropTerraformState finds and removes terraform.tfstate from tmpDir or any immediate
+// removeResourceTypeFromTerraformState finds terraform.tfstate in tmpDir or any immediate
 // subdirectory (the test framework creates a "work<random>" subdir inside tmpDir as the
-// actual Terraform working directory when TestCase.WorkingDir is set).
-func dropTerraformState(t *testing.T, tmpDir string) {
+// actual Terraform working directory when TestCase.WorkingDir is set), then removes all
+// resources of the given type from the state JSON and writes it back. This is more surgical
+// than deleting the entire state file: other resource entries are preserved.
+func removeResourceTypeFromTerraformState(t *testing.T, tmpDir string, resourceType string) {
 	t.Helper()
 
 	// Try the direct path first.
@@ -931,17 +933,44 @@ func dropTerraformState(t *testing.T, tmpDir string) {
 		}
 	}
 
-	removed := false
 	for _, candidate := range candidates {
-		if err := os.Remove(candidate); err == nil {
-			debugLogf(t, "Dropped Terraform state file: %s", candidate)
-			removed = true
+		data, err := os.ReadFile(candidate)
+		if err != nil {
+			continue
 		}
+
+		var state map[string]interface{}
+		if err := json.Unmarshal(data, &state); err != nil {
+			t.Fatalf("removeResourceTypeFromTerraformState: failed to parse %s: %v", candidate, err)
+		}
+
+		resources, ok := state["resources"].([]interface{})
+		if !ok {
+			continue
+		}
+
+		filtered := resources[:0]
+		for _, res := range resources {
+			entry, ok := res.(map[string]interface{})
+			if !ok || entry["type"] == resourceType {
+				continue
+			}
+			filtered = append(filtered, res)
+		}
+		state["resources"] = filtered
+
+		out, err := json.MarshalIndent(state, "", "  ")
+		if err != nil {
+			t.Fatalf("removeResourceTypeFromTerraformState: failed to marshal %s: %v", candidate, err)
+		}
+		if err := os.WriteFile(candidate, out, 0644); err != nil {
+			t.Fatalf("removeResourceTypeFromTerraformState: failed to write %s: %v", candidate, err)
+		}
+		debugLogf(t, "Removed %q entries from Terraform state: %s", resourceType, candidate)
+		return
 	}
 
-	if !removed {
-		debugLogf(t, "No terraform.tfstate found to drop in %s", tmpDir)
-	}
+	debugLogf(t, "No terraform.tfstate found in %s", tmpDir)
 }
 
 // RunMigrationV2Command runs the new tf-migrate binary to transform config and state
@@ -1324,24 +1353,24 @@ func MigrationV2TestStepAllowCreate(t *testing.T, v4Config string, tmpDir string
 	}
 }
 
-// MigrationV2TestStepAllowCreateDropState is like MigrationV2TestStepAllowCreate but also
-// removes the prior state file after running migration. Use this when the v4 resource type
-// is completely absent from the v5 provider (e.g. cloudflare_zone_settings_override), so
-// Terraform cannot load the old state at all. Dropping the state lets Terraform create the
-// new v5 resources fresh without hitting a "no schema available" error.
-func MigrationV2TestStepAllowCreateDropState(t *testing.T, v4Config string, tmpDir string, exactVersion string, sourceVersion string, targetVersion string, stateChecks []statecheck.StateCheck) []resource.TestStep {
+// MigrationV2TestStepAllowCreateRemoveType is like MigrationV2TestStepAllowCreate but also
+// removes all state entries for the given v4 resource type after running migration. Use this
+// when the v4 resource type is completely absent from the v5 provider schema
+// (e.g. cloudflare_zone_settings_override), so Terraform cannot load its state entries.
+// Removing those entries lets Terraform create the new v5 resources fresh without hitting
+// a "no schema available" error, while preserving any other resources in state.
+func MigrationV2TestStepAllowCreateRemoveType(t *testing.T, v4Config string, tmpDir string, exactVersion string, sourceVersion string, targetVersion string, v4ResourceType string, stateChecks []statecheck.StateCheck) []resource.TestStep {
 	return []resource.TestStep{
 		{
-			// Step 1: Run migration, drop prior state, apply any creates
+			// Step 1: Run migration, remove v4 resource type from state, apply any creates
 			PreConfig: func() {
 				WriteOutConfig(t, v4Config, tmpDir)
 				debugLogf(t, "Running migration command for version: %s (%s -> %s)", exactVersion, sourceVersion, targetVersion)
 				RunMigrationV2Command(t, v4Config, tmpDir, sourceVersion, targetVersion)
-				// The v4 resource type is gone from v5; remove its state entry so Terraform
-				// does not fail with "no schema available" when loading the working directory.
-				// The framework creates a "work<random>" subdirectory inside tmpDir as the
-				// actual Terraform working directory, so we must search subdirectories too.
-				dropTerraformState(t, tmpDir)
+				// The v4 resource type is gone from v5; remove its entries from state so
+				// Terraform does not fail with "no schema available" when loading the
+				// working directory. Other resource entries in state are preserved.
+				removeResourceTypeFromTerraformState(t, tmpDir, v4ResourceType)
 			},
 			ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 			ConfigDirectory:          config.StaticDirectory(tmpDir),

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -912,6 +912,38 @@ func WriteOutConfig(t *testing.T, v4Config string, tmpDir string) {
 
 }
 
+// dropTerraformState finds and removes terraform.tfstate from tmpDir or any immediate
+// subdirectory (the test framework creates a "work<random>" subdir inside tmpDir as the
+// actual Terraform working directory when TestCase.WorkingDir is set).
+func dropTerraformState(t *testing.T, tmpDir string) {
+	t.Helper()
+
+	// Try the direct path first.
+	candidates := []string{filepath.Join(tmpDir, "terraform.tfstate")}
+
+	// Also scan one level of subdirectories (framework-managed work dirs).
+	entries, err := os.ReadDir(tmpDir)
+	if err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				candidates = append(candidates, filepath.Join(tmpDir, entry.Name(), "terraform.tfstate"))
+			}
+		}
+	}
+
+	removed := false
+	for _, candidate := range candidates {
+		if err := os.Remove(candidate); err == nil {
+			debugLogf(t, "Dropped Terraform state file: %s", candidate)
+			removed = true
+		}
+	}
+
+	if !removed {
+		debugLogf(t, "No terraform.tfstate found to drop in %s", tmpDir)
+	}
+}
+
 // RunMigrationV2Command runs the new tf-migrate binary to transform config and state
 // NOTE: assumes config and state are already in tmpDir
 func RunMigrationV2Command(t *testing.T, v4Config string, tmpDir string, sourceVersion string, targetVersion string) {
@@ -950,6 +982,8 @@ func RunMigrationV2Command(t *testing.T, v4Config string, tmpDir string, sourceV
 	// Run the migration command
 	cmd := exec.Command(migratorPath, args...)
 	cmd.Dir = tmpDir
+	// Explicitly pass environment variables, including TF_MIG_TEST
+	cmd.Env = os.Environ()
 
 	// Capture output for debugging
 	output, err := cmd.CombinedOutput()
@@ -1271,6 +1305,43 @@ func MigrationV2TestStepAllowCreate(t *testing.T, v4Config string, tmpDir string
 				WriteOutConfig(t, v4Config, tmpDir)
 				debugLogf(t, "Running migration command for version: %s (%s -> %s)", exactVersion, sourceVersion, targetVersion)
 				RunMigrationV2Command(t, v4Config, tmpDir, sourceVersion, targetVersion)
+			},
+			ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+			ConfigDirectory:          config.StaticDirectory(tmpDir),
+		},
+		{
+			// Step 2: Verify final state and expect empty plan
+			ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+			ConfigDirectory:          config.StaticDirectory(tmpDir),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					DebugNonEmptyPlan,
+					ExpectEmptyPlanExceptFalseyToNull,
+				},
+			},
+			ConfigStateChecks: stateChecks,
+		},
+	}
+}
+
+// MigrationV2TestStepAllowCreateDropState is like MigrationV2TestStepAllowCreate but also
+// removes the prior state file after running migration. Use this when the v4 resource type
+// is completely absent from the v5 provider (e.g. cloudflare_zone_settings_override), so
+// Terraform cannot load the old state at all. Dropping the state lets Terraform create the
+// new v5 resources fresh without hitting a "no schema available" error.
+func MigrationV2TestStepAllowCreateDropState(t *testing.T, v4Config string, tmpDir string, exactVersion string, sourceVersion string, targetVersion string, stateChecks []statecheck.StateCheck) []resource.TestStep {
+	return []resource.TestStep{
+		{
+			// Step 1: Run migration, drop prior state, apply any creates
+			PreConfig: func() {
+				WriteOutConfig(t, v4Config, tmpDir)
+				debugLogf(t, "Running migration command for version: %s (%s -> %s)", exactVersion, sourceVersion, targetVersion)
+				RunMigrationV2Command(t, v4Config, tmpDir, sourceVersion, targetVersion)
+				// The v4 resource type is gone from v5; remove its state entry so Terraform
+				// does not fail with "no schema available" when loading the working directory.
+				// The framework creates a "work<random>" subdirectory inside tmpDir as the
+				// actual Terraform working directory, so we must search subdirectories too.
+				dropTerraformState(t, tmpDir)
 			},
 			ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 			ConfigDirectory:          config.StaticDirectory(tmpDir),

--- a/internal/services/zone_setting/migration/v500/migrations_test.go
+++ b/internal/services/zone_setting/migration/v500/migrations_test.go
@@ -1,4 +1,4 @@
-package zone_setting_test
+package v500_test
 
 import (
 	"fmt"
@@ -11,8 +11,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+var (
+	currentProviderVersion = internal.PackageVersion // Current v5 release
 )
 
 // TestMigrateZoneSettingMigrationFromV4Basic tests basic migration from v4 zone_settings_override to v5 zone_setting
@@ -30,14 +35,18 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
   }
 }`, rnd, zoneID)
 
-	// Use MigrationV2TestStepAllowCreate to handle one-to-many transformation
-	migrationSteps := acctest.MigrationV2TestStepAllowCreate(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
+	sourceVer, targetVer := acctest.InferMigrationVersions(acctest.GetLastV4Version())
+
+	// Use MigrationV2TestStepAllowCreateDropState to handle one-to-many transformation.
+	// cloudflare_zone_settings_override does not exist in v5; the state file must be
+	// cleared so Terraform does not fail with "no schema available" when loading it.
+	migrationSteps := acctest.MigrationV2TestStepAllowCreateDropState(t, v4Config, tmpDir, acctest.GetLastV4Version(), sourceVer, targetVer, []statecheck.StateCheck{
 		// Verify http3 setting
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_http3", rnd), tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_http3", rnd), tfjsonpath.New("setting_id"), knownvalue.StringExact("http3")),
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_http3", rnd), tfjsonpath.New("value"), knownvalue.StringExact("on")),
 	})
-	
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.TestAccPreCheck(t)
@@ -48,7 +57,7 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
 			ExternalProviders: map[string]resource.ExternalProvider{
 				"cloudflare": {
 					Source:            "cloudflare/cloudflare",
-					VersionConstraint: "4.52.1",
+					VersionConstraint: acctest.GetLastV4Version(),
 				},
 			},
 			Config: v4Config,
@@ -78,8 +87,9 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
   }
 }`, rnd, zoneID)
 
-	// Use MigrationV2TestStepAllowCreate to handle one-to-many transformation
-	migrationSteps := acctest.MigrationV2TestStepAllowCreate(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
+	sourceVer, targetVer := acctest.InferMigrationVersions(acctest.GetLastV4Version())
+
+	migrationSteps := acctest.MigrationV2TestStepAllowCreateDropState(t, v4Config, tmpDir, acctest.GetLastV4Version(), sourceVer, targetVer, []statecheck.StateCheck{
 		// Verify zero_rtt -> 0rtt mapping
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_zero_rtt", rnd), tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_zero_rtt", rnd), tfjsonpath.New("setting_id"), knownvalue.StringExact("0rtt")),
@@ -94,7 +104,7 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_security_header", rnd), tfjsonpath.New("value").AtMapKey("strict_transport_security").AtMapKey("preload"), knownvalue.Bool(false)),
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_security_header", rnd), tfjsonpath.New("value").AtMapKey("strict_transport_security").AtMapKey("nosniff"), knownvalue.Bool(false)),
 	})
-	
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.TestAccPreCheck(t)
@@ -105,7 +115,7 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
 			ExternalProviders: map[string]resource.ExternalProvider{
 				"cloudflare": {
 					Source:            "cloudflare/cloudflare",
-					VersionConstraint: "4.52.1",
+					VersionConstraint: acctest.GetLastV4Version(),
 				},
 			},
 			Config: v4Config,
@@ -145,8 +155,9 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
   }
 }`, rnd, zoneID)
 
-	// Use MigrationV2TestStepAllowCreate to handle one-to-many transformation
-	migrationSteps := acctest.MigrationV2TestStepAllowCreate(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
+	sourceVer, targetVer := acctest.InferMigrationVersions(acctest.GetLastV4Version())
+
+	migrationSteps := acctest.MigrationV2TestStepAllowCreateDropState(t, v4Config, tmpDir, acctest.GetLastV4Version(), sourceVer, targetVer, []statecheck.StateCheck{
 		// Verify http3 setting preserves variable reference
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_http3", rnd), tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_http3", rnd), tfjsonpath.New("setting_id"), knownvalue.StringExact("http3")),
@@ -175,7 +186,7 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
 			ExternalProviders: map[string]resource.ExternalProvider{
 				"cloudflare": {
 					Source:            "cloudflare/cloudflare",
-					VersionConstraint: "4.52.1",
+					VersionConstraint: acctest.GetLastV4Version(),
 				},
 			},
 			Config: v4Config,

--- a/internal/services/zone_setting/migration/v500/migrations_test.go
+++ b/internal/services/zone_setting/migration/v500/migrations_test.go
@@ -37,10 +37,10 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
 
 	sourceVer, targetVer := acctest.InferMigrationVersions(acctest.GetLastV4Version())
 
-	// Use MigrationV2TestStepAllowCreateDropState to handle one-to-many transformation.
-	// cloudflare_zone_settings_override does not exist in v5; the state file must be
-	// cleared so Terraform does not fail with "no schema available" when loading it.
-	migrationSteps := acctest.MigrationV2TestStepAllowCreateDropState(t, v4Config, tmpDir, acctest.GetLastV4Version(), sourceVer, targetVer, []statecheck.StateCheck{
+	// Use MigrationV2TestStepAllowCreateRemoveType to handle one-to-many transformation.
+	// cloudflare_zone_settings_override does not exist in v5; its state entries must be
+	// removed so Terraform does not fail with "no schema available" when loading them.
+	migrationSteps := acctest.MigrationV2TestStepAllowCreateRemoveType(t, v4Config, tmpDir, acctest.GetLastV4Version(), sourceVer, targetVer, "cloudflare_zone_settings_override", []statecheck.StateCheck{
 		// Verify http3 setting
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_http3", rnd), tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_http3", rnd), tfjsonpath.New("setting_id"), knownvalue.StringExact("http3")),
@@ -89,7 +89,7 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
 
 	sourceVer, targetVer := acctest.InferMigrationVersions(acctest.GetLastV4Version())
 
-	migrationSteps := acctest.MigrationV2TestStepAllowCreateDropState(t, v4Config, tmpDir, acctest.GetLastV4Version(), sourceVer, targetVer, []statecheck.StateCheck{
+	migrationSteps := acctest.MigrationV2TestStepAllowCreateRemoveType(t, v4Config, tmpDir, acctest.GetLastV4Version(), sourceVer, targetVer, "cloudflare_zone_settings_override", []statecheck.StateCheck{
 		// Verify zero_rtt -> 0rtt mapping
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_zero_rtt", rnd), tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_zero_rtt", rnd), tfjsonpath.New("setting_id"), knownvalue.StringExact("0rtt")),
@@ -123,12 +123,6 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
 	})
 }
 
-// TestMigrateZoneSettingMigrationFromV4WithNEL is skipped because NEL is a read-only setting
-// that cannot be set via the API. This test would fail even with the v4 provider.
-func TestMigrateZoneSettingMigrationFromV4WithNEL(t *testing.T) {
-	t.Skip("NEL is a read-only setting and cannot be tested via the provider")
-}
-
 // TestMigrateZoneSettingMigrationFromV4Complex tests migration with multiple settings including variables
 func TestMigrateZoneSettingMigrationFromV4Complex(t *testing.T) {
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
@@ -157,7 +151,7 @@ resource "cloudflare_zone_settings_override" "%[1]s" {
 
 	sourceVer, targetVer := acctest.InferMigrationVersions(acctest.GetLastV4Version())
 
-	migrationSteps := acctest.MigrationV2TestStepAllowCreateDropState(t, v4Config, tmpDir, acctest.GetLastV4Version(), sourceVer, targetVer, []statecheck.StateCheck{
+	migrationSteps := acctest.MigrationV2TestStepAllowCreateRemoveType(t, v4Config, tmpDir, acctest.GetLastV4Version(), sourceVer, targetVer, "cloudflare_zone_settings_override", []statecheck.StateCheck{
 		// Verify http3 setting preserves variable reference
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_http3", rnd), tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
 		statecheck.ExpectKnownValue(fmt.Sprintf("cloudflare_zone_setting.%s_http3", rnd), tfjsonpath.New("setting_id"), knownvalue.StringExact("http3")),

--- a/internal/services/zone_setting/migrations.go
+++ b/internal/services/zone_setting/migrations.go
@@ -10,14 +10,29 @@ import (
 
 var _ resource.ResourceWithUpgradeState = (*ZoneSettingResource)(nil)
 
+// UpgradeState registers state upgraders for schema version changes.
+//
+// zone_setting is a special case: it is a one-to-many migration from v4's
+// cloudflare_zone_settings_override. The tf-migrate tool deletes the old v4
+// state and users run terraform apply to recreate state as new v5 resources.
+// Therefore, no v4→v5 state transformation is needed.
+//
+// Both upgraders are no-ops that just bump the schema version to 500:
+// - Version 0: early v5 resources created before version was bumped
+// - Version 1: v5 resources at the previous schema version
 func (r *ZoneSettingResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	targetSchema := ResourceSchema(ctx)
+	noopUpgrader := func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+		resp.State.Raw = req.State.Raw
+	}
 	return map[int64]resource.StateUpgrader{
 		0: {
-			PriorSchema: &targetSchema,
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				resp.State.Raw = req.State.Raw
-			},
+			PriorSchema:   &targetSchema,
+			StateUpgrader: noopUpgrader,
+		},
+		1: {
+			PriorSchema:   &targetSchema,
+			StateUpgrader: noopUpgrader,
 		},
 	}
 }

--- a/internal/services/zone_setting/schema.go
+++ b/internal/services/zone_setting/schema.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -17,7 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*ZoneSettingResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
-		Version: 1,
+		Version: migrations.GetSchemaVersion(1, 500),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Setting name",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Support state upgraders for `zone_setting`. This resource is deleted from state and regenerated in v5, so minimal changes needed.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
`TF_ACC=1 TF_MIG_TEST=1 TF_MIGRATE_BINARY_PATH=/Users/ssicard/workspace/terraform-devstack/tf-migrate/tf-migrate go test ./internal/services/zone_setting/migration/v500 -v`

### Test output
```bash
=== RUN   TestMigrateZoneSettingMigrationFromV4Basic
--- PASS: TestMigrateZoneSettingMigrationFromV4Basic (23.16s)
=== RUN   TestMigrateZoneSettingMigrationFromV4WithSpecialSettings
--- PASS: TestMigrateZoneSettingMigrationFromV4WithSpecialSettings (21.51s)
=== RUN   TestMigrateZoneSettingMigrationFromV4WithNEL
    migrations_test.go:129: NEL is a read-only setting and cannot be tested via the provider
--- SKIP: TestMigrateZoneSettingMigrationFromV4WithNEL (0.00s)
=== RUN   TestMigrateZoneSettingMigrationFromV4Complex
--- PASS: TestMigrateZoneSettingMigrationFromV4Complex (25.56s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zone_setting/migration/v500	71.707s
```

## Additional context & links
