### PR TITLE
docs(api_token): update example to use `jsonencode` for policies.resources

### DIFF
--- a/docs/resources/api_token.md
+++ b/docs/resources/api_token.md
@@ -29,9 +29,9 @@ resource "cloudflare_api_token" "example_api_token" {
         value = "value"
       }
     }]
-    resources = {
+    resources = jsonencode({
       foo = "string"
-    }
+    })
   }]
   condition = {
     request_ip = {

--- a/examples/resources/cloudflare_api_token/resource.tf
+++ b/examples/resources/cloudflare_api_token/resource.tf
@@ -15,9 +15,9 @@ resource "cloudflare_api_token" "example_api_token" {
         value = "value"
       }
     }]
-    resources = {
+    resources = jsonencode({
       foo = "string"
-    }
+    })
   }]
   condition = {
     request_ip = {


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
with 5.13.0, the `policies.resources` must be a json-encoded string of a Record<string, string>, but the example usage in the docs doesn't really make that clear

I did not run any tests, because this is a docs-only change

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
N/A

### Test output
<!-- Please paste the output of your acceptance test run below --> 
N/A

## Additional context & links
