### PR TITLE
feat(argo): state upgraders

### DIFF
--- a/internal/services/argo_smart_routing/migration/v500/handler.go
+++ b/internal/services/argo_smart_routing/migration/v500/handler.go
@@ -1,0 +1,48 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// UpgradeArgoToSmartRouting handles state upgrades from v4 SDKv2 cloudflare_argo (schema_version=0) to v5 cloudflare_argo_smart_routing (version=500).
+//
+// This performs a full transformation from v4 cloudflare_argo → v5 cloudflare_argo_smart_routing.
+// The v4 state has schema_version=0 (SDKv2 default), and we transform it to v5 format.
+func UpgradeArgoToSmartRouting(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading argo_smart_routing state from v4 cloudflare_argo (schema_version=0)")
+
+	// Parse v4 state using v4 model
+	var v4State SourceCloudflareArgoModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &v4State)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform v4 cloudflare_argo → v5 cloudflare_argo_smart_routing
+	v5State, diags := TransformArgoToSmartRouting(ctx, v4State)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Write transformed state
+	resp.Diagnostics.Append(resp.State.Set(ctx, v5State)...)
+	tflog.Info(ctx, "State upgrade from v4 cloudflare_argo to v5 cloudflare_argo_smart_routing completed successfully")
+}
+
+// UpgradeFromV5SmartRouting handles state upgrades from v5 Plugin Framework provider (version=1) to v5 (version=500).
+//
+// This is a no-op upgrade since the schema is compatible - just bumps the version.
+// This handler is only triggered when TF_MIG_TEST=1 (GetSchemaVersion returns 500).
+func UpgradeFromV5SmartRouting(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading argo_smart_routing state from version=1 to version=500 (no-op)")
+
+	// CRITICAL: For no-op upgrades, copy raw state directly
+	// This preserves all state data without any transformation
+	resp.State.Raw = req.State.Raw
+
+	tflog.Info(ctx, "State version bump from 1 to 500 completed")
+}

--- a/internal/services/argo_smart_routing/migration/v500/migrations_test.go
+++ b/internal/services/argo_smart_routing/migration/v500/migrations_test.go
@@ -1,0 +1,301 @@
+package v500_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+var (
+	currentProviderVersion = internal.PackageVersion // Current v5 release
+)
+
+// Embed test configs
+//go:embed testdata/v4_smart_routing_only.tf
+var v4SmartRoutingOnlyConfig string
+
+//go:embed testdata/v5_smart_routing_only.tf
+var v5SmartRoutingOnlyConfig string
+
+//go:embed testdata/v4_both_attributes.tf
+var v4BothAttributesConfig string
+
+//go:embed testdata/v5_both_attributes.tf
+var v5BothAttributesConfig string
+
+//go:embed testdata/v4_neither_attribute.tf
+var v4NeitherAttributeConfig string
+
+//go:embed testdata/v5_neither_attribute.tf
+var v5NeitherAttributeConfig string
+
+// argoSmartRoutingMigrationTestStep creates a test step for argo_smart_routing migration
+func argoSmartRoutingMigrationTestStep(t *testing.T, testConfig string, tmpDir string, exactVersion string, sourceVersion string, targetVersion string, stateChecks []statecheck.StateCheck) resource.TestStep {
+	return resource.TestStep{
+		PreConfig: func() {
+			acctest.WriteOutConfig(t, testConfig, tmpDir)
+			acctest.RunMigrationV2Command(t, testConfig, tmpDir, sourceVersion, targetVersion)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		ConfigDirectory:          config.StaticDirectory(tmpDir),
+		ConfigPlanChecks: resource.ConfigPlanChecks{
+			PreApply: []plancheck.PlanCheck{
+				acctest.DebugNonEmptyPlan,
+			},
+		},
+		ConfigStateChecks: stateChecks,
+	}
+}
+
+// TestMigrateArgoSmartRouting_V4ToV5_SmartRoutingOnly tests migration when only smart_routing is set
+// This covers Scenario 1: smart_routing attribute only
+func TestMigrateArgoSmartRouting_V4ToV5_SmartRoutingOnly(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID string) string
+	}{
+		{
+			name:    "from_v4_latest", // Tests legacy v4 → current v5
+			version: os.Getenv("LAST_V4_VERSION"),
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v4SmartRoutingOnlyConfig, rnd, zoneID)
+			},
+		},
+		{
+			name:    "from_v5", // Tests within v5 (version bump)
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v5SmartRoutingOnlyConfig, rnd, zoneID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test setup
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						// Step 1: Create with specific provider version
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					// Step 2: Run migration and verify state
+					argoSmartRoutingMigrationTestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							// Verify zone_id is preserved
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_smart_routing."+rnd,
+								tfjsonpath.New("zone_id"),
+								knownvalue.StringExact(zoneID),
+							),
+							// Verify smart_routing → value transformation
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_smart_routing."+rnd,
+								tfjsonpath.New("value"),
+								knownvalue.StringExact("on"),
+							),
+							// Verify id changed from checksum to zone_id
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_smart_routing."+rnd,
+								tfjsonpath.New("id"),
+								knownvalue.StringExact(zoneID),
+							),
+							// Verify editable is set (computed field)
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_smart_routing."+rnd,
+								tfjsonpath.New("editable"),
+								knownvalue.Bool(true),
+							),
+						},
+					),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateArgoSmartRouting_V4ToV5_BothAttributes tests migration when both smart_routing and tiered_caching are set
+// This covers Scenario 2: Both attributes (smart_routing gets moved block in config)
+func TestMigrateArgoSmartRouting_V4ToV5_BothAttributes(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: os.Getenv("LAST_V4_VERSION"),
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v4BothAttributesConfig, rnd, zoneID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v5BothAttributesConfig, rnd, zoneID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					argoSmartRoutingMigrationTestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_smart_routing."+rnd,
+								tfjsonpath.New("zone_id"),
+								knownvalue.StringExact(zoneID),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_smart_routing."+rnd,
+								tfjsonpath.New("value"),
+								knownvalue.StringExact("on"),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_smart_routing."+rnd,
+								tfjsonpath.New("id"),
+								knownvalue.StringExact(zoneID),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_smart_routing."+rnd,
+								tfjsonpath.New("editable"),
+								knownvalue.Bool(true),
+							),
+						},
+					),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateArgoSmartRouting_V4ToV5_NeitherAttribute tests migration when neither attribute is set
+// This covers Scenario 3: No attributes (defaults to smart_routing with value="off")
+func TestMigrateArgoSmartRouting_V4ToV5_NeitherAttribute(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: os.Getenv("LAST_V4_VERSION"),
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v4NeitherAttributeConfig, rnd, zoneID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v5NeitherAttributeConfig, rnd, zoneID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					argoSmartRoutingMigrationTestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_smart_routing."+rnd,
+								tfjsonpath.New("zone_id"),
+								knownvalue.StringExact(zoneID),
+							),
+							// Verify default value is "off" when smart_routing not set
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_smart_routing."+rnd,
+								tfjsonpath.New("value"),
+								knownvalue.StringExact("off"),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_smart_routing."+rnd,
+								tfjsonpath.New("id"),
+								knownvalue.StringExact(zoneID),
+							),
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_smart_routing."+rnd,
+								tfjsonpath.New("editable"),
+								knownvalue.Bool(true),
+							),
+						},
+					),
+				},
+			})
+		})
+	}
+}

--- a/internal/services/argo_smart_routing/migration/v500/model.go
+++ b/internal/services/argo_smart_routing/migration/v500/model.go
@@ -1,0 +1,40 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ============================================================================
+// Source Models (Legacy Provider - v4.x)
+// ============================================================================
+
+// SourceCloudflareArgoModel represents the legacy cloudflare_argo state from v4.x provider.
+// Schema version: 0 (SDK v2 default)
+// Resource type: cloudflare_argo
+//
+// This resource could have smart_routing, tiered_caching, or both attributes.
+// The decision logic determines whether this becomes argo_smart_routing or argo_tiered_caching.
+type SourceCloudflareArgoModel struct {
+	ID             types.String `tfsdk:"id"`              // Checksum-based ID: stringChecksum(fmt.Sprintf("%s/argo", zoneID))
+	ZoneID         types.String `tfsdk:"zone_id"`         // Zone identifier
+	SmartRouting   types.String `tfsdk:"smart_routing"`   // Optional, "on" or "off"
+	TieredCaching  types.String `tfsdk:"tiered_caching"`  // Optional, "on" or "off"
+}
+
+// ============================================================================
+// Target Models (Current Provider - v5.x+)
+// ============================================================================
+
+// TargetArgoSmartRoutingModel represents the current cloudflare_argo_smart_routing state from v5.x+ provider.
+// Schema version: 500
+// Resource type: cloudflare_argo_smart_routing
+//
+// This model matches the ArgoSmartRoutingModel in the parent package's model.go file.
+type TargetArgoSmartRoutingModel struct {
+	ID         types.String      `tfsdk:"id"`          // Zone ID (changed from checksum)
+	ZoneID     types.String      `tfsdk:"zone_id"`     // Zone identifier
+	Value      types.String      `tfsdk:"value"`       // Renamed from smart_routing, required
+	Editable   types.Bool        `tfsdk:"editable"`    // New computed field
+	ModifiedOn timetypes.RFC3339 `tfsdk:"modified_on"` // New computed field
+}

--- a/internal/services/argo_smart_routing/migration/v500/move.go
+++ b/internal/services/argo_smart_routing/migration/v500/move.go
@@ -1,0 +1,45 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// MoveArgoToSmartRouting handles moving state from legacy cloudflare_argo to cloudflare_argo_smart_routing.
+// This is triggered by Terraform 1.8+ when it encounters a `moved` block:
+//
+//   moved {
+//     from = cloudflare_argo.example
+//     to   = cloudflare_argo_smart_routing.example
+//   }
+//
+// This handler is called when:
+// - Scenario 1: Neither smart_routing nor tiered_caching attributes exist
+// - Scenario 2: Both smart_routing and tiered_caching exist (smart_routing is primary)
+// - Scenario 3: Only smart_routing attribute exists
+//
+// For Scenario 4 (only tiered_caching), the moved block points to cloudflare_argo_tiered_caching instead.
+func MoveArgoToSmartRouting(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+	tflog.Info(ctx, "Moving state from legacy cloudflare_argo to cloudflare_argo_smart_routing")
+
+	// Parse the source state (legacy v4 cloudflare_argo format)
+	var sourceState SourceCloudflareArgoModel
+	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform to target (current v5 cloudflare_argo_smart_routing format)
+	targetState, diags := TransformArgoToSmartRouting(ctx, sourceState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Set the moved state
+	resp.Diagnostics.Append(resp.TargetState.Set(ctx, targetState)...)
+
+	tflog.Info(ctx, "State move from legacy cloudflare_argo to cloudflare_argo_smart_routing completed successfully")
+}

--- a/internal/services/argo_smart_routing/migration/v500/schema.go
+++ b/internal/services/argo_smart_routing/migration/v500/schema.go
@@ -1,0 +1,32 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// SourceCloudflareArgoSchema returns the source schema for legacy cloudflare_argo resource.
+// Schema version: 0 (SDK v2 default)
+// Resource type: cloudflare_argo
+//
+// This minimal schema is used only for reading v4 state during migration.
+// It includes only the properties needed for state parsing (Required, Optional, Computed).
+// Validators, PlanModifiers, and Descriptions are intentionally omitted.
+func SourceCloudflareArgoSchema() schema.Schema {
+	return schema.Schema{
+		Version: 0, // SDK v2 default version
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"zone_id": schema.StringAttribute{
+				Required: true,
+			},
+			"smart_routing": schema.StringAttribute{
+				Optional: true, // "on" or "off"
+			},
+			"tiered_caching": schema.StringAttribute{
+				Optional: true, // "on" or "off"
+			},
+		},
+	}
+}

--- a/internal/services/argo_smart_routing/migration/v500/testdata/v4_both_attributes.tf
+++ b/internal/services/argo_smart_routing/migration/v500/testdata/v4_both_attributes.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_argo" "%s" {
+  zone_id         = "%s"
+  smart_routing   = "on"
+  tiered_caching  = "on"
+}

--- a/internal/services/argo_smart_routing/migration/v500/testdata/v4_neither_attribute.tf
+++ b/internal/services/argo_smart_routing/migration/v500/testdata/v4_neither_attribute.tf
@@ -1,0 +1,3 @@
+resource "cloudflare_argo" "%s" {
+  zone_id = "%s"
+}

--- a/internal/services/argo_smart_routing/migration/v500/testdata/v4_smart_routing_only.tf
+++ b/internal/services/argo_smart_routing/migration/v500/testdata/v4_smart_routing_only.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_argo" "%s" {
+  zone_id        = "%s"
+  smart_routing  = "on"
+}

--- a/internal/services/argo_smart_routing/migration/v500/testdata/v5_both_attributes.tf
+++ b/internal/services/argo_smart_routing/migration/v500/testdata/v5_both_attributes.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_argo_smart_routing" "%s" {
+  zone_id = "%s"
+  value   = "on"
+}

--- a/internal/services/argo_smart_routing/migration/v500/testdata/v5_neither_attribute.tf
+++ b/internal/services/argo_smart_routing/migration/v500/testdata/v5_neither_attribute.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_argo_smart_routing" "%s" {
+  zone_id = "%s"
+  value   = "off"
+}

--- a/internal/services/argo_smart_routing/migration/v500/testdata/v5_smart_routing_only.tf
+++ b/internal/services/argo_smart_routing/migration/v500/testdata/v5_smart_routing_only.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_argo_smart_routing" "%s" {
+  zone_id = "%s"
+  value   = "on"
+}

--- a/internal/services/argo_smart_routing/migration/v500/transform.go
+++ b/internal/services/argo_smart_routing/migration/v500/transform.go
@@ -1,0 +1,55 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TransformArgoToSmartRouting converts source (legacy v4 cloudflare_argo) state to target (current v5 cloudflare_argo_smart_routing) state.
+// This function is shared by both UpgradeArgoToSmartRouting and MoveArgoToSmartRouting handlers.
+//
+// Transformation logic:
+// - zone_id: Direct copy
+// - smart_routing → value: Rename, default to "off" if missing
+// - tiered_caching: Removed (goes to separate resource)
+// - id: Change from checksum to zone_id
+// - editable: Add as true
+// - modified_on: Add as null (will be populated on refresh)
+func TransformArgoToSmartRouting(ctx context.Context, source SourceCloudflareArgoModel) (*TargetArgoSmartRoutingModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Validate required fields
+	if source.ZoneID.IsNull() || source.ZoneID.IsUnknown() {
+		diags.AddError(
+			"Missing required field",
+			"zone_id is required for argo migration. The source state is missing this field, which indicates corrupted state.",
+		)
+		return nil, diags
+	}
+
+	// Initialize target
+	target := &TargetArgoSmartRoutingModel{
+		ZoneID: source.ZoneID,
+		// ID changes from checksum to zone_id
+		ID: source.ZoneID,
+		// Add computed fields
+		Editable:   types.BoolValue(true),
+		ModifiedOn: timetypes.NewRFC3339Null(),
+	}
+
+	// Handle smart_routing → value transformation
+	// Default to "off" if smart_routing is missing/null/empty
+	if !source.SmartRouting.IsNull() && !source.SmartRouting.IsUnknown() && source.SmartRouting.ValueString() != "" {
+		target.Value = source.SmartRouting
+	} else {
+		target.Value = types.StringValue("off")
+	}
+
+	// Note: source.TieredCaching is intentionally not copied
+	// It goes to a separate cloudflare_argo_tiered_caching resource
+
+	return target, diags
+}

--- a/internal/services/argo_smart_routing/migrations.go
+++ b/internal/services/argo_smart_routing/migrations.go
@@ -5,19 +5,50 @@ package argo_smart_routing
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/argo_smart_routing/migration/v500"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 var _ resource.ResourceWithUpgradeState = (*ArgoSmartRoutingResource)(nil)
+var _ resource.ResourceWithMoveState = (*ArgoSmartRoutingResource)(nil)
 
+// MoveState registers state movers for resource renames.
+// This enables Terraform 1.8+ `moved` blocks to automatically trigger state migration.
+func (r *ArgoSmartRoutingResource) MoveState(ctx context.Context) []resource.StateMover {
+	sourceSchema := v500.SourceCloudflareArgoSchema()
+
+	return []resource.StateMover{
+		{
+			SourceSchema: &sourceSchema,
+			StateMover:   v500.MoveArgoToSmartRouting,
+		},
+	}
+}
+
+// UpgradeState registers state upgraders for schema version changes.
+//
+// This handles two upgrade paths:
+// 1. v4 state (schema_version=0) → v5 (version=500): Full transformation from cloudflare_argo
+// 2. v5 state (version=1) → v5 (version=500): No-op upgrade (when TF_MIG_TEST=1)
+//
+// The separation of schema versions (v4=0, v5=1/500) eliminates the need for
+// dual-format detection that was required in earlier implementations.
 func (r *ArgoSmartRoutingResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	sourceSchema := v500.SourceCloudflareArgoSchema()
 	targetSchema := ResourceSchema(ctx)
+
 	return map[int64]resource.StateUpgrader{
+		// Handle state from v4 SDKv2 provider cloudflare_argo (schema_version=0)
 		0: {
-			PriorSchema: &targetSchema,
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				resp.State.Raw = req.State.Raw
-			},
+			PriorSchema:   &sourceSchema,
+			StateUpgrader: v500.UpgradeArgoToSmartRouting,
+		},
+
+		// Handle state from v5 Plugin Framework provider with version=1
+		// This is a no-op upgrade that just bumps the version to 500
+		1: {
+			PriorSchema:   &targetSchema,
+			StateUpgrader: v500.UpgradeFromV5SmartRouting,
 		},
 	}
 }

--- a/internal/services/argo_smart_routing/schema.go
+++ b/internal/services/argo_smart_routing/schema.go
@@ -5,6 +5,7 @@ package argo_smart_routing
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -18,7 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*ArgoSmartRoutingResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
-		Version: 1,
+		Version: migrations.GetSchemaVersion(1, 500),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Specifies the zone associated with the API call.",

--- a/internal/services/argo_tiered_caching/migration/v500/handler.go
+++ b/internal/services/argo_tiered_caching/migration/v500/handler.go
@@ -1,0 +1,48 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// UpgradeArgoToTieredCaching handles state upgrades from v4 SDKv2 cloudflare_argo (schema_version=0) to v5 cloudflare_argo_tiered_caching (version=500).
+//
+// This performs a full transformation from v4 cloudflare_argo → v5 cloudflare_argo_tiered_caching.
+// The v4 state has schema_version=0 (SDKv2 default), and we transform it to v5 format.
+func UpgradeArgoToTieredCaching(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading argo_tiered_caching state from v4 cloudflare_argo (schema_version=0)")
+
+	// Parse v4 state using v4 model
+	var v4State SourceCloudflareArgoModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &v4State)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform v4 cloudflare_argo → v5 cloudflare_argo_tiered_caching
+	v5State, diags := TransformArgoToTieredCaching(ctx, v4State)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Write transformed state
+	resp.Diagnostics.Append(resp.State.Set(ctx, v5State)...)
+	tflog.Info(ctx, "State upgrade from v4 cloudflare_argo to v5 cloudflare_argo_tiered_caching completed successfully")
+}
+
+// UpgradeFromV5TieredCaching handles state upgrades from v5 Plugin Framework provider (version=1) to v5 (version=500).
+//
+// This is a no-op upgrade since the schema is compatible - just bumps the version.
+// This handler is only triggered when TF_MIG_TEST=1 (GetSchemaVersion returns 500).
+func UpgradeFromV5TieredCaching(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading argo_tiered_caching state from version=1 to version=500 (no-op)")
+
+	// CRITICAL: For no-op upgrades, copy raw state directly
+	// This preserves all state data without any transformation
+	resp.State.Raw = req.State.Raw
+
+	tflog.Info(ctx, "State version bump from 1 to 500 completed")
+}

--- a/internal/services/argo_tiered_caching/migration/v500/migrations_test.go
+++ b/internal/services/argo_tiered_caching/migration/v500/migrations_test.go
@@ -1,0 +1,132 @@
+package v500_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+var (
+	currentProviderVersion = internal.PackageVersion // Current v5 release
+)
+
+// Embed test configs
+//go:embed testdata/v4_tiered_caching_only.tf
+var v4TieredCachingOnlyConfig string
+
+//go:embed testdata/v5_tiered_caching_only.tf
+var v5TieredCachingOnlyConfig string
+
+// argoTieredCachingMigrationTestStep creates a test step for argo_tiered_caching migration
+func argoTieredCachingMigrationTestStep(t *testing.T, testConfig string, tmpDir string, exactVersion string, sourceVersion string, targetVersion string, stateChecks []statecheck.StateCheck) resource.TestStep {
+	return resource.TestStep{
+		PreConfig: func() {
+			acctest.WriteOutConfig(t, testConfig, tmpDir)
+			acctest.RunMigrationV2Command(t, testConfig, tmpDir, sourceVersion, targetVersion)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		ConfigDirectory:          config.StaticDirectory(tmpDir),
+		ConfigPlanChecks: resource.ConfigPlanChecks{
+			PreApply: []plancheck.PlanCheck{
+				acctest.DebugNonEmptyPlan,
+			},
+		},
+		ConfigStateChecks: stateChecks,
+	}
+}
+
+// TestMigrateArgoTieredCaching_V4ToV5_TieredCachingOnly tests migration when only tiered_caching is set
+// This covers Scenario 4: tiered_caching attribute only
+func TestMigrateArgoTieredCaching_V4ToV5_TieredCachingOnly(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID string) string
+	}{
+		{
+			name:    "from_v4_latest", // Tests legacy v4 → current v5
+			version: os.Getenv("LAST_V4_VERSION"),
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v4TieredCachingOnlyConfig, rnd, zoneID)
+			},
+		},
+		{
+			name:    "from_v5", // Tests within v5 (version bump)
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v5TieredCachingOnlyConfig, rnd, zoneID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test setup
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						// Step 1: Create with specific provider version
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					// Step 2: Run migration and verify state
+					argoTieredCachingMigrationTestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							// Verify zone_id is preserved
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_tiered_caching."+rnd,
+								tfjsonpath.New("zone_id"),
+								knownvalue.StringExact(zoneID),
+							),
+							// Verify tiered_caching → value transformation
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_tiered_caching."+rnd,
+								tfjsonpath.New("value"),
+								knownvalue.StringExact("on"),
+							),
+							// Verify id changed from checksum to zone_id
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_tiered_caching."+rnd,
+								tfjsonpath.New("id"),
+								knownvalue.StringExact(zoneID),
+							),
+							// Verify editable is set (computed field)
+							statecheck.ExpectKnownValue(
+								"cloudflare_argo_tiered_caching."+rnd,
+								tfjsonpath.New("editable"),
+								knownvalue.Bool(true),
+							),
+						},
+					),
+				},
+			})
+		})
+	}
+}

--- a/internal/services/argo_tiered_caching/migration/v500/model.go
+++ b/internal/services/argo_tiered_caching/migration/v500/model.go
@@ -1,0 +1,40 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ============================================================================
+// Source Models (Legacy Provider - v4.x)
+// ============================================================================
+
+// SourceCloudflareArgoModel represents the legacy cloudflare_argo state from v4.x provider.
+// Schema version: 0 (SDK v2 default)
+// Resource type: cloudflare_argo
+//
+// This resource could have smart_routing, tiered_caching, or both attributes.
+// The decision logic determines whether this becomes argo_smart_routing or argo_tiered_caching.
+type SourceCloudflareArgoModel struct {
+	ID             types.String `tfsdk:"id"`              // Checksum-based ID: stringChecksum(fmt.Sprintf("%s/argo", zoneID))
+	ZoneID         types.String `tfsdk:"zone_id"`         // Zone identifier
+	SmartRouting   types.String `tfsdk:"smart_routing"`   // Optional, "on" or "off"
+	TieredCaching  types.String `tfsdk:"tiered_caching"`  // Optional, "on" or "off"
+}
+
+// ============================================================================
+// Target Models (Current Provider - v5.x+)
+// ============================================================================
+
+// TargetArgoTieredCachingModel represents the current cloudflare_argo_tiered_caching state from v5.x+ provider.
+// Schema version: 500
+// Resource type: cloudflare_argo_tiered_caching
+//
+// This model matches the ArgoTieredCachingModel in the parent package's model.go file.
+type TargetArgoTieredCachingModel struct {
+	ID         types.String      `tfsdk:"id"`          // Zone ID (changed from checksum)
+	ZoneID     types.String      `tfsdk:"zone_id"`     // Zone identifier
+	Value      types.String      `tfsdk:"value"`       // Renamed from tiered_caching, required
+	Editable   types.Bool        `tfsdk:"editable"`    // New computed field
+	ModifiedOn timetypes.RFC3339 `tfsdk:"modified_on"` // New computed field
+}

--- a/internal/services/argo_tiered_caching/migration/v500/move.go
+++ b/internal/services/argo_tiered_caching/migration/v500/move.go
@@ -1,0 +1,43 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// MoveArgoToTieredCaching handles moving state from legacy cloudflare_argo to cloudflare_argo_tiered_caching.
+// This is triggered by Terraform 1.8+ when it encounters a `moved` block:
+//
+//   moved {
+//     from = cloudflare_argo.example
+//     to   = cloudflare_argo_tiered_caching.example
+//   }
+//
+// This handler is called when:
+// - Scenario 4: Only tiered_caching attribute exists (no smart_routing)
+//
+// For all other scenarios, the moved block points to cloudflare_argo_smart_routing instead.
+func MoveArgoToTieredCaching(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+	tflog.Info(ctx, "Moving state from legacy cloudflare_argo to cloudflare_argo_tiered_caching")
+
+	// Parse the source state (legacy v4 cloudflare_argo format)
+	var sourceState SourceCloudflareArgoModel
+	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform to target (current v5 cloudflare_argo_tiered_caching format)
+	targetState, diags := TransformArgoToTieredCaching(ctx, sourceState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Set the moved state
+	resp.Diagnostics.Append(resp.TargetState.Set(ctx, targetState)...)
+
+	tflog.Info(ctx, "State move from legacy cloudflare_argo to cloudflare_argo_tiered_caching completed successfully")
+}

--- a/internal/services/argo_tiered_caching/migration/v500/schema.go
+++ b/internal/services/argo_tiered_caching/migration/v500/schema.go
@@ -1,0 +1,32 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// SourceCloudflareArgoSchema returns the source schema for legacy cloudflare_argo resource.
+// Schema version: 0 (SDK v2 default)
+// Resource type: cloudflare_argo
+//
+// This minimal schema is used only for reading v4 state during migration.
+// It includes only the properties needed for state parsing (Required, Optional, Computed).
+// Validators, PlanModifiers, and Descriptions are intentionally omitted.
+func SourceCloudflareArgoSchema() schema.Schema {
+	return schema.Schema{
+		Version: 0, // SDK v2 default version
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"zone_id": schema.StringAttribute{
+				Required: true,
+			},
+			"smart_routing": schema.StringAttribute{
+				Optional: true, // "on" or "off"
+			},
+			"tiered_caching": schema.StringAttribute{
+				Optional: true, // "on" or "off"
+			},
+		},
+	}
+}

--- a/internal/services/argo_tiered_caching/migration/v500/testdata/v4_tiered_caching_only.tf
+++ b/internal/services/argo_tiered_caching/migration/v500/testdata/v4_tiered_caching_only.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_argo" "%s" {
+  zone_id         = "%s"
+  tiered_caching  = "on"
+}

--- a/internal/services/argo_tiered_caching/migration/v500/testdata/v5_tiered_caching_only.tf
+++ b/internal/services/argo_tiered_caching/migration/v500/testdata/v5_tiered_caching_only.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_argo_tiered_caching" "%s" {
+  zone_id = "%s"
+  value   = "on"
+}

--- a/internal/services/argo_tiered_caching/migration/v500/transform.go
+++ b/internal/services/argo_tiered_caching/migration/v500/transform.go
@@ -1,0 +1,58 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TransformArgoToTieredCaching converts source (legacy v4 cloudflare_argo) state to target (current v5 cloudflare_argo_tiered_caching) state.
+// This function is shared by both UpgradeArgoToTieredCaching and MoveArgoToTieredCaching handlers.
+//
+// Transformation logic:
+// - zone_id: Direct copy
+// - tiered_caching → value: Rename
+// - smart_routing: Removed (goes to separate resource)
+// - id: Change from checksum to zone_id
+// - editable: Add as true
+// - modified_on: Add as null (will be populated on refresh)
+func TransformArgoToTieredCaching(ctx context.Context, source SourceCloudflareArgoModel) (*TargetArgoTieredCachingModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Validate required fields
+	if source.ZoneID.IsNull() || source.ZoneID.IsUnknown() {
+		diags.AddError(
+			"Missing required field",
+			"zone_id is required for argo migration. The source state is missing this field, which indicates corrupted state.",
+		)
+		return nil, diags
+	}
+
+	// Validate tiered_caching exists (this transformation only happens for scenario 4)
+	if source.TieredCaching.IsNull() || source.TieredCaching.IsUnknown() || source.TieredCaching.ValueString() == "" {
+		diags.AddError(
+			"Missing tiered_caching attribute",
+			"tiered_caching attribute is required for transforming to argo_tiered_caching. The source state is missing this field.",
+		)
+		return nil, diags
+	}
+
+	// Initialize target
+	target := &TargetArgoTieredCachingModel{
+		ZoneID: source.ZoneID,
+		// ID changes from checksum to zone_id
+		ID: source.ZoneID,
+		// tiered_caching → value
+		Value: source.TieredCaching,
+		// Add computed fields
+		Editable:   types.BoolValue(true),
+		ModifiedOn: timetypes.NewRFC3339Null(),
+	}
+
+	// Note: source.SmartRouting is intentionally not copied
+	// It goes to a separate cloudflare_argo_smart_routing resource
+
+	return target, diags
+}

--- a/internal/services/argo_tiered_caching/migrations.go
+++ b/internal/services/argo_tiered_caching/migrations.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/argo_tiered_caching/migration/v500"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -18,14 +19,30 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ArgoTieredCachingResource)(nil)
 var _ resource.ResourceWithMoveState = (*ArgoTieredCachingResource)(nil)
 
+// UpgradeState registers state upgraders for schema version changes.
+//
+// This handles two upgrade paths:
+// 1. v4 state (schema_version=0) → v5 (version=500): Full transformation from cloudflare_argo
+// 2. v5 state (version=1) → v5 (version=500): No-op upgrade (when TF_MIG_TEST=1)
+//
+// The separation of schema versions (v4=0, v5=1/500) eliminates the need for
+// dual-format detection that was required in earlier implementations.
 func (r *ArgoTieredCachingResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	sourceSchema := v500.SourceCloudflareArgoSchema()
 	targetSchema := ResourceSchema(ctx)
+
 	return map[int64]resource.StateUpgrader{
+		// Handle state from v4 SDKv2 provider cloudflare_argo (schema_version=0)
 		0: {
-			PriorSchema: &targetSchema,
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				resp.State.Raw = req.State.Raw
-			},
+			PriorSchema:   &sourceSchema,
+			StateUpgrader: v500.UpgradeArgoToTieredCaching,
+		},
+
+		// Handle state from v5 Plugin Framework provider with version=1
+		// This is a no-op upgrade that just bumps the version to 500
+		1: {
+			PriorSchema:   &targetSchema,
+			StateUpgrader: v500.UpgradeFromV5TieredCaching,
 		},
 	}
 }
@@ -56,10 +73,19 @@ var tieredCacheSourceSchema = schema.Schema{
 }
 
 // MoveState implements ResourceWithMoveState interface
-// This enables moving state from cloudflare_tiered_cache (with cache_type="generic")
-// to cloudflare_argo_tiered_caching (with value="on")
+// This enables moving state from TWO different source resources:
+// 1. cloudflare_tiered_cache (with cache_type="generic") → cloudflare_argo_tiered_caching (with value="on")
+// 2. cloudflare_argo (with tiered_caching attribute) → cloudflare_argo_tiered_caching (with value from tiered_caching)
 func (r *ArgoTieredCachingResource) MoveState(ctx context.Context) []resource.StateMover {
+	argoSourceSchema := v500.SourceCloudflareArgoSchema()
+
 	return []resource.StateMover{
+		// StateMover 1: cloudflare_argo → cloudflare_argo_tiered_caching
+		{
+			SourceSchema: &argoSourceSchema,
+			StateMover:   v500.MoveArgoToTieredCaching,
+		},
+		// StateMover 2: cloudflare_tiered_cache → cloudflare_argo_tiered_caching
 		{
 			SourceSchema: &tieredCacheSourceSchema,
 			StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {

--- a/internal/services/argo_tiered_caching/schema.go
+++ b/internal/services/argo_tiered_caching/schema.go
@@ -5,6 +5,7 @@ package argo_tiered_caching
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -18,7 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*ArgoTieredCachingResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
-		Version: 1,
+		Version: migrations.GetSchemaVersion(1, 500),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",


### PR DESCRIPTION
```
=== RUN   TestMigrateArgoSmartRouting_V4ToV5_SmartRoutingOnly
=== RUN   TestMigrateArgoSmartRouting_V4ToV5_SmartRoutingOnly/from_v4_latest
=== RUN   TestMigrateArgoSmartRouting_V4ToV5_SmartRoutingOnly/from_v5
--- PASS: TestMigrateArgoSmartRouting_V4ToV5_SmartRoutingOnly (20.98s)
    --- PASS: TestMigrateArgoSmartRouting_V4ToV5_SmartRoutingOnly/from_v4_latest (12.07s)
    --- PASS: TestMigrateArgoSmartRouting_V4ToV5_SmartRoutingOnly/from_v5 (8.91s)
=== RUN   TestMigrateArgoSmartRouting_V4ToV5_BothAttributes
=== RUN   TestMigrateArgoSmartRouting_V4ToV5_BothAttributes/from_v4_latest
=== RUN   TestMigrateArgoSmartRouting_V4ToV5_BothAttributes/from_v5
--- PASS: TestMigrateArgoSmartRouting_V4ToV5_BothAttributes (22.28s)
    --- PASS: TestMigrateArgoSmartRouting_V4ToV5_BothAttributes/from_v4_latest (13.35s)
    --- PASS: TestMigrateArgoSmartRouting_V4ToV5_BothAttributes/from_v5 (8.93s)
=== RUN   TestMigrateArgoSmartRouting_V4ToV5_NeitherAttribute
=== RUN   TestMigrateArgoSmartRouting_V4ToV5_NeitherAttribute/from_v4_latest
=== RUN   TestMigrateArgoSmartRouting_V4ToV5_NeitherAttribute/from_v5
--- PASS: TestMigrateArgoSmartRouting_V4ToV5_NeitherAttribute (19.37s)
    --- PASS: TestMigrateArgoSmartRouting_V4ToV5_NeitherAttribute/from_v4_latest (10.44s)
    --- PASS: TestMigrateArgoSmartRouting_V4ToV5_NeitherAttribute/from_v5 (8.93s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/argo_smart_routing/migration/v500 64.054s

=== RUN   TestMigrateArgoTieredCaching_V4ToV5_TieredCachingOnly
=== RUN   TestMigrateArgoTieredCaching_V4ToV5_TieredCachingOnly/from_v4_latest
=== RUN   TestMigrateArgoTieredCaching_V4ToV5_TieredCachingOnly/from_v5
--- PASS: TestMigrateArgoTieredCaching_V4ToV5_TieredCachingOnly (22.54s)
    --- PASS: TestMigrateArgoTieredCaching_V4ToV5_TieredCachingOnly/from_v4_latest (12.99s)
    --- PASS: TestMigrateArgoTieredCaching_V4ToV5_TieredCachingOnly/from_v5 (9.56s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/argo_tiered_caching/migration/v500        24.066s
```