### PR TITLE
feat(api_shield_operation): state upgrader

### DIFF
--- a/internal/services/api_shield_operation/migration/v500/handler.go
+++ b/internal/services/api_shield_operation/migration/v500/handler.go
@@ -1,0 +1,48 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// UpgradeFromV4 handles state upgrades from v4 SDKv2 provider (schema_version=0) to v5 (version=500).
+//
+// This performs a full transformation from v4 → v5 format.
+// The v4 state has schema_version=0 (SDKv2 default), and we transform it to v5 format.
+func UpgradeFromV4(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading api_shield_operation state from v4 SDKv2 provider (schema_version=0)")
+
+	// Parse v4 state using v4 model
+	var v4State SourceCloudflareAPIShieldOperationModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &v4State)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform v4 → v5
+	v5State, diags := Transform(ctx, v4State)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Write transformed state
+	resp.Diagnostics.Append(resp.State.Set(ctx, v5State)...)
+	tflog.Info(ctx, "State upgrade from v4 to v5 completed successfully")
+}
+
+// UpgradeFromV5 handles state upgrades from v5 Plugin Framework provider (version=1) to v5 (version=500).
+//
+// This is a no-op upgrade since the schema is compatible - just bumps the version.
+// This handler is only triggered when TF_MIG_TEST=1 (GetSchemaVersion returns 500).
+func UpgradeFromV5(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading api_shield_operation state from version=1 to version=500 (no-op)")
+
+	// CRITICAL: For no-op upgrades, copy raw state directly
+	// This preserves all state data without any transformation
+	resp.State.Raw = req.State.Raw
+
+	tflog.Info(ctx, "State version bump from 1 to 500 completed")
+}

--- a/internal/services/api_shield_operation/migration/v500/migrations_test.go
+++ b/internal/services/api_shield_operation/migration/v500/migrations_test.go
@@ -1,0 +1,259 @@
+package v500_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+var (
+	currentProviderVersion = internal.PackageVersion // Current v5 release
+)
+
+// Embed test configs
+//
+//go:embed testdata/v4_basic.tf
+var v4BasicConfig string
+
+//go:embed testdata/v5_basic.tf
+var v5BasicConfig string
+
+//go:embed testdata/v4_post_method.tf
+var v4PostMethodConfig string
+
+//go:embed testdata/v5_post_method.tf
+var v5PostMethodConfig string
+
+//go:embed testdata/v4_path_params.tf
+var v4PathParamsConfig string
+
+//go:embed testdata/v5_path_params.tf
+var v5PathParamsConfig string
+
+// TestMigrateAPIShieldOperation_V4ToV5_Basic tests basic migration with GET method
+func TestMigrateAPIShieldOperation_V4ToV5_Basic(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID string) string
+	}{
+		{
+			name:    "from_v4_latest", // Tests legacy v4 → current v5
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v4BasicConfig, rnd, zoneID)
+			},
+		},
+		{
+			name:    "from_v5", // Tests within v5 (version bump)
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v5BasicConfig, rnd, zoneID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			// For v5 tests, use local provider; for v4 tests, use external provider
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				// Use local v5 provider (has GetSchemaVersion, will create version=1 state)
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				// Use external v4 provider (will create version=0 state)
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config: testConfig,
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					// Step 2: Run migration and verify state
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+						// Verify v4 fields migrated correctly
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("method"), knownvalue.StringExact("GET")),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("host"), knownvalue.StringExact("api.example.com")),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("endpoint"), knownvalue.StringExact("/api/v1/users")),
+						// Verify new v5 computed fields exist (populated by API)
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("operation_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("id"), knownvalue.NotNull()),
+					}),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateAPIShieldOperation_V4ToV5_PostMethod tests migration with POST method
+func TestMigrateAPIShieldOperation_V4ToV5_PostMethod(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v4PostMethodConfig, rnd, zoneID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v5PostMethodConfig, rnd, zoneID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config: testConfig,
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("method"), knownvalue.StringExact("POST")),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("host"), knownvalue.StringExact("api.example.com")),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("endpoint"), knownvalue.StringExact("/api/v1/users")),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("operation_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("id"), knownvalue.NotNull()),
+					}),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateAPIShieldOperation_V4ToV5_PathParams tests migration with path parameters
+func TestMigrateAPIShieldOperation_V4ToV5_PathParams(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v4PathParamsConfig, rnd, zoneID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID string) string {
+				return fmt.Sprintf(v5PathParamsConfig, rnd, zoneID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, zoneID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config: testConfig,
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("method"), knownvalue.StringExact("GET")),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("host"), knownvalue.StringExact("api.example.com")),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("endpoint"), knownvalue.StringExact("/api/v1/users/{var1}/posts/{var2}")),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("operation_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("cloudflare_api_shield_operation."+rnd, tfjsonpath.New("id"), knownvalue.NotNull()),
+					}),
+				},
+			})
+		})
+	}
+}

--- a/internal/services/api_shield_operation/migration/v500/model.go
+++ b/internal/services/api_shield_operation/migration/v500/model.go
@@ -1,0 +1,123 @@
+package v500
+
+import (
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ============================================================================
+// Source Models (Legacy Provider - v4.x)
+// ============================================================================
+
+// SourceCloudflareAPIShieldOperationModel represents the source cloudflare_api_shield_operation state structure.
+// This corresponds to schema_version=0 from the legacy (SDKv2) cloudflare provider.
+// Used by UpgradeFromV4 to parse legacy state.
+//
+// Note: This resource was added late to v4 and has a very simple schema with no nested structures.
+type SourceCloudflareAPIShieldOperationModel struct {
+	ID       types.String `tfsdk:"id"`
+	ZoneID   types.String `tfsdk:"zone_id"`
+	Method   types.String `tfsdk:"method"`
+	Host     types.String `tfsdk:"host"`
+	Endpoint types.String `tfsdk:"endpoint"`
+}
+
+// ============================================================================
+// Target Models (Current Provider - v5.x+)
+// ============================================================================
+
+// TargetAPIShieldOperationModel represents the target cloudflare_api_shield_operation state structure (v500).
+// This matches the structure in the parent package's model.go file.
+type TargetAPIShieldOperationModel struct {
+	ID          types.String                                                          `tfsdk:"id"`
+	OperationID types.String                                                          `tfsdk:"operation_id"`
+	ZoneID      types.String                                                          `tfsdk:"zone_id"`
+	Endpoint    types.String                                                          `tfsdk:"endpoint"`
+	Host        types.String                                                          `tfsdk:"host"`
+	Method      types.String                                                          `tfsdk:"method"`
+	LastUpdated timetypes.RFC3339                                                     `tfsdk:"last_updated"`
+	Features    customfield.NestedObject[TargetAPIShieldOperationFeaturesModel]       `tfsdk:"features"`
+}
+
+// TargetAPIShieldOperationFeaturesModel represents the features nested structure.
+// All fields are computed and populated by the API.
+type TargetAPIShieldOperationFeaturesModel struct {
+	Thresholds          customfield.NestedObject[TargetAPIShieldOperationFeaturesThresholdsModel]          `tfsdk:"thresholds"`
+	ParameterSchemas    customfield.NestedObject[TargetAPIShieldOperationFeaturesParameterSchemasModel]    `tfsdk:"parameter_schemas"`
+	APIRouting          customfield.NestedObject[TargetAPIShieldOperationFeaturesAPIRoutingModel]          `tfsdk:"api_routing"`
+	ConfidenceIntervals customfield.NestedObject[TargetAPIShieldOperationFeaturesConfidenceIntervalsModel] `tfsdk:"confidence_intervals"`
+	SchemaInfo          customfield.NestedObject[TargetAPIShieldOperationFeaturesSchemaInfoModel]          `tfsdk:"schema_info"`
+}
+
+type TargetAPIShieldOperationFeaturesThresholdsModel struct {
+	AuthIDTokens       types.Int64       `tfsdk:"auth_id_tokens"`
+	DataPoints         types.Int64       `tfsdk:"data_points"`
+	LastUpdated        timetypes.RFC3339 `tfsdk:"last_updated"`
+	P50                types.Int64       `tfsdk:"p50"`
+	P90                types.Int64       `tfsdk:"p90"`
+	P99                types.Int64       `tfsdk:"p99"`
+	PeriodSeconds      types.Int64       `tfsdk:"period_seconds"`
+	Requests           types.Int64       `tfsdk:"requests"`
+	SuggestedThreshold types.Int64       `tfsdk:"suggested_threshold"`
+}
+
+type TargetAPIShieldOperationFeaturesParameterSchemasModel struct {
+	LastUpdated      timetypes.RFC3339                                                                                     `tfsdk:"last_updated"`
+	ParameterSchemas customfield.NestedObject[TargetAPIShieldOperationFeaturesParameterSchemasParameterSchemasModel]       `tfsdk:"parameter_schemas"`
+}
+
+type TargetAPIShieldOperationFeaturesParameterSchemasParameterSchemasModel struct {
+	Parameters customfield.List[jsontypes.Normalized] `tfsdk:"parameters"`
+	Responses  jsontypes.Normalized                   `tfsdk:"responses"`
+}
+
+type TargetAPIShieldOperationFeaturesAPIRoutingModel struct {
+	LastUpdated timetypes.RFC3339 `tfsdk:"last_updated"`
+	Route       types.String      `tfsdk:"route"`
+}
+
+type TargetAPIShieldOperationFeaturesConfidenceIntervalsModel struct {
+	LastUpdated        timetypes.RFC3339                                                                                          `tfsdk:"last_updated"`
+	SuggestedThreshold customfield.NestedObject[TargetAPIShieldOperationFeaturesConfidenceIntervalsSuggestedThresholdModel]      `tfsdk:"suggested_threshold"`
+}
+
+type TargetAPIShieldOperationFeaturesConfidenceIntervalsSuggestedThresholdModel struct {
+	ConfidenceIntervals customfield.NestedObject[TargetAPIShieldOperationFeaturesConfidenceIntervalsSuggestedThresholdConfidenceIntervalsModel] `tfsdk:"confidence_intervals"`
+	Mean                types.Float64                                                                                                            `tfsdk:"mean"`
+}
+
+type TargetAPIShieldOperationFeaturesConfidenceIntervalsSuggestedThresholdConfidenceIntervalsModel struct {
+	P90 customfield.NestedObject[TargetAPIShieldOperationFeaturesConfidenceIntervalsSuggestedThresholdConfidenceIntervalsP90Model] `tfsdk:"p90"`
+	P95 customfield.NestedObject[TargetAPIShieldOperationFeaturesConfidenceIntervalsSuggestedThresholdConfidenceIntervalsP95Model] `tfsdk:"p95"`
+	P99 customfield.NestedObject[TargetAPIShieldOperationFeaturesConfidenceIntervalsSuggestedThresholdConfidenceIntervalsP99Model] `tfsdk:"p99"`
+}
+
+type TargetAPIShieldOperationFeaturesConfidenceIntervalsSuggestedThresholdConfidenceIntervalsP90Model struct {
+	Lower types.Float64 `tfsdk:"lower"`
+	Upper types.Float64 `tfsdk:"upper"`
+}
+
+type TargetAPIShieldOperationFeaturesConfidenceIntervalsSuggestedThresholdConfidenceIntervalsP95Model struct {
+	Lower types.Float64 `tfsdk:"lower"`
+	Upper types.Float64 `tfsdk:"upper"`
+}
+
+type TargetAPIShieldOperationFeaturesConfidenceIntervalsSuggestedThresholdConfidenceIntervalsP99Model struct {
+	Lower types.Float64 `tfsdk:"lower"`
+	Upper types.Float64 `tfsdk:"upper"`
+}
+
+type TargetAPIShieldOperationFeaturesSchemaInfoModel struct {
+	ActiveSchema     customfield.NestedObject[TargetAPIShieldOperationFeaturesSchemaInfoActiveSchemaModel] `tfsdk:"active_schema"`
+	LearnedAvailable types.Bool                                                                            `tfsdk:"learned_available"`
+	MitigationAction types.String                                                                          `tfsdk:"mitigation_action"`
+}
+
+type TargetAPIShieldOperationFeaturesSchemaInfoActiveSchemaModel struct {
+	ID        types.String      `tfsdk:"id"`
+	CreatedAt timetypes.RFC3339 `tfsdk:"created_at"`
+	IsLearned types.Bool        `tfsdk:"is_learned"`
+	Name      types.String      `tfsdk:"name"`
+}

--- a/internal/services/api_shield_operation/migration/v500/schema.go
+++ b/internal/services/api_shield_operation/migration/v500/schema.go
@@ -1,0 +1,37 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// SourceCloudflareAPIShieldOperationSchema returns the legacy cloudflare_api_shield_operation schema (schema_version=0).
+// This is used by UpgradeFromV4 to parse state from the legacy SDKv2 provider.
+//
+// This schema is minimal - it includes only the properties needed for state parsing:
+// Required, Optional, Computed, and ElementType. Validators, PlanModifiers, and
+// Descriptions are intentionally omitted.
+//
+// Reference: Reconstructed from git history commit ebcb42f1d
+// (v4 files were deleted in commit 595774b9b after internal migration)
+func SourceCloudflareAPIShieldOperationSchema() schema.Schema {
+	return schema.Schema{
+		Version: 0, // v4 SDKv2 default schema version
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"zone_id": schema.StringAttribute{
+				Required: true,
+			},
+			"method": schema.StringAttribute{
+				Required: true,
+			},
+			"host": schema.StringAttribute{
+				Required: true,
+			},
+			"endpoint": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+}

--- a/internal/services/api_shield_operation/migration/v500/testdata/v4_basic.tf
+++ b/internal/services/api_shield_operation/migration/v500/testdata/v4_basic.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_api_shield_operation" "%s" {
+  zone_id  = "%s"
+  method   = "GET"
+  host     = "api.example.com"
+  endpoint = "/api/v1/users"
+}

--- a/internal/services/api_shield_operation/migration/v500/testdata/v4_path_params.tf
+++ b/internal/services/api_shield_operation/migration/v500/testdata/v4_path_params.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_api_shield_operation" "%s" {
+  zone_id  = "%s"
+  method   = "GET"
+  host     = "api.example.com"
+  endpoint = "/api/v1/users/{var1}/posts/{var2}"
+}

--- a/internal/services/api_shield_operation/migration/v500/testdata/v4_post_method.tf
+++ b/internal/services/api_shield_operation/migration/v500/testdata/v4_post_method.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_api_shield_operation" "%s" {
+  zone_id  = "%s"
+  method   = "POST"
+  host     = "api.example.com"
+  endpoint = "/api/v1/users"
+}

--- a/internal/services/api_shield_operation/migration/v500/testdata/v5_basic.tf
+++ b/internal/services/api_shield_operation/migration/v500/testdata/v5_basic.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_api_shield_operation" "%s" {
+  zone_id  = "%s"
+  method   = "GET"
+  host     = "api.example.com"
+  endpoint = "/api/v1/users"
+}

--- a/internal/services/api_shield_operation/migration/v500/testdata/v5_path_params.tf
+++ b/internal/services/api_shield_operation/migration/v500/testdata/v5_path_params.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_api_shield_operation" "%s" {
+  zone_id  = "%s"
+  method   = "GET"
+  host     = "api.example.com"
+  endpoint = "/api/v1/users/{var1}/posts/{var2}"
+}

--- a/internal/services/api_shield_operation/migration/v500/testdata/v5_post_method.tf
+++ b/internal/services/api_shield_operation/migration/v500/testdata/v5_post_method.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_api_shield_operation" "%s" {
+  zone_id  = "%s"
+  method   = "POST"
+  host     = "api.example.com"
+  endpoint = "/api/v1/users"
+}

--- a/internal/services/api_shield_operation/migration/v500/transform.go
+++ b/internal/services/api_shield_operation/migration/v500/transform.go
@@ -1,0 +1,73 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// Transform converts source (v4 SDKv2) state to target (v5 Plugin Framework) state.
+//
+// This is one of the simplest transformations:
+// - All v4 fields are direct copies (no renames, no type changes)
+// - New v5 fields are all Computed and set to Null (API will populate on read)
+//
+// This function is used by UpgradeFromV4 handler.
+func Transform(ctx context.Context, source SourceCloudflareAPIShieldOperationModel) (*TargetAPIShieldOperationModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Validate required fields
+	if source.ZoneID.IsNull() || source.ZoneID.IsUnknown() {
+		diags.AddError(
+			"Missing required field",
+			"zone_id is required for api_shield_operation migration. The source state is missing this field, which indicates corrupted state.",
+		)
+		return nil, diags
+	}
+
+	if source.Method.IsNull() || source.Method.IsUnknown() {
+		diags.AddError(
+			"Missing required field",
+			"method is required for api_shield_operation migration. The source state is missing this field, which indicates corrupted state.",
+		)
+		return nil, diags
+	}
+
+	if source.Host.IsNull() || source.Host.IsUnknown() {
+		diags.AddError(
+			"Missing required field",
+			"host is required for api_shield_operation migration. The source state is missing this field, which indicates corrupted state.",
+		)
+		return nil, diags
+	}
+
+	if source.Endpoint.IsNull() || source.Endpoint.IsUnknown() {
+		diags.AddError(
+			"Missing required field",
+			"endpoint is required for api_shield_operation migration. The source state is missing this field, which indicates corrupted state.",
+		)
+		return nil, diags
+	}
+
+	// Initialize target model
+	target := &TargetAPIShieldOperationModel{}
+
+	// Step 1: Direct field copies (all v4 fields)
+	// These are all unchanged between v4 and v5
+	target.ID = source.ID
+	target.ZoneID = source.ZoneID
+	target.Method = source.Method
+	target.Host = source.Host
+	target.Endpoint = source.Endpoint
+
+	// Step 2: New v5 Computed fields
+	// CRITICAL: OperationID must be set to ID value (not Null) because the Read function
+	// uses OperationID to make API calls. In v5, ID and OperationID are the same value.
+	target.OperationID = source.ID
+	target.LastUpdated = timetypes.NewRFC3339Null()
+	target.Features = customfield.NullObject[TargetAPIShieldOperationFeaturesModel](ctx)
+
+	return target, diags
+}

--- a/internal/services/api_shield_operation/migrations.go
+++ b/internal/services/api_shield_operation/migrations.go
@@ -5,11 +5,36 @@ package api_shield_operation
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_shield_operation/migration/v500"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 var _ resource.ResourceWithUpgradeState = (*APIShieldOperationResource)(nil)
 
+// UpgradeState registers state upgraders for schema version changes.
+//
+// This handles two upgrade paths:
+// 1. v4 state (schema_version=0) → v5 (version=500): Full transformation
+// 2. v5 state (version=1) → v5 (version=500): No-op upgrade (when TF_MIG_TEST=1)
+//
+// The separation of schema versions (v4=0, v5=1/500) eliminates the need for
+// dual-format detection that was required in earlier implementations.
 func (r *APIShieldOperationResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	sourceSchema := v500.SourceCloudflareAPIShieldOperationSchema()
+	targetSchema := ResourceSchema(ctx)
+
+	return map[int64]resource.StateUpgrader{
+		// Handle state from v4 SDKv2 provider (schema_version=0)
+		0: {
+			PriorSchema:   &sourceSchema,
+			StateUpgrader: v500.UpgradeFromV4,
+		},
+
+		// Handle state from v5 Plugin Framework provider with version=1
+		// This is a no-op upgrade that just bumps the version to 500
+		1: {
+			PriorSchema:   &targetSchema,
+			StateUpgrader: v500.UpgradeFromV5,
+		},
+	}
 }

--- a/internal/services/api_shield_operation/schema.go
+++ b/internal/services/api_shield_operation/schema.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -20,6 +21,7 @@ var _ resource.ResourceWithConfigValidators = (*APIShieldOperationResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: migrations.GetSchemaVersion(1, 500),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "UUID.",


### PR DESCRIPTION
```
=== RUN   TestMigrateAPIShieldOperation_V4ToV5_Basic
=== RUN   TestMigrateAPIShieldOperation_V4ToV5_Basic/from_v4_latest
=== RUN   TestMigrateAPIShieldOperation_V4ToV5_Basic/from_v5
--- PASS: TestMigrateAPIShieldOperation_V4ToV5_Basic (19.65s)
    --- PASS: TestMigrateAPIShieldOperation_V4ToV5_Basic/from_v4_latest (14.93s)
    --- PASS: TestMigrateAPIShieldOperation_V4ToV5_Basic/from_v5 (4.72s)
=== RUN   TestMigrateAPIShieldOperation_V4ToV5_PostMethod
=== RUN   TestMigrateAPIShieldOperation_V4ToV5_PostMethod/from_v4_latest
=== RUN   TestMigrateAPIShieldOperation_V4ToV5_PostMethod/from_v5
--- PASS: TestMigrateAPIShieldOperation_V4ToV5_PostMethod (17.57s)
    --- PASS: TestMigrateAPIShieldOperation_V4ToV5_PostMethod/from_v4_latest (13.05s)
    --- PASS: TestMigrateAPIShieldOperation_V4ToV5_PostMethod/from_v5 (4.53s)
=== RUN   TestMigrateAPIShieldOperation_V4ToV5_PathParams
=== RUN   TestMigrateAPIShieldOperation_V4ToV5_PathParams/from_v4_latest
=== RUN   TestMigrateAPIShieldOperation_V4ToV5_PathParams/from_v5
--- PASS: TestMigrateAPIShieldOperation_V4ToV5_PathParams (17.95s)
    --- PASS: TestMigrateAPIShieldOperation_V4ToV5_PathParams/from_v4_latest (13.37s)
    --- PASS: TestMigrateAPIShieldOperation_V4ToV5_PathParams/from_v5 (4.58s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_shield_operation/migration/v500       56.718s
```