### PR TITLE
chore(queue_consumer): support state upgraders

### DIFF
--- a/internal/services/queue_consumer/migration/v500/handler.go
+++ b/internal/services/queue_consumer/migration/v500/handler.go
@@ -1,0 +1,36 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// UpgradeFromV0 handles state upgrades from schema_version=0 to schema_version=500.
+// This is a no-op upgrade: cloudflare_queue_consumer is a v5-native resource with no v4
+// predecessor. States at version=0 were created before explicit schema versioning was
+// applied to this resource. The schema is fully compatible — just copy state through.
+func UpgradeFromV0(
+	ctx context.Context,
+	req resource.UpgradeStateRequest,
+	resp *resource.UpgradeStateResponse,
+) {
+	tflog.Info(ctx, "Upgrading queue_consumer state from schema_version=0")
+	// No-op: schema is compatible, just copy raw state through.
+	// Using raw state avoids issues with custom field type serialization.
+	resp.State.Raw = req.State.Raw
+}
+
+// UpgradeFromV1 handles state upgrades from schema_version=1 to schema_version=500.
+// This is a no-op upgrade: version 1 is the dormant production version of the v5 schema.
+// No schema changes occurred between version 1 and version 500.
+func UpgradeFromV1(
+	ctx context.Context,
+	req resource.UpgradeStateRequest,
+	resp *resource.UpgradeStateResponse,
+) {
+	tflog.Info(ctx, "Upgrading queue_consumer state from schema_version=1")
+	// No-op: schema is compatible, just copy raw state through.
+	resp.State.Raw = req.State.Raw
+}

--- a/internal/services/queue_consumer/migration/v500/migrations_test.go
+++ b/internal/services/queue_consumer/migration/v500/migrations_test.go
@@ -1,0 +1,129 @@
+package v500_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+var (
+	currentProviderVersion = internal.PackageVersion
+)
+
+//go:embed testdata/v5_http.tf
+var v5HTTPConfig string
+
+//go:embed testdata/v5_worker.tf
+var v5WorkerConfig string
+
+// TestMigrateQueueConsumer_HTTP tests migration of an HTTP pull queue consumer.
+//
+// cloudflare_queue_consumer is a v5-native resource; this test verifies that
+// existing states at schema_version=0 (before explicit versioning) upgrade
+// cleanly to schema_version=500 with no data loss.
+func TestMigrateQueueConsumer_HTTP(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(accountID, rnd string) string
+	}{
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(accountID, rnd string) string {
+				return fmt.Sprintf(v5HTTPConfig, accountID, rnd)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(accountID, rnd)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			firstStep := resource.TestStep{
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				Config:                   testConfig,
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("cloudflare_queue_consumer."+rnd, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+						statecheck.ExpectKnownValue("cloudflare_queue_consumer."+rnd, tfjsonpath.New("type"), knownvalue.StringExact("http_pull")),
+					}),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateQueueConsumer_Worker tests migration of a worker-type queue consumer.
+//
+// cloudflare_queue_consumer is a v5-native resource; this test verifies that
+// existing states at schema_version=0 (before explicit versioning) upgrade
+// cleanly to schema_version=500 with no data loss.
+func TestMigrateQueueConsumer_Worker(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(accountID, rnd string) string
+	}{
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(accountID, rnd string) string {
+				return fmt.Sprintf(v5WorkerConfig, accountID, rnd)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(accountID, rnd)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			firstStep := resource.TestStep{
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				Config:                   testConfig,
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("cloudflare_queue_consumer."+rnd, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+						statecheck.ExpectKnownValue("cloudflare_queue_consumer."+rnd, tfjsonpath.New("type"), knownvalue.StringExact("worker")),
+					}),
+				},
+			})
+		})
+	}
+}

--- a/internal/services/queue_consumer/migration/v500/model.go
+++ b/internal/services/queue_consumer/migration/v500/model.go
@@ -1,0 +1,30 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// SourceQueueConsumerModel represents the queue_consumer state at schema_version=0.
+// This resource was introduced in v5 with no v4 predecessor; this model captures the
+// state as it existed before explicit schema versioning was applied.
+type SourceQueueConsumerModel struct {
+	AccountID       types.String                      `tfsdk:"account_id"`
+	QueueID         types.String                      `tfsdk:"queue_id"`
+	ConsumerID      types.String                      `tfsdk:"consumer_id"`
+	DeadLetterQueue types.String                      `tfsdk:"dead_letter_queue"`
+	ScriptName      types.String                      `tfsdk:"script_name"`
+	Type            types.String                      `tfsdk:"type"`
+	Settings        *SourceQueueConsumerSettingsModel `tfsdk:"settings"`
+	CreatedOn       types.String                      `tfsdk:"created_on"`
+	Script          types.String                      `tfsdk:"script"`
+}
+
+// SourceQueueConsumerSettingsModel represents the settings nested object at schema_version=0.
+type SourceQueueConsumerSettingsModel struct {
+	BatchSize           types.Float64 `tfsdk:"batch_size"`
+	MaxConcurrency      types.Float64 `tfsdk:"max_concurrency"`
+	MaxRetries          types.Float64 `tfsdk:"max_retries"`
+	MaxWaitTimeMs       types.Float64 `tfsdk:"max_wait_time_ms"`
+	RetryDelay          types.Float64 `tfsdk:"retry_delay"`
+	VisibilityTimeoutMs types.Float64 `tfsdk:"visibility_timeout_ms"`
+}

--- a/internal/services/queue_consumer/migration/v500/schema.go
+++ b/internal/services/queue_consumer/migration/v500/schema.go
@@ -1,0 +1,65 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// SourceCloudflareQueueConsumerSchema returns the schema for cloudflare_queue_consumer at schema_version=0.
+// This resource was introduced in v5 with no v4 predecessor. The source schema matches the original
+// v5 schema before explicit versioning was applied (i.e., before Version: GetSchemaVersion(1, 500)).
+//
+// Note: PlanModifiers and Validators are intentionally omitted — they are not stored in state
+// and are not needed for state parsing.
+func SourceCloudflareQueueConsumerSchema() schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"account_id": schema.StringAttribute{
+				Required: true,
+			},
+			"queue_id": schema.StringAttribute{
+				Required: true,
+			},
+			"consumer_id": schema.StringAttribute{
+				Computed: true,
+			},
+			"dead_letter_queue": schema.StringAttribute{
+				Optional: true,
+			},
+			"script_name": schema.StringAttribute{
+				Optional: true,
+			},
+			"type": schema.StringAttribute{
+				Optional: true,
+			},
+			"settings": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"batch_size": schema.Float64Attribute{
+						Optional: true,
+					},
+					"max_concurrency": schema.Float64Attribute{
+						Optional: true,
+					},
+					"max_retries": schema.Float64Attribute{
+						Optional: true,
+					},
+					"max_wait_time_ms": schema.Float64Attribute{
+						Optional: true,
+					},
+					"retry_delay": schema.Float64Attribute{
+						Optional: true,
+					},
+					"visibility_timeout_ms": schema.Float64Attribute{
+						Optional: true,
+					},
+				},
+			},
+			"created_on": schema.StringAttribute{
+				Computed: true,
+			},
+			"script": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}

--- a/internal/services/queue_consumer/migration/v500/testdata/v5_http.tf
+++ b/internal/services/queue_consumer/migration/v500/testdata/v5_http.tf
@@ -1,0 +1,14 @@
+resource "cloudflare_queue" "test_queue" {
+  account_id = "%[1]s"
+  queue_name = "%[2]s"
+}
+
+resource "cloudflare_queue_consumer" "%[2]s" {
+  account_id = "%[1]s"
+  queue_id   = cloudflare_queue.test_queue.id
+  type       = "http_pull"
+
+  lifecycle {
+    ignore_changes = [settings]
+  }
+}

--- a/internal/services/queue_consumer/migration/v500/testdata/v5_worker.tf
+++ b/internal/services/queue_consumer/migration/v500/testdata/v5_worker.tf
@@ -1,0 +1,32 @@
+resource "cloudflare_queue" "test_queue" {
+  account_id = "%[1]s"
+  queue_name = "%[2]s"
+}
+
+resource "cloudflare_workers_script" "worker_script" {
+  account_id  = "%[1]s"
+  script_name = "%[2]s"
+  content     = <<-EOT
+export default {
+  async queue(batch, env, ctx) {
+    for (const message of batch.messages) {
+      console.log('Received', message);
+    }
+  }
+};
+EOT
+  main_module = "index.js"
+  depends_on  = [cloudflare_queue.test_queue]
+}
+
+resource "cloudflare_queue_consumer" "%[2]s" {
+  account_id  = "%[1]s"
+  queue_id    = cloudflare_queue.test_queue.id
+  type        = "worker"
+  script_name = cloudflare_workers_script.worker_script.script_name
+  depends_on  = [cloudflare_workers_script.worker_script]
+
+  lifecycle {
+    ignore_changes = [settings]
+  }
+}

--- a/internal/services/queue_consumer/migrations.go
+++ b/internal/services/queue_consumer/migrations.go
@@ -6,10 +6,34 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/queue_consumer/migration/v500"
 )
 
 var _ resource.ResourceWithUpgradeState = (*QueueConsumerResource)(nil)
 
+// UpgradeState handles schema version upgrades for cloudflare_queue_consumer.
+//
+// cloudflare_queue_consumer is a v5-native resource with no v4 predecessor.
+// Both upgraders are no-ops — the schema has not changed, only the version number.
+//
+// Version history:
+//   - 0: Original v5 state (before schema versioning was applied)
+//   - 1: Dormant production version (GetSchemaVersion returns 1 normally)
+//   - 500: Active migration version (GetSchemaVersion returns 500 when TF_MIG_TEST=1)
 func (r *QueueConsumerResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	sourceSchema := v500.SourceCloudflareQueueConsumerSchema()
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		// Handle v5 states created before explicit schema versioning (schema_version=0)
+		0: {
+			PriorSchema:   &sourceSchema,
+			StateUpgrader: v500.UpgradeFromV0,
+		},
+		// Handle dormant production v5 states (schema_version=1) → v500 (no-op)
+		1: {
+			PriorSchema:   &targetSchema,
+			StateUpgrader: v500.UpgradeFromV1,
+		},
+	}
 }

--- a/internal/services/queue_consumer/schema.go
+++ b/internal/services/queue_consumer/schema.go
@@ -11,12 +11,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 )
 
 var _ resource.ResourceWithConfigValidators = (*QueueConsumerResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: migrations.GetSchemaVersion(1, 500),
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "A Resource identifier.",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Support state upgraders for `queue_consumer`. _Note:_ This resource did not exist in v4, so this is essentially stub code to match all other resources.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
`TF_ACC=1 TF_MIG_TEST=1 TF_MIGRATE_BINARY_PATH=/Users/ssicard/workspace/terraform-devstack/tf-migrate/tf-migrate go test ./internal/services/queue_consumer/migration/v500 -v`

### Test output
```bash
=== RUN   TestMigrateQueueConsumer_HTTP
=== RUN   TestMigrateQueueConsumer_HTTP/from_v5
--- PASS: TestMigrateQueueConsumer_HTTP (5.52s)
    --- PASS: TestMigrateQueueConsumer_HTTP/from_v5 (5.52s)
=== RUN   TestMigrateQueueConsumer_Worker
=== RUN   TestMigrateQueueConsumer_Worker/from_v5
--- PASS: TestMigrateQueueConsumer_Worker (15.48s)
    --- PASS: TestMigrateQueueConsumer_Worker/from_v5 (15.48s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/queue_consumer/migration/v500	22.462s
```

## Additional context & links
