### PR TITLE
 feat(zero_trust_device_managed_networks): state upgrader

### DIFF
--- a/internal/services/zero_trust_device_managed_networks/migration/v500/handler.go
+++ b/internal/services/zero_trust_device_managed_networks/migration/v500/handler.go
@@ -1,0 +1,49 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// UpgradeFromV1 handles state upgrades from earlier v5 versions (schema_version=1) to current v500.
+// This is a no-op upgrade since the schema is compatible - just copy state through.
+func UpgradeFromV1(
+	ctx context.Context,
+	req resource.UpgradeStateRequest,
+	resp *resource.UpgradeStateResponse,
+) {
+	tflog.Info(ctx, "Upgrading zero trust device managed networks state from schema_version=1")
+	// No-op upgrade: schema is compatible, just copy raw state through
+	resp.State.Raw = req.State.Raw
+}
+
+// UpgradeFromLegacyV0 handles state upgrades from the legacy cloudflare_device_managed_networks resource to cloudflare_zero_trust_device_managed_networks.
+// This is triggered when users manually run `terraform state mv cloudflare_device_managed_networks.x cloudflare_zero_trust_device_managed_networks.x`
+// (Terraform < 1.8), which preserves the source schema_version=0 from the legacy provider.
+//
+// Note: schema_version=0 (implicit) was the schema version of cloudflare_device_managed_networks in the legacy (SDKv2) provider
+// before it was renamed. The state structure matches SourceCloudflareDeviceManagedNetworksModel.
+func UpgradeFromLegacyV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading state from legacy cloudflare_device_managed_networks (schema_version=0)")
+
+	// Parse the state (schema_version=0, source resource type)
+	var sourceState SourceCloudflareDeviceManagedNetworksModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &sourceState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform to target
+	targetState, diags := Transform(ctx, sourceState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Set the upgraded state
+	resp.Diagnostics.Append(resp.State.Set(ctx, targetState)...)
+
+	tflog.Info(ctx, "State upgrade from legacy cloudflare_device_managed_networks completed successfully")
+}

--- a/internal/services/zero_trust_device_managed_networks/migration/v500/migrations_test.go
+++ b/internal/services/zero_trust_device_managed_networks/migration/v500/migrations_test.go
@@ -1,0 +1,126 @@
+package v500_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+var (
+	currentProviderVersion = internal.PackageVersion // Current v5 release
+)
+
+// Embed migration test configuration files
+//
+//go:embed testdata/v4_basic.tf
+var v4BasicConfig string
+
+//go:embed testdata/v5_basic.tf
+var v5BasicConfig string
+
+// TestMigrateZeroTrustDeviceManagedNetworksBasic tests migration from v4 cloudflare_device_managed_networks to v5 cloudflare_zero_trust_device_managed_networks
+func TestMigrateZeroTrustDeviceManagedNetworksBasic(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, accountID string) string
+	}{
+		{
+			name:     "from_v4_latest",
+			version:  acctest.GetLastV4Version(),
+			configFn: func(rnd, accountID string) string { return fmt.Sprintf(v4BasicConfig, rnd, accountID, rnd) },
+		},
+		{
+			name:     "from_v5",
+			version:  currentProviderVersion,
+			configFn: func(rnd, accountID string) string { return fmt.Sprintf(v5BasicConfig, rnd, accountID, rnd) },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, accountID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			// For v5 tests, use local provider; for v4 tests, use external provider
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				// Use local v5 provider (has GetSchemaVersion, will create version=1 state)
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				// Use external v4 provider (will create version=0 state)
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config: testConfig,
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					// Step 2: Run migration and verify state
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+						// Resource should be renamed to cloudflare_zero_trust_device_managed_networks
+						// Validate ALL fields as requested
+
+						// Required fields - exact match
+						statecheck.ExpectKnownValue("cloudflare_zero_trust_device_managed_networks."+rnd,
+							tfjsonpath.New("account_id"),
+							knownvalue.StringExact(accountID)),
+						statecheck.ExpectKnownValue("cloudflare_zero_trust_device_managed_networks."+rnd,
+							tfjsonpath.New("name"),
+							knownvalue.StringExact(fmt.Sprintf("tf-test-managed-network-%s", rnd))),
+						statecheck.ExpectKnownValue("cloudflare_zero_trust_device_managed_networks."+rnd,
+							tfjsonpath.New("type"),
+							knownvalue.StringExact("tls")),
+
+						// Computed fields - verify they exist
+						statecheck.ExpectKnownValue("cloudflare_zero_trust_device_managed_networks."+rnd,
+							tfjsonpath.New("id"),
+							knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("cloudflare_zero_trust_device_managed_networks."+rnd,
+							tfjsonpath.New("network_id"),
+							knownvalue.NotNull()),
+
+						// Config nested object - verify structure conversion (array → object) and field values
+						statecheck.ExpectKnownValue("cloudflare_zero_trust_device_managed_networks."+rnd,
+							tfjsonpath.New("config"),
+							knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("cloudflare_zero_trust_device_managed_networks."+rnd,
+							tfjsonpath.New("config").AtMapKey("tls_sockaddr"),
+							knownvalue.StringExact("example.com:443")),
+						statecheck.ExpectKnownValue("cloudflare_zero_trust_device_managed_networks."+rnd,
+							tfjsonpath.New("config").AtMapKey("sha256"),
+							knownvalue.StringExact("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c")),
+					}),
+				},
+			})
+		})
+	}
+}

--- a/internal/services/zero_trust_device_managed_networks/migration/v500/model.go
+++ b/internal/services/zero_trust_device_managed_networks/migration/v500/model.go
@@ -1,0 +1,41 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// SourceCloudflareDeviceManagedNetworksModel represents the source cloudflare_device_managed_networks state structure.
+// This corresponds to schema_version=0 from the legacy (SDKv2) cloudflare provider.
+// Used by both MoveState (Terraform 1.8+) and UpgradeFromLegacyV0 (Terraform < 1.8) to parse legacy state.
+type SourceCloudflareDeviceManagedNetworksModel struct {
+	ID        types.String        `tfsdk:"id"`
+	AccountID types.String        `tfsdk:"account_id"`
+	Name      types.String        `tfsdk:"name"`
+	Type      types.String        `tfsdk:"type"`
+	Config    []SourceConfigModel `tfsdk:"config"` // TypeList MaxItems:1 in v4 (stored as array)
+}
+
+// SourceConfigModel represents the source config block structure.
+// In the legacy provider, this is a list with MaxItems: 1, so it's stored as a single-element array.
+type SourceConfigModel struct {
+	TLSSockaddr types.String `tfsdk:"tls_sockaddr"`
+	Sha256      types.String `tfsdk:"sha256"`
+}
+
+// TargetZeroTrustDeviceManagedNetworksModel represents the target cloudflare_zero_trust_device_managed_networks state structure (v500).
+// Must match zero_trust_device_managed_networks.ZeroTrustDeviceManagedNetworksModel structure exactly.
+type TargetZeroTrustDeviceManagedNetworksModel struct {
+	ID        types.String         `tfsdk:"id"`
+	NetworkID types.String         `tfsdk:"network_id"` // New computed field in v5
+	AccountID types.String         `tfsdk:"account_id"`
+	Name      types.String         `tfsdk:"name"`
+	Type      types.String         `tfsdk:"type"`
+	Config    *TargetConfigModel   `tfsdk:"config"` // SingleNestedAttribute in v5 (stored as object pointer)
+}
+
+// TargetConfigModel represents the target config nested object (v500).
+// Must match zero_trust_device_managed_networks.ZeroTrustDeviceManagedNetworksConfigModel structure exactly.
+type TargetConfigModel struct {
+	TLSSockaddr types.String `tfsdk:"tls_sockaddr"`
+	Sha256      types.String `tfsdk:"sha256"`
+}

--- a/internal/services/zero_trust_device_managed_networks/migration/v500/move_state.go
+++ b/internal/services/zero_trust_device_managed_networks/migration/v500/move_state.go
@@ -1,0 +1,62 @@
+package v500
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// MoveState handles state moves from cloudflare_device_managed_networks (v0) to cloudflare_zero_trust_device_managed_networks (v500).
+// This is triggered when users use the `moved` block (Terraform 1.8+):
+//
+//	moved {
+//	    from = cloudflare_device_managed_networks.example
+//	    to   = cloudflare_zero_trust_device_managed_networks.example
+//	}
+func MoveState(
+	ctx context.Context,
+	req resource.MoveStateRequest,
+	resp *resource.MoveStateResponse,
+) {
+	// Verify source is cloudflare_device_managed_networks from cloudflare provider
+	if req.SourceTypeName != "cloudflare_device_managed_networks" {
+		return
+	}
+
+	if !isCloudflareProvider(req.SourceProviderAddress) {
+		return
+	}
+
+	tflog.Info(ctx, "Starting state move from cloudflare_device_managed_networks to cloudflare_zero_trust_device_managed_networks",
+		map[string]interface{}{
+			"source_type":           req.SourceTypeName,
+			"source_schema_version": req.SourceSchemaVersion,
+			"source_provider":       req.SourceProviderAddress,
+		})
+
+	// Parse the source state
+	var sourceState SourceCloudflareDeviceManagedNetworksModel
+	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform source state to target state
+	targetState, diags := Transform(ctx, sourceState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Set the target state
+	resp.Diagnostics.Append(resp.TargetState.Set(ctx, targetState)...)
+
+	tflog.Info(ctx, "State move from cloudflare_device_managed_networks to cloudflare_zero_trust_device_managed_networks completed successfully")
+}
+
+func isCloudflareProvider(addr string) bool {
+	return strings.Contains(addr, "cloudflare/cloudflare") ||
+		strings.Contains(addr, "registry.terraform.io/cloudflare")
+}

--- a/internal/services/zero_trust_device_managed_networks/migration/v500/schema.go
+++ b/internal/services/zero_trust_device_managed_networks/migration/v500/schema.go
@@ -1,0 +1,43 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// SourceCloudflareDeviceManagedNetworksSchema returns the legacy cloudflare_device_managed_networks schema (schema_version=0).
+// This is used by MoveState and UpgradeFromLegacyV0 to parse state from the legacy SDKv2 provider.
+// Reference: https://github.com/cloudflare/terraform-provider-cloudflare/blob/v4/internal/sdkv2provider/schema_cloudflare_device_managed_networks.go
+func SourceCloudflareDeviceManagedNetworksSchema() schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"account_id": schema.StringAttribute{
+				Required: true,
+			},
+			"type": schema.StringAttribute{
+				Required: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			// Source config is a list block with MaxItems: 1 (TypeList in SDKv2)
+			// Target config is a SingleNestedAttribute
+			"config": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"tls_sockaddr": schema.StringAttribute{
+							Required: true,
+						},
+						"sha256": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/services/zero_trust_device_managed_networks/migration/v500/testdata/v4_basic.tf
+++ b/internal/services/zero_trust_device_managed_networks/migration/v500/testdata/v4_basic.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_device_managed_networks" "%s" {
+  account_id = "%s"
+  name       = "tf-test-managed-network-%s"
+  type       = "tls"
+
+  config {
+    tls_sockaddr = "example.com:443"
+    sha256       = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
+  }
+}

--- a/internal/services/zero_trust_device_managed_networks/migration/v500/testdata/v5_basic.tf
+++ b/internal/services/zero_trust_device_managed_networks/migration/v500/testdata/v5_basic.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_zero_trust_device_managed_networks" "%s" {
+  account_id = "%s"
+  name       = "tf-test-managed-network-%s"
+  type       = "tls"
+
+  config = {
+    tls_sockaddr = "example.com:443"
+    sha256       = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
+  }
+}

--- a/internal/services/zero_trust_device_managed_networks/migration/v500/transform.go
+++ b/internal/services/zero_trust_device_managed_networks/migration/v500/transform.go
@@ -1,0 +1,52 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// Transform converts a source cloudflare_device_managed_networks state to target cloudflare_zero_trust_device_managed_networks state.
+func Transform(ctx context.Context, source SourceCloudflareDeviceManagedNetworksModel) (*TargetZeroTrustDeviceManagedNetworksModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Validate required fields
+	if source.AccountID.IsNull() || source.AccountID.IsUnknown() {
+		diags.AddError("Missing required field", "account_id is required for device managed networks migration")
+		return nil, diags
+	}
+	if source.Name.IsNull() || source.Name.IsUnknown() {
+		diags.AddError("Missing required field", "name is required for device managed networks migration")
+		return nil, diags
+	}
+	if source.Type.IsNull() || source.Type.IsUnknown() {
+		diags.AddError("Missing required field", "type is required for device managed networks migration")
+		return nil, diags
+	}
+
+	target := &TargetZeroTrustDeviceManagedNetworksModel{
+		ID:        source.ID,
+		AccountID: source.AccountID,
+		Name:      source.Name,
+		Type:      source.Type,
+		// NetworkID: v4 stored the network ID in the id field, v5 has both id and network_id
+		// Copy id to network_id (they should have the same value)
+		NetworkID: source.ID,
+	}
+
+	// Config: Transform from []SourceConfigModel (TypeList MaxItems:1 in v4) to *TargetConfigModel (SingleNestedAttribute in v5)
+	// v4 stores config as a single-element array, v5 stores as an object
+	if len(source.Config) > 0 {
+		sourceConfig := source.Config[0]
+		target.Config = &TargetConfigModel{
+			TLSSockaddr: sourceConfig.TLSSockaddr,
+			Sha256:      sourceConfig.Sha256,
+		}
+	} else {
+		// If config is missing, this is an error since it's required in both v4 and v5
+		diags.AddError("Missing required field", "config is required for device managed networks migration")
+		return nil, diags
+	}
+
+	return target, diags
+}

--- a/internal/services/zero_trust_device_managed_networks/migrations.go
+++ b/internal/services/zero_trust_device_managed_networks/migrations.go
@@ -1,23 +1,50 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 package zero_trust_device_managed_networks
 
 import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_device_managed_networks/migration/v500"
 )
 
+var _ resource.ResourceWithMoveState = (*ZeroTrustDeviceManagedNetworksResource)(nil)
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustDeviceManagedNetworksResource)(nil)
 
+// MoveState handles moves from cloudflare_device_managed_networks (v0) to cloudflare_zero_trust_device_managed_networks (v500).
+// This is triggered when users use the `moved` block (Terraform 1.8+):
+//
+//	moved {
+//	    from = cloudflare_device_managed_networks.example
+//	    to   = cloudflare_zero_trust_device_managed_networks.example
+//	}
+func (r *ZeroTrustDeviceManagedNetworksResource) MoveState(ctx context.Context) []resource.StateMover {
+	sourceSchema := v500.SourceCloudflareDeviceManagedNetworksSchema()
+	return []resource.StateMover{
+		{
+			SourceSchema: &sourceSchema,
+			StateMover:   v500.MoveState,
+		},
+	}
+}
+
+// UpgradeState handles schema version upgrades for cloudflare_zero_trust_device_managed_networks.
+// This is triggered when users manually run `terraform state mv` (Terraform < 1.8).
 func (r *ZeroTrustDeviceManagedNetworksResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	sourceSchema := v500.SourceCloudflareDeviceManagedNetworksSchema()
 	targetSchema := ResourceSchema(ctx)
 	return map[int64]resource.StateUpgrader{
+		// Handle upgrades from earlier v500 versions (no schema changes, just version bump)
+		1: {
+			PriorSchema:   &targetSchema,
+			StateUpgrader: v500.UpgradeFromV1,
+		},
+		// Handle state moved from legacy cloudflare_device_managed_networks (schema_version=0 from the SDKv2 provider)
+		// When users run `terraform state mv cloudflare_device_managed_networks.x cloudflare_zero_trust_device_managed_networks.x`,
+		// the schema_version=0 is preserved, triggering this upgrader.
 		0: {
-			PriorSchema: &targetSchema,
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				resp.State.Raw = req.State.Raw
-			},
+			PriorSchema:   &sourceSchema,
+			StateUpgrader: v500.UpgradeFromLegacyV0,
 		},
 	}
 }

--- a/internal/services/zero_trust_device_managed_networks/schema.go
+++ b/internal/services/zero_trust_device_managed_networks/schema.go
@@ -11,13 +11,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 )
 
 var _ resource.ResourceWithConfigValidators = (*ZeroTrustDeviceManagedNetworksResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
-		Version: 1,
+		Version: migrations.GetSchemaVersion(1, 500),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "API UUID.",


### PR DESCRIPTION
```
=== RUN   TestMigrateZeroTrustDeviceManagedNetworksBasic
=== RUN   TestMigrateZeroTrustDeviceManagedNetworksBasic/from_v4_latest
=== RUN   TestMigrateZeroTrustDeviceManagedNetworksBasic/from_v5
--- PASS: TestMigrateZeroTrustDeviceManagedNetworksBasic (15.79s)
    --- PASS: TestMigrateZeroTrustDeviceManagedNetworksBasic/from_v4_latest (12.70s)
    --- PASS: TestMigrateZeroTrustDeviceManagedNetworksBasic/from_v5 (3.09s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_device_managed_networks/migration/v500 17.269s
```