### PR TITLE
 feat(zero_trust_gateway_settings): state upgraders

### DIFF
--- a/internal/services/zero_trust_gateway_settings/migration/v500/handler.go
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/handler.go
@@ -1,0 +1,50 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// UpgradeFromV4 handles state upgrades from v4 SDKv2 provider (schema_version=0) to v5 (version=500).
+//
+// Transforms cloudflare_teams_account v4 state to cloudflare_zero_trust_gateway_settings v5 format:
+//   - Flat boolean fields → nested under settings.*
+//   - TypeList MaxItems:1 blocks → SingleNestedAttribute pointers under settings.*
+//   - notification_settings: message → msg (field rename)
+//   - logging, proxy, ssh_session_log, payload_log: dropped (handled by tf-migrate)
+func UpgradeFromV4(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading zero_trust_gateway_settings state from v4 SDKv2 provider (schema_version=0)")
+
+	// Parse v4 state using v4 source model
+	var v4State SourceV4ZeroTrustGatewaySettingsModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &v4State)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform v4 → v5
+	v5State, diags := Transform(ctx, v4State)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Write transformed state
+	resp.Diagnostics.Append(resp.State.Set(ctx, v5State)...)
+	tflog.Info(ctx, "State upgrade from v4 to v5 completed successfully")
+}
+
+// UpgradeFromV5 handles state upgrades from v5 Plugin Framework provider (version=1) to v5 (version=500).
+//
+// This is a no-op upgrade that just bumps the schema version. It is only triggered when
+// TF_MIG_TEST=1 causes GetSchemaVersion to return 500 instead of 1.
+func UpgradeFromV5(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading zero_trust_gateway_settings state from version=1 to version=500 (no-op)")
+
+	// CRITICAL: For no-op upgrades, copy raw state directly to preserve all state data
+	resp.State.Raw = req.State.Raw
+
+	tflog.Info(ctx, "State version bump from 1 to 500 completed")
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/migrations_test.go
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/migrations_test.go
@@ -1,0 +1,715 @@
+package v500_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+var (
+	currentProviderVersion = internal.PackageVersion
+)
+
+// Embed test configs
+//
+//go:embed testdata/v4_flat_booleans.tf
+var v4FlatBooleansConfig string
+
+//go:embed testdata/v5_flat_booleans.tf
+var v5FlatBooleansConfig string
+
+//go:embed testdata/v4_antivirus.tf
+var v4AntivirusConfig string
+
+//go:embed testdata/v5_antivirus.tf
+var v5AntivirusConfig string
+
+//go:embed testdata/v4_comprehensive.tf
+var v4ComprehensiveConfig string
+
+//go:embed testdata/v5_comprehensive.tf
+var v5ComprehensiveConfig string
+
+//go:embed testdata/v4_browser_isolation.tf
+var v4BrowserIsolationConfig string
+
+//go:embed testdata/v5_browser_isolation.tf
+var v5BrowserIsolationConfig string
+
+//go:embed testdata/v4_block_page.tf
+var v4BlockPageConfig string
+
+//go:embed testdata/v5_block_page.tf
+var v5BlockPageConfig string
+
+//go:embed testdata/v4_maxitems1_blocks.tf
+var v4MaxItems1BlocksConfig string
+
+//go:embed testdata/v5_maxitems1_blocks.tf
+var v5MaxItems1BlocksConfig string
+
+// skipIfAPIToken skips the test when using API token auth.
+// Zero Trust resources don't support API token authentication.
+func skipIfAPIToken(t *testing.T) {
+	t.Helper()
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Skip("Skipping: zero_trust_gateway_settings does not support API token authentication")
+	}
+}
+
+// TestMigrateZeroTrustGatewaySettings_V4ToV5_FlatBooleans tests flat boolean field
+// transformations using the dual test case pattern (from_v4_latest and from_v5).
+//
+// Validates:
+//   - activity_log_enabled → settings.activity_log.enabled
+//   - tls_decrypt_enabled → settings.tls_decrypt.enabled
+//   - protocol_detection_enabled → settings.protocol_detection.enabled
+//   - Resource rename: cloudflare_teams_account → cloudflare_zero_trust_gateway_settings
+func TestMigrateZeroTrustGatewaySettings_V4ToV5_FlatBooleans(t *testing.T) {
+	skipIfAPIToken(t)
+
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, accountID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v4FlatBooleansConfig, rnd, accountID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v5FlatBooleansConfig, rnd, accountID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			resourceName := "cloudflare_zero_trust_gateway_settings." + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, accountID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config: testConfig,
+					// Gateway settings is a singleton; account may have pre-existing settings
+					ExpectNonEmptyPlan: true,
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+							// Verify flat booleans were moved to nested settings
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("activity_log").AtMapKey("enabled"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("tls_decrypt").AtMapKey("enabled"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("protocol_detection").AtMapKey("enabled"), knownvalue.Bool(false)),
+						},
+					),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateZeroTrustGatewaySettings_V4ToV5_Antivirus tests nested block transformation
+// with field rename using the dual test case pattern.
+//
+// Validates:
+//   - antivirus block → settings.antivirus attribute
+//   - notification_settings nested block → notification_settings attribute
+//   - Field rename: message → msg (v4 → v5)
+//   - notification_settings[0] array element → object
+func TestMigrateZeroTrustGatewaySettings_V4ToV5_Antivirus(t *testing.T) {
+	skipIfAPIToken(t)
+
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, accountID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v4AntivirusConfig, rnd, accountID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v5AntivirusConfig, rnd, accountID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			resourceName := "cloudflare_zero_trust_gateway_settings." + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, accountID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config:             testConfig,
+					ExpectNonEmptyPlan: true,
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+							// Verify antivirus fields
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus").AtMapKey("enabled_download_phase"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus").AtMapKey("enabled_upload_phase"), knownvalue.Bool(false)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus").AtMapKey("fail_closed"), knownvalue.Bool(true)),
+							// Verify notification_settings with field rename (message → msg)
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus").AtMapKey("notification_settings").AtMapKey("enabled"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus").AtMapKey("notification_settings").AtMapKey("msg"), knownvalue.StringExact("File scanning in progress")),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus").AtMapKey("notification_settings").AtMapKey("support_url"), knownvalue.StringExact("https://support.example.com/")),
+						},
+					),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateZeroTrustGatewaySettings_V4ToV5_Comprehensive tests multiple transformations
+// together using the dual test case pattern.
+//
+// Validates:
+//   - All flat boolean fields → nested under settings.*
+//   - Browser isolation field rename: non_identity_browser_isolation_enabled → non_identity_enabled
+//   - fips MaxItems:1 block → settings.fips attribute
+//   - body_scanning MaxItems:1 block → settings.body_scanning attribute
+//   - antivirus with nested notification_settings + message → msg rename
+//
+// Note: block_page and extended_email_matching are excluded due to pre-existing v5 provider
+// drift on API-computed fields (mode, version, suppress_footer, etc.) that are not in config.
+func TestMigrateZeroTrustGatewaySettings_V4ToV5_Comprehensive(t *testing.T) {
+	skipIfAPIToken(t)
+
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, accountID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v4ComprehensiveConfig, rnd, accountID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v5ComprehensiveConfig, rnd, accountID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			resourceName := "cloudflare_zero_trust_gateway_settings." + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, accountID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config:             testConfig,
+					ExpectNonEmptyPlan: true,
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+
+							// Flat boolean → nested
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("activity_log").AtMapKey("enabled"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("tls_decrypt").AtMapKey("enabled"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("protocol_detection").AtMapKey("enabled"), knownvalue.Bool(false)),
+
+							// Browser isolation with field rename
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("browser_isolation").AtMapKey("url_browser_isolation_enabled"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("browser_isolation").AtMapKey("non_identity_enabled"), knownvalue.Bool(false)),
+
+							// fips
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("fips").AtMapKey("tls"), knownvalue.Bool(true)),
+
+							// body_scanning
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("body_scanning").AtMapKey("inspection_mode"), knownvalue.StringExact("deep")),
+
+							// antivirus with field rename (message → msg)
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus").AtMapKey("enabled_download_phase"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus").AtMapKey("enabled_upload_phase"), knownvalue.Bool(false)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus").AtMapKey("fail_closed"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus").AtMapKey("notification_settings").AtMapKey("enabled"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus").AtMapKey("notification_settings").AtMapKey("msg"), knownvalue.StringExact("Scanning")),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus").AtMapKey("notification_settings").AtMapKey("support_url"), knownvalue.StringExact("https://support.example.com/")),
+
+						},
+					),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateZeroTrustGatewaySettings_V4ToV5_Minimal tests that fields absent from the
+// user's config are null in migrated state (null-cleanup behavior).
+//
+// Validates:
+//   - Fields in config are correctly set after migration
+//   - Fields NOT in config (block_page, fips, antivirus, etc.) are null — the migration
+//     must not carry over v4 API-returned values for blocks the user never configured
+func TestMigrateZeroTrustGatewaySettings_V4ToV5_Minimal(t *testing.T) {
+	skipIfAPIToken(t)
+
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, accountID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v4FlatBooleansConfig, rnd, accountID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v5FlatBooleansConfig, rnd, accountID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			resourceName := "cloudflare_zero_trust_gateway_settings." + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, accountID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config:             testConfig,
+					ExpectNonEmptyPlan: true,
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+							// Flat booleans in config are present and correct
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("activity_log").AtMapKey("enabled"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("tls_decrypt").AtMapKey("enabled"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("protocol_detection").AtMapKey("enabled"), knownvalue.Bool(false)),
+							// Fields NOT in user config must be null — migration must not carry
+							// over v4 API-returned values for blocks the user never configured
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("block_page"), knownvalue.Null()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("body_scanning"), knownvalue.Null()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("extended_email_matching"), knownvalue.Null()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("fips"), knownvalue.Null()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus"), knownvalue.Null()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("custom_certificate"), knownvalue.Null()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("certificate"), knownvalue.Null()),
+						},
+					),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateZeroTrustGatewaySettings_V4ToV5_BrowserIsolation tests browser isolation
+// field rename using the dual test case pattern.
+//
+// Validates:
+//   - url_browser_isolation_enabled → settings.browser_isolation.url_browser_isolation_enabled
+//   - non_identity_browser_isolation_enabled → settings.browser_isolation.non_identity_enabled
+func TestMigrateZeroTrustGatewaySettings_V4ToV5_BrowserIsolation(t *testing.T) {
+	skipIfAPIToken(t)
+
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, accountID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v4BrowserIsolationConfig, rnd, accountID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v5BrowserIsolationConfig, rnd, accountID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			resourceName := "cloudflare_zero_trust_gateway_settings." + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, accountID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config:             testConfig,
+					ExpectNonEmptyPlan: true,
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+							// Key test: non_identity_browser_isolation_enabled → non_identity_enabled
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("browser_isolation").AtMapKey("url_browser_isolation_enabled"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("browser_isolation").AtMapKey("non_identity_enabled"), knownvalue.Bool(false)),
+						},
+					),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateZeroTrustGatewaySettings_V4ToV5_BlockPage tests block_page MaxItems:1 block
+// conversion using the dual test case pattern.
+//
+// Validates:
+//   - block_page block → settings.block_page attribute
+//   - All user-configurable fields preserved after migration
+//
+// Note: This test uses ExpectNonEmptyPlan on the migration step because the v5 provider
+// has a known drift issue on API-computed block_page fields (mode, version, suppress_footer,
+// target_uri, include_context) that are returned by the API but not present in user config.
+// This is a pre-existing v5 provider issue, not a migration bug.
+func TestMigrateZeroTrustGatewaySettings_V4ToV5_BlockPage(t *testing.T) {
+	skipIfAPIToken(t)
+
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, accountID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v4BlockPageConfig, rnd, accountID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v5BlockPageConfig, rnd, accountID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			resourceName := "cloudflare_zero_trust_gateway_settings." + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, accountID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+					// block_page computed fields (mode, version, etc.) cause drift even in pure v5
+					ExpectNonEmptyPlan: true,
+				}
+			} else {
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config:             testConfig,
+					ExpectNonEmptyPlan: true,
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					// Use manual migration step (not MigrationV2TestStep) to allow ExpectNonEmptyPlan
+					// due to the pre-existing block_page computed-field drift in the v5 provider.
+					{
+						PreConfig: func() {
+							acctest.WriteOutConfig(t, testConfig, tmpDir)
+							acctest.RunMigrationV2Command(t, testConfig, tmpDir, sourceVer, targetVer)
+						},
+						ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+						ConfigDirectory:          config.StaticDirectory(tmpDir),
+						ExpectNonEmptyPlan:       true,
+						ConfigStateChecks: []statecheck.StateCheck{
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+							// Verify user-configurable block_page fields were migrated correctly
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("block_page").AtMapKey("enabled"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("block_page").AtMapKey("name"), knownvalue.StringExact(rnd)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("block_page").AtMapKey("footer_text"), knownvalue.StringExact("Contact IT")),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("block_page").AtMapKey("header_text"), knownvalue.StringExact("Blocked")),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("block_page").AtMapKey("logo_path"), knownvalue.StringExact("https://example.com/logo.png")),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("block_page").AtMapKey("background_color"), knownvalue.StringExact("#FF0000")),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("block_page").AtMapKey("mailto_address"), knownvalue.StringExact("security@example.com")),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("block_page").AtMapKey("mailto_subject"), knownvalue.StringExact("Access Request")),
+							// Other blocks not in config are null
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("fips"), knownvalue.Null()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus"), knownvalue.Null()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("body_scanning"), knownvalue.Null()),
+						},
+					},
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateZeroTrustGatewaySettings_V4ToV5_MultipleMaxItems1 tests that multiple
+// MaxItems:1 blocks are all correctly converted to nested attributes using the dual
+// test case pattern.
+//
+// Validates:
+//   - fips MaxItems:1 block → settings.fips attribute
+//   - body_scanning MaxItems:1 block → settings.body_scanning attribute
+func TestMigrateZeroTrustGatewaySettings_V4ToV5_MultipleMaxItems1(t *testing.T) {
+	skipIfAPIToken(t)
+
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, accountID string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v4MaxItems1BlocksConfig, rnd, accountID)
+			},
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, accountID string) string {
+				return fmt.Sprintf(v5MaxItems1BlocksConfig, rnd, accountID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			resourceName := "cloudflare_zero_trust_gateway_settings." + rnd
+			tmpDir := t.TempDir()
+			testConfig := tc.configFn(rnd, accountID)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config:             testConfig,
+					ExpectNonEmptyPlan: true,
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					firstStep,
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+							// Verify all MaxItems:1 blocks are attributes under settings
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("fips").AtMapKey("tls"), knownvalue.Bool(true)),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("body_scanning").AtMapKey("inspection_mode"), knownvalue.StringExact("deep")),
+							// Other blocks not in config are null
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("antivirus"), knownvalue.Null()),
+							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("settings").AtMapKey("extended_email_matching"), knownvalue.Null()),
+						},
+					),
+				},
+			})
+		})
+	}
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/model.go
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/model.go
@@ -1,0 +1,257 @@
+package v500
+
+import (
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ============================================================================
+// Source V4 Models (Legacy SDKv2 Provider - cloudflare_teams_account)
+// ============================================================================
+
+// SourceV4ZeroTrustGatewaySettingsModel represents the teams_account state from
+// v4.x provider (SDKv2). Schema version: 0 (SDKv2 default).
+//
+// All TypeList MaxItems:1 blocks are stored as arrays in SDKv2 state.
+// All fields from v4 schema are included, even those dropped in v5 (logging,
+// proxy, ssh_session_log, payload_log), to allow the framework to parse v4 state.
+type SourceV4ZeroTrustGatewaySettingsModel struct {
+	AccountID types.String `tfsdk:"account_id"`
+
+	// Flat boolean fields (v4 top-level → v5 nested under settings.*)
+	ActivityLogEnabled                types.Bool `tfsdk:"activity_log_enabled"`
+	TLSDecryptEnabled                 types.Bool `tfsdk:"tls_decrypt_enabled"`
+	ProtocolDetectionEnabled          types.Bool `tfsdk:"protocol_detection_enabled"`
+	URLBrowserIsolationEnabled        types.Bool `tfsdk:"url_browser_isolation_enabled"`
+	NonIdentityBrowserIsolationEnabled types.Bool `tfsdk:"non_identity_browser_isolation_enabled"`
+
+	// MaxItems:1 blocks (stored as arrays in v4 SDKv2 state)
+	BlockPage             []SourceV4BlockPageModel             `tfsdk:"block_page"`
+	BodyScanning          []SourceV4BodyScanningModel          `tfsdk:"body_scanning"`
+	Fips                  []SourceV4FipsModel                  `tfsdk:"fips"`
+	Antivirus             []SourceV4AntivirusModel             `tfsdk:"antivirus"`
+	ExtendedEmailMatching []SourceV4ExtendedEmailMatchingModel `tfsdk:"extended_email_matching"`
+	CustomCertificate     []SourceV4CustomCertificateModel     `tfsdk:"custom_certificate"`
+	Certificate           []SourceV4CertificateModel           `tfsdk:"certificate"`
+
+	// Blocks dropped in v5 (migrated to separate resources or removed entirely)
+	// These must be in the source schema so the framework can parse v4 state.
+	Logging       []SourceV4LoggingModel       `tfsdk:"logging"`
+	Proxy         []SourceV4ProxyModel         `tfsdk:"proxy"`
+	SSHSessionLog []SourceV4SSHSessionLogModel `tfsdk:"ssh_session_log"`
+	PayloadLog    []SourceV4PayloadLogModel    `tfsdk:"payload_log"`
+}
+
+type SourceV4BlockPageModel struct {
+	BackgroundColor types.String `tfsdk:"background_color"`
+	Enabled         types.Bool   `tfsdk:"enabled"`
+	FooterText      types.String `tfsdk:"footer_text"`
+	HeaderText      types.String `tfsdk:"header_text"`
+	LogoPath        types.String `tfsdk:"logo_path"`
+	MailtoAddress   types.String `tfsdk:"mailto_address"`
+	MailtoSubject   types.String `tfsdk:"mailto_subject"`
+	Name            types.String `tfsdk:"name"`
+}
+
+type SourceV4BodyScanningModel struct {
+	InspectionMode types.String `tfsdk:"inspection_mode"`
+}
+
+type SourceV4FipsModel struct {
+	TLS types.Bool `tfsdk:"tls"`
+}
+
+// SourceV4AntivirusModel represents the antivirus block in v4.
+// notification_settings is a nested TypeList MaxItems:1 → stored as array.
+type SourceV4AntivirusModel struct {
+	EnabledDownloadPhase types.Bool                       `tfsdk:"enabled_download_phase"`
+	EnabledUploadPhase   types.Bool                       `tfsdk:"enabled_upload_phase"`
+	FailClosed           types.Bool                       `tfsdk:"fail_closed"`
+	NotificationSettings []SourceV4NotificationSettingsModel `tfsdk:"notification_settings"`
+}
+
+// SourceV4NotificationSettingsModel represents the notification_settings block in v4.
+// Note: v4 field is "message"; v5 renames this to "msg".
+type SourceV4NotificationSettingsModel struct {
+	Enabled    types.Bool   `tfsdk:"enabled"`
+	Message    types.String `tfsdk:"message"`
+	SupportURL types.String `tfsdk:"support_url"`
+}
+
+type SourceV4ExtendedEmailMatchingModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+type SourceV4CustomCertificateModel struct {
+	Enabled   types.Bool   `tfsdk:"enabled"`
+	ID        types.String `tfsdk:"id"`
+	UpdatedAt types.String `tfsdk:"updated_at"` // Plain string in v4
+}
+
+type SourceV4CertificateModel struct {
+	ID types.String `tfsdk:"id"`
+}
+
+// SourceV4LoggingModel is included for state parsing only; logging is
+// migrated to cloudflare_zero_trust_gateway_logging by tf-migrate.
+type SourceV4LoggingModel struct {
+	RedactPII         types.Bool                          `tfsdk:"redact_pii"`
+	SettingsByRuleType []SourceV4LoggingSettingsByRuleTypeModel `tfsdk:"settings_by_rule_type"`
+}
+
+type SourceV4LoggingSettingsByRuleTypeModel struct {
+	DNS  []SourceV4LoggingEnabledModel `tfsdk:"dns"`
+	HTTP []SourceV4LoggingEnabledModel `tfsdk:"http"`
+	L4   []SourceV4LoggingEnabledModel `tfsdk:"l4"`
+}
+
+type SourceV4LoggingEnabledModel struct {
+	LogAll    types.Bool `tfsdk:"log_all"`
+	LogBlocks types.Bool `tfsdk:"log_blocks"`
+}
+
+// SourceV4ProxyModel is included for state parsing only; proxy is migrated to
+// cloudflare_zero_trust_device_settings by tf-migrate.
+type SourceV4ProxyModel struct {
+	TCP           types.Bool  `tfsdk:"tcp"`
+	UDP           types.Bool  `tfsdk:"udp"`
+	RootCA        types.Bool  `tfsdk:"root_ca"`
+	VirtualIP     types.Bool  `tfsdk:"virtual_ip"`
+	DisableForTime types.Int64 `tfsdk:"disable_for_time"`
+}
+
+// SourceV4SSHSessionLogModel is included for state parsing only; dropped in v5.
+type SourceV4SSHSessionLogModel struct {
+	PublicKey types.String `tfsdk:"public_key"`
+}
+
+// SourceV4PayloadLogModel is included for state parsing only; dropped in v5.
+type SourceV4PayloadLogModel struct {
+	PublicKey types.String `tfsdk:"public_key"`
+}
+
+// ============================================================================
+// Target V5 Models (Current Plugin Framework Provider)
+// ============================================================================
+
+// TargetV5ZeroTrustGatewaySettingsModel represents the zero_trust_gateway_settings
+// state for v5.x+ provider (Plugin Framework). Schema version: 500.
+type TargetV5ZeroTrustGatewaySettingsModel struct {
+	ID        types.String                         `tfsdk:"id"`
+	AccountID types.String                         `tfsdk:"account_id"`
+	Settings  *TargetV5SettingsModel               `tfsdk:"settings"`
+	CreatedAt timetypes.RFC3339                    `tfsdk:"created_at"`
+	UpdatedAt timetypes.RFC3339                    `tfsdk:"updated_at"`
+}
+
+type TargetV5SettingsModel struct {
+	ActivityLog           *TargetV5ActivityLogModel           `tfsdk:"activity_log"`
+	Antivirus             *TargetV5AntivirusModel             `tfsdk:"antivirus"`
+	BlockPage             *TargetV5BlockPageModel             `tfsdk:"block_page"`
+	BodyScanning          *TargetV5BodyScanningModel          `tfsdk:"body_scanning"`
+	BrowserIsolation      *TargetV5BrowserIsolationModel      `tfsdk:"browser_isolation"`
+	Certificate           *TargetV5CertificateModel           `tfsdk:"certificate"`
+	CustomCertificate     *TargetV5CustomCertificateModel     `tfsdk:"custom_certificate"`
+	ExtendedEmailMatching *TargetV5ExtendedEmailMatchingModel `tfsdk:"extended_email_matching"`
+	Fips                  *TargetV5FipsModel                  `tfsdk:"fips"`
+	HostSelector          *TargetV5HostSelectorModel          `tfsdk:"host_selector"`
+	Inspection            *TargetV5InspectionModel            `tfsdk:"inspection"`
+	ProtocolDetection     *TargetV5ProtocolDetectionModel     `tfsdk:"protocol_detection"`
+	Sandbox               *TargetV5SandboxModel               `tfsdk:"sandbox"`
+	TLSDecrypt            *TargetV5TLSDecryptModel            `tfsdk:"tls_decrypt"`
+}
+
+type TargetV5ActivityLogModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+// TargetV5AntivirusModel represents the v5 antivirus settings.
+// notification_settings uses customfield.NestedObject because the v5 schema
+// uses customfield.NewNestedObjectType for this attribute.
+type TargetV5AntivirusModel struct {
+	EnabledDownloadPhase types.Bool                                                         `tfsdk:"enabled_download_phase"`
+	EnabledUploadPhase   types.Bool                                                         `tfsdk:"enabled_upload_phase"`
+	FailClosed           types.Bool                                                         `tfsdk:"fail_closed"`
+	NotificationSettings customfield.NestedObject[TargetV5NotificationSettingsModel]        `tfsdk:"notification_settings"`
+}
+
+// TargetV5NotificationSettingsModel represents the v5 notification_settings.
+// Note: v4 had "message" but v5 uses "msg" (field rename).
+// Also new in v5: include_context (not present in v4, will be null).
+type TargetV5NotificationSettingsModel struct {
+	Enabled        types.Bool   `tfsdk:"enabled"`
+	IncludeContext types.Bool   `tfsdk:"include_context"`
+	Msg            types.String `tfsdk:"msg"`
+	SupportURL     types.String `tfsdk:"support_url"`
+}
+
+type TargetV5BlockPageModel struct {
+	BackgroundColor types.String `tfsdk:"background_color"`
+	Enabled         types.Bool   `tfsdk:"enabled"`
+	FooterText      types.String `tfsdk:"footer_text"`
+	HeaderText      types.String `tfsdk:"header_text"`
+	IncludeContext  types.Bool   `tfsdk:"include_context"`
+	LogoPath        types.String `tfsdk:"logo_path"`
+	MailtoAddress   types.String `tfsdk:"mailto_address"`
+	MailtoSubject   types.String `tfsdk:"mailto_subject"`
+	Mode            types.String `tfsdk:"mode"`
+	Name            types.String `tfsdk:"name"`
+	ReadOnly        types.Bool   `tfsdk:"read_only"`
+	SourceAccount   types.String `tfsdk:"source_account"`
+	SuppressFooter  types.Bool   `tfsdk:"suppress_footer"`
+	TargetURI       types.String `tfsdk:"target_uri"`
+	Version         types.Int64  `tfsdk:"version"`
+}
+
+type TargetV5BodyScanningModel struct {
+	InspectionMode types.String `tfsdk:"inspection_mode"`
+}
+
+type TargetV5BrowserIsolationModel struct {
+	NonIdentityEnabled         types.Bool `tfsdk:"non_identity_enabled"`
+	URLBrowserIsolationEnabled types.Bool `tfsdk:"url_browser_isolation_enabled"`
+}
+
+type TargetV5CertificateModel struct {
+	ID types.String `tfsdk:"id"`
+}
+
+type TargetV5CustomCertificateModel struct {
+	Enabled       types.Bool        `tfsdk:"enabled"`
+	ID            types.String      `tfsdk:"id"`
+	BindingStatus types.String      `tfsdk:"binding_status"`
+	UpdatedAt     timetypes.RFC3339 `tfsdk:"updated_at"`
+}
+
+type TargetV5ExtendedEmailMatchingModel struct {
+	Enabled       types.Bool   `tfsdk:"enabled"`
+	ReadOnly      types.Bool   `tfsdk:"read_only"`
+	SourceAccount types.String `tfsdk:"source_account"`
+	Version       types.Int64  `tfsdk:"version"`
+}
+
+type TargetV5FipsModel struct {
+	TLS types.Bool `tfsdk:"tls"`
+}
+
+type TargetV5HostSelectorModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+type TargetV5InspectionModel struct {
+	Mode types.String `tfsdk:"mode"`
+}
+
+type TargetV5ProtocolDetectionModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+type TargetV5SandboxModel struct {
+	Enabled        types.Bool   `tfsdk:"enabled"`
+	FallbackAction types.String `tfsdk:"fallback_action"`
+}
+
+type TargetV5TLSDecryptModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/move_state.go
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/move_state.go
@@ -1,0 +1,43 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// MoveFromCloudflareTeamsAccount handles moving state from the legacy
+// cloudflare_teams_account resource type to cloudflare_zero_trust_gateway_settings.
+//
+// This is triggered by Terraform 1.8+ when it processes a `moved` block:
+//
+//	moved {
+//	  from = cloudflare_teams_account.example
+//	  to   = cloudflare_zero_trust_gateway_settings.example
+//	}
+//
+// The source state is the v4 cloudflare_teams_account format (schema_version=0).
+// The transformation logic is shared with UpgradeFromV4.
+func MoveFromCloudflareTeamsAccount(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+	tflog.Info(ctx, "Moving state from legacy cloudflare_teams_account to cloudflare_zero_trust_gateway_settings")
+
+	// Parse the source state using the v4 source schema
+	var sourceState SourceV4ZeroTrustGatewaySettingsModel
+	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Transform v4 → v5 (same logic as UpgradeFromV4)
+	targetState, diags := Transform(ctx, sourceState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Set the moved state
+	resp.Diagnostics.Append(resp.TargetState.Set(ctx, targetState)...)
+
+	tflog.Info(ctx, "State move from cloudflare_teams_account completed successfully")
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/schema.go
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/schema.go
@@ -1,0 +1,275 @@
+package v500
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// SourceV4ZeroTrustGatewaySettingsSchema returns the schema for the v4
+// cloudflare_teams_account resource (SDKv2 format, schema_version=0).
+//
+// This schema is used as PriorSchema in the state upgrader to parse v4 state.
+// All TypeList MaxItems:1 blocks from v4 are represented as ListNestedAttribute.
+func SourceV4ZeroTrustGatewaySettingsSchema() schema.Schema {
+	return schema.Schema{
+		Version: 0,
+		Attributes: map[string]schema.Attribute{
+			"account_id": schema.StringAttribute{
+				Required: true,
+			},
+
+			// Flat boolean fields
+			"activity_log_enabled": schema.BoolAttribute{
+				Optional: true,
+			},
+			"tls_decrypt_enabled": schema.BoolAttribute{
+				Optional: true,
+			},
+			"protocol_detection_enabled": schema.BoolAttribute{
+				Optional: true,
+			},
+			"url_browser_isolation_enabled": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"non_identity_browser_isolation_enabled": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+			},
+
+			// MaxItems:1 blocks as ListNestedAttribute (SDKv2 stores TypeList as arrays)
+			"block_page": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"background_color": schema.StringAttribute{
+							Optional: true,
+						},
+						"enabled": schema.BoolAttribute{
+							Optional: true,
+						},
+						"footer_text": schema.StringAttribute{
+							Optional: true,
+						},
+						"header_text": schema.StringAttribute{
+							Optional: true,
+						},
+						"logo_path": schema.StringAttribute{
+							Optional: true,
+						},
+						"mailto_address": schema.StringAttribute{
+							Optional: true,
+						},
+						"mailto_subject": schema.StringAttribute{
+							Optional: true,
+						},
+						"name": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"body_scanning": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"inspection_mode": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"fips": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"tls": schema.BoolAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"antivirus": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"enabled_download_phase": schema.BoolAttribute{
+							Required: true,
+						},
+						"enabled_upload_phase": schema.BoolAttribute{
+							Required: true,
+						},
+						"fail_closed": schema.BoolAttribute{
+							Required: true,
+						},
+						// notification_settings is also a TypeList MaxItems:1 in v4
+						"notification_settings": schema.ListNestedAttribute{
+							Optional: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"enabled": schema.BoolAttribute{
+										Optional: true,
+									},
+									// v4 field name is "message"; v5 renames it to "msg"
+									"message": schema.StringAttribute{
+										Optional: true,
+									},
+									"support_url": schema.StringAttribute{
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"extended_email_matching": schema.ListNestedAttribute{
+				Optional: true,
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"enabled": schema.BoolAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"custom_certificate": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"enabled": schema.BoolAttribute{
+							Required: true,
+						},
+						"id": schema.StringAttribute{
+							Optional: true,
+							Computed: true,
+						},
+						// updated_at is plain string in v4 (no CustomType)
+						"updated_at": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"certificate": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+
+			// Blocks dropped in v5 - included for state parsing only
+			"logging": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"redact_pii": schema.BoolAttribute{
+							Required: true,
+						},
+						"settings_by_rule_type": schema.ListNestedAttribute{
+							Required: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"dns": schema.ListNestedAttribute{
+										Required: true,
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"log_all": schema.BoolAttribute{
+													Required: true,
+												},
+												"log_blocks": schema.BoolAttribute{
+													Required: true,
+												},
+											},
+										},
+									},
+									"http": schema.ListNestedAttribute{
+										Required: true,
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"log_all": schema.BoolAttribute{
+													Required: true,
+												},
+												"log_blocks": schema.BoolAttribute{
+													Required: true,
+												},
+											},
+										},
+									},
+									"l4": schema.ListNestedAttribute{
+										Required: true,
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"log_all": schema.BoolAttribute{
+													Required: true,
+												},
+												"log_blocks": schema.BoolAttribute{
+													Required: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"proxy": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"tcp": schema.BoolAttribute{
+							Required: true,
+						},
+						"udp": schema.BoolAttribute{
+							Required: true,
+						},
+						"root_ca": schema.BoolAttribute{
+							Required: true,
+						},
+						"virtual_ip": schema.BoolAttribute{
+							Required: true,
+						},
+						"disable_for_time": schema.Int64Attribute{
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"ssh_session_log": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"public_key": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"payload_log": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"public_key": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v4_antivirus.tf
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v4_antivirus.tf
@@ -1,0 +1,18 @@
+resource "cloudflare_teams_account" "%[1]s" {
+  account_id                 = "%[2]s"
+  activity_log_enabled       = false
+  tls_decrypt_enabled        = false
+  protocol_detection_enabled = false
+
+  antivirus {
+    enabled_download_phase = true
+    enabled_upload_phase   = false
+    fail_closed            = true
+
+    notification_settings {
+      enabled     = true
+      message     = "File scanning in progress"
+      support_url = "https://support.example.com/"
+    }
+  }
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v4_block_page.tf
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v4_block_page.tf
@@ -1,0 +1,17 @@
+resource "cloudflare_teams_account" "%[1]s" {
+  account_id                 = "%[2]s"
+  activity_log_enabled       = false
+  tls_decrypt_enabled        = false
+  protocol_detection_enabled = false
+
+  block_page {
+    enabled          = true
+    name             = "%[1]s"
+    footer_text      = "Contact IT"
+    header_text      = "Blocked"
+    logo_path        = "https://example.com/logo.png"
+    background_color = "#FF0000"
+    mailto_address   = "security@example.com"
+    mailto_subject   = "Access Request"
+  }
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v4_browser_isolation.tf
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v4_browser_isolation.tf
@@ -1,0 +1,8 @@
+resource "cloudflare_teams_account" "%[1]s" {
+  account_id                             = "%[2]s"
+  activity_log_enabled                   = false
+  tls_decrypt_enabled                    = false
+  protocol_detection_enabled             = false
+  url_browser_isolation_enabled          = true
+  non_identity_browser_isolation_enabled = false
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v4_comprehensive.tf
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v4_comprehensive.tf
@@ -1,0 +1,28 @@
+resource "cloudflare_teams_account" "%[1]s" {
+  account_id                             = "%[2]s"
+  activity_log_enabled                   = true
+  tls_decrypt_enabled                    = true
+  protocol_detection_enabled             = false
+  url_browser_isolation_enabled          = true
+  non_identity_browser_isolation_enabled = false
+
+  fips {
+    tls = true
+  }
+
+  body_scanning {
+    inspection_mode = "deep"
+  }
+
+  antivirus {
+    enabled_download_phase = true
+    enabled_upload_phase   = false
+    fail_closed            = true
+
+    notification_settings {
+      enabled     = true
+      message     = "Scanning"
+      support_url = "https://support.example.com/"
+    }
+  }
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v4_flat_booleans.tf
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v4_flat_booleans.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_teams_account" "%[1]s" {
+  account_id                 = "%[2]s"
+  activity_log_enabled       = true
+  tls_decrypt_enabled        = true
+  protocol_detection_enabled = false
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v4_maxitems1_blocks.tf
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v4_maxitems1_blocks.tf
@@ -1,0 +1,14 @@
+resource "cloudflare_teams_account" "%[1]s" {
+  account_id                 = "%[2]s"
+  activity_log_enabled       = false
+  tls_decrypt_enabled        = false
+  protocol_detection_enabled = false
+
+  fips {
+    tls = true
+  }
+
+  body_scanning {
+    inspection_mode = "deep"
+  }
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v5_antivirus.tf
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v5_antivirus.tf
@@ -1,0 +1,24 @@
+resource "cloudflare_zero_trust_gateway_settings" "%[1]s" {
+  account_id = "%[2]s"
+  settings = {
+    activity_log = {
+      enabled = false
+    }
+    tls_decrypt = {
+      enabled = false
+    }
+    protocol_detection = {
+      enabled = false
+    }
+    antivirus = {
+      enabled_download_phase = true
+      enabled_upload_phase   = false
+      fail_closed            = true
+      notification_settings = {
+        enabled     = true
+        msg         = "File scanning in progress"
+        support_url = "https://support.example.com/"
+      }
+    }
+  }
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v5_block_page.tf
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v5_block_page.tf
@@ -1,0 +1,24 @@
+resource "cloudflare_zero_trust_gateway_settings" "%[1]s" {
+  account_id = "%[2]s"
+  settings = {
+    activity_log = {
+      enabled = false
+    }
+    tls_decrypt = {
+      enabled = false
+    }
+    protocol_detection = {
+      enabled = false
+    }
+    block_page = {
+      enabled          = true
+      name             = "%[1]s"
+      footer_text      = "Contact IT"
+      header_text      = "Blocked"
+      logo_path        = "https://example.com/logo.png"
+      background_color = "#FF0000"
+      mailto_address   = "security@example.com"
+      mailto_subject   = "Access Request"
+    }
+  }
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v5_browser_isolation.tf
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v5_browser_isolation.tf
@@ -1,0 +1,18 @@
+resource "cloudflare_zero_trust_gateway_settings" "%[1]s" {
+  account_id = "%[2]s"
+  settings = {
+    activity_log = {
+      enabled = false
+    }
+    tls_decrypt = {
+      enabled = false
+    }
+    protocol_detection = {
+      enabled = false
+    }
+    browser_isolation = {
+      url_browser_isolation_enabled = true
+      non_identity_enabled          = false
+    }
+  }
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v5_comprehensive.tf
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v5_comprehensive.tf
@@ -1,0 +1,34 @@
+resource "cloudflare_zero_trust_gateway_settings" "%[1]s" {
+  account_id = "%[2]s"
+  settings = {
+    activity_log = {
+      enabled = true
+    }
+    tls_decrypt = {
+      enabled = true
+    }
+    protocol_detection = {
+      enabled = false
+    }
+    browser_isolation = {
+      url_browser_isolation_enabled = true
+      non_identity_enabled          = false
+    }
+    fips = {
+      tls = true
+    }
+    body_scanning = {
+      inspection_mode = "deep"
+    }
+    antivirus = {
+      enabled_download_phase = true
+      enabled_upload_phase   = false
+      fail_closed            = true
+      notification_settings = {
+        enabled     = true
+        msg         = "Scanning"
+        support_url = "https://support.example.com/"
+      }
+    }
+  }
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v5_flat_booleans.tf
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v5_flat_booleans.tf
@@ -1,0 +1,14 @@
+resource "cloudflare_zero_trust_gateway_settings" "%[1]s" {
+  account_id = "%[2]s"
+  settings = {
+    activity_log = {
+      enabled = true
+    }
+    tls_decrypt = {
+      enabled = true
+    }
+    protocol_detection = {
+      enabled = false
+    }
+  }
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v5_maxitems1_blocks.tf
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/testdata/v5_maxitems1_blocks.tf
@@ -1,0 +1,20 @@
+resource "cloudflare_zero_trust_gateway_settings" "%[1]s" {
+  account_id = "%[2]s"
+  settings = {
+    activity_log = {
+      enabled = false
+    }
+    tls_decrypt = {
+      enabled = false
+    }
+    protocol_detection = {
+      enabled = false
+    }
+    fips = {
+      tls = true
+    }
+    body_scanning = {
+      inspection_mode = "deep"
+    }
+  }
+}

--- a/internal/services/zero_trust_gateway_settings/migration/v500/transform.go
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/transform.go
@@ -1,0 +1,224 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Transform converts a v4 SourceV4ZeroTrustGatewaySettingsModel to the v5
+// TargetV5ZeroTrustGatewaySettingsModel.
+//
+// Key transformations:
+//   - Flat booleans (activity_log_enabled, etc.) → settings.*
+//   - TypeList MaxItems:1 blocks → pointer structs under settings.*
+//   - antivirus.notification_settings[0].message → notification_settings.msg
+//   - logging, proxy, ssh_session_log, payload_log → dropped
+//   - New v5 computed fields (created_at, updated_at, id) → null
+func Transform(ctx context.Context, source SourceV4ZeroTrustGatewaySettingsModel) (*TargetV5ZeroTrustGatewaySettingsModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	target := &TargetV5ZeroTrustGatewaySettingsModel{
+		// id, created_at, updated_at are computed by v5 API; set null for migration
+		ID:        types.StringNull(),
+		AccountID: source.AccountID,
+		CreatedAt: timetypes.NewRFC3339Null(),
+		UpdatedAt: timetypes.NewRFC3339Null(),
+	}
+
+	settings, settingsDiags := transformSettings(ctx, source)
+	diags.Append(settingsDiags...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	target.Settings = settings
+
+	return target, diags
+}
+
+// transformSettings converts all v4 settings fields into the v5 TargetV5SettingsModel.
+func transformSettings(ctx context.Context, source SourceV4ZeroTrustGatewaySettingsModel) (*TargetV5SettingsModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	settings := &TargetV5SettingsModel{
+		// New in v5; not in v4 → null
+		HostSelector: nil,
+		Inspection:   nil,
+		Sandbox:      nil,
+	}
+
+	// Flat boolean: activity_log_enabled → settings.activity_log.enabled
+	if !source.ActivityLogEnabled.IsNull() && !source.ActivityLogEnabled.IsUnknown() {
+		settings.ActivityLog = &TargetV5ActivityLogModel{
+			Enabled: source.ActivityLogEnabled,
+		}
+	}
+
+	// Flat boolean: tls_decrypt_enabled → settings.tls_decrypt.enabled
+	if !source.TLSDecryptEnabled.IsNull() && !source.TLSDecryptEnabled.IsUnknown() {
+		settings.TLSDecrypt = &TargetV5TLSDecryptModel{
+			Enabled: source.TLSDecryptEnabled,
+		}
+	}
+
+	// Flat boolean: protocol_detection_enabled → settings.protocol_detection.enabled
+	if !source.ProtocolDetectionEnabled.IsNull() && !source.ProtocolDetectionEnabled.IsUnknown() {
+		settings.ProtocolDetection = &TargetV5ProtocolDetectionModel{
+			Enabled: source.ProtocolDetectionEnabled,
+		}
+	}
+
+	// Browser isolation: combine two flat fields → settings.browser_isolation
+	// Both fields had Default: false in v4, so they're always present in v4 state.
+	// We create the browser_isolation block when either field is non-null.
+	urlEnabled := source.URLBrowserIsolationEnabled
+	nonIdentityEnabled := source.NonIdentityBrowserIsolationEnabled
+	if (!urlEnabled.IsNull() && !urlEnabled.IsUnknown()) ||
+		(!nonIdentityEnabled.IsNull() && !nonIdentityEnabled.IsUnknown()) {
+		settings.BrowserIsolation = &TargetV5BrowserIsolationModel{
+			URLBrowserIsolationEnabled: urlEnabled,
+			// Rename: non_identity_browser_isolation_enabled → non_identity_enabled
+			NonIdentityEnabled: nonIdentityEnabled,
+		}
+	}
+
+	// block_page: TypeList MaxItems:1 array → pointer struct
+	if len(source.BlockPage) > 0 {
+		bp := source.BlockPage[0]
+		settings.BlockPage = &TargetV5BlockPageModel{
+			BackgroundColor: bp.BackgroundColor,
+			Enabled:         bp.Enabled,
+			FooterText:      bp.FooterText,
+			HeaderText:      bp.HeaderText,
+			LogoPath:        bp.LogoPath,
+			MailtoAddress:   bp.MailtoAddress,
+			MailtoSubject:   bp.MailtoSubject,
+			Name:            bp.Name,
+			// New v5 fields not in v4 → null (will be populated on next refresh)
+			IncludeContext: types.BoolNull(),
+			Mode:           types.StringNull(),
+			ReadOnly:       types.BoolNull(),
+			SourceAccount:  types.StringNull(),
+			SuppressFooter: types.BoolNull(),
+			TargetURI:      types.StringNull(),
+			Version:        types.Int64Null(),
+		}
+	}
+
+	// body_scanning: TypeList MaxItems:1 array → pointer struct
+	if len(source.BodyScanning) > 0 {
+		bs := source.BodyScanning[0]
+		settings.BodyScanning = &TargetV5BodyScanningModel{
+			InspectionMode: bs.InspectionMode,
+		}
+	}
+
+	// fips: TypeList MaxItems:1 array → pointer struct
+	if len(source.Fips) > 0 {
+		f := source.Fips[0]
+		settings.Fips = &TargetV5FipsModel{
+			TLS: f.TLS,
+		}
+	}
+
+	// antivirus: TypeList MaxItems:1 array → pointer struct
+	// notification_settings is a nested TypeList MaxItems:1 with field rename
+	if len(source.Antivirus) > 0 {
+		av := source.Antivirus[0]
+		antivirusModel, avDiags := transformAntivirus(ctx, av)
+		diags.Append(avDiags...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		settings.Antivirus = antivirusModel
+	}
+
+	// extended_email_matching: TypeList MaxItems:1 array → pointer struct
+	if len(source.ExtendedEmailMatching) > 0 {
+		eem := source.ExtendedEmailMatching[0]
+		settings.ExtendedEmailMatching = &TargetV5ExtendedEmailMatchingModel{
+			Enabled: eem.Enabled,
+			// New v5 computed fields not in v4 → null
+			ReadOnly:      types.BoolNull(),
+			SourceAccount: types.StringNull(),
+			Version:       types.Int64Null(),
+		}
+	}
+
+	// custom_certificate: TypeList MaxItems:1 array → pointer struct
+	if len(source.CustomCertificate) > 0 {
+		cc := source.CustomCertificate[0]
+		settings.CustomCertificate = transformCustomCertificate(cc)
+	}
+
+	// certificate: TypeList MaxItems:1 array → pointer struct
+	if len(source.Certificate) > 0 {
+		cert := source.Certificate[0]
+		settings.Certificate = &TargetV5CertificateModel{
+			ID: cert.ID,
+		}
+	}
+
+	// logging, proxy, ssh_session_log, payload_log: dropped
+	// These are handled by tf-migrate (logging → cloudflare_zero_trust_gateway_logging,
+	// proxy → cloudflare_zero_trust_device_settings; ssh_session_log and payload_log dropped)
+
+	return settings, diags
+}
+
+// transformAntivirus handles the antivirus block transformation including the
+// nested notification_settings with field rename (message → msg).
+func transformAntivirus(ctx context.Context, source SourceV4AntivirusModel) (*TargetV5AntivirusModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	target := &TargetV5AntivirusModel{
+		EnabledDownloadPhase: source.EnabledDownloadPhase,
+		EnabledUploadPhase:   source.EnabledUploadPhase,
+		FailClosed:           source.FailClosed,
+	}
+
+	if len(source.NotificationSettings) > 0 {
+		ns := source.NotificationSettings[0]
+		notifModel := &TargetV5NotificationSettingsModel{
+			Enabled:    ns.Enabled,
+			Msg:        ns.Message, // Rename: message → msg
+			SupportURL: ns.SupportURL,
+			// include_context is new in v5, not in v4 → null
+			IncludeContext: types.BoolNull(),
+		}
+		notifObj, objDiags := customfield.NewObject(ctx, notifModel)
+		diags.Append(objDiags...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		target.NotificationSettings = notifObj
+	} else {
+		target.NotificationSettings = customfield.NullObject[TargetV5NotificationSettingsModel](ctx)
+	}
+
+	return target, diags
+}
+
+// transformCustomCertificate handles the custom_certificate block transformation.
+// updated_at is a plain string in v4; v5 uses timetypes.RFC3339.
+func transformCustomCertificate(source SourceV4CustomCertificateModel) *TargetV5CustomCertificateModel {
+	target := &TargetV5CustomCertificateModel{
+		Enabled: source.Enabled,
+		ID:      source.ID,
+		// binding_status is new computed in v5 → null
+		BindingStatus: types.StringNull(),
+	}
+
+	// Convert updated_at: plain string → RFC3339
+	// If the v4 string is empty or null, set to null RFC3339
+	if source.UpdatedAt.IsNull() || source.UpdatedAt.IsUnknown() || source.UpdatedAt.ValueString() == "" {
+		target.UpdatedAt = timetypes.NewRFC3339Null()
+	} else {
+		target.UpdatedAt = timetypes.NewRFC3339ValueMust(source.UpdatedAt.ValueString())
+	}
+
+	return target
+}

--- a/internal/services/zero_trust_gateway_settings/migrations.go
+++ b/internal/services/zero_trust_gateway_settings/migrations.go
@@ -4,20 +4,71 @@ package zero_trust_gateway_settings
 
 import (
 	"context"
+	"os"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_gateway_settings/migration/v500"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustGatewaySettingsResource)(nil)
+var _ resource.ResourceWithMoveState = (*ZeroTrustGatewaySettingsResource)(nil)
 
+// MoveState registers state movers for the resource rename:
+// cloudflare_teams_account → cloudflare_zero_trust_gateway_settings.
+//
+// This enables Terraform 1.8+ `moved` blocks to automatically trigger state migration
+// when renaming resources from the old type to the new type.
+func (r *ZeroTrustGatewaySettingsResource) MoveState(ctx context.Context) []resource.StateMover {
+	sourceSchema := v500.SourceV4ZeroTrustGatewaySettingsSchema()
+
+	return []resource.StateMover{
+		{
+			SourceSchema: &sourceSchema,
+			StateMover:   v500.MoveFromCloudflareTeamsAccount,
+		},
+	}
+}
+
+// UpgradeState registers state upgraders for schema version changes.
+//
+// Version history:
+//   - 0: v4 SDKv2 state (full transformation needed)
+//   - 1: Dormant production v5 state (GetSchemaVersion returns 1 normally)
+//   - 500: Active migration version (GetSchemaVersion returns 500 when TF_MIG_TEST=1)
 func (r *ZeroTrustGatewaySettingsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	targetSchema := ResourceSchema(ctx)
-	return map[int64]resource.StateUpgrader{
-		0: {
-			PriorSchema: &targetSchema,
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				resp.State.Raw = req.State.Raw
+
+	if os.Getenv("TF_MIG_TEST") == "" {
+		return map[int64]resource.StateUpgrader{
+			0: {
+				PriorSchema: &targetSchema,
+				StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+					resp.State.Raw = req.State.Raw
+				},
 			},
+		}
+	}
+
+	// v4 source schema for parsing old SDKv2 state (schema_version=0)
+	v4Schema := v500.SourceV4ZeroTrustGatewaySettingsSchema()
+
+	// v5 schema at version=1 for no-op pass-through upgrader
+	v5SchemaVersion1 := ResourceSchema(ctx)
+	v5SchemaVersion1.Version = 1
+
+	return map[int64]resource.StateUpgrader{
+		// Handle state from v4 SDKv2 provider (schema_version=0)
+		// Uses v4 PriorSchema to parse, then transforms flat structure to v5 nested
+		0: {
+			PriorSchema:   &v4Schema,
+			StateUpgrader: v500.UpgradeFromV4,
+		},
+
+		// Handle state from v5 Plugin Framework provider (version=1)
+		// No-op version bump to 500; only triggered when TF_MIG_TEST=1
+		1: {
+			PriorSchema:   &v5SchemaVersion1,
+			StateUpgrader: v500.UpgradeFromV5,
 		},
 	}
 }

--- a/internal/services/zero_trust_gateway_settings/schema.go
+++ b/internal/services/zero_trust_gateway_settings/schema.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -19,7 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustGatewaySettingsResource
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
-		Version: 1,
+		Version: migrations.GetSchemaVersion(1, 500),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,


### PR DESCRIPTION
```
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_FlatBooleans
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_FlatBooleans/from_v4_latest
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_FlatBooleans/from_v5
--- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_FlatBooleans (19.23s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_FlatBooleans/from_v4_latest (16.75s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_FlatBooleans/from_v5 (2.48s)
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_Antivirus
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_Antivirus/from_v4_latest
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_Antivirus/from_v5
--- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_Antivirus (15.24s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_Antivirus/from_v4_latest (12.99s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_Antivirus/from_v5 (2.24s)
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_Comprehensive
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_Comprehensive/from_v4_latest
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_Comprehensive/from_v5
--- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_Comprehensive (15.87s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_Comprehensive/from_v4_latest (13.71s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_Comprehensive/from_v5 (2.16s)
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_Minimal
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_Minimal/from_v4_latest
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_Minimal/from_v5
--- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_Minimal (16.45s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_Minimal/from_v4_latest (14.37s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_Minimal/from_v5 (2.07s)
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_BrowserIsolation
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_BrowserIsolation/from_v4_latest
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_BrowserIsolation/from_v5
--- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_BrowserIsolation (16.80s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_BrowserIsolation/from_v4_latest (14.49s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_BrowserIsolation/from_v5 (2.31s)
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_BlockPage
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_BlockPage/from_v4_latest
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_BlockPage/from_v5
--- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_BlockPage (16.75s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_BlockPage/from_v4_latest (13.68s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_BlockPage/from_v5 (3.07s)
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_MultipleMaxItems1
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_MultipleMaxItems1/from_v4_latest
=== RUN   TestMigrateZeroTrustGatewaySettings_V4ToV5_MultipleMaxItems1/from_v5
--- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_MultipleMaxItems1 (17.01s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_MultipleMaxItems1/from_v4_latest (14.23s)
    --- PASS: TestMigrateZeroTrustGatewaySettings_V4ToV5_MultipleMaxItems1/from_v5 (2.79s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_gateway_settings/migration/v500        118.939s
```
