### PR TITLE
fix(calls): populate key_id and app_id from API response in state

### DIFF
--- a/internal/services/calls_sfu_app/model.go
+++ b/internal/services/calls_sfu_app/model.go
@@ -14,7 +14,7 @@ type CallsSFUAppResultEnvelope struct {
 
 type CallsSFUAppModel struct {
 	AccountID types.String      `tfsdk:"account_id" path:"account_id,required"`
-	AppID     types.String      `tfsdk:"app_id" path:"app_id,optional"`
+	AppID     types.String      `tfsdk:"app_id" path:"app_id,optional" json:"app_id,computed"`
 	Name      types.String      `tfsdk:"name" json:"name,computed_optional"`
 	Created   timetypes.RFC3339 `tfsdk:"created" json:"created,computed" format:"date-time"`
 	Modified  timetypes.RFC3339 `tfsdk:"modified" json:"modified,computed" format:"date-time"`

--- a/internal/services/calls_sfu_app/schema.go
+++ b/internal/services/calls_sfu_app/schema.go
@@ -25,6 +25,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"app_id": schema.StringAttribute{
 				Description:   "A Cloudflare-generated unique identifier for a item.",
+				Computed:      true,
 				Optional:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},

--- a/internal/services/calls_turn_app/model.go
+++ b/internal/services/calls_turn_app/model.go
@@ -14,7 +14,7 @@ type CallsTURNAppResultEnvelope struct {
 
 type CallsTURNAppModel struct {
 	AccountID types.String      `tfsdk:"account_id" path:"account_id,required"`
-	KeyID     types.String      `tfsdk:"key_id" path:"key_id,optional"`
+	KeyID     types.String      `tfsdk:"key_id" path:"key_id,optional" json:"key_id,computed"`
 	Name      types.String      `tfsdk:"name" json:"name,computed_optional"`
 	Created   timetypes.RFC3339 `tfsdk:"created" json:"created,computed" format:"date-time"`
 	Key       types.String      `tfsdk:"key" json:"key,computed,no_refresh"`

--- a/internal/services/calls_turn_app/schema.go
+++ b/internal/services/calls_turn_app/schema.go
@@ -25,6 +25,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"key_id": schema.StringAttribute{
 				Description:   "A Cloudflare-generated unique identifier for a item.",
+				Computed:      true,
 				Optional:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},


### PR DESCRIPTION
The calls_turn_app and calls_sfu_app resources failed on subsequent terraform plan after creation because key_id/app_id were never deserialized from the API response into state. The model fields lacked a json struct tag, and the schema did not mark them as Computed.

Fixes #6613

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
