### PR TITLE
feat: add cloudflare_container_application resource

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/cloudforce_one_request_message"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/cloudforce_one_request_priority"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/connectivity_directory_service"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/container_application"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/content_scanning"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/content_scanning_expression"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/custom_hostname"
@@ -615,6 +616,7 @@ func (p *CloudflareProvider) Resources(ctx context.Context) []func() resource.Re
 		workflow.NewResource,
 		leaked_credential_check.NewResource,
 		leaked_credential_check_rule.NewResource,
+		container_application.NewResource,
 		content_scanning.NewResource,
 		content_scanning_expression.NewResource,
 		ai_search_instance.NewResource,

--- a/internal/services/container_application/model.go
+++ b/internal/services/container_application/model.go
@@ -1,0 +1,443 @@
+package container_application
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Terraform state model
+
+type ContainerApplicationModel struct {
+	ID                       types.String                          `tfsdk:"id"`
+	AccountID                types.String                          `tfsdk:"account_id"`
+	ApplicationID            types.String                          `tfsdk:"application_id"`
+	ScriptName               types.String                          `tfsdk:"script_name"`
+	ClassName                types.String                          `tfsdk:"class_name"`
+	Name                     types.String                          `tfsdk:"name"`
+	Image                    types.String                          `tfsdk:"image"`
+	MaxInstances             types.Int64                           `tfsdk:"max_instances"`
+	InstanceType             types.String                          `tfsdk:"instance_type"`
+	Vcpu                     types.Float64                         `tfsdk:"vcpu"`
+	MemoryMib                types.Int64                           `tfsdk:"memory_mib"`
+	DiskSizeMb               types.Int64                           `tfsdk:"disk_size_mb"`
+	SchedulingPolicy         types.String                          `tfsdk:"scheduling_policy"`
+	RolloutStepPercentage    types.Int64                           `tfsdk:"rollout_step_percentage"`
+	RolloutKind              types.String                          `tfsdk:"rollout_kind"`
+	RolloutActiveGracePeriod types.Int64                           `tfsdk:"rollout_active_grace_period"`
+	Constraints              *ContainerApplicationConstraintsModel `tfsdk:"constraints"`
+	Affinities               *ContainerApplicationAffinitiesModel  `tfsdk:"affinities"`
+	Observability            *ContainerApplicationObservabilityModel `tfsdk:"observability"`
+	WranglerSSH              *ContainerApplicationWranglerSSHModel `tfsdk:"wrangler_ssh"`
+	AuthorizedKeys           *[]*ContainerApplicationAuthorizedKeyModel  `tfsdk:"authorized_keys"`
+	TrustedUserCAKeys        *[]*ContainerApplicationTrustedCAKeyModel   `tfsdk:"trusted_user_ca_keys"`
+}
+
+type ContainerApplicationConstraintsModel struct {
+	Tiers   types.List `tfsdk:"tiers"`
+	Regions types.List `tfsdk:"regions"`
+	Cities  types.List `tfsdk:"cities"`
+}
+
+type ContainerApplicationAffinitiesModel struct {
+	Colocation         types.String `tfsdk:"colocation"`
+	HardwareGeneration types.String `tfsdk:"hardware_generation"`
+}
+
+type ContainerApplicationObservabilityModel struct {
+	LogsEnabled types.Bool `tfsdk:"logs_enabled"`
+}
+
+type ContainerApplicationWranglerSSHModel struct {
+	Enabled types.Bool  `tfsdk:"enabled"`
+	Port    types.Int64 `tfsdk:"port"`
+}
+
+type ContainerApplicationAuthorizedKeyModel struct {
+	Name      types.String `tfsdk:"name"`
+	PublicKey types.String `tfsdk:"public_key"`
+}
+
+type ContainerApplicationTrustedCAKeyModel struct {
+	Name      types.String `tfsdk:"name"`
+	PublicKey types.String `tfsdk:"public_key"`
+}
+
+// API request/response types
+
+type apiApplicationEnvelope struct {
+	Result  apiApplication `json:"result"`
+	Success bool           `json:"success"`
+}
+
+type apiApplicationListEnvelope struct {
+	Result  []apiApplication `json:"result"`
+	Success bool             `json:"success"`
+}
+
+type apiDONamespaceListEnvelope struct {
+	Result  []apiDurableObjectNamespace `json:"result"`
+	Success bool                        `json:"success"`
+}
+
+type apiApplication struct {
+	ID                       string             `json:"id"`
+	Name                     string             `json:"name"`
+	Configuration            apiConfiguration   `json:"configuration"`
+	Instances                int64              `json:"instances"`
+	MaxInstances             int64              `json:"max_instances"`
+	SchedulingPolicy         string             `json:"scheduling_policy"`
+	Constraints              *apiConstraints    `json:"constraints,omitempty"`
+	Affinities               *apiAffinities     `json:"affinities,omitempty"`
+	DurableObjects           *apiDurableObjects `json:"durable_objects,omitempty"`
+	RolloutActiveGracePeriod int64              `json:"rollout_active_grace_period"`
+}
+
+type apiConfiguration struct {
+	Image         string            `json:"image"`
+	InstanceType  string            `json:"instance_type,omitempty"`
+	Vcpu          *float64          `json:"vcpu,omitempty"`
+	MemoryMib     *int64            `json:"memory_mib,omitempty"`
+	Disk          *apiDisk          `json:"disk,omitempty"`
+	Observability *apiObservability `json:"observability,omitempty"`
+	WranglerSSH   *apiWranglerSSH  `json:"wrangler_ssh,omitempty"`
+	AuthorizedKeys    []apiAuthorizedKey `json:"authorized_keys,omitempty"`
+	TrustedUserCAKeys []apiTrustedCAKey  `json:"trusted_user_ca_keys,omitempty"`
+}
+
+type apiDisk struct {
+	SizeMb int64 `json:"size_mb"`
+}
+
+type apiObservability struct {
+	Logs *apiObservabilityLogs `json:"logs,omitempty"`
+}
+
+type apiObservabilityLogs struct {
+	Enabled bool `json:"enabled"`
+}
+
+type apiWranglerSSH struct {
+	Enabled bool  `json:"enabled"`
+	Port    int64 `json:"port,omitempty"`
+}
+
+type apiAuthorizedKey struct {
+	Name      string `json:"name"`
+	PublicKey string `json:"public_key"`
+}
+
+type apiTrustedCAKey struct {
+	Name      string `json:"name,omitempty"`
+	PublicKey string `json:"public_key"`
+}
+
+type apiConstraints struct {
+	Tiers   []int64  `json:"tiers,omitempty"`
+	Regions []string `json:"regions,omitempty"`
+	Cities  []string `json:"cities,omitempty"`
+}
+
+type apiAffinities struct {
+	Colocation         string `json:"colocation,omitempty"`
+	HardwareGeneration string `json:"hardware_generation,omitempty"`
+}
+
+type apiDurableObjects struct {
+	NamespaceID string `json:"namespace_id"`
+}
+
+type apiCreateApplicationRequest struct {
+	Name                     string            `json:"name"`
+	SchedulingPolicy         string            `json:"scheduling_policy"`
+	Configuration            apiConfiguration  `json:"configuration"`
+	Instances                int64             `json:"instances"`
+	MaxInstances             int64             `json:"max_instances"`
+	Constraints              *apiConstraints   `json:"constraints,omitempty"`
+	Affinities               *apiAffinities    `json:"affinities,omitempty"`
+	DurableObjects           apiDurableObjects `json:"durable_objects"`
+	RolloutActiveGracePeriod int64             `json:"rollout_active_grace_period"`
+}
+
+type apiModifyApplicationRequest struct {
+	Configuration            *apiConfiguration `json:"configuration,omitempty"`
+	MaxInstances             *int64            `json:"max_instances,omitempty"`
+	SchedulingPolicy         *string           `json:"scheduling_policy,omitempty"`
+	Constraints              *apiConstraints   `json:"constraints,omitempty"`
+	Affinities               *apiAffinities    `json:"affinities,omitempty"`
+	RolloutActiveGracePeriod *int64            `json:"rollout_active_grace_period,omitempty"`
+}
+
+type apiCreateRolloutRequest struct {
+	Description         string           `json:"description"`
+	Strategy            string           `json:"strategy"`
+	TargetConfiguration apiConfiguration `json:"target_configuration"`
+	StepPercentage      int64            `json:"step_percentage,omitempty"`
+	Kind                string           `json:"kind"`
+}
+
+type apiDurableObjectNamespace struct {
+	ID     string `json:"id"`
+	Class  string `json:"class"`
+	Name   string `json:"name"`
+	Script string `json:"script"`
+}
+
+// Conversion functions
+
+func (m *ContainerApplicationModel) effectiveName() string {
+	name := m.Name.ValueString()
+	if name == "" || m.Name.IsNull() || m.Name.IsUnknown() {
+		return fmt.Sprintf("%s-%s", m.ScriptName.ValueString(), m.ClassName.ValueString())
+	}
+	return name
+}
+
+func (m *ContainerApplicationModel) buildConfiguration() apiConfiguration {
+	cfg := apiConfiguration{
+		Image: m.Image.ValueString(),
+	}
+
+	// Named instance type vs custom resources (mutually exclusive)
+	if !m.InstanceType.IsNull() && !m.InstanceType.IsUnknown() && m.InstanceType.ValueString() != "" {
+		cfg.InstanceType = m.InstanceType.ValueString()
+	}
+	if !m.Vcpu.IsNull() && !m.Vcpu.IsUnknown() {
+		v := m.Vcpu.ValueFloat64()
+		cfg.Vcpu = &v
+	}
+	if !m.MemoryMib.IsNull() && !m.MemoryMib.IsUnknown() {
+		v := m.MemoryMib.ValueInt64()
+		cfg.MemoryMib = &v
+	}
+	if !m.DiskSizeMb.IsNull() && !m.DiskSizeMb.IsUnknown() && m.DiskSizeMb.ValueInt64() > 0 {
+		cfg.Disk = &apiDisk{SizeMb: m.DiskSizeMb.ValueInt64()}
+	}
+
+	// Observability — default to logs enabled if not specified
+	if m.Observability != nil {
+		cfg.Observability = &apiObservability{
+			Logs: &apiObservabilityLogs{
+				Enabled: m.Observability.LogsEnabled.ValueBool(),
+			},
+		}
+	} else {
+		cfg.Observability = &apiObservability{
+			Logs: &apiObservabilityLogs{Enabled: true},
+		}
+	}
+
+	// SSH config
+	if m.WranglerSSH != nil {
+		ssh := &apiWranglerSSH{
+			Enabled: m.WranglerSSH.Enabled.ValueBool(),
+		}
+		if !m.WranglerSSH.Port.IsNull() && !m.WranglerSSH.Port.IsUnknown() {
+			ssh.Port = m.WranglerSSH.Port.ValueInt64()
+		}
+		cfg.WranglerSSH = ssh
+	}
+
+	if m.AuthorizedKeys != nil {
+		for _, k := range *m.AuthorizedKeys {
+			cfg.AuthorizedKeys = append(cfg.AuthorizedKeys, apiAuthorizedKey{
+				Name:      k.Name.ValueString(),
+				PublicKey: k.PublicKey.ValueString(),
+			})
+		}
+	}
+
+	if m.TrustedUserCAKeys != nil {
+		for _, k := range *m.TrustedUserCAKeys {
+			cfg.TrustedUserCAKeys = append(cfg.TrustedUserCAKeys, apiTrustedCAKey{
+				Name:      k.Name.ValueString(),
+				PublicKey: k.PublicKey.ValueString(),
+			})
+		}
+	}
+
+	return cfg
+}
+
+func (m *ContainerApplicationModel) affinitesToAPI() *apiAffinities {
+	if m.Affinities == nil {
+		return nil
+	}
+	a := &apiAffinities{}
+	if !m.Affinities.Colocation.IsNull() && !m.Affinities.Colocation.IsUnknown() {
+		a.Colocation = m.Affinities.Colocation.ValueString()
+	}
+	if !m.Affinities.HardwareGeneration.IsNull() && !m.Affinities.HardwareGeneration.IsUnknown() {
+		a.HardwareGeneration = m.Affinities.HardwareGeneration.ValueString()
+	}
+	return a
+}
+
+func (m *ContainerApplicationModel) toCreateRequest(ctx context.Context, namespaceID string) (apiCreateApplicationRequest, error) {
+	req := apiCreateApplicationRequest{
+		Name:             m.effectiveName(),
+		SchedulingPolicy: m.SchedulingPolicy.ValueString(),
+		Configuration:    m.buildConfiguration(),
+		Instances:        0,
+		MaxInstances:     m.MaxInstances.ValueInt64(),
+		DurableObjects: apiDurableObjects{
+			NamespaceID: namespaceID,
+		},
+		RolloutActiveGracePeriod: m.RolloutActiveGracePeriod.ValueInt64(),
+		Affinities:               m.affinitesToAPI(),
+	}
+
+	constraints, err := m.constraintsToAPI(ctx)
+	if err != nil {
+		return req, err
+	}
+	req.Constraints = constraints
+
+	return req, nil
+}
+
+func (m *ContainerApplicationModel) toModifyRequest(ctx context.Context) (apiModifyApplicationRequest, error) {
+	maxInstances := m.MaxInstances.ValueInt64()
+	schedulingPolicy := m.SchedulingPolicy.ValueString()
+	rolloutActiveGracePeriod := m.RolloutActiveGracePeriod.ValueInt64()
+	cfg := m.buildConfiguration()
+
+	req := apiModifyApplicationRequest{
+		Configuration:            &cfg,
+		MaxInstances:             &maxInstances,
+		SchedulingPolicy:         &schedulingPolicy,
+		RolloutActiveGracePeriod: &rolloutActiveGracePeriod,
+		Affinities:               m.affinitesToAPI(),
+	}
+
+	constraints, err := m.constraintsToAPI(ctx)
+	if err != nil {
+		return req, err
+	}
+	req.Constraints = constraints
+
+	return req, nil
+}
+
+func (m *ContainerApplicationModel) toRolloutRequest() apiCreateRolloutRequest {
+	return apiCreateRolloutRequest{
+		Description:         "Progressive update",
+		Strategy:            "rolling",
+		TargetConfiguration: m.buildConfiguration(),
+		StepPercentage:      m.RolloutStepPercentage.ValueInt64(),
+		Kind:                m.RolloutKind.ValueString(),
+	}
+}
+
+func (m *ContainerApplicationModel) constraintsToAPI(ctx context.Context) (*apiConstraints, error) {
+	if m.Constraints == nil {
+		return nil, nil
+	}
+
+	constraints := &apiConstraints{}
+
+	if !m.Constraints.Tiers.IsNull() && !m.Constraints.Tiers.IsUnknown() {
+		var tiers []int64
+		diags := m.Constraints.Tiers.ElementsAs(ctx, &tiers, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to convert tiers: %s", diags.Errors())
+		}
+		constraints.Tiers = tiers
+	}
+
+	if !m.Constraints.Regions.IsNull() && !m.Constraints.Regions.IsUnknown() {
+		var regions []string
+		diags := m.Constraints.Regions.ElementsAs(ctx, &regions, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to convert regions: %s", diags.Errors())
+		}
+		constraints.Regions = regions
+	}
+
+	if !m.Constraints.Cities.IsNull() && !m.Constraints.Cities.IsUnknown() {
+		var cities []string
+		diags := m.Constraints.Cities.ElementsAs(ctx, &cities, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to convert cities: %s", diags.Errors())
+		}
+		constraints.Cities = cities
+	}
+
+	return constraints, nil
+}
+
+func (m *ContainerApplicationModel) fromAPIApplication(app apiApplication) {
+	m.ApplicationID = types.StringValue(app.ID)
+	m.ID = types.StringValue(app.ID)
+	m.Name = types.StringValue(app.Name)
+	m.Image = types.StringValue(app.Configuration.Image)
+	m.MaxInstances = types.Int64Value(app.MaxInstances)
+	m.SchedulingPolicy = types.StringValue(app.SchedulingPolicy)
+	m.RolloutActiveGracePeriod = types.Int64Value(app.RolloutActiveGracePeriod)
+
+	if app.Configuration.InstanceType != "" {
+		m.InstanceType = types.StringValue(app.Configuration.InstanceType)
+	}
+	if app.Configuration.Vcpu != nil {
+		m.Vcpu = types.Float64Value(*app.Configuration.Vcpu)
+	}
+	if app.Configuration.MemoryMib != nil {
+		m.MemoryMib = types.Int64Value(*app.Configuration.MemoryMib)
+	}
+	if app.Configuration.Disk != nil {
+		m.DiskSizeMb = types.Int64Value(app.Configuration.Disk.SizeMb)
+	}
+
+	// Affinities
+	if app.Affinities != nil {
+		m.Affinities = &ContainerApplicationAffinitiesModel{}
+		if app.Affinities.Colocation != "" {
+			m.Affinities.Colocation = types.StringValue(app.Affinities.Colocation)
+		}
+		if app.Affinities.HardwareGeneration != "" {
+			m.Affinities.HardwareGeneration = types.StringValue(app.Affinities.HardwareGeneration)
+		}
+	}
+
+	// Observability
+	if app.Configuration.Observability != nil && app.Configuration.Observability.Logs != nil {
+		m.Observability = &ContainerApplicationObservabilityModel{
+			LogsEnabled: types.BoolValue(app.Configuration.Observability.Logs.Enabled),
+		}
+	}
+
+	// SSH config
+	if app.Configuration.WranglerSSH != nil {
+		m.WranglerSSH = &ContainerApplicationWranglerSSHModel{
+			Enabled: types.BoolValue(app.Configuration.WranglerSSH.Enabled),
+		}
+		if app.Configuration.WranglerSSH.Port != 0 {
+			m.WranglerSSH.Port = types.Int64Value(app.Configuration.WranglerSSH.Port)
+		}
+	}
+
+	// Authorized keys
+	if len(app.Configuration.AuthorizedKeys) > 0 {
+		keys := make([]*ContainerApplicationAuthorizedKeyModel, len(app.Configuration.AuthorizedKeys))
+		for i, k := range app.Configuration.AuthorizedKeys {
+			keys[i] = &ContainerApplicationAuthorizedKeyModel{
+				Name:      types.StringValue(k.Name),
+				PublicKey: types.StringValue(k.PublicKey),
+			}
+		}
+		m.AuthorizedKeys = &keys
+	}
+
+	// Trusted CA keys
+	if len(app.Configuration.TrustedUserCAKeys) > 0 {
+		keys := make([]*ContainerApplicationTrustedCAKeyModel, len(app.Configuration.TrustedUserCAKeys))
+		for i, k := range app.Configuration.TrustedUserCAKeys {
+			keys[i] = &ContainerApplicationTrustedCAKeyModel{
+				Name:      types.StringValue(k.Name),
+				PublicKey: types.StringValue(k.PublicKey),
+			}
+		}
+		m.TrustedUserCAKeys = &keys
+	}
+}

--- a/internal/services/container_application/resource.go
+++ b/internal/services/container_application/resource.go
@@ -1,0 +1,423 @@
+package container_application
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.ResourceWithConfigure = (*ContainerApplicationResource)(nil)
+var _ resource.ResourceWithImportState = (*ContainerApplicationResource)(nil)
+
+func NewResource() resource.Resource {
+	return &ContainerApplicationResource{}
+}
+
+type ContainerApplicationResource struct {
+	client *cloudflare.Client
+}
+
+func (r *ContainerApplicationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_container_application"
+}
+
+func (r *ContainerApplicationResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*cloudflare.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"unexpected resource configure type",
+			fmt.Sprintf("Expected *cloudflare.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+}
+
+func (r *ContainerApplicationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *ContainerApplicationModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	accountID := data.AccountID.ValueString()
+	scriptName := data.ScriptName.ValueString()
+	className := data.ClassName.ValueString()
+
+	// Compute default name if not provided
+	if data.Name.IsNull() || data.Name.IsUnknown() || data.Name.ValueString() == "" {
+		data.Name = types.StringValue(fmt.Sprintf("%s-%s", scriptName, className))
+	}
+
+	// Resolve Durable Object namespace
+	namespaceID, err := r.resolveDONamespace(ctx, accountID, scriptName, className)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to resolve Durable Object namespace", err.Error())
+		return
+	}
+
+	// Build create request
+	createReq, err := data.toCreateRequest(ctx, namespaceID)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to build create request", err.Error())
+		return
+	}
+
+	bodyBytes, err := json.Marshal(createReq)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to serialize create request", err.Error())
+		return
+	}
+
+	// POST /accounts/{account_id}/containers/applications
+	res := new(http.Response)
+	err = r.client.Post(
+		ctx,
+		fmt.Sprintf("accounts/%s/containers/applications", accountID),
+		nil,
+		&res,
+		option.WithRequestBody("application/json", bodyBytes),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create container application", err.Error())
+		return
+	}
+	defer res.Body.Close()
+
+	respBytes, _ := io.ReadAll(res.Body)
+
+	var envelope apiApplicationEnvelope
+	err = json.Unmarshal(respBytes, &envelope)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to deserialize create response", err.Error())
+		return
+	}
+
+	data.fromAPIApplication(envelope.Result)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *ContainerApplicationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *ContainerApplicationModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	accountID := data.AccountID.ValueString()
+	appID := data.ApplicationID.ValueString()
+
+	// Preserve state-only fields before API read (not returned by the API)
+	scriptName := data.ScriptName
+	className := data.ClassName
+	rolloutStepPercentage := data.RolloutStepPercentage
+	rolloutKind := data.RolloutKind
+	constraints := data.Constraints
+	vcpu := data.Vcpu
+	memoryMib := data.MemoryMib
+	diskSizeMb := data.DiskSizeMb
+	observability := data.Observability
+	wranglerSSH := data.WranglerSSH
+	authorizedKeys := data.AuthorizedKeys
+	trustedUserCAKeys := data.TrustedUserCAKeys
+
+	app, err := r.getApplication(ctx, accountID, appID)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read container application", err.Error())
+		return
+	}
+	if app == nil {
+		resp.Diagnostics.AddWarning("Resource not found", "The container application was not found on the server and will be removed from state.")
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	data.fromAPIApplication(*app)
+
+	// Restore state-only fields
+	data.ScriptName = scriptName
+	data.ClassName = className
+	data.RolloutStepPercentage = rolloutStepPercentage
+	data.RolloutKind = rolloutKind
+
+	// Preserve these from state if the API didn't return them
+	if data.Constraints == nil {
+		data.Constraints = constraints
+	}
+	if data.Vcpu.IsNull() || data.Vcpu.IsUnknown() {
+		data.Vcpu = vcpu
+	}
+	if data.MemoryMib.IsNull() || data.MemoryMib.IsUnknown() {
+		data.MemoryMib = memoryMib
+	}
+	if data.DiskSizeMb.IsNull() || data.DiskSizeMb.IsUnknown() {
+		data.DiskSizeMb = diskSizeMb
+	}
+	if data.Observability == nil {
+		data.Observability = observability
+	}
+	if data.WranglerSSH == nil {
+		data.WranglerSSH = wranglerSSH
+	}
+	if data.AuthorizedKeys == nil {
+		data.AuthorizedKeys = authorizedKeys
+	}
+	if data.TrustedUserCAKeys == nil {
+		data.TrustedUserCAKeys = trustedUserCAKeys
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *ContainerApplicationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *ContainerApplicationModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	accountID := data.AccountID.ValueString()
+	appID := data.ApplicationID.ValueString()
+
+	// Build modify request
+	modifyReq, err := data.toModifyRequest(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to build modify request", err.Error())
+		return
+	}
+
+	bodyBytes, err := json.Marshal(modifyReq)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to serialize modify request", err.Error())
+		return
+	}
+
+	// PATCH /accounts/{account_id}/containers/applications/{app_id}
+	res := new(http.Response)
+	err = r.client.Patch(
+		ctx,
+		fmt.Sprintf("accounts/%s/containers/applications/%s", accountID, appID),
+		nil,
+		&res,
+		option.WithRequestBody("application/json", bodyBytes),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to modify container application", err.Error())
+		return
+	}
+	defer res.Body.Close()
+
+	respBytes, _ := io.ReadAll(res.Body)
+	var envelope apiApplicationEnvelope
+	err = json.Unmarshal(respBytes, &envelope)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to deserialize modify response", err.Error())
+		return
+	}
+
+	// Create rollout if rollout_kind is not "none"
+	rolloutKind := data.RolloutKind.ValueString()
+	if rolloutKind != "none" {
+		rolloutReq := data.toRolloutRequest()
+		rolloutBytes, err := json.Marshal(rolloutReq)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to serialize rollout request", err.Error())
+			return
+		}
+
+		rolloutRes := new(http.Response)
+		err = r.client.Post(
+			ctx,
+			fmt.Sprintf("accounts/%s/containers/applications/%s/rollouts", accountID, appID),
+			nil,
+			&rolloutRes,
+			option.WithRequestBody("application/json", rolloutBytes),
+			option.WithMiddleware(logging.Middleware(ctx)),
+		)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to create container rollout", err.Error())
+			return
+		}
+		defer rolloutRes.Body.Close()
+	}
+
+	data.fromAPIApplication(envelope.Result)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *ContainerApplicationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *ContainerApplicationModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	accountID := data.AccountID.ValueString()
+	appID := data.ApplicationID.ValueString()
+
+	// DELETE /accounts/{account_id}/containers/applications/{app_id}
+	res := new(http.Response)
+	err := r.client.Delete(
+		ctx,
+		fmt.Sprintf("accounts/%s/containers/applications/%s", accountID, appID),
+		nil,
+		&res,
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to delete container application", err.Error())
+		return
+	}
+	if res != nil && res.Body != nil {
+		defer res.Body.Close()
+	}
+}
+
+func (r *ContainerApplicationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	var data = new(ContainerApplicationModel)
+
+	pathAccountID := ""
+	pathAppID := ""
+	diags := importpath.ParseImportID(
+		req.ID,
+		"<account_id>/<application_id>",
+		&pathAccountID,
+		&pathAppID,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.AccountID = types.StringValue(pathAccountID)
+
+	app, err := r.getApplication(ctx, pathAccountID, pathAppID)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read container application for import", err.Error())
+		return
+	}
+	if app == nil {
+		resp.Diagnostics.AddError("container application not found", fmt.Sprintf("Application %s not found in account %s", pathAppID, pathAccountID))
+		return
+	}
+
+	data.fromAPIApplication(*app)
+
+	// These fields aren't available from the API; user will need to set them after import
+	data.ScriptName = types.StringValue("")
+	data.ClassName = types.StringValue("")
+	data.RolloutStepPercentage = types.Int64Value(100)
+	data.RolloutKind = types.StringValue("full_auto")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// resolveDONamespace looks up the Durable Object namespace ID for the given
+// script_name and class_name combination. It retries a few times because the
+// namespace may not be immediately available after script deployment.
+func (r *ContainerApplicationResource) resolveDONamespace(ctx context.Context, accountID, scriptName, className string) (string, error) {
+	const maxRetries = 5
+	const retryDelay = 3 * time.Second
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			tflog.Info(ctx, fmt.Sprintf("Durable Object namespace not found yet, retrying in %s (attempt %d/%d)", retryDelay, attempt+1, maxRetries))
+			time.Sleep(retryDelay)
+		}
+
+		nsID, err := r.fetchDONamespace(ctx, accountID, scriptName, className)
+		if err != nil {
+			return "", err
+		}
+		if nsID != "" {
+			return nsID, nil
+		}
+	}
+
+	return "", fmt.Errorf("Durable Object namespace not found for class %q in script %q after %d attempts. Ensure the Worker script is deployed with the Durable Object binding before creating the container application", className, scriptName, maxRetries)
+}
+
+func (r *ContainerApplicationResource) fetchDONamespace(ctx context.Context, accountID, scriptName, className string) (string, error) {
+	res := new(http.Response)
+	err := r.client.Get(
+		ctx,
+		fmt.Sprintf("accounts/%s/workers/durable_objects/namespaces?per_page=1000", accountID),
+		nil,
+		&res,
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to list Durable Object namespaces: %w", err)
+	}
+	defer res.Body.Close()
+
+	respBytes, _ := io.ReadAll(res.Body)
+	var envelope apiDONamespaceListEnvelope
+	err = json.Unmarshal(respBytes, &envelope)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse Durable Object namespaces: %w", err)
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Found %d Durable Object namespaces, looking for class=%q script=%q", len(envelope.Result), className, scriptName))
+
+	for _, ns := range envelope.Result {
+		if ns.Class == className && ns.Script == scriptName {
+			tflog.Info(ctx, fmt.Sprintf("Resolved Durable Object namespace: %s", ns.ID))
+			return ns.ID, nil
+		}
+	}
+
+	return "", nil
+}
+
+// getApplication fetches a single container application by listing all applications
+// and filtering by ID.
+func (r *ContainerApplicationResource) getApplication(ctx context.Context, accountID, appID string) (*apiApplication, error) {
+	res := new(http.Response)
+	err := r.client.Get(
+		ctx,
+		fmt.Sprintf("accounts/%s/containers/applications", accountID),
+		nil,
+		&res,
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list container applications: %w", err)
+	}
+	defer res.Body.Close()
+
+	respBytes, _ := io.ReadAll(res.Body)
+	var envelope apiApplicationListEnvelope
+	err = json.Unmarshal(respBytes, &envelope)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse container applications: %w", err)
+	}
+
+	for _, app := range envelope.Result {
+		if app.ID == appID {
+			return &app, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/internal/services/container_application/resource_test.go
+++ b/internal/services/container_application/resource_test.go
@@ -1,0 +1,655 @@
+package container_application
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerApplicationDefaultName(t *testing.T) {
+	tests := []struct {
+		name       string
+		scriptName string
+		className  string
+		appName    string
+		expected   string
+	}{
+		{
+			name:       "default name from script and class",
+			scriptName: "my-worker",
+			className:  "MyDO",
+			appName:    "",
+			expected:   "my-worker-MyDO",
+		},
+		{
+			name:       "explicit name overrides default",
+			scriptName: "my-worker",
+			className:  "MyDO",
+			appName:    "custom-app",
+			expected:   "custom-app",
+		},
+		{
+			name:       "null name generates default",
+			scriptName: "api-worker",
+			className:  "Container",
+			appName:    "", // will be set as null
+			expected:   "api-worker-Container",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := &ContainerApplicationModel{
+				ScriptName: types.StringValue(tt.scriptName),
+				ClassName:  types.StringValue(tt.className),
+			}
+			if tt.appName != "" {
+				model.Name = types.StringValue(tt.appName)
+			} else {
+				model.Name = types.StringNull()
+			}
+
+			assert.Equal(t, tt.expected, model.effectiveName())
+		})
+	}
+}
+
+func TestContainerApplicationModelToCreateRequest(t *testing.T) {
+	ctx := context.Background()
+
+	model := &ContainerApplicationModel{
+		AccountID:                types.StringValue("test-account"),
+		ScriptName:               types.StringValue("my-worker"),
+		ClassName:                types.StringValue("MyDO"),
+		Name:                     types.StringValue("my-app"),
+		Image:                    types.StringValue("registry.example.com/image:v1"),
+		MaxInstances:             types.Int64Value(10),
+		InstanceType:             types.StringValue("basic"),
+		SchedulingPolicy:         types.StringValue("default"),
+		RolloutActiveGracePeriod: types.Int64Value(30),
+	}
+
+	req, err := model.toCreateRequest(ctx, "ns-12345")
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-app", req.Name)
+	assert.Equal(t, "default", req.SchedulingPolicy)
+	assert.Equal(t, "registry.example.com/image:v1", req.Configuration.Image)
+	assert.Equal(t, "basic", req.Configuration.InstanceType)
+	assert.Equal(t, int64(0), req.Instances)
+	assert.Equal(t, int64(10), req.MaxInstances)
+	assert.Equal(t, "ns-12345", req.DurableObjects.NamespaceID)
+	assert.Equal(t, int64(30), req.RolloutActiveGracePeriod)
+	assert.Nil(t, req.Constraints)
+
+	// Default observability should be logs enabled
+	require.NotNil(t, req.Configuration.Observability)
+	require.NotNil(t, req.Configuration.Observability.Logs)
+	assert.True(t, req.Configuration.Observability.Logs.Enabled)
+
+	// Verify JSON serialization
+	jsonBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &parsed)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-app", parsed["name"])
+	assert.Equal(t, float64(0), parsed["instances"])
+	assert.Equal(t, float64(10), parsed["max_instances"])
+
+	config := parsed["configuration"].(map[string]interface{})
+	assert.Equal(t, "registry.example.com/image:v1", config["image"])
+	assert.Equal(t, "basic", config["instance_type"])
+
+	do := parsed["durable_objects"].(map[string]interface{})
+	assert.Equal(t, "ns-12345", do["namespace_id"])
+}
+
+func TestContainerApplicationModelToCreateRequestWithConstraints(t *testing.T) {
+	ctx := context.Background()
+
+	tiers, _ := types.ListValueFrom(ctx, types.Int64Type, []int64{1, 2})
+	regions, _ := types.ListValueFrom(ctx, types.StringType, []string{"us-east", "eu-west"})
+	cities, _ := types.ListValueFrom(ctx, types.StringType, []string{})
+
+	model := &ContainerApplicationModel{
+		AccountID:                types.StringValue("test-account"),
+		ScriptName:               types.StringValue("my-worker"),
+		ClassName:                types.StringValue("MyDO"),
+		Name:                     types.StringValue("my-app"),
+		Image:                    types.StringValue("image:v1"),
+		MaxInstances:             types.Int64Value(20),
+		InstanceType:             types.StringValue("lite"),
+		SchedulingPolicy:         types.StringValue("default"),
+		RolloutActiveGracePeriod: types.Int64Value(0),
+		Constraints: &ContainerApplicationConstraintsModel{
+			Tiers:   tiers,
+			Regions: regions,
+			Cities:  cities,
+		},
+	}
+
+	req, err := model.toCreateRequest(ctx, "ns-abc")
+	require.NoError(t, err)
+
+	require.NotNil(t, req.Constraints)
+	assert.Equal(t, []int64{1, 2}, req.Constraints.Tiers)
+	assert.Equal(t, []string{"us-east", "eu-west"}, req.Constraints.Regions)
+	assert.Equal(t, []string{}, req.Constraints.Cities)
+}
+
+func TestContainerApplicationModelToModifyRequest(t *testing.T) {
+	ctx := context.Background()
+
+	model := &ContainerApplicationModel{
+		Image:                    types.StringValue("registry.example.com/image:v2"),
+		InstanceType:             types.StringValue("standard-1"),
+		MaxInstances:             types.Int64Value(50),
+		SchedulingPolicy:         types.StringValue("regional"),
+		RolloutActiveGracePeriod: types.Int64Value(60),
+	}
+
+	req, err := model.toModifyRequest(ctx)
+	require.NoError(t, err)
+
+	require.NotNil(t, req.Configuration)
+	assert.Equal(t, "registry.example.com/image:v2", req.Configuration.Image)
+	assert.Equal(t, "standard-1", req.Configuration.InstanceType)
+	require.NotNil(t, req.MaxInstances)
+	assert.Equal(t, int64(50), *req.MaxInstances)
+	require.NotNil(t, req.SchedulingPolicy)
+	assert.Equal(t, "regional", *req.SchedulingPolicy)
+	require.NotNil(t, req.RolloutActiveGracePeriod)
+	assert.Equal(t, int64(60), *req.RolloutActiveGracePeriod)
+}
+
+func TestContainerApplicationRolloutRequest(t *testing.T) {
+	tests := []struct {
+		name               string
+		image              string
+		instanceType       string
+		stepPercentage     int64
+		rolloutKind        string
+		expectedStrategy   string
+		expectedPercentage int64
+	}{
+		{
+			name:               "full auto with 100%",
+			image:              "image:v1",
+			instanceType:       "lite",
+			stepPercentage:     100,
+			rolloutKind:        "full_auto",
+			expectedStrategy:   "rolling",
+			expectedPercentage: 100,
+		},
+		{
+			name:               "full manual with 10%",
+			image:              "image:v2",
+			instanceType:       "basic",
+			stepPercentage:     10,
+			rolloutKind:        "full_manual",
+			expectedStrategy:   "rolling",
+			expectedPercentage: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := &ContainerApplicationModel{
+				Image:                 types.StringValue(tt.image),
+				InstanceType:         types.StringValue(tt.instanceType),
+				RolloutStepPercentage: types.Int64Value(tt.stepPercentage),
+				RolloutKind:          types.StringValue(tt.rolloutKind),
+			}
+
+			req := model.toRolloutRequest()
+
+			assert.Equal(t, "Progressive update", req.Description)
+			assert.Equal(t, tt.expectedStrategy, req.Strategy)
+			assert.Equal(t, tt.image, req.TargetConfiguration.Image)
+			assert.Equal(t, tt.instanceType, req.TargetConfiguration.InstanceType)
+			assert.Equal(t, tt.expectedPercentage, req.StepPercentage)
+			assert.Equal(t, tt.rolloutKind, req.Kind)
+		})
+	}
+}
+
+func TestContainerApplicationFromAPIApplication(t *testing.T) {
+	app := apiApplication{
+		ID:               "app-123",
+		Name:             "my-app",
+		MaxInstances:     20,
+		SchedulingPolicy: "default",
+		Configuration: apiConfiguration{
+			Image:        "registry.example.com/image:v1",
+			InstanceType: "lite",
+		},
+		RolloutActiveGracePeriod: 30,
+	}
+
+	model := &ContainerApplicationModel{}
+	model.fromAPIApplication(app)
+
+	assert.Equal(t, "app-123", model.ID.ValueString())
+	assert.Equal(t, "app-123", model.ApplicationID.ValueString())
+	assert.Equal(t, "my-app", model.Name.ValueString())
+	assert.Equal(t, "registry.example.com/image:v1", model.Image.ValueString())
+	assert.Equal(t, int64(20), model.MaxInstances.ValueInt64())
+	assert.Equal(t, "default", model.SchedulingPolicy.ValueString())
+	assert.Equal(t, "lite", model.InstanceType.ValueString())
+	assert.Equal(t, int64(30), model.RolloutActiveGracePeriod.ValueInt64())
+}
+
+func TestContainerApplicationSchemaValidity(t *testing.T) {
+	ctx := context.Background()
+	s := ResourceSchema(ctx)
+
+	// Verify all expected attributes exist
+	expectedAttrs := []string{
+		"id", "account_id", "application_id", "script_name", "class_name",
+		"name", "image", "max_instances", "instance_type", "scheduling_policy",
+		"rollout_step_percentage", "rollout_kind", "rollout_active_grace_period",
+		"constraints", "affinities", "observability", "vcpu", "memory_mib",
+		"disk_size_mb", "wrangler_ssh", "authorized_keys", "trusted_user_ca_keys",
+	}
+
+	for _, attr := range expectedAttrs {
+		_, ok := s.Attributes[attr]
+		assert.True(t, ok, "schema should have attribute %q", attr)
+	}
+
+	// Verify required attributes
+	requiredAttrs := []string{"account_id", "script_name", "class_name", "image"}
+	for _, attr := range requiredAttrs {
+		a := s.Attributes[attr]
+		assert.True(t, a.IsRequired(), "attribute %q should be required", attr)
+	}
+
+	// Verify computed attributes
+	computedAttrs := []string{"id", "application_id"}
+	for _, attr := range computedAttrs {
+		a := s.Attributes[attr]
+		assert.True(t, a.IsComputed(), "attribute %q should be computed", attr)
+		assert.False(t, a.IsRequired(), "attribute %q should not be required", attr)
+	}
+
+	// Verify optional attributes
+	optionalAttrs := []string{
+		"vcpu", "memory_mib", "disk_size_mb",
+		"affinities", "observability", "wrangler_ssh",
+		"authorized_keys", "trusted_user_ca_keys",
+	}
+	for _, attr := range optionalAttrs {
+		a := s.Attributes[attr]
+		assert.True(t, a.IsOptional(), "attribute %q should be optional", attr)
+	}
+}
+
+func TestCreateRequestJSONShape(t *testing.T) {
+	ctx := context.Background()
+
+	model := &ContainerApplicationModel{
+		AccountID:                types.StringValue("acc-1"),
+		ScriptName:               types.StringValue("worker"),
+		ClassName:                types.StringValue("DO"),
+		Name:                     types.StringNull(),
+		Image:                    types.StringValue("ccr.ccs.cloudflare.com/acc-1/myimage:latest"),
+		MaxInstances:             types.Int64Value(20),
+		InstanceType:             types.StringValue("lite"),
+		SchedulingPolicy:         types.StringValue("default"),
+		RolloutActiveGracePeriod: types.Int64Value(0),
+	}
+
+	req, err := model.toCreateRequest(ctx, "ns-do-123")
+	require.NoError(t, err)
+
+	// Name should be computed from script+class
+	assert.Equal(t, "worker-DO", req.Name)
+
+	jsonBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	// Verify the JSON matches the expected API shape
+	var raw map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &raw)
+	require.NoError(t, err)
+
+	// Must have these top-level keys
+	for _, key := range []string{"name", "scheduling_policy", "configuration", "instances", "max_instances", "durable_objects", "rollout_active_grace_period"} {
+		_, ok := raw[key]
+		assert.True(t, ok, "JSON should have key %q", key)
+	}
+
+	// instances must be 0 (deprecated field)
+	assert.Equal(t, float64(0), raw["instances"])
+
+	// durable_objects.namespace_id must be set
+	do := raw["durable_objects"].(map[string]interface{})
+	assert.Equal(t, "ns-do-123", do["namespace_id"])
+}
+
+func TestContainerApplicationCustomInstanceType(t *testing.T) {
+	ctx := context.Background()
+
+	model := &ContainerApplicationModel{
+		AccountID:                types.StringValue("test-account"),
+		ScriptName:               types.StringValue("my-worker"),
+		ClassName:                types.StringValue("MyDO"),
+		Name:                     types.StringValue("my-app"),
+		Image:                    types.StringValue("image:v1"),
+		MaxInstances:             types.Int64Value(5),
+		Vcpu:                     types.Float64Value(2.0),
+		MemoryMib:                types.Int64Value(512),
+		DiskSizeMb:               types.Int64Value(1024),
+		SchedulingPolicy:         types.StringValue("default"),
+		RolloutActiveGracePeriod: types.Int64Value(0),
+	}
+
+	req, err := model.toCreateRequest(ctx, "ns-123")
+	require.NoError(t, err)
+
+	// Custom resources
+	require.NotNil(t, req.Configuration.Vcpu)
+	assert.Equal(t, 2.0, *req.Configuration.Vcpu)
+	require.NotNil(t, req.Configuration.MemoryMib)
+	assert.Equal(t, int64(512), *req.Configuration.MemoryMib)
+	require.NotNil(t, req.Configuration.Disk)
+	assert.Equal(t, int64(1024), req.Configuration.Disk.SizeMb)
+	// InstanceType should be empty when custom resources are used
+	assert.Equal(t, "", req.Configuration.InstanceType)
+
+	// Verify JSON
+	jsonBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &raw))
+	config := raw["configuration"].(map[string]interface{})
+	assert.Equal(t, 2.0, config["vcpu"])
+	assert.Equal(t, float64(512), config["memory_mib"])
+	disk := config["disk"].(map[string]interface{})
+	assert.Equal(t, float64(1024), disk["size_mb"])
+}
+
+func TestContainerApplicationObservability(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("explicit observability disabled", func(t *testing.T) {
+		model := &ContainerApplicationModel{
+			AccountID:                types.StringValue("test-account"),
+			ScriptName:               types.StringValue("worker"),
+			ClassName:                types.StringValue("DO"),
+			Name:                     types.StringValue("app"),
+			Image:                    types.StringValue("image:v1"),
+			MaxInstances:             types.Int64Value(1),
+			InstanceType:             types.StringValue("lite"),
+			SchedulingPolicy:         types.StringValue("default"),
+			RolloutActiveGracePeriod: types.Int64Value(0),
+			Observability: &ContainerApplicationObservabilityModel{
+				LogsEnabled: types.BoolValue(false),
+			},
+		}
+
+		req, err := model.toCreateRequest(ctx, "ns-1")
+		require.NoError(t, err)
+
+		require.NotNil(t, req.Configuration.Observability)
+		require.NotNil(t, req.Configuration.Observability.Logs)
+		assert.False(t, req.Configuration.Observability.Logs.Enabled)
+	})
+
+	t.Run("default observability when not specified", func(t *testing.T) {
+		model := &ContainerApplicationModel{
+			AccountID:                types.StringValue("test-account"),
+			ScriptName:               types.StringValue("worker"),
+			ClassName:                types.StringValue("DO"),
+			Name:                     types.StringValue("app"),
+			Image:                    types.StringValue("image:v1"),
+			MaxInstances:             types.Int64Value(1),
+			InstanceType:             types.StringValue("lite"),
+			SchedulingPolicy:         types.StringValue("default"),
+			RolloutActiveGracePeriod: types.Int64Value(0),
+		}
+
+		req, err := model.toCreateRequest(ctx, "ns-1")
+		require.NoError(t, err)
+
+		require.NotNil(t, req.Configuration.Observability)
+		require.NotNil(t, req.Configuration.Observability.Logs)
+		assert.True(t, req.Configuration.Observability.Logs.Enabled)
+	})
+}
+
+func TestContainerApplicationAffinities(t *testing.T) {
+	ctx := context.Background()
+
+	model := &ContainerApplicationModel{
+		AccountID:                types.StringValue("test-account"),
+		ScriptName:               types.StringValue("worker"),
+		ClassName:                types.StringValue("DO"),
+		Name:                     types.StringValue("app"),
+		Image:                    types.StringValue("image:v1"),
+		MaxInstances:             types.Int64Value(5),
+		InstanceType:             types.StringValue("lite"),
+		SchedulingPolicy:         types.StringValue("default"),
+		RolloutActiveGracePeriod: types.Int64Value(0),
+		Affinities: &ContainerApplicationAffinitiesModel{
+			Colocation:         types.StringValue("best_effort"),
+			HardwareGeneration: types.StringValue("metal"),
+		},
+	}
+
+	req, err := model.toCreateRequest(ctx, "ns-1")
+	require.NoError(t, err)
+
+	require.NotNil(t, req.Affinities)
+	assert.Equal(t, "best_effort", req.Affinities.Colocation)
+	assert.Equal(t, "metal", req.Affinities.HardwareGeneration)
+
+	// Verify JSON
+	jsonBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &raw))
+	affinities := raw["affinities"].(map[string]interface{})
+	assert.Equal(t, "best_effort", affinities["colocation"])
+	assert.Equal(t, "metal", affinities["hardware_generation"])
+}
+
+func TestContainerApplicationSSHConfig(t *testing.T) {
+	ctx := context.Background()
+
+	authKeys := []*ContainerApplicationAuthorizedKeyModel{
+		{Name: types.StringValue("my-key"), PublicKey: types.StringValue("ssh-ed25519 AAAA...")},
+	}
+	caKeys := []*ContainerApplicationTrustedCAKeyModel{
+		{Name: types.StringValue("ca-key"), PublicKey: types.StringValue("ssh-rsa BBBB...")},
+	}
+
+	model := &ContainerApplicationModel{
+		AccountID:                types.StringValue("test-account"),
+		ScriptName:               types.StringValue("worker"),
+		ClassName:                types.StringValue("DO"),
+		Name:                     types.StringValue("app"),
+		Image:                    types.StringValue("image:v1"),
+		MaxInstances:             types.Int64Value(1),
+		InstanceType:             types.StringValue("lite"),
+		SchedulingPolicy:         types.StringValue("default"),
+		RolloutActiveGracePeriod: types.Int64Value(0),
+		WranglerSSH: &ContainerApplicationWranglerSSHModel{
+			Enabled: types.BoolValue(true),
+			Port:    types.Int64Value(2222),
+		},
+		AuthorizedKeys:    &authKeys,
+		TrustedUserCAKeys: &caKeys,
+	}
+
+	req, err := model.toCreateRequest(ctx, "ns-1")
+	require.NoError(t, err)
+
+	// SSH
+	require.NotNil(t, req.Configuration.WranglerSSH)
+	assert.True(t, req.Configuration.WranglerSSH.Enabled)
+	assert.Equal(t, int64(2222), req.Configuration.WranglerSSH.Port)
+
+	// Authorized keys
+	require.Len(t, req.Configuration.AuthorizedKeys, 1)
+	assert.Equal(t, "my-key", req.Configuration.AuthorizedKeys[0].Name)
+	assert.Equal(t, "ssh-ed25519 AAAA...", req.Configuration.AuthorizedKeys[0].PublicKey)
+
+	// Trusted CA keys
+	require.Len(t, req.Configuration.TrustedUserCAKeys, 1)
+	assert.Equal(t, "ca-key", req.Configuration.TrustedUserCAKeys[0].Name)
+	assert.Equal(t, "ssh-rsa BBBB...", req.Configuration.TrustedUserCAKeys[0].PublicKey)
+
+	// Verify JSON
+	jsonBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &raw))
+	config := raw["configuration"].(map[string]interface{})
+
+	ssh := config["wrangler_ssh"].(map[string]interface{})
+	assert.Equal(t, true, ssh["enabled"])
+	assert.Equal(t, float64(2222), ssh["port"])
+
+	keys := config["authorized_keys"].([]interface{})
+	require.Len(t, keys, 1)
+	key := keys[0].(map[string]interface{})
+	assert.Equal(t, "my-key", key["name"])
+
+	caKeysJSON := config["trusted_user_ca_keys"].([]interface{})
+	require.Len(t, caKeysJSON, 1)
+}
+
+func TestContainerApplicationFromAPIApplicationFull(t *testing.T) {
+	vcpu := 1.5
+	memMib := int64(256)
+
+	app := apiApplication{
+		ID:               "app-full",
+		Name:             "full-app",
+		MaxInstances:     10,
+		SchedulingPolicy: "regional",
+		Configuration: apiConfiguration{
+			Image:     "image:v2",
+			Vcpu:      &vcpu,
+			MemoryMib: &memMib,
+			Disk:      &apiDisk{SizeMb: 2048},
+			Observability: &apiObservability{
+				Logs: &apiObservabilityLogs{Enabled: false},
+			},
+			WranglerSSH: &apiWranglerSSH{
+				Enabled: true,
+				Port:    2222,
+			},
+			AuthorizedKeys: []apiAuthorizedKey{
+				{Name: "key1", PublicKey: "ssh-ed25519 AAA"},
+			},
+			TrustedUserCAKeys: []apiTrustedCAKey{
+				{Name: "ca1", PublicKey: "ssh-rsa BBB"},
+			},
+		},
+		Affinities: &apiAffinities{
+			Colocation:         "best_effort",
+			HardwareGeneration: "intel",
+		},
+		RolloutActiveGracePeriod: 60,
+	}
+
+	model := &ContainerApplicationModel{}
+	model.fromAPIApplication(app)
+
+	assert.Equal(t, "app-full", model.ID.ValueString())
+	assert.Equal(t, "full-app", model.Name.ValueString())
+	assert.Equal(t, "image:v2", model.Image.ValueString())
+	assert.Equal(t, int64(10), model.MaxInstances.ValueInt64())
+	assert.Equal(t, "regional", model.SchedulingPolicy.ValueString())
+	assert.Equal(t, int64(60), model.RolloutActiveGracePeriod.ValueInt64())
+
+	// Custom resources
+	assert.Equal(t, 1.5, model.Vcpu.ValueFloat64())
+	assert.Equal(t, int64(256), model.MemoryMib.ValueInt64())
+	assert.Equal(t, int64(2048), model.DiskSizeMb.ValueInt64())
+
+	// Affinities
+	require.NotNil(t, model.Affinities)
+	assert.Equal(t, "best_effort", model.Affinities.Colocation.ValueString())
+	assert.Equal(t, "intel", model.Affinities.HardwareGeneration.ValueString())
+
+	// Observability
+	require.NotNil(t, model.Observability)
+	assert.False(t, model.Observability.LogsEnabled.ValueBool())
+
+	// SSH
+	require.NotNil(t, model.WranglerSSH)
+	assert.True(t, model.WranglerSSH.Enabled.ValueBool())
+	assert.Equal(t, int64(2222), model.WranglerSSH.Port.ValueInt64())
+
+	// Keys
+	require.NotNil(t, model.AuthorizedKeys)
+	require.Len(t, *model.AuthorizedKeys, 1)
+	assert.Equal(t, "key1", (*model.AuthorizedKeys)[0].Name.ValueString())
+
+	require.NotNil(t, model.TrustedUserCAKeys)
+	require.Len(t, *model.TrustedUserCAKeys, 1)
+	assert.Equal(t, "ca1", (*model.TrustedUserCAKeys)[0].Name.ValueString())
+}
+
+func TestContainerApplicationModifyWithAllFields(t *testing.T) {
+	ctx := context.Background()
+
+	authKeys := []*ContainerApplicationAuthorizedKeyModel{
+		{Name: types.StringValue("k1"), PublicKey: types.StringValue("ssh-ed25519 AAA")},
+		{Name: types.StringValue("k2"), PublicKey: types.StringValue("ssh-ed25519 BBB")},
+	}
+
+	model := &ContainerApplicationModel{
+		Image:                    types.StringValue("image:v3"),
+		Vcpu:                     types.Float64Value(4.0),
+		MemoryMib:                types.Int64Value(1024),
+		DiskSizeMb:               types.Int64Value(4096),
+		MaxInstances:             types.Int64Value(100),
+		SchedulingPolicy:         types.StringValue("moon"),
+		RolloutActiveGracePeriod: types.Int64Value(120),
+		Affinities: &ContainerApplicationAffinitiesModel{
+			Colocation: types.StringValue("best_effort"),
+		},
+		Observability: &ContainerApplicationObservabilityModel{
+			LogsEnabled: types.BoolValue(true),
+		},
+		WranglerSSH: &ContainerApplicationWranglerSSHModel{
+			Enabled: types.BoolValue(true),
+			Port:    types.Int64Value(3333),
+		},
+		AuthorizedKeys: &authKeys,
+	}
+
+	req, err := model.toModifyRequest(ctx)
+	require.NoError(t, err)
+
+	require.NotNil(t, req.Configuration)
+	assert.Equal(t, "image:v3", req.Configuration.Image)
+	require.NotNil(t, req.Configuration.Vcpu)
+	assert.Equal(t, 4.0, *req.Configuration.Vcpu)
+	require.NotNil(t, req.Configuration.MemoryMib)
+	assert.Equal(t, int64(1024), *req.Configuration.MemoryMib)
+	require.NotNil(t, req.Configuration.Disk)
+	assert.Equal(t, int64(4096), req.Configuration.Disk.SizeMb)
+	require.NotNil(t, req.Configuration.WranglerSSH)
+	assert.True(t, req.Configuration.WranglerSSH.Enabled)
+	assert.Equal(t, int64(3333), req.Configuration.WranglerSSH.Port)
+	require.Len(t, req.Configuration.AuthorizedKeys, 2)
+	require.NotNil(t, req.Affinities)
+	assert.Equal(t, "best_effort", req.Affinities.Colocation)
+	assert.Equal(t, int64(100), *req.MaxInstances)
+	assert.Equal(t, "moon", *req.SchedulingPolicy)
+}

--- a/internal/services/container_application/schema.go
+++ b/internal/services/container_application/schema.go
@@ -1,0 +1,199 @@
+package container_application
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func ResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Description: "Manages a Cloudflare Workers Container Application.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description:   "The container application ID.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"account_id": schema.StringAttribute{
+				Description:   "The account identifier to target for the resource.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"application_id": schema.StringAttribute{
+				Description:   "The container application ID assigned by the API.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"script_name": schema.StringAttribute{
+				Description:   "The name of the Workers script that this container is associated with.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"class_name": schema.StringAttribute{
+				Description:   "The Durable Object class name that this container backs.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"name": schema.StringAttribute{
+				Description:   "The container application name. Defaults to {script_name}-{class_name}.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown(), stringplanmodifier.RequiresReplace()},
+			},
+			"image": schema.StringAttribute{
+				Description: "The container image URI (e.g. registry.example.com/image:tag).",
+				Required:    true,
+			},
+			"max_instances": schema.Int64Attribute{
+				Description: "Maximum number of container instances. Defaults to 20.",
+				Optional:    true,
+				Computed:    true,
+				Default:     int64default.StaticInt64(20),
+			},
+			"instance_type": schema.StringAttribute{
+				Description: "The instance type for the container (lite, dev, basic, standard, standard-1, standard-2, standard-3, standard-4). Mutually exclusive with vcpu/memory_mib.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("lite"),
+			},
+			"vcpu": schema.Float64Attribute{
+				Description: "Custom vCPU allocation. Mutually exclusive with instance_type.",
+				Optional:    true,
+			},
+			"memory_mib": schema.Int64Attribute{
+				Description: "Custom memory allocation in MiB. Mutually exclusive with instance_type.",
+				Optional:    true,
+			},
+			"disk_size_mb": schema.Int64Attribute{
+				Description: "Disk size in MB.",
+				Optional:    true,
+			},
+			"scheduling_policy": schema.StringAttribute{
+				Description: "The scheduling policy (default, regional, moon, gpu, fill_metals).",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("default"),
+			},
+			"rollout_step_percentage": schema.Int64Attribute{
+				Description: "Rollout step percentage for progressive deployments.",
+				Optional:    true,
+				Computed:    true,
+				Default:     int64default.StaticInt64(100),
+			},
+			"rollout_kind": schema.StringAttribute{
+				Description: "Rollout kind: full_auto, full_manual, or none.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("full_auto"),
+			},
+			"rollout_active_grace_period": schema.Int64Attribute{
+				Description: "Rollout active grace period in seconds.",
+				Optional:    true,
+				Computed:    true,
+				Default:     int64default.StaticInt64(0),
+			},
+			"constraints": schema.SingleNestedAttribute{
+				Description: "Placement constraints for container instances.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"tiers": schema.ListAttribute{
+						Description: "Tier constraints (e.g. [1, 2]).",
+						Optional:    true,
+						ElementType: types.Int64Type,
+					},
+					"regions": schema.ListAttribute{
+						Description: "Region constraints.",
+						Optional:    true,
+						ElementType: types.StringType,
+					},
+					"cities": schema.ListAttribute{
+						Description: "City constraints.",
+						Optional:    true,
+						ElementType: types.StringType,
+					},
+				},
+			},
+			"affinities": schema.SingleNestedAttribute{
+				Description: "Affinity preferences for container placement.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"colocation": schema.StringAttribute{
+						Description: "Colocation affinity (datacenter).",
+						Optional:    true,
+					},
+					"hardware_generation": schema.StringAttribute{
+						Description: "Hardware generation affinity (highest-overall-performance).",
+						Optional:    true,
+					},
+				},
+			},
+			"observability": schema.SingleNestedAttribute{
+				Description: "Observability configuration. Defaults to logs enabled.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"logs_enabled": schema.BoolAttribute{
+						Description: "Whether container logs are enabled.",
+						Optional:    true,
+					},
+				},
+			},
+			"wrangler_ssh": schema.SingleNestedAttribute{
+				Description: "SSH configuration for the container.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Description: "Whether SSH is enabled.",
+						Required:    true,
+					},
+					"port": schema.Int64Attribute{
+						Description: "SSH port number.",
+						Optional:    true,
+					},
+				},
+			},
+			"authorized_keys": schema.ListNestedAttribute{
+				Description: "SSH authorized keys for container access.",
+				Optional:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Description: "Name for the authorized key.",
+							Required:    true,
+						},
+						"public_key": schema.StringAttribute{
+							Description: "SSH public key.",
+							Required:    true,
+						},
+					},
+				},
+			},
+			"trusted_user_ca_keys": schema.ListNestedAttribute{
+				Description: "Trusted user CA keys for SSH certificate authentication.",
+				Optional:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Description: "Name for the CA key.",
+							Optional:    true,
+						},
+						"public_key": schema.StringAttribute{
+							Description: "CA public key.",
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *ContainerApplicationResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = ResourceSchema(ctx)
+}

--- a/internal/services/container_application/testdata/basic.tf
+++ b/internal/services/container_application/testdata/basic.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_container_application" "example" {
+  account_id  = "%[1]s"
+  script_name = "my-worker"
+  class_name  = "MyDurableObject"
+  image       = "registry.example.com/my-image:latest"
+}

--- a/internal/services/container_application/testdata/full.tf
+++ b/internal/services/container_application/testdata/full.tf
@@ -1,0 +1,20 @@
+resource "cloudflare_container_application" "example" {
+  account_id  = "%[1]s"
+  script_name = "my-worker"
+  class_name  = "MyDurableObject"
+  name        = "custom-app-name"
+  image       = "registry.example.com/my-image:v2"
+
+  max_instances               = 50
+  instance_type               = "standard-1"
+  scheduling_policy           = "regional"
+  rollout_step_percentage     = 10
+  rollout_kind                = "full_manual"
+  rollout_active_grace_period = 60
+
+  constraints {
+    tiers   = [1, 2]
+    regions = ["us-east", "eu-west"]
+    cities  = []
+  }
+}

--- a/internal/services/container_application/testdata/update.tf
+++ b/internal/services/container_application/testdata/update.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_container_application" "example" {
+  account_id  = "%[1]s"
+  script_name = "my-worker"
+  class_name  = "MyDurableObject"
+  name        = "custom-app-name"
+  image       = "registry.example.com/my-image:v3"
+
+  max_instances = 100
+  instance_type = "standard-1"
+}

--- a/internal/services/workers_script/containers_test.go
+++ b/internal/services/workers_script/containers_test.go
@@ -1,0 +1,92 @@
+package workers_script
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainersMetadataSerialization(t *testing.T) {
+	containers := []*WorkersScriptMetadataContainersModel{
+		{ClassName: types.StringValue("MyContainer")},
+	}
+
+	metadata := WorkersScriptMetadataModel{
+		MainModule: types.StringValue("index.js"),
+		Containers: &containers,
+	}
+
+	payload, err := apijson.Marshal(metadata)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	err = json.Unmarshal(payload, &raw)
+	require.NoError(t, err)
+
+	// Verify containers array is present
+	containersRaw, ok := raw["containers"]
+	require.True(t, ok, "metadata should contain 'containers' key")
+
+	containersList, ok := containersRaw.([]interface{})
+	require.True(t, ok, "containers should be an array")
+	require.Len(t, containersList, 1)
+
+	first := containersList[0].(map[string]interface{})
+	assert.Equal(t, "MyContainer", first["class_name"])
+}
+
+func TestContainersMetadataMultipleClasses(t *testing.T) {
+	containers := []*WorkersScriptMetadataContainersModel{
+		{ClassName: types.StringValue("ContainerA")},
+		{ClassName: types.StringValue("ContainerB")},
+	}
+
+	metadata := WorkersScriptMetadataModel{
+		MainModule: types.StringValue("index.js"),
+		Containers: &containers,
+	}
+
+	payload, err := apijson.Marshal(metadata)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	err = json.Unmarshal(payload, &raw)
+	require.NoError(t, err)
+
+	containersList := raw["containers"].([]interface{})
+	require.Len(t, containersList, 2)
+
+	assert.Equal(t, "ContainerA", containersList[0].(map[string]interface{})["class_name"])
+	assert.Equal(t, "ContainerB", containersList[1].(map[string]interface{})["class_name"])
+}
+
+func TestContainersMetadataOmittedWhenNil(t *testing.T) {
+	metadata := WorkersScriptMetadataModel{
+		MainModule: types.StringValue("index.js"),
+		Containers: nil,
+	}
+
+	payload, err := apijson.Marshal(metadata)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	err = json.Unmarshal(payload, &raw)
+	require.NoError(t, err)
+
+	_, ok := raw["containers"]
+	assert.False(t, ok, "containers should not be present when nil")
+}
+
+func TestContainersSchemaExists(t *testing.T) {
+	ctx := context.Background()
+	s := ResourceSchema(ctx)
+
+	attr, ok := s.Attributes["containers"]
+	require.True(t, ok, "schema should have 'containers' attribute")
+	assert.True(t, attr.IsOptional(), "containers should be optional")
+}

--- a/internal/services/workers_script/model.go
+++ b/internal/services/workers_script/model.go
@@ -105,6 +105,7 @@ type WorkersScriptMetadataModel struct {
 	CompatibilityFlags customfield.Set[types.String]                                    `tfsdk:"compatibility_flags" json:"compatibility_flags,computed_optional"`
 	KeepAssets         types.Bool                                                       `tfsdk:"keep_assets" json:"keep_assets,optional"`
 	KeepBindings       *[]types.String                                                  `tfsdk:"keep_bindings" json:"keep_bindings,optional"`
+	Containers         *[]*WorkersScriptMetadataContainersModel                         `tfsdk:"containers" json:"containers,optional"`
 	Limits             *WorkersScriptMetadataLimitsModel                                `tfsdk:"limits" json:"limits,optional"`
 	Logpush            types.Bool                                                       `tfsdk:"logpush" json:"logpush,computed_optional"`
 	MainModule         types.String                                                     `tfsdk:"main_module" json:"main_module,optional"`
@@ -182,6 +183,10 @@ type WorkersScriptMetadataBindingsOutboundWorkerModel struct {
 type WorkersScriptMetadataBindingsSimpleModel struct {
 	Limit  types.Float64 `tfsdk:"limit" json:"limit,required"`
 	Period types.Int64   `tfsdk:"period" json:"period,required"`
+}
+
+type WorkersScriptMetadataContainersModel struct {
+	ClassName types.String `tfsdk:"class_name" json:"class_name,required"`
 }
 
 type WorkersScriptMetadataLimitsModel struct {

--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -438,6 +438,18 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Optional:    true,
 				ElementType: types.StringType,
 			},
+			"containers": schema.ListNestedAttribute{
+				Description: "List of container-enabled Durable Object class names. Required when using Cloudflare Containers.",
+				Optional:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"class_name": schema.StringAttribute{
+							Description: "The Durable Object class name to enable as a container.",
+							Required:    true,
+						},
+					},
+				},
+			},
 			"limits": schema.SingleNestedAttribute{
 				Description: "Limits to apply for this Worker.",
 				Optional:    true,


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adds support for Cloudflare Workers Containers via two changes:

### New resource: `cloudflare_container_application`
A standalone Terraform resource for managing container applications through the Containers API (`/accounts/{id}/containers/applications`). Supports the full lifecycle (create, read, update, delete, import).

**Supported attributes:**
- Core: `name`, `image`, `script_name`, `class_name`
- Scaling: `max_instances`, `instance_type` (or custom `vcpu`/`memory_mib`/`disk_size_mb`)
- Scheduling: `scheduling_policy`, `constraints`, `affinities`
- Rollout: `rollout_step_percentage`, `rollout_kind`, `rollout_active_grace_period`
- Observability: `observability` (logs enabled/disabled, defaults to enabled)
- SSH: `wrangler_ssh`, `authorized_keys`, `trusted_user_ca_keys`

**Design decisions:**
- Separate resource (not extending `workers_script`) — Terraform-idiomatic, 1 API resource = 1 TF resource
- Auto-resolves Durable Object namespace from `script_name` + `class_name` (mirrors wrangler behavior)
- Uses raw HTTP calls since `cloudflare-go` has no containers API support
- Rollouts are auto-created on update when `rollout_kind != "none"`

### `cloudflare_workers_script`: new `containers` metadata field
Adds `containers` attribute to the worker upload metadata, which marks Durable Objects as container-enabled. Required for the Containers API to accept applications.

```hcl
resource "cloudflare_workers_script" "my_worker" {
  # ...
  containers = [{ class_name = "MyContainer" }]
}
```

### Example usage

```hcl
resource "cloudflare_container_application" "my_app" {
  account_id  = var.account_id
  script_name = cloudflare_workers_script.my_worker.name
  class_name  = "MyContainer"
  image       = "registry.cloudflare.com/account-id/my-image:latest"

  max_instances     = 10
  instance_type     = "lite"
  scheduling_policy = "default"
}
```

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

Unit tests (no API credentials required):
```bash
go test -v ./internal/services/container_application/...
go test -v -run TestContainers ./internal/services/workers_script/...
```

Manual end-to-end testing was performed against a real Cloudflare account using `terraform apply` with a dev override provider build.

### Test output

```
=== RUN   TestContainerApplicationDefaultName
--- PASS: TestContainerApplicationDefaultName (0.00s)
=== RUN   TestContainerApplicationModelToCreateRequest
--- PASS: TestContainerApplicationModelToCreateRequest (0.00s)
=== RUN   TestContainerApplicationModelToCreateRequestWithConstraints
--- PASS: TestContainerApplicationModelToCreateRequestWithConstraints (0.00s)
=== RUN   TestContainerApplicationModelToModifyRequest
--- PASS: TestContainerApplicationModelToModifyRequest (0.00s)
=== RUN   TestContainerApplicationRolloutRequest
--- PASS: TestContainerApplicationRolloutRequest (0.00s)
=== RUN   TestContainerApplicationFromAPIApplication
--- PASS: TestContainerApplicationFromAPIApplication (0.00s)
=== RUN   TestContainerApplicationSchemaValidity
--- PASS: TestContainerApplicationSchemaValidity (0.00s)
=== RUN   TestCreateRequestJSONShape
--- PASS: TestCreateRequestJSONShape (0.00s)
=== RUN   TestContainerApplicationCustomInstanceType
--- PASS: TestContainerApplicationCustomInstanceType (0.00s)
=== RUN   TestContainerApplicationObservability
--- PASS: TestContainerApplicationObservability (0.00s)
=== RUN   TestContainerApplicationAffinities
--- PASS: TestContainerApplicationAffinities (0.00s)
=== RUN   TestContainerApplicationSSHConfig
--- PASS: TestContainerApplicationSSHConfig (0.00s)
=== RUN   TestContainerApplicationFromAPIApplicationFull
--- PASS: TestContainerApplicationFromAPIApplicationFull (0.00s)
=== RUN   TestContainerApplicationModifyWithAllFields
--- PASS: TestContainerApplicationModifyWithAllFields (0.00s)
PASS
ok  github.com/cloudflare/terraform-provider-cloudflare/internal/services/container_application

=== RUN   TestContainersMetadataSerialization
--- PASS: TestContainersMetadataSerialization (0.00s)
=== RUN   TestContainersMetadataMultipleClasses
--- PASS: TestContainersMetadataMultipleClasses (0.00s)
=== RUN   TestContainersMetadataOmittedWhenNil
--- PASS: TestContainersMetadataOmittedWhenNil (0.00s)
=== RUN   TestContainersSchemaExists
--- PASS: TestContainersSchemaExists (0.00s)
PASS
ok  github.com/cloudflare/terraform-provider-cloudflare/internal/services/workers_script
```

## Additional context & links

- Cross-referenced against wrangler SDK source types: `ContainerApp`, `CreateApplicationRequest`, `Application`, `UserDeploymentConfiguration`
- API fields not yet implemented (can be added incrementally): `environment_variables`, `command`, `entrypoint`, `ports`, `secrets`, `labels`, `network`, `dns`, `checks`