### PR TITLE
fix(custom_origin_trust_store): fix certificate drift with normalization

### DIFF
--- a/internal/services/custom_origin_trust_store/resource.go
+++ b/internal/services/custom_origin_trust_store/resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/acm"
@@ -92,6 +93,18 @@ func (r *CustomOriginTrustStoreResource) Create(ctx context.Context, req resourc
 	}
 	data = &env.Result
 
+	// Get the original config value to preserve its format
+	var configData CustomOriginTrustStoreModel
+	req.Config.Get(ctx, &configData)
+
+	apiNormalized := strings.TrimRight(data.Certificate.ValueString(), "\n")
+	configNormalized := strings.TrimRight(configData.Certificate.ValueString(), "\n")
+
+	// If they match, use the config format
+	if apiNormalized == configNormalized {
+		data.Certificate = configData.Certificate
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -135,6 +148,17 @@ func (r *CustomOriginTrustStoreResource) Read(ctx context.Context, req resource.
 		return
 	}
 	data = &env.Result
+
+	// Keep the original state format if they're semantically equal
+	var stateData CustomOriginTrustStoreModel
+	req.State.Get(ctx, &stateData)
+
+	apiNormalized := strings.TrimRight(data.Certificate.ValueString(), "\n")
+	stateNormalized := strings.TrimRight(stateData.Certificate.ValueString(), "\n")
+
+	if apiNormalized == stateNormalized {
+		data.Certificate = stateData.Certificate
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/custom_origin_trust_store/resource_test.go
+++ b/internal/services/custom_origin_trust_store/resource_test.go
@@ -205,12 +205,10 @@ func testAccCloudflareCustomOriginTrustStoreConfig(rnd, zoneID, cert string) str
 	return acctest.LoadTestCase("customorigintruststorelifecycle.tf", rnd, zoneID, cert)
 }
 
-// Known drift issue:
-// API returns certificate with trailing newline. If config cert does not end with /n, drift occurs causing perpetual replacement.
-// Skipping until normalization is added.
+// TestAccCloudflareCustomOriginTrustStore_NoTrailingNewline tests that
+// the provider properly handles certificates without trailing newlines and doesn't
+// detect drift. This verifies the normalization logic for the certificate field.
 func TestAccCloudflareCustomOriginTrustStore_NoTrailingNewline(t *testing.T) {
-	t.Skip("Skipping acceptance test")
-
 	rnd := utils.GenerateRandomResourceName()
 	name := fmt.Sprintf("cloudflare_custom_origin_trust_store.%s", rnd)
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")

--- a/internal/services/custom_origin_trust_store/schema.go
+++ b/internal/services/custom_origin_trust_store/schema.go
@@ -5,6 +5,7 @@ package custom_origin_trust_store
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -32,7 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"certificate": schema.StringAttribute{
 				Description:   "The zone's SSL certificate or certificate and the intermediate(s).",
 				Required:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.String{utils.RequiresReplaceIfNotCertificateSemantic()},
 			},
 			"expires_on": schema.StringAttribute{
 				Description: "When the certificate expires.",

--- a/internal/services/custom_origin_trust_store/testdata/customorigintruststorelifecycle.tf
+++ b/internal/services/custom_origin_trust_store/testdata/customorigintruststorelifecycle.tf
@@ -1,7 +1,3 @@
-# Known drift issue with certificate field.
-# Workaround:
-# Certificate must be in this format or if hardcoded (ends with \n).
-
 resource "cloudflare_custom_origin_trust_store" "%[1]s" {
   zone_id     = "%[2]s"
   certificate = <<EOT


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [X] I have added or updated acceptance tests for my changes
- [X] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
TF_ACC=1 go test -v ./internal/services/custom_origin_trust_store/... -run TestAccCloudflareCustomOriginTrustStore_NoTrailingNewline 

### Test output
<!-- Please paste the output of your acceptance test run below --> 
TF_ACC=1 go test -v ./internal/services/custom_origin_trust_store/... -run TestAccCloudflareCustomOriginTrustStore_NoTrailingNewline 
=== RUN   TestAccCloudflareCustomOriginTrustStore_NoTrailingNewline
--- PASS: TestAccCloudflareCustomOriginTrustStore_NoTrailingNewline (5.52s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/custom_origin_trust_store	7.285s

## Additional context & links
