### PR TITLE
fix(custom_hostname): allow ssl as null

### DIFF
--- a/internal/services/custom_hostname/model.go
+++ b/internal/services/custom_hostname/model.go
@@ -17,7 +17,7 @@ type CustomHostnameModel struct {
 	ID                        types.String                                                           `tfsdk:"id" json:"id,computed"`
 	ZoneID                    types.String                                                           `tfsdk:"zone_id" path:"zone_id,required"`
 	Hostname                  types.String                                                           `tfsdk:"hostname" json:"hostname,required"`
-	SSL                       *CustomHostnameSSLModel                                                `tfsdk:"ssl" json:"ssl,required"`
+	SSL                       *CustomHostnameSSLModel                                                `tfsdk:"ssl" json:"ssl,optional"`
 	CustomOriginServer        types.String                                                           `tfsdk:"custom_origin_server" json:"custom_origin_server,optional"`
 	CustomOriginSNI           types.String                                                           `tfsdk:"custom_origin_sni" json:"custom_origin_sni,optional"`
 	CustomMetadata            *map[string]types.String                                               `tfsdk:"custom_metadata" json:"custom_metadata,optional"`

--- a/internal/services/custom_hostname/resource_test.go
+++ b/internal/services/custom_hostname/resource_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
@@ -180,6 +180,53 @@ func TestAccCustomHostname_WithSSLSettings(t *testing.T) {
 	})
 }
 
+// TestAccCustomHostname_WithoutSSL tests creating a custom hostname without an SSL block.
+// This validates that the ssl attribute is truly optional and that the API accepts
+// a request with no ssl object (ssl: null).
+func TestAccCustomHostname_WithoutSSL(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_custom_hostname." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck_Credentials(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+			acctest.TestAccPreCheck_Domain(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareCustomHostnameDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomHostnameWithoutSSLConfig(zoneID, domain, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("hostname"), knownvalue.StringExact(fmt.Sprintf("%s.%s", rnd, domain))),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("ssl"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("id"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					return fmt.Sprintf("%s/%s", zoneID, s.RootModule().Resources[name].Primary.ID), nil
+				},
+				ImportStateVerifyIgnore: []string{
+					"ownership_verification",
+					"ownership_verification_http",
+					"created_at",
+					"status",
+					"verification_errors",
+					"wait_for_ssl_pending_validation",
+				},
+			},
+		},
+	})
+}
+
 func testAccCustomHostnameBasicConfig(zoneID, domain, rnd string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_custom_hostname" "%[3]s" {
@@ -253,6 +300,10 @@ resource "cloudflare_custom_hostname" "%[3]s" {
     ]
   }
 }`, zoneID, domain, rnd)
+}
+
+func testAccCustomHostnameWithoutSSLConfig(zoneID, domain, rnd string) string {
+	return acctest.LoadTestCase("customhostnamewithnossl.tf", zoneID, rnd, domain)
 }
 
 func TestAccUpgradeCustomHostname_FromPublishedV5(t *testing.T) {

--- a/internal/services/custom_hostname/schema.go
+++ b/internal/services/custom_hostname/schema.go
@@ -40,7 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"ssl": schema.SingleNestedAttribute{
 				Description: "SSL properties used when creating the custom hostname.",
-				Required:    true,
+				Optional:    true,
 				Attributes: map[string]schema.Attribute{
 					"bundle_method": schema.StringAttribute{
 						Description: "A ubiquitous bundle has the highest probability of being verified everywhere, even by clients using outdated or unusual trust stores. An optimal bundle uses the shortest chain and newest intermediates. And the force bundle verifies the chain, but does not otherwise modify it.\nAvailable values: \"ubiquitous\", \"optimal\", \"force\".",

--- a/internal/services/custom_hostname/testdata/customhostnamewithnossl.tf
+++ b/internal/services/custom_hostname/testdata/customhostnamewithnossl.tf
@@ -1,6 +1,14 @@
 
 resource "cloudflare_custom_hostname" "%[2]s" {
-  zone_id = "%[1]s"
+  zone_id  = "%[1]s"
   hostname = "%[2]s.%[3]s"
-  ssl = {}
+  lifecycle {
+    ignore_changes = [
+      created_at,
+      ownership_verification,
+      ownership_verification_http,
+      status,
+      verification_errors,
+    ]
+  }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [X] I have added or updated acceptance tests for my changes
- [X] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
TF_ACC=1 go test ./internal/services/custom_hostname/ -run TestAccCustomHostname_WithoutSSL -v 

### Test output
<!-- Please paste the output of your acceptance test run below --> 
=== RUN   TestAccCustomHostname_WithoutSSL
--- PASS: TestAccCustomHostname_WithoutSSL (11.23s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/custom_hostname	12.874s

## Additional context & links
Full suite: TF_ACC=1 go test ./internal/services/custom_hostname/ -v 
=== RUN   TestCustomHostnameDataSourceModelSchemaParity
=== PAUSE TestCustomHostnameDataSourceModelSchemaParity
=== RUN   TestCustomHostnamesDataSourceModelSchemaParity
=== PAUSE TestCustomHostnamesDataSourceModelSchemaParity
=== RUN   TestCustomHostnameModelSchemaParity
=== PAUSE TestCustomHostnameModelSchemaParity
=== RUN   TestAccCustomHostname_Basic
--- PASS: TestAccCustomHostname_Basic (15.60s)
=== RUN   TestAccCustomHostname_WithSSLSettings
--- PASS: TestAccCustomHostname_WithSSLSettings (12.90s)
=== RUN   TestAccCustomHostname_WithoutSSL
--- PASS: TestAccCustomHostname_WithoutSSL (12.19s)
=== RUN   TestAccUpgradeCustomHostname_FromPublishedV5
--- PASS: TestAccUpgradeCustomHostname_FromPublishedV5 (17.50s)
=== CONT  TestCustomHostnameDataSourceModelSchemaParity
=== CONT  TestCustomHostnameModelSchemaParity
=== CONT  TestCustomHostnamesDataSourceModelSchemaParity
--- PASS: TestCustomHostnameModelSchemaParity (0.00s)
--- PASS: TestCustomHostnameDataSourceModelSchemaParity (0.00s)
--- PASS: TestCustomHostnamesDataSourceModelSchemaParity (0.00s)