### PR TITLE
chore(auth_origin_pulls_cert): add test cases for migration

### DIFF
--- a/internal/services/authenticated_origin_pulls_certificate/migration/v500/handler.go
+++ b/internal/services/authenticated_origin_pulls_certificate/migration/v500/handler.go
@@ -36,18 +36,18 @@ func UpgradeFromV0(ctx context.Context, req resource.UpgradeStateRequest, resp *
 
 	// Transform v4 model to v5 model
 	v5Model := V5Model{
-		ID:          v4Model.ID,          // Preserve ID from v4
-		ZoneID:      v4Model.ZoneID,
-		Certificate: v4Model.Certificate,
-		PrivateKey:  v4Model.PrivateKey,
-		Issuer:      v4Model.Issuer,
-		Signature:   v4Model.Signature,
-		ExpiresOn:   v4Model.ExpiresOn,
-		Status:      v4Model.Status,
-		UploadedOn:  v4Model.UploadedOn,
+		ID:           v4Model.ID, // Preserve ID from v4
+		ZoneID:       v4Model.ZoneID,
+		Certificate:  v4Model.Certificate,
+		PrivateKey:   v4Model.PrivateKey,
+		Issuer:       v4Model.Issuer,
+		SerialNumber: v4Model.SerialNumber, // Preserve serial_number from v4
+		Signature:    v4Model.Signature,
+		ExpiresOn:    v4Model.ExpiresOn,
+		Status:       v4Model.Status,
+		UploadedOn:   v4Model.UploadedOn,
 		// Note: certificate_id will be set from ID by the resource Read
 		// Note: enabled is computed and will be populated by Read
-		// Note: serial_number is removed (not in v5 per-zone schema)
 		// Note: type is removed (not in v5 schema)
 	}
 

--- a/internal/services/authenticated_origin_pulls_certificate/migration/v500/migrations_test.go
+++ b/internal/services/authenticated_origin_pulls_certificate/migration/v500/migrations_test.go
@@ -28,6 +28,18 @@ var v4PerZoneConfig string
 //go:embed testdata/v5_per_zone.tf
 var v5PerZoneConfig string
 
+//go:embed testdata/v4_per_zone_minimal.tf
+var v4PerZoneMinimalConfig string
+
+//go:embed testdata/v5_per_zone_minimal.tf
+var v5PerZoneMinimalConfig string
+
+//go:embed testdata/v4_per_zone_with_variables.tf
+var v4PerZoneWithVariablesConfig string
+
+//go:embed testdata/v5_per_zone_with_variables.tf
+var v5PerZoneWithVariablesConfig string
+
 // TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone tests per-zone certificate migration.
 // This test validates:
 // - Migration from v4 (with type="per-zone") to v5 (without type field)
@@ -129,6 +141,214 @@ func TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone(t *testing.T)
 							),
 							// Note: type and serial_number should be removed after migration
 							// These will be checked implicitly by the absence of errors
+						},
+					),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_Minimal tests minimal config migration.
+// This test validates that resources with only required fields migrate correctly.
+func TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_Minimal(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID, cert, key string) string
+	}{
+		{
+			name:    "from_v4_latest_minimal",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID, cert, key string) string {
+				return fmt.Sprintf(v4PerZoneMinimalConfig, rnd, zoneID, cert, key)
+			},
+		},
+		{
+			name:    "from_v5_minimal",
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID, cert, key string) string {
+				return fmt.Sprintf(v5PerZoneMinimalConfig, rnd, zoneID, cert, key)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			if zoneID == "" {
+				t.Skip("CLOUDFLARE_ZONE_ID must be set for this test")
+			}
+
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+
+			expiry := time.Now().Add(time.Hour * 24 * 365)
+			cert, key, err := utils.GenerateEphemeralCertAndKey([]string{"aop-minimal-test.example.com"}, expiry)
+			if err != nil {
+				t.Fatalf("Failed to generate certificate: %s", err)
+			}
+
+			testConfig := tc.configFn(rnd, zoneID, cert, key)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+			resourceName := "cloudflare_authenticated_origin_pulls_certificate." + rnd
+
+			resource.Test(t, resource.TestCase{
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("zone_id"),
+								knownvalue.StringExact(zoneID),
+							),
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("certificate"),
+								knownvalue.NotNull(),
+							),
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("private_key"),
+								knownvalue.NotNull(),
+							),
+						},
+					),
+				},
+			})
+		})
+	}
+}
+
+// TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_AllFields tests that all fields are preserved.
+// This test validates:
+// - All required fields (zone_id, certificate, private_key) are preserved
+// - All computed fields (issuer, signature, serial_number, expires_on, status, uploaded_on) are preserved
+// - The type field is properly removed during migration
+func TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_AllFields(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, zoneID, cert, key string) string
+	}{
+		{
+			name:    "from_v4_latest_all_fields",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, zoneID, cert, key string) string {
+				return fmt.Sprintf(v4PerZoneConfig, rnd, zoneID, cert, key)
+			},
+		},
+		{
+			name:    "from_v5_all_fields",
+			version: currentProviderVersion,
+			configFn: func(rnd, zoneID, cert, key string) string {
+				return fmt.Sprintf(v5PerZoneConfig, rnd, zoneID, cert, key)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			if zoneID == "" {
+				t.Skip("CLOUDFLARE_ZONE_ID must be set for this test")
+			}
+
+			rnd := utils.GenerateRandomResourceName()
+			tmpDir := t.TempDir()
+
+			expiry := time.Now().Add(time.Hour * 24 * 365)
+			cert, key, err := utils.GenerateEphemeralCertAndKey([]string{"aop-allfields-test.example.com"}, expiry)
+			if err != nil {
+				t.Fatalf("Failed to generate certificate: %s", err)
+			}
+
+			testConfig := tc.configFn(rnd, zoneID, cert, key)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+			resourceName := "cloudflare_authenticated_origin_pulls_certificate." + rnd
+
+			resource.Test(t, resource.TestCase{
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
+						[]statecheck.StateCheck{
+							// Required fields
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("zone_id"),
+								knownvalue.StringExact(zoneID),
+							),
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("certificate"),
+								knownvalue.NotNull(),
+							),
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("private_key"),
+								knownvalue.NotNull(),
+							),
+							// Computed fields - verify they exist and are preserved
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("issuer"),
+								knownvalue.NotNull(),
+							),
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("signature"),
+								knownvalue.NotNull(),
+							),
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("serial_number"),
+								knownvalue.NotNull(),
+							),
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("expires_on"),
+								knownvalue.NotNull(),
+							),
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("status"),
+								knownvalue.NotNull(),
+							),
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("uploaded_on"),
+								knownvalue.NotNull(),
+							),
+							// v5-specific computed fields
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("certificate_id"),
+								knownvalue.NotNull(),
+							),
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("id"),
+								knownvalue.NotNull(),
+							),
 						},
 					),
 				},

--- a/internal/services/authenticated_origin_pulls_certificate/migration/v500/model.go
+++ b/internal/services/authenticated_origin_pulls_certificate/migration/v500/model.go
@@ -21,7 +21,7 @@ type V4Model struct {
 }
 
 // V5Model represents the v5 schema structure for per-zone certificates
-// Note: Does NOT include 'type' or 'serial_number' fields
+// Note: Does NOT include 'type' field (removed in v5)
 type V5Model struct {
 	ZoneID        types.String `tfsdk:"zone_id"`
 	CertificateID types.String `tfsdk:"certificate_id"`
@@ -31,6 +31,7 @@ type V5Model struct {
 	ExpiresOn     types.String `tfsdk:"expires_on"`
 	ID            types.String `tfsdk:"id"`
 	Issuer        types.String `tfsdk:"issuer"`
+	SerialNumber  types.String `tfsdk:"serial_number"`
 	Signature     types.String `tfsdk:"signature"`
 	Status        types.String `tfsdk:"status"`
 	UploadedOn    types.String `tfsdk:"uploaded_on"`

--- a/internal/services/authenticated_origin_pulls_certificate/migration/v500/testdata/v4_per_zone_minimal.tf
+++ b/internal/services/authenticated_origin_pulls_certificate/migration/v500/testdata/v4_per_zone_minimal.tf
@@ -1,0 +1,9 @@
+# v4 minimal per-zone certificate - only required fields
+resource "cloudflare_authenticated_origin_pulls_certificate" "%s" {
+  zone_id     = "%s"
+  certificate = <<-EOT
+%sEOT
+  private_key = <<-EOT
+%sEOT
+  type        = "per-zone"
+}

--- a/internal/services/authenticated_origin_pulls_certificate/migration/v500/testdata/v4_per_zone_with_variables.tf
+++ b/internal/services/authenticated_origin_pulls_certificate/migration/v500/testdata/v4_per_zone_with_variables.tf
@@ -1,0 +1,8 @@
+# v4 per-zone certificate using file() references
+# Tests that migration handles expressions correctly
+resource "cloudflare_authenticated_origin_pulls_certificate" {
+  zone_id     = "%s"
+  certificate = file("${path.module}/cert.pem")
+  private_key = file("${path.module}/key.pem")
+  type        = "per-zone"
+}

--- a/internal/services/authenticated_origin_pulls_certificate/migration/v500/testdata/v5_per_zone_minimal.tf
+++ b/internal/services/authenticated_origin_pulls_certificate/migration/v500/testdata/v5_per_zone_minimal.tf
@@ -1,0 +1,8 @@
+# v5 minimal per-zone certificate - only required fields
+resource "cloudflare_authenticated_origin_pulls_certificate" "%s" {
+  zone_id     = "%s"
+  certificate = <<-EOT
+%sEOT
+  private_key = <<-EOT
+%sEOT
+}

--- a/internal/services/authenticated_origin_pulls_certificate/migration/v500/testdata/v5_per_zone_with_variables.tf
+++ b/internal/services/authenticated_origin_pulls_certificate/migration/v500/testdata/v5_per_zone_with_variables.tf
@@ -1,0 +1,7 @@
+# v5 per-zone certificate using file() references
+# type field removed in v5
+resource "cloudflare_authenticated_origin_pulls_certificate" {
+  zone_id     = "%s"
+  certificate = file("${path.module}/cert.pem")
+  private_key = file("${path.module}/key.pem")
+}

--- a/internal/services/authenticated_origin_pulls_certificate/migrations.go
+++ b/internal/services/authenticated_origin_pulls_certificate/migrations.go
@@ -4,7 +4,6 @@ package authenticated_origin_pulls_certificate
 
 import (
 	"context"
-	"os"
 
 	v500 "github.com/cloudflare/terraform-provider-cloudflare/internal/services/authenticated_origin_pulls_certificate/migration/v500"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -13,21 +12,6 @@ import (
 var _ resource.ResourceWithUpgradeState = (*AuthenticatedOriginPullsCertificateResource)(nil)
 
 func (r *AuthenticatedOriginPullsCertificateResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	targetSchema := ResourceSchema(ctx)
-
-	if os.Getenv("TF_MIG_TEST") == "" {
-		// Production mode: preserve existing upgraders only
-		return map[int64]resource.StateUpgrader{
-			0: {
-				PriorSchema: &targetSchema,
-				StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-					resp.State.Raw = req.State.Raw
-				},
-			},
-		}
-	}
-
-	// Test mode (TF_MIG_TEST=1): full StateUpgrader migration
 	v4Schema := v500.ResourceSchema(ctx)
 	v5Schema := ResourceSchema(ctx)
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Add more test cases and get current migration tests to pass for `auth_origin_pulls_certificate`

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
`TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/ssicard/workspace/terraform-devstack/tf-migrate/tf-migrate go test ./internal/services/authenticated_origin_pulls_certificate/migration/v500 -v`

### Test output
#### Resource Tests
```bash
=== RUN   TestAuthenticatedOriginPullsCertificateDataSourceModelSchemaParity
=== PAUSE TestAuthenticatedOriginPullsCertificateDataSourceModelSchemaParity
=== RUN   TestAuthenticatedOriginPullsCertificatesDataSourceModelSchemaParity
=== PAUSE TestAuthenticatedOriginPullsCertificatesDataSourceModelSchemaParity
=== RUN   TestAuthenticatedOriginPullsCertificateModelSchemaParity
=== PAUSE TestAuthenticatedOriginPullsCertificateModelSchemaParity
=== RUN   TestAccAuthenticatedOriginPullsCertificate_FullLifecycle
--- PASS: TestAccAuthenticatedOriginPullsCertificate_FullLifecycle (3.96s)
=== RUN   TestAccUpgradeAuthenticatedOriginPullsCertificate_FromPublishedV5
--- PASS: TestAccUpgradeAuthenticatedOriginPullsCertificate_FromPublishedV5 (20.68s)
=== CONT  TestAuthenticatedOriginPullsCertificateDataSourceModelSchemaParity
=== CONT  TestAuthenticatedOriginPullsCertificateModelSchemaParity
=== CONT  TestAuthenticatedOriginPullsCertificatesDataSourceModelSchemaParity
--- PASS: TestAuthenticatedOriginPullsCertificateModelSchemaParity (0.00s)
--- PASS: TestAuthenticatedOriginPullsCertificatesDataSourceModelSchemaParity (0.00s)
--- PASS: TestAuthenticatedOriginPullsCertificateDataSourceModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/authenticated_origin_pulls_certificate	26.226s
```
#### Migration Tests
```bash
=== RUN   TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone
=== RUN   TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone/from_v4_latest
=== RUN   TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone/from_v5
--- PASS: TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone (47.09s)
    --- PASS: TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone/from_v4_latest (26.80s)
    --- PASS: TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone/from_v5 (20.30s)
=== RUN   TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_Minimal
=== RUN   TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_Minimal/from_v4_latest_minimal
=== RUN   TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_Minimal/from_v5_minimal
--- PASS: TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_Minimal (40.38s)
    --- PASS: TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_Minimal/from_v4_latest_minimal (24.17s)
    --- PASS: TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_Minimal/from_v5_minimal (16.21s)
=== RUN   TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_AllFields
=== RUN   TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_AllFields/from_v4_latest_all_fields
=== RUN   TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_AllFields/from_v5_all_fields
--- PASS: TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_AllFields (39.67s)
    --- PASS: TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_AllFields/from_v4_latest_all_fields (21.77s)
    --- PASS: TestMigrateAuthenticatedOriginPullsCertificate_V4ToV5_PerZone_AllFields/from_v5_all_fields (17.89s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/authenticated_origin_pulls_certificate/migration/v500	128.611s
```
## Additional context & links
