### PR TITLE
feat(workers_custom_domain): state upgraders

### DIFF
--- a/internal/services/workers_custom_domain/migration/v500/handler.go
+++ b/internal/services/workers_custom_domain/migration/v500/handler.go
@@ -1,0 +1,46 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+func UpgradeStateV0toV500(sourceSchema schema.Schema) resource.StateUpgrader {
+	return resource.StateUpgrader{
+		PriorSchema:   &sourceSchema,
+		StateUpgrader: upgradeStateV0toV500,
+	}
+}
+
+func UpgradeStateV1toV500(targetSchema schema.Schema) resource.StateUpgrader {
+	return resource.StateUpgrader{
+		PriorSchema:   &targetSchema,
+		StateUpgrader: upgradeStateV1toV500,
+	}
+}
+
+func upgradeStateV0toV500(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading workers_custom_domain state from schema_version=0")
+
+	var source SourceV4WorkersCustomDomainModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &source)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	target, diags := TransformV4toV500(ctx, source)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, target)...)
+}
+
+func upgradeStateV1toV500(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading workers_custom_domain state from schema_version=1 (no-op)")
+	resp.State.Raw = req.State.Raw
+}

--- a/internal/services/workers_custom_domain/migration/v500/handler_test.go
+++ b/internal/services/workers_custom_domain/migration/v500/handler_test.go
@@ -1,0 +1,271 @@
+package v500
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestUpgradeStateV0toV500(t *testing.T) {
+	ctx := context.Background()
+	sourceSchema := SourceSchemaV0()
+
+	raw := createTerraformValue(t, sourceSchema, map[string]interface{}{
+		"id":          "domain-id",
+		"account_id":  "account-id",
+		"hostname":    "api.example.com",
+		"service":     "worker-service",
+		"zone_id":     "zone-id",
+		"environment": "production",
+		"zone_name":   "example.com",
+	})
+
+	state := tfsdk.State{Raw: raw, Schema: sourceSchema}
+	req := resource.UpgradeStateRequest{State: &state}
+	resp := &resource.UpgradeStateResponse{State: tfsdk.State{Schema: sourceSchema}}
+
+	upgrader := UpgradeStateV0toV500(sourceSchema)
+	upgrader.StateUpgrader(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	var got TargetWorkersCustomDomainModel
+	if diags := resp.State.Get(ctx, &got); diags.HasError() {
+		t.Fatalf("failed to read upgraded state: %v", diags)
+	}
+
+	if got.Hostname.ValueString() != "api.example.com" ||
+		got.Environment.ValueString() != "production" ||
+		got.ZoneName.ValueString() != "example.com" {
+		t.Fatalf("unexpected upgraded state: %+v", got)
+	}
+}
+
+func TestMoveStateV4toV500(t *testing.T) {
+	ctx := context.Background()
+	sourceSchema := SourceSchemaV0()
+
+	raw := createTerraformValue(t, sourceSchema, map[string]interface{}{
+		"id":          "domain-id",
+		"account_id":  "account-id",
+		"hostname":    "api.example.com",
+		"service":     "worker-service",
+		"zone_id":     "zone-id",
+		"environment": "staging",
+		"zone_name":   "example.com",
+	})
+
+	sourceState := tfsdk.State{Raw: raw, Schema: sourceSchema}
+	req := resource.MoveStateRequest{
+		SourceTypeName:        "cloudflare_worker_domain",
+		SourceProviderAddress: "registry.terraform.io/cloudflare/cloudflare",
+		SourceSchemaVersion:   0,
+		SourceState:           &sourceState,
+	}
+	resp := &resource.MoveStateResponse{TargetState: tfsdk.State{Schema: sourceSchema}}
+
+	MoveStateV4toV500(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	var got TargetWorkersCustomDomainModel
+	if diags := resp.TargetState.Get(ctx, &got); diags.HasError() {
+		t.Fatalf("failed to read moved state: %v", diags)
+	}
+
+	if got.Environment.ValueString() != "staging" || got.Hostname.ValueString() != "api.example.com" {
+		t.Fatalf("unexpected moved state: %+v", got)
+	}
+}
+
+func TestUpgradeStateV1toV500_NoOp(t *testing.T) {
+	ctx := context.Background()
+	targetSchema := SourceSchemaV0()
+
+	raw := createTerraformValue(t, targetSchema, map[string]interface{}{
+		"id":          "domain-id",
+		"account_id":  "account-id",
+		"hostname":    "api.example.com",
+		"service":     "worker-service",
+		"zone_id":     "zone-id",
+		"environment": "production",
+		"zone_name":   "example.com",
+	})
+
+	state := tfsdk.State{Raw: raw, Schema: targetSchema}
+	req := resource.UpgradeStateRequest{State: &state}
+	resp := &resource.UpgradeStateResponse{State: tfsdk.State{Schema: targetSchema}}
+
+	upgrader := UpgradeStateV1toV500(targetSchema)
+	upgrader.StateUpgrader(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	var got TargetWorkersCustomDomainModel
+	if diags := resp.State.Get(ctx, &got); diags.HasError() {
+		t.Fatalf("failed to read no-op upgraded state: %v", diags)
+	}
+
+	if got.ID.ValueString() != "domain-id" || got.ZoneName.ValueString() != "example.com" {
+		t.Fatalf("unexpected no-op upgraded state: %+v", got)
+	}
+}
+
+func TestUpgradeStateV0toV500_NullOptionalField(t *testing.T) {
+	ctx := context.Background()
+	sourceSchema := SourceSchemaV0()
+
+	raw := createTerraformValue(t, sourceSchema, map[string]interface{}{
+		"id":          "domain-id",
+		"account_id":  "account-id",
+		"hostname":    "api.example.com",
+		"service":     "worker-service",
+		"zone_id":     "zone-id",
+		"environment": nil,
+		"zone_name":   nil,
+	})
+
+	state := tfsdk.State{Raw: raw, Schema: sourceSchema}
+	req := resource.UpgradeStateRequest{State: &state}
+	resp := &resource.UpgradeStateResponse{State: tfsdk.State{Schema: sourceSchema}}
+
+	upgrader := UpgradeStateV0toV500(sourceSchema)
+	upgrader.StateUpgrader(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	var got TargetWorkersCustomDomainModel
+	if diags := resp.State.Get(ctx, &got); diags.HasError() {
+		t.Fatalf("failed to read upgraded state: %v", diags)
+	}
+
+	if !got.Environment.IsNull() {
+		t.Fatalf("expected null environment after upgrade, got: %v", got.Environment)
+	}
+
+	if !got.ZoneName.IsNull() {
+		t.Fatalf("expected null zone_name after upgrade, got: %v", got.ZoneName)
+	}
+}
+
+func TestMoveStateV4toV500_IgnoresUnknownSourceType(t *testing.T) {
+	ctx := context.Background()
+	sourceSchema := SourceSchemaV0()
+
+	raw := createTerraformValue(t, sourceSchema, map[string]interface{}{
+		"id":          "domain-id",
+		"account_id":  "account-id",
+		"hostname":    "api.example.com",
+		"service":     "worker-service",
+		"zone_id":     "zone-id",
+		"environment": "staging",
+		"zone_name":   "example.com",
+	})
+
+	sourceState := tfsdk.State{Raw: raw, Schema: sourceSchema}
+	req := resource.MoveStateRequest{
+		SourceTypeName:        "cloudflare_workers_custom_domain",
+		SourceProviderAddress: "registry.terraform.io/cloudflare/cloudflare",
+		SourceSchemaVersion:   0,
+		SourceState:           &sourceState,
+	}
+	resp := &resource.MoveStateResponse{TargetState: tfsdk.State{Schema: sourceSchema}}
+
+	MoveStateV4toV500(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	if !resp.TargetState.Raw.IsNull() {
+		t.Fatalf("expected target state to remain unset for unknown source type")
+	}
+}
+
+func TestMoveStateV4toV500_IgnoresNonCloudflareProvider(t *testing.T) {
+	ctx := context.Background()
+	sourceSchema := SourceSchemaV0()
+
+	raw := createTerraformValue(t, sourceSchema, map[string]interface{}{
+		"id":          "domain-id",
+		"account_id":  "account-id",
+		"hostname":    "api.example.com",
+		"service":     "worker-service",
+		"zone_id":     "zone-id",
+		"environment": "staging",
+		"zone_name":   "example.com",
+	})
+
+	sourceState := tfsdk.State{Raw: raw, Schema: sourceSchema}
+	req := resource.MoveStateRequest{
+		SourceTypeName:        "cloudflare_worker_domain",
+		SourceProviderAddress: "registry.terraform.io/hashicorp/random",
+		SourceSchemaVersion:   0,
+		SourceState:           &sourceState,
+	}
+	resp := &resource.MoveStateResponse{TargetState: tfsdk.State{Schema: sourceSchema}}
+
+	MoveStateV4toV500(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	if !resp.TargetState.Raw.IsNull() {
+		t.Fatalf("expected target state to remain unset for non-cloudflare provider")
+	}
+}
+
+func TestIsCloudflareProvider(t *testing.T) {
+	testCases := []struct {
+		name string
+		addr string
+		want bool
+	}{
+		{name: "registry address", addr: "registry.terraform.io/cloudflare/cloudflare", want: true},
+		{name: "short cloudflare address", addr: "cloudflare/cloudflare", want: true},
+		{name: "different provider", addr: "registry.terraform.io/hashicorp/random", want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCloudflareProvider(tc.addr); got != tc.want {
+				t.Fatalf("isCloudflareProvider(%q) = %t, want %t", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+func createTerraformValue(t *testing.T, s schema.Schema, values map[string]interface{}) tftypes.Value {
+	t.Helper()
+
+	attrTypes := make(map[string]tftypes.Type)
+	for name := range s.Attributes {
+		attrTypes[name] = tftypes.String
+	}
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	valueMap := make(map[string]tftypes.Value)
+	for name, val := range values {
+		if val == nil {
+			valueMap[name] = tftypes.NewValue(attrTypes[name], nil)
+		} else {
+			valueMap[name] = tftypes.NewValue(attrTypes[name], val)
+		}
+	}
+
+	return tftypes.NewValue(objectType, valueMap)
+}

--- a/internal/services/workers_custom_domain/migration/v500/migrations_test.go
+++ b/internal/services/workers_custom_domain/migration/v500/migrations_test.go
@@ -1,0 +1,235 @@
+package v500_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+const defaultWorkersService = "mute-truth-fdb1"
+
+func testWorkersService() string {
+	if v := os.Getenv("WORKERS_CUSTOM_DOMAIN_TEST_SERVICE"); v != "" {
+		return v
+	}
+	return defaultWorkersService
+}
+
+func testWorkersEnvironment() string {
+	if v, ok := os.LookupEnv("WORKERS_CUSTOM_DOMAIN_TEST_ENVIRONMENT"); ok {
+		return v
+	}
+	return "production"
+}
+
+var (
+	currentProviderVersion = internal.PackageVersion
+)
+
+//go:embed testdata/v4_basic.tf
+var v4BasicConfig string
+
+//go:embed testdata/v5_basic.tf
+var v5BasicConfig string
+
+//go:embed testdata/v4_without_environment.tf
+var v4WithoutEnvironmentConfig string
+
+//go:embed testdata/v5_without_environment.tf
+var v5WithoutEnvironmentConfig string
+
+func TestMigrateWorkersCustomDomain_Basic(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func() string
+	}{
+		{
+			name:     "from_v4_latest",
+			version:  acctest.GetLastV4Version(),
+			configFn: func() string { return v4BasicConfig },
+		},
+		{
+			name:     "from_v5",
+			version:  currentProviderVersion,
+			configFn: func() string { return v5BasicConfig },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if os.Getenv("TF_ACC") == "" {
+				t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+			}
+
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+			rnd := utils.GenerateRandomResourceName()
+			hostname := fmt.Sprintf("%s.%s", rnd, zoneName)
+			workersService := testWorkersService()
+			workersEnvironment := testWorkersEnvironment()
+			resourceName := "cloudflare_workers_custom_domain.test"
+			tmpDir := t.TempDir()
+			testConfig := fmt.Sprintf(tc.configFn(), accountID, zoneID, hostname, workersService, workersEnvironment)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+				}
+			} else {
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config: testConfig,
+				}
+			}
+
+			checks := []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service"), knownvalue.StringExact(workersService)),
+			}
+			if workersEnvironment != "" {
+				checks = append(checks, statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("environment"), knownvalue.StringExact(workersEnvironment)))
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					// Step 1: Create with source provider version.
+					firstStep,
+					// Step 2: Run migration and verify state parity.
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, checks),
+				},
+			})
+		})
+	}
+}
+
+func TestMigrateWorkersCustomDomain_WithoutEnvironment(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func() string
+	}{
+		{
+			name:     "from_v4_latest",
+			version:  acctest.GetLastV4Version(),
+			configFn: func() string { return v4WithoutEnvironmentConfig },
+		},
+		{
+			name:     "from_v5",
+			version:  currentProviderVersion,
+			configFn: func() string { return v5WithoutEnvironmentConfig },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if os.Getenv("TF_ACC") == "" {
+				t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+			}
+
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+			zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+			rnd := utils.GenerateRandomResourceName()
+			hostname := fmt.Sprintf("%s.%s", rnd, zoneName)
+			workersService := testWorkersService()
+			resourceName := "cloudflare_workers_custom_domain.test"
+			tmpDir := t.TempDir()
+			testConfig := fmt.Sprintf(tc.configFn(), accountID, zoneID, hostname, workersService)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			var firstStep resource.TestStep
+			if tc.version == currentProviderVersion {
+				firstStep = resource.TestStep{
+					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+					Config:                   testConfig,
+					ExpectNonEmptyPlan:       true,
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+						},
+					},
+				}
+			} else {
+				firstStep = resource.TestStep{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
+						},
+					},
+					Config: testConfig,
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+					acctest.TestAccPreCheck_ZoneID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					// Step 1: Create with source provider version.
+					firstStep,
+					// Step 2: Run migration and expect known environment replacement drift.
+					migrationStepExpectEnvironmentReplacement(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, resourceName, []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname)),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service"), knownvalue.StringExact(workersService)),
+					}),
+				},
+			})
+		})
+	}
+}
+
+func migrationStepExpectEnvironmentReplacement(t *testing.T, cfg string, tmpDir string, exactVersion string, sourceVersion string, targetVersion string, resourceName string, stateChecks []statecheck.StateCheck) resource.TestStep {
+	return resource.TestStep{
+		PreConfig: func() {
+			acctest.WriteOutConfig(t, cfg, tmpDir)
+			acctest.RunMigrationV2Command(t, cfg, tmpDir, sourceVersion, targetVersion)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		ConfigDirectory:          config.StaticDirectory(tmpDir),
+		ExpectNonEmptyPlan:       true,
+		ConfigPlanChecks: resource.ConfigPlanChecks{
+			PreApply: []plancheck.PlanCheck{
+				acctest.DebugNonEmptyPlan,
+			},
+			PostApplyPostRefresh: []plancheck.PlanCheck{
+				plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+			},
+		},
+		ConfigStateChecks: stateChecks,
+	}
+}

--- a/internal/services/workers_custom_domain/migration/v500/model.go
+++ b/internal/services/workers_custom_domain/migration/v500/model.go
@@ -1,0 +1,25 @@
+package v500
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+// SourceV4WorkersCustomDomainModel represents v4 cloudflare_worker_domain state.
+type SourceV4WorkersCustomDomainModel struct {
+	ID          types.String `tfsdk:"id"`
+	AccountID   types.String `tfsdk:"account_id"`
+	Hostname    types.String `tfsdk:"hostname"`
+	Service     types.String `tfsdk:"service"`
+	ZoneID      types.String `tfsdk:"zone_id"`
+	Environment types.String `tfsdk:"environment"`
+	ZoneName    types.String `tfsdk:"zone_name"`
+}
+
+// TargetWorkersCustomDomainModel represents v5 cloudflare_workers_custom_domain state.
+type TargetWorkersCustomDomainModel struct {
+	ID          types.String `tfsdk:"id"`
+	AccountID   types.String `tfsdk:"account_id"`
+	Hostname    types.String `tfsdk:"hostname"`
+	Service     types.String `tfsdk:"service"`
+	ZoneID      types.String `tfsdk:"zone_id"`
+	Environment types.String `tfsdk:"environment"`
+	ZoneName    types.String `tfsdk:"zone_name"`
+}

--- a/internal/services/workers_custom_domain/migration/v500/move_state.go
+++ b/internal/services/workers_custom_domain/migration/v500/move_state.go
@@ -1,0 +1,49 @@
+package v500
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// MoveStateV4toV500 handles moved blocks from cloudflare_worker_domain
+// to cloudflare_workers_custom_domain.
+func MoveStateV4toV500(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+	if req.SourceTypeName != "cloudflare_worker_domain" {
+		return
+	}
+
+	if !isCloudflareProvider(req.SourceProviderAddress) {
+		return
+	}
+
+	tflog.Info(ctx, "Starting state move from cloudflare_worker_domain to cloudflare_workers_custom_domain",
+		map[string]interface{}{
+			"source_type":           req.SourceTypeName,
+			"source_schema_version": req.SourceSchemaVersion,
+			"source_provider":       req.SourceProviderAddress,
+		})
+
+	var source SourceV4WorkersCustomDomainModel
+	resp.Diagnostics.Append(req.SourceState.Get(ctx, &source)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	target, diags := TransformV4toV500(ctx, source)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.TargetState.Set(ctx, target)...)
+
+	tflog.Info(ctx, "State move from cloudflare_worker_domain to cloudflare_workers_custom_domain completed")
+}
+
+func isCloudflareProvider(addr string) bool {
+	return strings.Contains(addr, "cloudflare/cloudflare") ||
+		strings.Contains(addr, "registry.terraform.io/cloudflare")
+}

--- a/internal/services/workers_custom_domain/migration/v500/schema.go
+++ b/internal/services/workers_custom_domain/migration/v500/schema.go
@@ -1,0 +1,33 @@
+package v500
+
+import "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+
+// SourceSchemaV0 returns the v4 cloudflare_worker_domain schema.
+func SourceSchemaV0() schema.Schema {
+	return schema.Schema{
+		Version: 0,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"account_id": schema.StringAttribute{
+				Required: true,
+			},
+			"hostname": schema.StringAttribute{
+				Required: true,
+			},
+			"service": schema.StringAttribute{
+				Required: true,
+			},
+			"zone_id": schema.StringAttribute{
+				Required: true,
+			},
+			"environment": schema.StringAttribute{
+				Optional: true,
+			},
+			"zone_name": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}

--- a/internal/services/workers_custom_domain/migration/v500/testdata/v4_basic.tf
+++ b/internal/services/workers_custom_domain/migration/v500/testdata/v4_basic.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_worker_domain" "test" {
+  account_id  = "%s"
+  zone_id     = "%s"
+  hostname    = "%s"
+  service     = "%s"
+  environment = "%s"
+}

--- a/internal/services/workers_custom_domain/migration/v500/testdata/v4_without_environment.tf
+++ b/internal/services/workers_custom_domain/migration/v500/testdata/v4_without_environment.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_worker_domain" "test" {
+  account_id = "%s"
+  zone_id    = "%s"
+  hostname   = "%s"
+  service    = "%s"
+}

--- a/internal/services/workers_custom_domain/migration/v500/testdata/v5_basic.tf
+++ b/internal/services/workers_custom_domain/migration/v500/testdata/v5_basic.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_workers_custom_domain" "test" {
+  account_id  = "%s"
+  zone_id     = "%s"
+  hostname    = "%s"
+  service     = "%s"
+  environment = "%s"
+}

--- a/internal/services/workers_custom_domain/migration/v500/testdata/v5_without_environment.tf
+++ b/internal/services/workers_custom_domain/migration/v500/testdata/v5_without_environment.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_workers_custom_domain" "test" {
+  account_id = "%s"
+  zone_id    = "%s"
+  hostname   = "%s"
+  service    = "%s"
+}

--- a/internal/services/workers_custom_domain/migration/v500/transform.go
+++ b/internal/services/workers_custom_domain/migration/v500/transform.go
@@ -1,0 +1,21 @@
+package v500
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// TransformV4toV500 converts v4 cloudflare_worker_domain state to
+// v5 cloudflare_workers_custom_domain state.
+func TransformV4toV500(_ context.Context, source SourceV4WorkersCustomDomainModel) (*TargetWorkersCustomDomainModel, diag.Diagnostics) {
+	return &TargetWorkersCustomDomainModel{
+		ID:          source.ID,
+		AccountID:   source.AccountID,
+		Hostname:    source.Hostname,
+		Service:     source.Service,
+		ZoneID:      source.ZoneID,
+		Environment: source.Environment,
+		ZoneName:    source.ZoneName,
+	}, nil
+}

--- a/internal/services/workers_custom_domain/migration/v500/transform_test.go
+++ b/internal/services/workers_custom_domain/migration/v500/transform_test.go
@@ -1,0 +1,95 @@
+package v500
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestTransformV4toV500_Identity(t *testing.T) {
+	ctx := context.Background()
+
+	source := SourceV4WorkersCustomDomainModel{
+		ID:          types.StringValue("domain-id"),
+		AccountID:   types.StringValue("account-id"),
+		Hostname:    types.StringValue("api.example.com"),
+		Service:     types.StringValue("worker-service"),
+		ZoneID:      types.StringValue("zone-id"),
+		Environment: types.StringValue("production"),
+		ZoneName:    types.StringValue("example.com"),
+	}
+
+	target, diags := TransformV4toV500(ctx, source)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if target.ID != source.ID ||
+		target.AccountID != source.AccountID ||
+		target.Hostname != source.Hostname ||
+		target.Service != source.Service ||
+		target.ZoneID != source.ZoneID ||
+		target.Environment != source.Environment ||
+		target.ZoneName != source.ZoneName {
+		t.Fatalf("identity mapping failed: got %+v, source %+v", target, source)
+	}
+}
+
+func TestTransformV4toV500_NullAndEmptyValues(t *testing.T) {
+	ctx := context.Background()
+
+	source := SourceV4WorkersCustomDomainModel{
+		ID:          types.StringNull(),
+		AccountID:   types.StringValue("account-id"),
+		Hostname:    types.StringValue(""),
+		Service:     types.StringValue("worker-service"),
+		ZoneID:      types.StringValue("zone-id"),
+		Environment: types.StringNull(),
+		ZoneName:    types.StringNull(),
+	}
+
+	target, diags := TransformV4toV500(ctx, source)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if !target.ID.IsNull() {
+		t.Fatalf("expected null id, got: %v", target.ID)
+	}
+
+	if target.Hostname.ValueString() != "" {
+		t.Fatalf("expected empty hostname to be preserved, got: %q", target.Hostname.ValueString())
+	}
+
+	if !target.Environment.IsNull() {
+		t.Fatalf("expected null environment, got: %v", target.Environment)
+	}
+
+	if !target.ZoneName.IsNull() {
+		t.Fatalf("expected null zone_name, got: %v", target.ZoneName)
+	}
+}
+
+func TestTransformV4toV500_UnknownValues(t *testing.T) {
+	ctx := context.Background()
+
+	source := SourceV4WorkersCustomDomainModel{
+		ID:          types.StringUnknown(),
+		AccountID:   types.StringValue("account-id"),
+		Hostname:    types.StringUnknown(),
+		Service:     types.StringValue("worker-service"),
+		ZoneID:      types.StringValue("zone-id"),
+		Environment: types.StringUnknown(),
+		ZoneName:    types.StringUnknown(),
+	}
+
+	target, diags := TransformV4toV500(ctx, source)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if !target.ID.IsUnknown() || !target.Hostname.IsUnknown() || !target.Environment.IsUnknown() || !target.ZoneName.IsUnknown() {
+		t.Fatalf("expected unknown values to be preserved, got: %+v", target)
+	}
+}

--- a/internal/services/workers_custom_domain/migrations.go
+++ b/internal/services/workers_custom_domain/migrations.go
@@ -5,25 +5,32 @@ package workers_custom_domain
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/workers_custom_domain/migration/v500"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 var _ resource.ResourceWithUpgradeState = (*WorkersCustomDomainResource)(nil)
+var _ resource.ResourceWithMoveState = (*WorkersCustomDomainResource)(nil)
+
+// MoveState handles state moves from cloudflare_worker_domain (v4)
+// to cloudflare_workers_custom_domain (v5).
+func (r *WorkersCustomDomainResource) MoveState(ctx context.Context) []resource.StateMover {
+	sourceSchema := v500.SourceSchemaV0()
+
+	return []resource.StateMover{
+		{
+			SourceSchema: &sourceSchema,
+			StateMover:   v500.MoveStateV4toV500,
+		},
+	}
+}
 
 func (r *WorkersCustomDomainResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	sourceV0Schema := v500.SourceSchemaV0()
 	targetSchema := ResourceSchema(ctx)
+
 	return map[int64]resource.StateUpgrader{
-		0: {
-			PriorSchema: &targetSchema,
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				resp.State.Raw = req.State.Raw
-			},
-		},
-		1: {
-			PriorSchema: &targetSchema,
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				resp.State.Raw = req.State.Raw
-			},
-		},
+		0: v500.UpgradeStateV0toV500(sourceV0Schema),
+		1: v500.UpgradeStateV1toV500(targetSchema),
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
```
TF_ACC=1 go test -v ./internal/services/workers_custom_domain/... -run "Test"
```

### Test output
```
~/cf-repos/github/terraform-provider-cloudflare vaishak/workers-domain *1 ❯ TF_ACC=1 go test -v ./internal/services/workers_custom_domain/... -run "Test"


=== RUN   TestWorkersCustomDomainDataSourceModelSchemaParity
=== PAUSE TestWorkersCustomDomainDataSourceModelSchemaParity
=== RUN   TestWorkersCustomDomainsDataSourceModelSchemaParity
=== PAUSE TestWorkersCustomDomainsDataSourceModelSchemaParity
=== RUN   TestWorkersCustomDomainModelSchemaParity
=== PAUSE TestWorkersCustomDomainModelSchemaParity
=== CONT  TestWorkersCustomDomainDataSourceModelSchemaParity
=== CONT  TestWorkersCustomDomainModelSchemaParity
=== CONT  TestWorkersCustomDomainsDataSourceModelSchemaParity
--- PASS: TestWorkersCustomDomainModelSchemaParity (0.00s)
--- PASS: TestWorkersCustomDomainDataSourceModelSchemaParity (0.00s)
--- PASS: TestWorkersCustomDomainsDataSourceModelSchemaParity (0.00s)

=== RUN   TestUpgradeStateV0toV500
--- PASS: TestUpgradeStateV0toV500 (0.00s)
=== RUN   TestMoveStateV4toV500
--- PASS: TestMoveStateV4toV500 (0.00s)
=== RUN   TestUpgradeStateV1toV500_NoOp
--- PASS: TestUpgradeStateV1toV500_NoOp (0.00s)
=== RUN   TestUpgradeStateV0toV500_NullOptionalField
--- PASS: TestUpgradeStateV0toV500_NullOptionalField (0.00s)
=== RUN   TestMoveStateV4toV500_IgnoresUnknownSourceType
--- PASS: TestMoveStateV4toV500_IgnoresUnknownSourceType (0.00s)
=== RUN   TestMoveStateV4toV500_IgnoresNonCloudflareProvider
--- PASS: TestMoveStateV4toV500_IgnoresNonCloudflareProvider (0.00s)
=== RUN   TestIsCloudflareProvider
=== RUN   TestIsCloudflareProvider/registry_address
=== RUN   TestIsCloudflareProvider/short_cloudflare_address
=== RUN   TestIsCloudflareProvider/different_provider
--- PASS: TestIsCloudflareProvider (0.00s)
    --- PASS: TestIsCloudflareProvider/registry_address (0.00s)
    --- PASS: TestIsCloudflareProvider/short_cloudflare_address (0.00s)
    --- PASS: TestIsCloudflareProvider/different_provider (0.00s)
=== RUN   TestTransformV4toV500_Identity
--- PASS: TestTransformV4toV500_Identity (0.00s)
=== RUN   TestTransformV4toV500_NullAndEmptyValues
--- PASS: TestTransformV4toV500_NullAndEmptyValues (0.00s)
=== RUN   TestTransformV4toV500_UnknownValues
--- PASS: TestTransformV4toV500_UnknownValues (0.00s)
=== RUN   TestMigrateWorkersCustomDomain_Basic
=== RUN   TestMigrateWorkersCustomDomain_Basic/from_v4_latest
=== RUN   TestMigrateWorkersCustomDomain_Basic/from_v5
--- PASS: TestMigrateWorkersCustomDomain_Basic (18.68s)
    --- PASS: TestMigrateWorkersCustomDomain_Basic/from_v4_latest (14.21s)
    --- PASS: TestMigrateWorkersCustomDomain_Basic/from_v5 (4.46s)
=== RUN   TestMigrateWorkersCustomDomain_WithoutEnvironment
=== RUN   TestMigrateWorkersCustomDomain_WithoutEnvironment/from_v4_latest
=== RUN   TestMigrateWorkersCustomDomain_WithoutEnvironment/from_v5
--- PASS: TestMigrateWorkersCustomDomain_WithoutEnvironment (18.93s)
    --- PASS: TestMigrateWorkersCustomDomain_WithoutEnvironment/from_v4_latest (12.93s)
    --- PASS: TestMigrateWorkersCustomDomain_WithoutEnvironment/from_v5 (6.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/workers_custom_domain/migration/v500
```

## Additional context & links
