### PR TITLE
test(r2_data_catalog): add acceptance tests

### DIFF
--- a/internal/services/r2_data_catalog/resource_test.go
+++ b/internal/services/r2_data_catalog/resource_test.go
@@ -1,0 +1,104 @@
+package r2_data_catalog_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/r2_data_catalog"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareR2DataCatalog_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_r2_data_catalog." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareR2DataCatalogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccR2DataCatalogConfig(rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("bucket_name"), knownvalue.StringExact(rnd)),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("bucket_name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s/%s", accountID, rnd),
+				ImportStateVerify: true,
+				// Enable (POST) returns only {id, name}; Get (GET) returns all fields.
+				// These 4 computed-only fields are null after Create but populated after Import.
+				ImportStateVerifyIgnore: []string{
+					"bucket",
+					"credential_status",
+					"maintenance_config",
+					"status",
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareR2DataCatalogDestroy(s *terraform.State) error {
+	client := acctest.SharedClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_r2_data_catalog" {
+			continue
+		}
+
+		accountID := rs.Primary.Attributes[consts.AccountIDSchemaKey]
+		bucketName := rs.Primary.Attributes["bucket_name"]
+		res, err := client.R2DataCatalog.Get(
+			context.Background(),
+			bucketName,
+			r2_data_catalog.R2DataCatalogGetParams{
+				AccountID: cloudflare.F(accountID),
+			},
+		)
+		if err != nil {
+			// API error means resource is gone, which is fine
+			continue
+		}
+		if res.Status == r2_data_catalog.R2DataCatalogGetResponseStatusActive {
+			return fmt.Errorf("r2 data catalog %s still active", bucketName)
+		}
+	}
+
+	return nil
+}
+
+func testAccR2DataCatalogConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("r2dc_enable.tf", rnd, accountID)
+}

--- a/internal/services/r2_data_catalog/testdata/r2dc_enable.tf
+++ b/internal/services/r2_data_catalog/testdata/r2dc_enable.tf
@@ -1,0 +1,9 @@
+resource "cloudflare_r2_bucket" "%[1]s" {
+    account_id = "%[2]s"
+    name       = "%[1]s"
+}
+
+resource "cloudflare_r2_data_catalog" "%[1]s" {
+    account_id  = "%[2]s"
+    bucket_name = cloudflare_r2_bucket.%[1]s.name
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Add acceptance tests for the `cloudflare_r2_data_catalog` resource.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
`TF_ACC=1 go test -count 1 ./internal/services/r2_data_catalog -run "TestAcc" -v`

### Test output
```
❯ TF_ACC=1 go test -count 1 ./internal/services/r2_data_catalog -run "TestAcc" -v
=== RUN   TestAccCloudflareR2DataCatalog_Basic
--- PASS: TestAccCloudflareR2DataCatalog_Basic (5.81s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_data_catalog   7.570s
```

## Additional context & links
