### PR TITLE
feat(certificate_authorities_hostname_associations): add mtls cert id…

### DIFF
--- a/internal/services/certificate_authorities_hostname_associations/resource.go
+++ b/internal/services/certificate_authorities_hostname_associations/resource.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/certificate_authorities"
 	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -156,11 +156,15 @@ func (r *CertificateAuthoritiesHostnameAssociationsResource) Read(ctx context.Co
 
 	res := new(http.Response)
 	env := CertificateAuthoritiesHostnameAssociationsResultEnvelope{*data}
+	getParams := certificate_authorities.HostnameAssociationGetParams{
+		ZoneID: cloudflare.F(data.ZoneID.ValueString()),
+	}
+	if !data.MTLSCertificateID.IsNull() && !data.MTLSCertificateID.IsUnknown() {
+		getParams.MTLSCertificateID = cloudflare.F(data.MTLSCertificateID.ValueString())
+	}
 	_, err := r.client.CertificateAuthorities.HostnameAssociations.Get(
 		ctx,
-		certificate_authorities.HostnameAssociationGetParams{
-			ZoneID: cloudflare.F(data.ZoneID.ValueString()),
-		},
+		getParams,
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)
@@ -192,26 +196,32 @@ func (r *CertificateAuthoritiesHostnameAssociationsResource) Delete(ctx context.
 func (r *CertificateAuthoritiesHostnameAssociationsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	var data = new(CertificateAuthoritiesHostnameAssociationsModel)
 
-	path := ""
-	diags := importpath.ParseImportID(
-		req.ID,
-		"<zone_id>",
-		&path,
-	)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	// Support import formats:
+	//   <zone_id>                        - for managed CA associations
+	//   <zone_id>/<mtls_certificate_id>  - for mTLS certificate associations
+	parts := strings.Split(req.ID, "/")
+	if len(parts) < 1 || len(parts) > 2 {
+		resp.Diagnostics.AddError(
+			"invalid import ID",
+			fmt.Sprintf("expected format \"<zone_id>\" or \"<zone_id>/<mtls_certificate_id>\", got %q", req.ID),
+		)
 		return
 	}
 
-	data.ZoneID = types.StringValue(path)
+	data.ZoneID = types.StringValue(parts[0])
+	getParams := certificate_authorities.HostnameAssociationGetParams{
+		ZoneID: cloudflare.F(parts[0]),
+	}
+	if len(parts) == 2 && parts[1] != "" {
+		data.MTLSCertificateID = types.StringValue(parts[1])
+		getParams.MTLSCertificateID = cloudflare.F(parts[1])
+	}
 
 	res := new(http.Response)
 	env := CertificateAuthoritiesHostnameAssociationsResultEnvelope{*data}
 	_, err := r.client.CertificateAuthorities.HostnameAssociations.Get(
 		ctx,
-		certificate_authorities.HostnameAssociationGetParams{
-			ZoneID: cloudflare.F(path),
-		},
+		getParams,
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)

--- a/internal/services/certificate_authorities_hostname_associations/resource_test.go
+++ b/internal/services/certificate_authorities_hostname_associations/resource_test.go
@@ -1,0 +1,136 @@
+package certificate_authorities_hostname_associations_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareCertificateAuthoritiesHostnameAssociations_FullLifecycle(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_certificate_authorities_hostname_associations.%s", rnd)
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+
+	hostname := fmt.Sprintf("%s.%s", rnd, domain)
+	hostnameUpdated := fmt.Sprintf("%s-updated.%s", rnd, domain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read
+			{
+				Config: testAccCloudflareCertificateAuthoritiesHostnameAssociationsConfig(rnd, zoneID, hostname),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("hostnames"), knownvalue.NotNull()),
+				},
+			},
+			// Re-apply same config to verify no drift
+			{
+				Config: testAccCloudflareCertificateAuthoritiesHostnameAssociationsConfig(rnd, zoneID, hostname),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Update hostnames
+			{
+				Config: testAccCloudflareCertificateAuthoritiesHostnameAssociationsConfig(rnd, zoneID, hostnameUpdated),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("hostnames"), knownvalue.ListExact(
+						[]knownvalue.Check{knownvalue.StringExact(hostnameUpdated)},
+					)),
+				},
+			},
+			// Import
+			{
+				ResourceName:            name,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"mtls_certificate_id"},
+			},
+		},
+	})
+}
+
+func testAccCloudflareCertificateAuthoritiesHostnameAssociationsConfig(rnd, zoneID, hostname string) string {
+	return acctest.LoadTestCase("certificateauthoritieshostnameassociationslifecycle.tf", rnd, zoneID, hostname)
+}
+
+func TestAccCloudflareCertificateAuthoritiesHostnameAssociations_WithMTLSCertificate(t *testing.T) {
+	mtlsCertID := os.Getenv("CLOUDFLARE_MTLS_CERTIFICATE_ID")
+	if mtlsCertID == "" {
+		t.Skip("CLOUDFLARE_MTLS_CERTIFICATE_ID not set, skipping mTLS certificate test")
+	}
+
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_certificate_authorities_hostname_associations.%s", rnd)
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	hostname := fmt.Sprintf("%s.%s", rnd, domain)
+	hostnameUpdated := fmt.Sprintf("%s-updated.%s", rnd, domain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read
+			{
+				Config: testAccCloudflareCertificateAuthoritiesHostnameAssociationsWithMTLSConfig(rnd, zoneID, hostname, mtlsCertID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("hostnames"), knownvalue.NotNull()),
+				},
+			},
+			// Re-apply same config to verify no drift
+			{
+				Config: testAccCloudflareCertificateAuthoritiesHostnameAssociationsWithMTLSConfig(rnd, zoneID, hostname, mtlsCertID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Update hostnames
+			{
+				Config: testAccCloudflareCertificateAuthoritiesHostnameAssociationsWithMTLSConfig(rnd, zoneID, hostnameUpdated, mtlsCertID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("hostnames"), knownvalue.ListExact(
+						[]knownvalue.Check{knownvalue.StringExact(hostnameUpdated)},
+					)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("mtls_certificate_id"), knownvalue.StringExact(mtlsCertID)),
+				},
+			},
+			// Import with <zone_id>/<mtls_certificate_id> format
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s/%s", zoneID, mtlsCertID),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCloudflareCertificateAuthoritiesHostnameAssociationsWithMTLSConfig(rnd, zoneID, hostname, mtlsCertID string) string {
+	return acctest.LoadTestCase("certificateauthoritieshostnameassociationswithmtls.tf", rnd, zoneID, hostname, mtlsCertID)
+}

--- a/internal/services/certificate_authorities_hostname_associations/testdata/certificateauthoritieshostnameassociationslifecycle.tf
+++ b/internal/services/certificate_authorities_hostname_associations/testdata/certificateauthoritieshostnameassociationslifecycle.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_certificate_authorities_hostname_associations" "%[1]s" {
+  zone_id   = "%[2]s"
+  hostnames = ["%[3]s"]
+}

--- a/internal/services/certificate_authorities_hostname_associations/testdata/certificateauthoritieshostnameassociationswithmtls.tf
+++ b/internal/services/certificate_authorities_hostname_associations/testdata/certificateauthoritieshostnameassociationswithmtls.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_certificate_authorities_hostname_associations" "%[1]s" {
+  zone_id             = "%[2]s"
+  hostnames           = ["%[3]s"]
+  mtls_certificate_id = "%[4]s"
+}


### PR DESCRIPTION
certificate_authorities_hostname_associations resource: query param and lifecycle tests

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Add acceptance test for new resource.
Add custom code to allow for mtls_certificate_id in query params:
- Without mtls_certificate_id, get will assume cloudflare managed CA. import <zone_id>
- With mtls_certificate_id, get will query by the BYO-CA id. import <zone_id>/<mtls_certificate_id>


## Acceptance test run results

- [X] I have added or updated acceptance tests for my changes
- [X] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
CLOUDFLARE_MTLS_CERTIFICATE_ID=XXX
TF_ACC=1 go test ./internal/services/certificate_authorities_hostname_associations/... -v -run TestAccCloudflareCertificateAuthoritiesHostnameAssociations

### Test output
<!-- Please paste the output of your acceptance test run below --> 
=== RUN   TestAccCloudflareCertificateAuthoritiesHostnameAssociations_FullLifecycle
--- PASS: TestAccCloudflareCertificateAuthoritiesHostnameAssociations_FullLifecycle (13.33s)
=== RUN   TestAccCloudflareCertificateAuthoritiesHostnameAssociations_WithMTLSCertificate
--- PASS: TestAccCloudflareCertificateAuthoritiesHostnameAssociations_WithMTLSCertificate (14.07s)
PASS
## Additional context & links
