### PR TITLE
bug(logpush_ownership_challenge): make sure filename gets carried over during state migration

### DIFF
--- a/internal/services/logpush_ownership_challenge/migration/v500/handler.go
+++ b/internal/services/logpush_ownership_challenge/migration/v500/handler.go
@@ -13,8 +13,8 @@ import (
 // The v4 state has schema_version=0 (SDKv2 default), and we transform it to v5 format.
 //
 // Key transformations:
-//   - ownership_challenge_filename (computed): removed
-//   - filename, message, valid: set to Null (new computed fields, populated by API)
+//   - ownership_challenge_filename (computed): renamed to filename
+//   - message, valid: set to Null (new computed fields, populated by API)
 func UpgradeFromV4(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 	tflog.Info(ctx, "Upgrading logpush_ownership_challenge state from v4 SDKv2 provider (schema_version=0)")
 

--- a/internal/services/logpush_ownership_challenge/migration/v500/migrations_test.go
+++ b/internal/services/logpush_ownership_challenge/migration/v500/migrations_test.go
@@ -39,7 +39,7 @@ var v5BasicAccountConfig string
 //
 // This verifies:
 // 1. zone_id and destination_conf are preserved (direct copies)
-// 2. ownership_challenge_filename is removed from v5 state
+// 2. ownership_challenge_filename is renamed to filename in v5 state (non-null)
 // 3. filename, message, valid are available as computed fields after API call
 func TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicZone(t *testing.T) {
 	testCases := []struct {
@@ -113,6 +113,12 @@ func TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicZone(t *testing.T) {
 								tfjsonpath.New("destination_conf"),
 								knownvalue.StringExact("gs://cf-terraform-provider-acct-test/ownership_challenges"),
 							),
+							// Validate filename is preserved from v4 ownership_challenge_filename (renamed, not dropped)
+							statecheck.ExpectKnownValue(
+								"cloudflare_logpush_ownership_challenge."+rnd,
+								tfjsonpath.New("filename"),
+								knownvalue.NotNull(),
+							),
 						},
 					),
 				},
@@ -126,7 +132,7 @@ func TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicZone(t *testing.T) {
 //
 // This verifies:
 // 1. account_id and destination_conf are preserved (direct copies)
-// 2. ownership_challenge_filename is removed from v5 state
+// 2. ownership_challenge_filename is renamed to filename in v5 state (non-null)
 // 3. filename, message, valid are available as computed fields after API call
 func TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicAccount(t *testing.T) {
 	testCases := []struct {
@@ -199,6 +205,12 @@ func TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicAccount(t *testing.T) {
 								"cloudflare_logpush_ownership_challenge."+rnd,
 								tfjsonpath.New("destination_conf"),
 								knownvalue.StringExact("gs://cf-terraform-provider-acct-test/ownership_challenges"),
+							),
+							// Validate filename is preserved from v4 ownership_challenge_filename (renamed, not dropped)
+							statecheck.ExpectKnownValue(
+								"cloudflare_logpush_ownership_challenge."+rnd,
+								tfjsonpath.New("filename"),
+								knownvalue.NotNull(),
 							),
 						},
 					),

--- a/internal/services/logpush_ownership_challenge/migration/v500/transform.go
+++ b/internal/services/logpush_ownership_challenge/migration/v500/transform.go
@@ -11,8 +11,8 @@ import (
 //
 // This is one of the simplest transformations:
 //   - account_id, zone_id, destination_conf: direct copies (no changes)
-//   - ownership_challenge_filename: dropped (removed in v5)
-//   - filename, message, valid: set to Null (new computed fields, API will populate)
+//   - ownership_challenge_filename: renamed to filename in v5
+//   - message, valid: set to Null (new computed fields, API will populate)
 //
 // This function is used by UpgradeFromV4 handler.
 func Transform(ctx context.Context, source SourceCloudflareLogpushOwnershipChallengeModel) (*TargetLogpushOwnershipChallengeModel, diag.Diagnostics) {
@@ -35,11 +35,10 @@ func Transform(ctx context.Context, source SourceCloudflareLogpushOwnershipChall
 	target.ZoneID = source.ZoneID
 	target.DestinationConf = source.DestinationConf
 
-	// Step 2: Drop ownership_challenge_filename (removed in v5)
-	// source.OwnershipChallengeFilename is intentionally not copied
+	// Step 2: Rename ownership_challenge_filename → filename
+	target.Filename = source.OwnershipChallengeFilename
 
 	// Step 3: Set new v5 computed fields to Null (API will populate on next read/create)
-	target.Filename = types.StringNull()
 	target.Message = types.StringNull()
 	target.Valid = types.BoolNull()
 


### PR DESCRIPTION
https://github.com/cloudflare/terraform-provider-cloudflare/issues/6675

The V4 `ownership_challenge_filename` attribute which is renamed to `filename` in V5 was being dropped during the state upgrader transform. This was causing future applies to fail with the error described in the above issue. This PR adds tests to make sure the attribute is renamed and carried over during migration as well as fixes the transform logic. 

```
=== RUN   TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicZone
=== RUN   TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicZone/from_v4_latest
=== RUN   TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicZone/from_v5
--- PASS: TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicZone (13.79s)
    --- PASS: TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicZone/from_v4_latest (11.69s)
    --- PASS: TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicZone/from_v5 (2.11s)
=== RUN   TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicAccount
=== RUN   TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicAccount/from_v4_latest
=== RUN   TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicAccount/from_v5
--- PASS: TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicAccount (14.06s)
    --- PASS: TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicAccount/from_v4_latest (11.71s)
    --- PASS: TestMigrateLogpushOwnershipChallenge_V4ToV5_BasicAccount/from_v5 (2.35s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/logpush_ownership_challenge/migration/v500        29.364s
```