### PR TITLE
perf(zero_trust_list): optimize large list performance with hash-base…

### DIFF
--- a/internal/services/zero_trust_list/hash_test.go
+++ b/internal/services/zero_trust_list/hash_test.go
@@ -153,14 +153,34 @@ func TestComputeItemsHash(t *testing.T) {
 		},
 		{
 			name: "two entries do not collide with one entry whose value looks like concatenated encodings",
-			// Checks that a single item whose value happens to equal the raw concatenation
-			// of two items' encodings does not produce a hash match.
+			// Checks that a single item whose value equals the raw concatenation of two
+			// items' encodings does not produce a hash match.
 			items1: []*ZeroTrustListItemsModel{
 				{Value: types.StringValue("a")},
 				{Value: types.StringValue("b")},
 			},
 			items2: []*ZeroTrustListItemsModel{
-				{Value: types.StringValue("4:v:a/null\x004:v:b/null")},
+				{Value: types.StringValue("v(1):a/d:null\x00v(1):b/d:null")},
+			},
+			shouldMatch: false,
+		},
+		{
+			name: "unknown value does not match null value",
+			items1: []*ZeroTrustListItemsModel{
+				{Value: types.StringUnknown()},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringNull()},
+			},
+			shouldMatch: false,
+		},
+		{
+			name: "unknown description does not match null description",
+			items1: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1"), Description: types.StringUnknown()},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1"), Description: types.StringNull()},
 			},
 			shouldMatch: false,
 		},

--- a/internal/services/zero_trust_list/hash_test.go
+++ b/internal/services/zero_trust_list/hash_test.go
@@ -127,16 +127,14 @@ func TestComputeItemsHash(t *testing.T) {
 			shouldMatch: false,
 		},
 		{
-			name: "nil item does not collide with empty-value item",
-			// A nil pointer in the items slice encodes as "nil", which is distinct
-			// from an item with empty value and null description.
+			name: "nil item is skipped — matches empty slice",
+			// nil pointers are skipped during hashing (consistent with nil-stripping
+			// in suppressItemsDiff), so [nil] hashes the same as [].
 			items1: []*ZeroTrustListItemsModel{
 				nil,
 			},
-			items2: []*ZeroTrustListItemsModel{
-				{Value: types.StringValue(""), Description: types.StringNull()},
-			},
-			shouldMatch: false,
+			items2:      []*ZeroTrustListItemsModel{},
+			shouldMatch: true,
 		},
 		{
 			name: "value containing null byte does not collide with value+description pair",

--- a/internal/services/zero_trust_list/hash_test.go
+++ b/internal/services/zero_trust_list/hash_test.go
@@ -104,14 +104,59 @@ func TestComputeItemsHash(t *testing.T) {
 			shouldMatch: true,
 		},
 		{
-			name: "null vs empty string value",
+			name: "null vs empty string description treated as equivalent",
+			items1: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1"), Description: types.StringNull()},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1"), Description: types.StringValue("")},
+			},
+			// Intentional: state will have description=null (from API response with absent
+			// description), while config may have description="" or omit the field entirely.
+			// The hash must treat these as equal to avoid a perpetual diff.
+			shouldMatch: true,
+		},
+		{
+			name: "null vs empty string value treated as equivalent",
 			items1: []*ZeroTrustListItemsModel{
 				{Value: types.StringNull()},
 			},
 			items2: []*ZeroTrustListItemsModel{
 				{Value: types.StringValue("")},
 			},
-			shouldMatch: true, // both result in empty string
+			// Intentional: null, unset, and "" are all semantically "no value" for
+			// this resource. The API treats them identically, and users should not
+			// see a plan diff when toggling between these forms in their config.
+			// types.String.ValueString() returns "" for null, unknown, and empty
+			// string — this collapse is deliberate, not a bug.
+			shouldMatch: true,
+		},
+		{
+			name: "value containing null byte does not collide with value+description pair",
+			// Regression: with the old "\x00" intra-item separator, {value="a", desc="b"}
+			// and {value="a\x00b", desc=""} both encoded as "a\x00b", producing a false match.
+			// Length-prefixed encoding eliminates this: "a"+"b" → "1:a/1:b", "a\x00b" → "4:a\x00b/0:".
+			items1: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("a"), Description: types.StringValue("b")},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("a\x00b"), Description: types.StringValue("")},
+			},
+			shouldMatch: false,
+		},
+		{
+			name: "two entries do not collide with one entry whose value looks like concatenated encodings",
+			// Checks that a single item whose value happens to equal the raw concatenation
+			// of two items' length-prefixed encodings does not produce a hash match.
+			// The null-byte inter-item separator prevents this cross-item collision.
+			items1: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("a")},
+				{Value: types.StringValue("b")},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("1:a/0:\x001:b/0:")},
+			},
+			shouldMatch: false,
 		},
 	}
 

--- a/internal/services/zero_trust_list/hash_test.go
+++ b/internal/services/zero_trust_list/hash_test.go
@@ -104,38 +104,45 @@ func TestComputeItemsHash(t *testing.T) {
 			shouldMatch: true,
 		},
 		{
-			name: "null vs empty string description treated as equivalent",
+			name: "null description does not match empty string description",
+			// The hash explicitly distinguishes null from "" to avoid suppressing
+			// a diff when a user changes description from null to "" or vice versa.
 			items1: []*ZeroTrustListItemsModel{
 				{Value: types.StringValue("10.0.0.1"), Description: types.StringNull()},
 			},
 			items2: []*ZeroTrustListItemsModel{
 				{Value: types.StringValue("10.0.0.1"), Description: types.StringValue("")},
 			},
-			// Intentional: state will have description=null (from API response with absent
-			// description), while config may have description="" or omit the field entirely.
-			// The hash must treat these as equal to avoid a perpetual diff.
-			shouldMatch: true,
+			shouldMatch: false,
 		},
 		{
-			name: "null vs empty string value treated as equivalent",
+			name: "null value does not match empty string value",
+			// The hash explicitly distinguishes null from "" for value as well.
 			items1: []*ZeroTrustListItemsModel{
 				{Value: types.StringNull()},
 			},
 			items2: []*ZeroTrustListItemsModel{
 				{Value: types.StringValue("")},
 			},
-			// Intentional: null, unset, and "" are all semantically "no value" for
-			// this resource. The API treats them identically, and users should not
-			// see a plan diff when toggling between these forms in their config.
-			// types.String.ValueString() returns "" for null, unknown, and empty
-			// string — this collapse is deliberate, not a bug.
-			shouldMatch: true,
+			shouldMatch: false,
+		},
+		{
+			name: "nil item does not collide with empty-value item",
+			// A nil pointer in the items slice encodes as "nil", which is distinct
+			// from an item with empty value and null description.
+			items1: []*ZeroTrustListItemsModel{
+				nil,
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue(""), Description: types.StringNull()},
+			},
+			shouldMatch: false,
 		},
 		{
 			name: "value containing null byte does not collide with value+description pair",
 			// Regression: with the old "\x00" intra-item separator, {value="a", desc="b"}
 			// and {value="a\x00b", desc=""} both encoded as "a\x00b", producing a false match.
-			// Length-prefixed encoding eliminates this: "a"+"b" → "1:a/1:b", "a\x00b" → "4:a\x00b/0:".
+			// Length-prefixed encoding with type tags eliminates this.
 			items1: []*ZeroTrustListItemsModel{
 				{Value: types.StringValue("a"), Description: types.StringValue("b")},
 			},
@@ -147,14 +154,13 @@ func TestComputeItemsHash(t *testing.T) {
 		{
 			name: "two entries do not collide with one entry whose value looks like concatenated encodings",
 			// Checks that a single item whose value happens to equal the raw concatenation
-			// of two items' length-prefixed encodings does not produce a hash match.
-			// The null-byte inter-item separator prevents this cross-item collision.
+			// of two items' encodings does not produce a hash match.
 			items1: []*ZeroTrustListItemsModel{
 				{Value: types.StringValue("a")},
 				{Value: types.StringValue("b")},
 			},
 			items2: []*ZeroTrustListItemsModel{
-				{Value: types.StringValue("1:a/0:\x001:b/0:")},
+				{Value: types.StringValue("4:v:a/null\x004:v:b/null")},
 			},
 			shouldMatch: false,
 		},

--- a/internal/services/zero_trust_list/hash_test.go
+++ b/internal/services/zero_trust_list/hash_test.go
@@ -1,0 +1,190 @@
+package zero_trust_list
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestComputeItemsHash verifies the hash function produces consistent,
+// order-independent hashes for list items.
+func TestComputeItemsHash(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		items1      []*ZeroTrustListItemsModel
+		items2      []*ZeroTrustListItemsModel
+		shouldMatch bool
+	}{
+		{
+			name:        "empty lists match",
+			items1:      []*ZeroTrustListItemsModel{},
+			items2:      []*ZeroTrustListItemsModel{},
+			shouldMatch: true,
+		},
+		{
+			name: "same items same order match",
+			items1: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1")},
+				{Value: types.StringValue("10.0.0.2")},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1")},
+				{Value: types.StringValue("10.0.0.2")},
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "same items different order match (set semantics)",
+			items1: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1")},
+				{Value: types.StringValue("10.0.0.2")},
+				{Value: types.StringValue("10.0.0.3")},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.3")},
+				{Value: types.StringValue("10.0.0.1")},
+				{Value: types.StringValue("10.0.0.2")},
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "different items do not match",
+			items1: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1")},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.2")},
+			},
+			shouldMatch: false,
+		},
+		{
+			name: "different count does not match",
+			items1: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1")},
+				{Value: types.StringValue("10.0.0.2")},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1")},
+			},
+			shouldMatch: false,
+		},
+		{
+			name: "same value different description does not match",
+			items1: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1"), Description: types.StringValue("server1")},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1"), Description: types.StringValue("server2")},
+			},
+			shouldMatch: false,
+		},
+		{
+			name: "same value and description match",
+			items1: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1"), Description: types.StringValue("server1")},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1"), Description: types.StringValue("server1")},
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "nil items handled gracefully",
+			items1: []*ZeroTrustListItemsModel{
+				nil,
+				{Value: types.StringValue("10.0.0.1")},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("10.0.0.1")},
+				nil,
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "null vs empty string value",
+			items1: []*ZeroTrustListItemsModel{
+				{Value: types.StringNull()},
+			},
+			items2: []*ZeroTrustListItemsModel{
+				{Value: types.StringValue("")},
+			},
+			shouldMatch: true, // both result in empty string
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash1 := computeItemsHash(tt.items1)
+			hash2 := computeItemsHash(tt.items2)
+
+			if tt.shouldMatch && hash1 != hash2 {
+				t.Errorf("expected hashes to match, got %x != %x", hash1, hash2)
+			}
+			if !tt.shouldMatch && hash1 == hash2 {
+				t.Errorf("expected hashes to differ, got %x == %x", hash1, hash2)
+			}
+		})
+	}
+}
+
+// TestComputeItemsHashDeterministic verifies the hash is deterministic
+// (same input always produces same output).
+func TestComputeItemsHashDeterministic(t *testing.T) {
+	t.Parallel()
+
+	items := []*ZeroTrustListItemsModel{
+		{Value: types.StringValue("10.0.0.1"), Description: types.StringValue("test")},
+		{Value: types.StringValue("10.0.0.2")},
+		{Value: types.StringValue("192.168.1.1")},
+	}
+
+	hash1 := computeItemsHash(items)
+	hash2 := computeItemsHash(items)
+	hash3 := computeItemsHash(items)
+
+	if hash1 != hash2 || hash2 != hash3 {
+		t.Errorf("hash should be deterministic: %x, %x, %x", hash1, hash2, hash3)
+	}
+}
+
+// TestComputeItemsHashLargeList verifies performance with large lists.
+func TestComputeItemsHashLargeList(t *testing.T) {
+	t.Parallel()
+
+	// Create a list with 5000 items
+	items := make([]*ZeroTrustListItemsModel, 5000)
+	for i := 0; i < 5000; i++ {
+		items[i] = &ZeroTrustListItemsModel{
+			Value: types.StringValue(fmt.Sprintf("10.%d.%d.1", i/256, i%256)),
+		}
+	}
+
+	// Should complete without timeout (test has default timeout)
+	hash := computeItemsHash(items)
+	if hash == [32]byte{} {
+		t.Error("hash should not be zero")
+	}
+}
+
+// BenchmarkComputeItemsHash measures hash performance for various list sizes.
+func BenchmarkComputeItemsHash(b *testing.B) {
+	sizes := []int{100, 1000, 2000, 5000}
+
+	for _, size := range sizes {
+		items := make([]*ZeroTrustListItemsModel, size)
+		for i := 0; i < size; i++ {
+			items[i] = &ZeroTrustListItemsModel{
+				Value: types.StringValue(fmt.Sprintf("10.%d.%d.1", i/256, i%256)),
+			}
+		}
+
+		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				computeItemsHash(items)
+			}
+		})
+	}
+}

--- a/internal/services/zero_trust_list/items.go
+++ b/internal/services/zero_trust_list/items.go
@@ -1,0 +1,131 @@
+package zero_trust_list
+
+// This file contains hand-written logic that extends the generated resource.go.
+// It is intentionally separate so generator regenerations leave it untouched.
+//
+// Hooks into resource.go:
+//   - Read()       calls fetchItems(ctx, client, accountID, listID) to populate data.Items
+//   - ModifyPlan() calls suppressItemsDiff(ctx, req, resp) for hash-based diff suppression
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// fetchItems retrieves all items for a gateway list via the dedicated items
+// endpoint (GET /gateway/lists/{id}/items), which is separate from the list
+// metadata endpoint that Read() uses. Returns nil, nil if the list is gone.
+func fetchItems(ctx context.Context, client *cloudflare.Client, accountID, listID string) ([]*ZeroTrustListItemsModel, error) {
+	page, err := client.ZeroTrust.Gateway.Lists.Items.List(
+		ctx,
+		listID,
+		zero_trust.GatewayListItemListParams{
+			AccountID: cloudflare.F(accountID),
+		},
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		var apiErr *cloudflare.Error
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Result is [][]GatewayItem: the outer slice always has exactly one element
+	// (SinglePage is never paginated), and the inner slice is the list of items.
+	var items []*ZeroTrustListItemsModel
+	if len(page.Result) > 0 {
+		for _, item := range page.Result[0] {
+			items = append(items, &ZeroTrustListItemsModel{
+				Value:       types.StringValue(item.Value),
+				Description: gatewayItemDescription(item),
+			})
+		}
+	}
+	return items, nil
+}
+
+// gatewayItemDescription maps a GatewayItem description to a Terraform string.
+// Returns StringNull() when the field is absent so state matches configs that
+// omit the description field entirely, avoiding perpetual plan diffs.
+func gatewayItemDescription(item zero_trust.GatewayItem) types.String {
+	if item.JSON.Description.IsNull() {
+		return types.StringNull()
+	}
+	return types.StringValue(item.Description)
+}
+
+// suppressItemsDiff suppresses spurious plan diffs for list items when the
+// config and state are semantically identical (same values and descriptions,
+// regardless of set ordering).
+//
+// Background: Terraform's SetNestedAttribute comparison is O(n²) with expensive
+// nested object hashing (~70s for 2000 items). This hash-based approach takes
+// ~0.5ms for 5000 items, providing ~70,000x speedup for no-change plans.
+func suppressItemsDiff(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Plan is null on destroy; state is null on first create.
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan, state *ZeroTrustListModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() || plan == nil || state == nil {
+		return
+	}
+
+	if plan.Items != nil && state.Items != nil {
+		if computeItemsHash(*plan.Items) == computeItemsHash(*state.Items) {
+			plan.Items = state.Items
+			resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+		}
+	}
+}
+
+// computeItemsHash computes a deterministic SHA-256 hash of list items for
+// efficient set comparison.
+//
+// Items are sorted before hashing to ensure order-independence (set semantics).
+// Each item is encoded as "<len(value)>:<value>/<len(desc)>:<desc>" using
+// length-prefixed fields to avoid separator-collision ambiguities.
+func computeItemsHash(items []*ZeroTrustListItemsModel) [32]byte {
+	encoded := make([]string, len(items))
+	for i, item := range items {
+		if item != nil {
+			v := item.Value.ValueString()
+			d := item.Description.ValueString()
+			encoded[i] = fmt.Sprintf("%d:%s/%d:%s", len(v), v, len(d), d)
+		}
+	}
+	sort.Strings(encoded)
+
+	h := sha256.New()
+	for _, v := range encoded {
+		h.Write([]byte(v))
+		h.Write([]byte{0})
+	}
+	var result [32]byte
+	copy(result[:], h.Sum(nil))
+	return result
+}
+
+// readBody reads all bytes from an http.Response body.
+func readBody(res *http.Response) ([]byte, error) {
+	defer res.Body.Close()
+	return io.ReadAll(res.Body)
+}

--- a/internal/services/zero_trust_list/items.go
+++ b/internal/services/zero_trust_list/items.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -48,11 +49,17 @@ func fetchItems(ctx context.Context, client *cloudflare.Client, accountID, listI
 		return nil, err
 	}
 
+	// A null result field means the API returned no data — treat as gone.
+	if page.JSON.Result.IsNull() {
+		return nil, fmt.Errorf("items endpoint returned null result for list %s", listID)
+	}
+
 	// Result is [][]GatewayItem: the outer slice always has exactly one element
 	// (SinglePage is never paginated), and the inner slice is the list of items.
 	if len(page.Result) > 1 {
 		return nil, fmt.Errorf("unexpected pagination: items endpoint returned %d result pages, expected at most 1", len(page.Result))
 	}
+
 	// Allocate a non-nil slice so the caller can distinguish "0 items" from "404".
 	items := make([]*ZeroTrustListItemsModel, 0)
 	if len(page.Result) == 1 {
@@ -86,16 +93,21 @@ func gatewayItemDescription(item zero_trust.GatewayItem) types.String {
 // element requires expensive nested object hashing (~70s for 2000 items).
 // This hash-based approach takes ~0.5ms for 5000 items (~70,000x speedup).
 func suppressItemsDiff(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	// Plan is null on destroy; state is null on first create.
-	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+	// Plan is null on destroy; state is null on first create. !IsKnown() means
+	// the resource itself is not yet known (e.g. ID computed from another resource).
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() ||
+		!req.State.Raw.IsKnown() || !req.Plan.Raw.IsKnown() {
 		return
 	}
 
 	var plan, state *ZeroTrustListModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
-	if resp.Diagnostics.HasError() || plan == nil || state == nil {
+	// Use local diagnostics so deserialization failures in this best-effort
+	// hook do not propagate as provider errors in the plan response.
+	var planDiags, stateDiags diag.Diagnostics
+	planDiags.Append(req.Plan.Get(ctx, &plan)...)
+	stateDiags.Append(req.State.Get(ctx, &state)...)
+	if planDiags.HasError() || stateDiags.HasError() || plan == nil || state == nil {
 		return
 	}
 
@@ -120,8 +132,8 @@ func suppressItemsDiff(ctx context.Context, req resource.ModifyPlanRequest, resp
 // efficient set comparison. Items are sorted before hashing to ensure
 // order-independence (set semantics).
 //
-// Encoding: each item is "<nil|v:value/d:desc>" using explicit type tags so
-// that nil items, empty strings, and null values are all distinguishable.
+// Each item is encoded with explicit type tags so that nil, null, unknown,
+// and empty-string values are all distinguishable from one another.
 func computeItemsHash(items []*ZeroTrustListItemsModel) [32]byte {
 	encoded := make([]string, len(items))
 	for i, item := range items {
@@ -129,18 +141,32 @@ func computeItemsHash(items []*ZeroTrustListItemsModel) [32]byte {
 			encoded[i] = "nil"
 			continue
 		}
-		// Encode value: prefix with "v:" to distinguish from nil sentinel.
-		v := "v:" + item.Value.ValueString()
 
-		// Encode description: distinguish null/unknown from an explicit empty string.
-		var d string
-		if item.Description.IsNull() || item.Description.IsUnknown() {
-			d = "null"
-		} else {
-			d = "s:" + item.Description.ValueString()
+		// Encode value with explicit null/unknown/string tags.
+		var v string
+		switch {
+		case item.Value.IsUnknown():
+			v = "v:unknown"
+		case item.Value.IsNull():
+			v = "v:null"
+		default:
+			raw := item.Value.ValueString()
+			v = fmt.Sprintf("v(%d):%s", len(raw), raw)
 		}
 
-		encoded[i] = fmt.Sprintf("%d:%s/%s", len(v), v, d)
+		// Encode description with explicit null/unknown/string tags.
+		var d string
+		switch {
+		case item.Description.IsUnknown():
+			d = "d:unknown"
+		case item.Description.IsNull():
+			d = "d:null"
+		default:
+			raw := item.Description.ValueString()
+			d = fmt.Sprintf("d(%d):%s", len(raw), raw)
+		}
+
+		encoded[i] = v + "/" + d
 	}
 	sort.Strings(encoded)
 

--- a/internal/services/zero_trust_list/items.go
+++ b/internal/services/zero_trust_list/items.go
@@ -12,14 +12,13 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"sort"
 
 	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -65,10 +64,10 @@ func fetchItems(ctx context.Context, client *cloudflare.Client, accountID, listI
 }
 
 // gatewayItemDescription maps a GatewayItem description to a Terraform string.
-// Returns StringNull() when the field is absent so state matches configs that
-// omit the description field entirely, avoiding perpetual plan diffs.
+// Returns StringNull() when the field is absent or null in the API response,
+// so state matches configs that omit the description field entirely.
 func gatewayItemDescription(item zero_trust.GatewayItem) types.String {
-	if item.JSON.Description.IsNull() {
+	if item.JSON.Description.IsNull() || item.JSON.Description.IsMissing() {
 		return types.StringNull()
 	}
 	return types.StringValue(item.Description)
@@ -97,25 +96,38 @@ func suppressItemsDiff(ctx context.Context, req resource.ModifyPlanRequest, resp
 
 	if plan.Items != nil && state.Items != nil {
 		if computeItemsHash(*plan.Items) == computeItemsHash(*state.Items) {
-			plan.Items = state.Items
-			resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+			// Use SetAttribute to surgically replace only the items attribute,
+			// avoiding clobbering unknown computed values in other plan fields.
+			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("items"), state.Items)...)
 		}
 	}
 }
 
 // computeItemsHash computes a deterministic SHA-256 hash of list items for
 // efficient set comparison. Items are sorted before hashing to ensure
-// order-independence (set semantics). Each item is encoded as
-// "<len(value)>:<value>/<len(desc)>:<desc>" using length-prefixed fields
-// to avoid separator-collision ambiguities.
+// order-independence (set semantics).
+//
+// Encoding: each item is "<nil|v:value/d:desc>" using explicit type tags so
+// that nil items, empty strings, and null values are all distinguishable.
 func computeItemsHash(items []*ZeroTrustListItemsModel) [32]byte {
 	encoded := make([]string, len(items))
 	for i, item := range items {
-		if item != nil {
-			v := item.Value.ValueString()
-			d := item.Description.ValueString()
-			encoded[i] = fmt.Sprintf("%d:%s/%d:%s", len(v), v, len(d), d)
+		if item == nil {
+			encoded[i] = "nil"
+			continue
 		}
+		// Encode value: prefix with "v:" to distinguish from nil sentinel.
+		v := "v:" + item.Value.ValueString()
+
+		// Encode description: distinguish null/unknown from an explicit empty string.
+		var d string
+		if item.Description.IsNull() || item.Description.IsUnknown() {
+			d = "null"
+		} else {
+			d = "s:" + item.Description.ValueString()
+		}
+
+		encoded[i] = fmt.Sprintf("%d:%s/%s", len(v), v, d)
 	}
 	sort.Strings(encoded)
 
@@ -127,10 +139,4 @@ func computeItemsHash(items []*ZeroTrustListItemsModel) [32]byte {
 	var result [32]byte
 	copy(result[:], h.Sum(nil))
 	return result
-}
-
-// readBody reads all bytes from an http.Response body.
-func readBody(res *http.Response) ([]byte, error) {
-	defer res.Body.Close()
-	return io.ReadAll(res.Body)
 }

--- a/internal/services/zero_trust_list/items.go
+++ b/internal/services/zero_trust_list/items.go
@@ -49,20 +49,12 @@ func fetchItems(ctx context.Context, client *cloudflare.Client, accountID, listI
 		return nil, err
 	}
 
-	// A null result field means the API returned no data — treat as gone.
-	if page.JSON.Result.IsNull() {
-		return nil, fmt.Errorf("items endpoint returned null result for list %s", listID)
-	}
-
-	// Result is [][]GatewayItem: the outer slice always has exactly one element
-	// (SinglePage is never paginated), and the inner slice is the list of items.
-	if len(page.Result) > 1 {
-		return nil, fmt.Errorf("unexpected pagination: items endpoint returned %d result pages, expected at most 1", len(page.Result))
-	}
-
 	// Allocate a non-nil slice so the caller can distinguish "0 items" from "404".
+	// A null or empty Result field both mean the list exists with zero items.
 	items := make([]*ZeroTrustListItemsModel, 0)
-	if len(page.Result) == 1 {
+	if !page.JSON.Result.IsNull() && len(page.Result) > 0 {
+		// Result is [][]GatewayItem where the outer slice is always length 1:
+		// SinglePage is not paginated; the inner slice holds all items.
 		for _, item := range page.Result[0] {
 			items = append(items, &ZeroTrustListItemsModel{
 				Value:       types.StringValue(item.Value),

--- a/internal/services/zero_trust_list/items.go
+++ b/internal/services/zero_trust_list/items.go
@@ -1,11 +1,11 @@
-package zero_trust_list
-
 // This file contains hand-written logic that extends the generated resource.go.
 // It is intentionally separate so generator regenerations leave it untouched.
 //
 // Hooks into resource.go:
 //   - Read()       calls fetchItems(ctx, client, accountID, listID) to populate data.Items
 //   - ModifyPlan() calls suppressItemsDiff(ctx, req, resp) for hash-based diff suppression
+
+package zero_trust_list
 
 import (
 	"context"
@@ -26,7 +26,12 @@ import (
 
 // fetchItems retrieves all items for a gateway list via the dedicated items
 // endpoint (GET /gateway/lists/{id}/items), which is separate from the list
-// metadata endpoint that Read() uses. Returns nil, nil if the list is gone.
+// metadata endpoint that Read() uses.
+//
+// Return values:
+//   - (items, nil)  — success; items is always non-nil (empty slice = list exists with 0 items)
+//   - (nil, nil)    — list was deleted (404); caller should remove resource from state
+//   - (nil, err)    — unexpected error
 func fetchItems(ctx context.Context, client *cloudflare.Client, accountID, listID string) ([]*ZeroTrustListItemsModel, error) {
 	page, err := client.ZeroTrust.Gateway.Lists.Items.List(
 		ctx,
@@ -46,7 +51,8 @@ func fetchItems(ctx context.Context, client *cloudflare.Client, accountID, listI
 
 	// Result is [][]GatewayItem: the outer slice always has exactly one element
 	// (SinglePage is never paginated), and the inner slice is the list of items.
-	var items []*ZeroTrustListItemsModel
+	// Allocate a non-nil slice so the caller can distinguish "0 items" from "404".
+	items := make([]*ZeroTrustListItemsModel, 0)
 	if len(page.Result) > 0 {
 		for _, item := range page.Result[0] {
 			items = append(items, &ZeroTrustListItemsModel{
@@ -72,9 +78,9 @@ func gatewayItemDescription(item zero_trust.GatewayItem) types.String {
 // config and state are semantically identical (same values and descriptions,
 // regardless of set ordering).
 //
-// Background: Terraform's SetNestedAttribute comparison is O(n²) with expensive
-// nested object hashing (~70s for 2000 items). This hash-based approach takes
-// ~0.5ms for 5000 items, providing ~70,000x speedup for no-change plans.
+// Background: Terraform's SetNestedAttribute comparison is O(n) but each
+// element requires expensive nested object hashing (~70s for 2000 items).
+// This hash-based approach takes ~0.5ms for 5000 items (~70,000x speedup).
 func suppressItemsDiff(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	// Plan is null on destroy; state is null on first create.
 	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
@@ -98,11 +104,10 @@ func suppressItemsDiff(ctx context.Context, req resource.ModifyPlanRequest, resp
 }
 
 // computeItemsHash computes a deterministic SHA-256 hash of list items for
-// efficient set comparison.
-//
-// Items are sorted before hashing to ensure order-independence (set semantics).
-// Each item is encoded as "<len(value)>:<value>/<len(desc)>:<desc>" using
-// length-prefixed fields to avoid separator-collision ambiguities.
+// efficient set comparison. Items are sorted before hashing to ensure
+// order-independence (set semantics). Each item is encoded as
+// "<len(value)>:<value>/<len(desc)>:<desc>" using length-prefixed fields
+// to avoid separator-collision ambiguities.
 func computeItemsHash(items []*ZeroTrustListItemsModel) [32]byte {
 	encoded := make([]string, len(items))
 	for i, item := range items {

--- a/internal/services/zero_trust_list/items.go
+++ b/internal/services/zero_trust_list/items.go
@@ -50,9 +50,12 @@ func fetchItems(ctx context.Context, client *cloudflare.Client, accountID, listI
 
 	// Result is [][]GatewayItem: the outer slice always has exactly one element
 	// (SinglePage is never paginated), and the inner slice is the list of items.
+	if len(page.Result) > 1 {
+		return nil, fmt.Errorf("unexpected pagination: items endpoint returned %d result pages, expected at most 1", len(page.Result))
+	}
 	// Allocate a non-nil slice so the caller can distinguish "0 items" from "404".
 	items := make([]*ZeroTrustListItemsModel, 0)
-	if len(page.Result) > 0 {
+	if len(page.Result) == 1 {
 		for _, item := range page.Result[0] {
 			items = append(items, &ZeroTrustListItemsModel{
 				Value:       types.StringValue(item.Value),
@@ -67,7 +70,9 @@ func fetchItems(ctx context.Context, client *cloudflare.Client, accountID, listI
 // Returns StringNull() when the field is absent or null in the API response,
 // so state matches configs that omit the description field entirely.
 func gatewayItemDescription(item zero_trust.GatewayItem) types.String {
-	if item.JSON.Description.IsNull() || item.JSON.Description.IsMissing() {
+	// IsNull() returns true for both null and missing fields (status <= null),
+	// so no separate IsMissing() check is needed.
+	if item.JSON.Description.IsNull() {
 		return types.StringNull()
 	}
 	return types.StringValue(item.Description)
@@ -95,6 +100,14 @@ func suppressItemsDiff(ctx context.Context, req resource.ModifyPlanRequest, resp
 	}
 
 	if plan.Items != nil && state.Items != nil {
+		// If any plan item has an unknown value we cannot reliably compare —
+		// bail out and let Terraform show the diff as-is.
+		for _, item := range *plan.Items {
+			if item != nil && (item.Value.IsUnknown() || item.Description.IsUnknown()) {
+				return
+			}
+		}
+
 		if computeItemsHash(*plan.Items) == computeItemsHash(*state.Items) {
 			// Use SetAttribute to surgically replace only the items attribute,
 			// avoiding clobbering unknown computed values in other plan fields.

--- a/internal/services/zero_trust_list/items.go
+++ b/internal/services/zero_trust_list/items.go
@@ -102,6 +102,11 @@ func suppressItemsDiff(ctx context.Context, req resource.ModifyPlanRequest, resp
 		return
 	}
 
+	// If items are not configured in either plan or state, there is nothing to suppress.
+	if plan.Items == nil && state.Items == nil {
+		return
+	}
+
 	// Treat nil pointer-to-slice as equivalent to pointer-to-empty-slice so that
 	// a config with `items = []` and a state with no items field are compared correctly.
 	emptySlice := []*ZeroTrustListItemsModel{}
@@ -144,10 +149,11 @@ func suppressItemsDiff(ctx context.Context, req resource.ModifyPlanRequest, resp
 // Each item is encoded with explicit type tags so that nil, null, unknown,
 // and empty-string values are all distinguishable from one another.
 func computeItemsHash(items []*ZeroTrustListItemsModel) [32]byte {
-	encoded := make([]string, len(items))
-	for i, item := range items {
+	// nil elements are skipped to match the nil-stripping in suppressItemsDiff,
+	// ensuring hash semantics are consistent with what gets written to the plan.
+	encoded := make([]string, 0, len(items))
+	for _, item := range items {
 		if item == nil {
-			encoded[i] = "nil"
 			continue
 		}
 
@@ -175,7 +181,7 @@ func computeItemsHash(items []*ZeroTrustListItemsModel) [32]byte {
 			d = fmt.Sprintf("d(%d):%s", len(raw), raw)
 		}
 
-		encoded[i] = v + "/" + d
+		encoded = append(encoded, v+"/"+d)
 	}
 	sort.Strings(encoded)
 

--- a/internal/services/zero_trust_list/items.go
+++ b/internal/services/zero_trust_list/items.go
@@ -68,9 +68,10 @@ func fetchItems(ctx context.Context, client *cloudflare.Client, accountID, listI
 // Returns StringNull() when the field is absent or null in the API response,
 // so state matches configs that omit the description field entirely.
 func gatewayItemDescription(item zero_trust.GatewayItem) types.String {
-	// IsNull() returns true for both null and missing fields (status <= null),
-	// so no separate IsMissing() check is needed.
-	if item.JSON.Description.IsNull() {
+	// IsNull() covers null and missing (status <= null).
+	// IsInvalid() covers fields present in JSON but that failed to decode —
+	// in that case item.Description is the zero value "", so treat it as null.
+	if item.JSON.Description.IsNull() || item.JSON.Description.IsInvalid() {
 		return types.StringNull()
 	}
 	return types.StringValue(item.Description)

--- a/internal/services/zero_trust_list/items.go
+++ b/internal/services/zero_trust_list/items.go
@@ -50,12 +50,11 @@ func fetchItems(ctx context.Context, client *cloudflare.Client, accountID, listI
 	}
 
 	// Allocate a non-nil slice so the caller can distinguish "0 items" from "404".
-	// A null or empty Result field both mean the list exists with zero items.
+	// Result is [][]GatewayItem (SinglePage wraps the response array in an outer slice).
+	// Iterate all outer elements defensively — in practice there is always 0 or 1.
 	items := make([]*ZeroTrustListItemsModel, 0)
-	if !page.JSON.Result.IsNull() && len(page.Result) > 0 {
-		// Result is [][]GatewayItem where the outer slice is always length 1:
-		// SinglePage is not paginated; the inner slice holds all items.
-		for _, item := range page.Result[0] {
+	for _, batch := range page.Result {
+		for _, item := range batch {
 			items = append(items, &ZeroTrustListItemsModel{
 				Value:       types.StringValue(item.Value),
 				Description: gatewayItemDescription(item),
@@ -103,20 +102,38 @@ func suppressItemsDiff(ctx context.Context, req resource.ModifyPlanRequest, resp
 		return
 	}
 
-	if plan.Items != nil && state.Items != nil {
-		// If any plan item has an unknown value we cannot reliably compare —
-		// bail out and let Terraform show the diff as-is.
-		for _, item := range *plan.Items {
-			if item != nil && (item.Value.IsUnknown() || item.Description.IsUnknown()) {
-				return
+	// Treat nil pointer-to-slice as equivalent to pointer-to-empty-slice so that
+	// a config with `items = []` and a state with no items field are compared correctly.
+	emptySlice := []*ZeroTrustListItemsModel{}
+	planItems := plan.Items
+	stateItems := state.Items
+	if planItems == nil {
+		planItems = &emptySlice
+	}
+	if stateItems == nil {
+		stateItems = &emptySlice
+	}
+
+	// If any plan item has an unknown value we cannot reliably compare —
+	// bail out and let Terraform show the diff as-is.
+	for _, item := range *planItems {
+		if item != nil && (item.Value.IsUnknown() || item.Description.IsUnknown()) {
+			return
+		}
+	}
+
+	if computeItemsHash(*planItems) == computeItemsHash(*stateItems) {
+		// Filter out any nil elements before writing to the plan — the framework's
+		// SetAttribute may not handle nil pointers inside a slice of struct pointers.
+		filtered := make([]*ZeroTrustListItemsModel, 0, len(*stateItems))
+		for _, item := range *stateItems {
+			if item != nil {
+				filtered = append(filtered, item)
 			}
 		}
-
-		if computeItemsHash(*plan.Items) == computeItemsHash(*state.Items) {
-			// Use SetAttribute to surgically replace only the items attribute,
-			// avoiding clobbering unknown computed values in other plan fields.
-			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("items"), state.Items)...)
-		}
+		// Use SetAttribute to surgically replace only the items attribute,
+		// avoiding clobbering unknown computed values in other plan fields.
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("items"), &filtered)...)
 	}
 }
 

--- a/internal/services/zero_trust_list/modify_plan_test.go
+++ b/internal/services/zero_trust_list/modify_plan_test.go
@@ -1,0 +1,243 @@
+package zero_trust_list
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// buildState constructs a tfsdk.State from a ZeroTrustListModel using the
+// resource schema. Items may be nil (resource has no items configured).
+func buildState(t *testing.T, items *[]*ZeroTrustListItemsModel) tfsdk.State {
+	t.Helper()
+	ctx := context.Background()
+	schema := ResourceSchema(ctx)
+	model := &ZeroTrustListModel{
+		ID:        types.StringValue("test-id"),
+		AccountID: types.StringValue("test-account"),
+		Type:      types.StringValue("SERIAL"),
+		Name:      types.StringValue("test-list"),
+		Items:     items,
+	}
+	state := tfsdk.State{Schema: schema}
+	diags := state.Set(ctx, model)
+	if diags.HasError() {
+		t.Fatalf("failed to set state: %v", diags)
+	}
+	return state
+}
+
+// buildPlan constructs a tfsdk.Plan from a ZeroTrustListModel using the
+// resource schema. Items may be nil (resource has no items configured).
+func buildPlan(t *testing.T, items *[]*ZeroTrustListItemsModel) tfsdk.Plan {
+	t.Helper()
+	s := buildState(t, items)
+	return tfsdk.Plan{Schema: s.Schema, Raw: s.Raw}
+}
+
+// buildNullState returns a null tfsdk.State (simulates first-apply / destroy).
+func buildNullState(t *testing.T) tfsdk.State {
+	t.Helper()
+	ctx := context.Background()
+	schema := ResourceSchema(ctx)
+	return tfsdk.State{
+		Schema: schema,
+		Raw:    tftypes.NewValue(schema.Type().TerraformType(ctx), nil),
+	}
+}
+
+// buildNullPlan returns a null tfsdk.Plan (simulates destroy).
+func buildNullPlan(t *testing.T) tfsdk.Plan {
+	t.Helper()
+	ctx := context.Background()
+	schema := ResourceSchema(ctx)
+	return tfsdk.Plan{
+		Schema: schema,
+		Raw:    tftypes.NewValue(schema.Type().TerraformType(ctx), nil),
+	}
+}
+
+// TestModifyPlan_NullPlanReturnsEarly verifies that ModifyPlan is a no-op on destroy
+// (null plan), consistent with the req.Plan.Raw.IsNull() guard.
+func TestModifyPlan_NullPlanReturnsEarly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	r := &ZeroTrustListResource{}
+	req := resource.ModifyPlanRequest{
+		State: buildState(t, &[]*ZeroTrustListItemsModel{
+			{Value: types.StringValue("10.0.0.1")},
+		}),
+		Plan: buildNullPlan(t),
+	}
+	resp := &resource.ModifyPlanResponse{Plan: req.Plan}
+
+	r.ModifyPlan(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("expected no error on null plan, got: %v", resp.Diagnostics)
+	}
+}
+
+// TestModifyPlan_NullStateReturnsEarly verifies that ModifyPlan is a no-op on first
+// create (null state), consistent with the req.State.Raw.IsNull() guard.
+func TestModifyPlan_NullStateReturnsEarly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	r := &ZeroTrustListResource{}
+	req := resource.ModifyPlanRequest{
+		State: buildNullState(t),
+		Plan:  buildPlan(t, &[]*ZeroTrustListItemsModel{{Value: types.StringValue("10.0.0.1")}}),
+	}
+	resp := &resource.ModifyPlanResponse{Plan: req.Plan}
+
+	r.ModifyPlan(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("expected no error on null state, got: %v", resp.Diagnostics)
+	}
+}
+
+// TestModifyPlan_SameItemsSuppressesDiff verifies that identical plan and state items
+// result in the plan being normalized to state (no-op diff suppression).
+func TestModifyPlan_SameItemsSuppressesDiff(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	items := &[]*ZeroTrustListItemsModel{
+		{Value: types.StringValue("10.0.0.1")},
+		{Value: types.StringValue("10.0.0.2")},
+	}
+
+	stateObj := buildState(t, items)
+	req := resource.ModifyPlanRequest{
+		State: stateObj,
+		Plan:  buildPlan(t, items),
+	}
+	resp := &resource.ModifyPlanResponse{Plan: req.Plan}
+
+	r := &ZeroTrustListResource{}
+	r.ModifyPlan(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+	// Plan raw should equal state raw — items normalized to state after suppression.
+	if !resp.Plan.Raw.Equal(stateObj.Raw) {
+		t.Error("expected plan to be normalized to state after diff suppression")
+	}
+}
+
+// TestModifyPlan_DifferentItemsDoesNotSuppressDiff verifies that when plan and state
+// items differ, ModifyPlan does NOT overwrite the plan — the diff is preserved.
+func TestModifyPlan_DifferentItemsDoesNotSuppressDiff(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	stateObj := buildState(t, &[]*ZeroTrustListItemsModel{
+		{Value: types.StringValue("10.0.0.1")},
+	})
+	planObj := buildPlan(t, &[]*ZeroTrustListItemsModel{
+		{Value: types.StringValue("10.0.0.2")}, // different
+	})
+	originalPlanRaw := planObj.Raw
+
+	req := resource.ModifyPlanRequest{
+		State: stateObj,
+		Plan:  planObj,
+	}
+	resp := &resource.ModifyPlanResponse{Plan: req.Plan}
+
+	r := &ZeroTrustListResource{}
+	r.ModifyPlan(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+	// Plan raw must be unchanged — ModifyPlan must not suppress a real diff.
+	if !resp.Plan.Raw.Equal(originalPlanRaw) {
+		t.Error("ModifyPlan must not suppress a diff when items actually changed")
+	}
+}
+
+// TestModifyPlan_NilPlanItemsSkipsComparison verifies that when plan has no items
+// (nil), ModifyPlan does not attempt a hash comparison or panic.
+func TestModifyPlan_NilPlanItemsSkipsComparison(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	req := resource.ModifyPlanRequest{
+		State: buildState(t, &[]*ZeroTrustListItemsModel{{Value: types.StringValue("10.0.0.1")}}),
+		Plan:  buildPlan(t, nil), // removing all items
+	}
+	resp := &resource.ModifyPlanResponse{Plan: req.Plan}
+
+	r := &ZeroTrustListResource{}
+	r.ModifyPlan(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("unexpected error when plan items are nil: %v", resp.Diagnostics)
+	}
+}
+
+// TestModifyPlan_NilStateItemsSkipsComparison verifies that when state has no items
+// (nil), ModifyPlan does not attempt a hash comparison or panic.
+func TestModifyPlan_NilStateItemsSkipsComparison(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	req := resource.ModifyPlanRequest{
+		State: buildState(t, nil), // first time adding items
+		Plan:  buildPlan(t, &[]*ZeroTrustListItemsModel{{Value: types.StringValue("10.0.0.1")}}),
+	}
+	resp := &resource.ModifyPlanResponse{Plan: req.Plan}
+
+	r := &ZeroTrustListResource{}
+	r.ModifyPlan(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("unexpected error when state items are nil: %v", resp.Diagnostics)
+	}
+}
+
+// TestModifyPlan_ReorderedItemsSuppressesDiff verifies that items in a different
+// order in the plan are treated as equivalent (set semantics) and the plan is
+// normalized to the state order.
+func TestModifyPlan_ReorderedItemsSuppressesDiff(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	stateItems := &[]*ZeroTrustListItemsModel{
+		{Value: types.StringValue("10.0.0.1")},
+		{Value: types.StringValue("10.0.0.2")},
+		{Value: types.StringValue("10.0.0.3")},
+	}
+	planItems := &[]*ZeroTrustListItemsModel{
+		{Value: types.StringValue("10.0.0.3")},
+		{Value: types.StringValue("10.0.0.1")},
+		{Value: types.StringValue("10.0.0.2")},
+	}
+
+	stateObj := buildState(t, stateItems)
+	req := resource.ModifyPlanRequest{
+		State: stateObj,
+		Plan:  buildPlan(t, planItems),
+	}
+	resp := &resource.ModifyPlanResponse{Plan: req.Plan}
+
+	r := &ZeroTrustListResource{}
+	r.ModifyPlan(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+	// Plan raw should equal state raw — reorder diff suppressed, normalized to state.
+	if !resp.Plan.Raw.Equal(stateObj.Raw) {
+		t.Error("expected plan to be normalized to state after reorder suppression")
+	}
+}

--- a/internal/services/zero_trust_list/resource.go
+++ b/internal/services/zero_trust_list/resource.go
@@ -4,9 +4,9 @@ package zero_trust_list
 
 import (
 	"context"
-	"crypto/sha256"
-	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
@@ -15,32 +15,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"io"
-	"net/http"
-	"sort"
 )
-
-// readBody reads all bytes from an http.Response body.
-func readBody(res *http.Response) ([]byte, error) {
-	defer res.Body.Close()
-	return io.ReadAll(res.Body)
-}
-
-// is404 reports whether err is an API 404 response.
-func is404(err error) bool {
-	var apiErr *cloudflare.Error
-	return errors.As(err, &apiErr) && apiErr.StatusCode == 404
-}
-
-// itemDescription returns the description as a Terraform string value.
-// types.StringNull() is used when the field is absent in the API response
-// so state matches configs that omit the field entirely.
-func itemDescription(item zero_trust.GatewayItem) types.String {
-	if item.JSON.Description.IsNull() {
-		return types.StringNull()
-	}
-	return types.StringValue(item.Description)
-}
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.ResourceWithConfigure = (*ZeroTrustListResource)(nil)
@@ -217,34 +192,16 @@ func (r *ZeroTrustListResource) Read(ctx context.Context, req resource.ReadReque
 	}
 	data = &env.Result
 
-	// GET /gateway/lists/{id} does not return items; fetch them separately.
-	itemsPage, err := r.client.ZeroTrust.Gateway.Lists.Items.List(
-		ctx,
-		data.ID.ValueString(),
-		zero_trust.GatewayListItemListParams{
-			AccountID: cloudflare.F(data.AccountID.ValueString()),
-		},
-		option.WithMiddleware(logging.Middleware(ctx)),
-	)
+	// Fetch items separately — see items.go.
+	items, err := fetchItems(ctx, r.client, data.AccountID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		if is404(err) {
-			resp.Diagnostics.AddWarning("Resource not found", "The resource was not found when fetching items and will be removed from state.")
-			resp.State.RemoveResource(ctx)
-			return
-		}
 		resp.Diagnostics.AddError("failed to fetch list items", err.Error())
 		return
 	}
-	// Result is [][]GatewayItem: the outer slice always has exactly one element
-	// (SinglePage is never paginated), and the inner slice is the list of items.
-	var items []*ZeroTrustListItemsModel
-	if len(itemsPage.Result) > 0 {
-		for _, item := range itemsPage.Result[0] {
-			items = append(items, &ZeroTrustListItemsModel{
-				Value:       types.StringValue(item.Value),
-				Description: itemDescription(item),
-			})
-		}
+	if items == nil {
+		resp.Diagnostics.AddWarning("Resource not found", "The resource was not found when fetching items and will be removed from state.")
+		resp.State.RemoveResource(ctx)
+		return
 	}
 	data.Items = &items
 
@@ -323,57 +280,8 @@ func (r *ZeroTrustListResource) ImportState(ctx context.Context, req resource.Im
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+// ModifyPlan suppresses spurious diffs when list items are semantically
+// unchanged — see items.go for the full implementation.
 func (r *ZeroTrustListResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	// Plan is null on destroy; state is null on first create. In both cases
-	// there is nothing to compare, so return early.
-	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
-		return
-	}
-
-	var plan, state *ZeroTrustListModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-
-	if resp.Diagnostics.HasError() || plan == nil || state == nil {
-		return
-	}
-
-	if plan.Items != nil && state.Items != nil {
-		if computeItemsHash(*plan.Items) == computeItemsHash(*state.Items) {
-			plan.Items = state.Items
-			resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
-		}
-	}
-}
-
-// computeItemsHash computes a deterministic hash of list items for efficient set
-// comparison. Terraform's SetNestedAttribute comparison is O(n) with expensive
-// nested object hashing (~70s for 2000 items). This hash-based approach takes
-// ~0.5ms for 5000 items, providing ~70,000x speedup for no-change plans.
-//
-// Items are sorted before hashing to ensure consistent results regardless of set
-// ordering. Both value and description are included in the hash.
-//
-// Encoding: each item is serialised as "<len(value)>:<value>/<len(desc)>:<desc>"
-// using length-prefixed fields. This avoids separator-collision ambiguities that
-// would arise if value or description contained the separator character.
-func computeItemsHash(items []*ZeroTrustListItemsModel) [32]byte {
-	values := make([]string, len(items))
-	for i, item := range items {
-		if item != nil {
-			v := item.Value.ValueString()
-			d := item.Description.ValueString()
-			values[i] = fmt.Sprintf("%d:%s/%d:%s", len(v), v, len(d), d)
-		}
-	}
-	sort.Strings(values)
-
-	h := sha256.New()
-	for _, v := range values {
-		h.Write([]byte(v))
-		h.Write([]byte{0})
-	}
-	var result [32]byte
-	copy(result[:], h.Sum(nil))
-	return result
+	suppressItemsDiff(ctx, req, resp)
 }

--- a/internal/services/zero_trust_list/resource.go
+++ b/internal/services/zero_trust_list/resource.go
@@ -4,9 +4,11 @@ package zero_trust_list
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 
 	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/option"
@@ -153,6 +155,8 @@ func (r *ZeroTrustListResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
+	existingItems := data.Items
+
 	res := new(http.Response)
 	env := ZeroTrustListResultEnvelope{*data}
 	_, err := r.client.ZeroTrust.Gateway.Lists.Get(
@@ -180,6 +184,10 @@ func (r *ZeroTrustListResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 	data = &env.Result
+
+	if existingItems != nil {
+		data.Items = existingItems
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -254,6 +262,54 @@ func (r *ZeroTrustListResource) ImportState(ctx context.Context, req resource.Im
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *ZeroTrustListResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, _ *resource.ModifyPlanResponse) {
+func (r *ZeroTrustListResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
 
+	var plan, state *ZeroTrustListModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() || plan == nil || state == nil {
+		return
+	}
+
+	if plan.Items != nil && state.Items != nil {
+		if computeItemsHash(*plan.Items) == computeItemsHash(*state.Items) {
+			plan.Items = state.Items
+			resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+		}
+	}
+}
+
+// computeItemsHash computes a deterministic hash of list items for efficient set
+// comparison. Terraform's SetNestedAttribute comparison is O(n) with expensive
+// nested object hashing (~70s for 2000 items). This hash-based approach takes
+// ~0.5ms for 5000 items, providing ~70,000x speedup for no-change plans.
+//
+// Items are sorted by value before hashing to ensure consistent results regardless
+// of set ordering. Both value and description are included in the hash.
+func computeItemsHash(items []*ZeroTrustListItemsModel) [32]byte {
+	values := make([]string, len(items))
+	for i, item := range items {
+		val := ""
+		if item != nil {
+			val = item.Value.ValueString()
+			if desc := item.Description.ValueString(); desc != "" {
+				val += "\x00" + desc
+			}
+		}
+		values[i] = val
+	}
+	sort.Strings(values)
+
+	h := sha256.New()
+	for _, v := range values {
+		h.Write([]byte(v))
+		h.Write([]byte{0})
+	}
+	var result [32]byte
+	copy(result[:], h.Sum(nil))
+	return result
 }

--- a/internal/services/zero_trust_list/resource.go
+++ b/internal/services/zero_trust_list/resource.go
@@ -5,6 +5,7 @@ package zero_trust_list
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -86,7 +87,11 @@ func (r *ZeroTrustListResource) Create(ctx context.Context, req resource.CreateR
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
-	bytes, _ := io.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read http response body", err.Error())
+		return
+	}
 	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
@@ -135,7 +140,11 @@ func (r *ZeroTrustListResource) Update(ctx context.Context, req resource.UpdateR
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
-	bytes, _ := io.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read http response body", err.Error())
+		return
+	}
 	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
@@ -154,8 +163,6 @@ func (r *ZeroTrustListResource) Read(ctx context.Context, req resource.ReadReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	existingItems := data.Items
 
 	res := new(http.Response)
 	env := ZeroTrustListResultEnvelope{*data}
@@ -177,7 +184,11 @@ func (r *ZeroTrustListResource) Read(ctx context.Context, req resource.ReadReque
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
-	bytes, _ := io.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read http response body", err.Error())
+		return
+	}
 	err = apijson.Unmarshal(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
@@ -185,9 +196,43 @@ func (r *ZeroTrustListResource) Read(ctx context.Context, req resource.ReadReque
 	}
 	data = &env.Result
 
-	if existingItems != nil {
-		data.Items = existingItems
+	// GET /gateway/lists/{id} does not return items; fetch them separately.
+	itemsPage, err := r.client.ZeroTrust.Gateway.Lists.Items.List(
+		ctx,
+		data.ID.ValueString(),
+		zero_trust.GatewayListItemListParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+		},
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		var apiErr *cloudflare.Error
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+			resp.Diagnostics.AddWarning("Resource not found", "The resource was not found when fetching items and will be removed from state.")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("failed to fetch list items", err.Error())
+		return
 	}
+	// Result is [][]GatewayItem: the outer slice always has exactly one element
+	// (SinglePage is never paginated), and the inner slice is the list of items.
+	var items []*ZeroTrustListItemsModel
+	if len(itemsPage.Result) > 0 {
+		for _, item := range itemsPage.Result[0] {
+			// Use StringNull() when description is absent/null in the API
+			// response so state matches configs that omit the field.
+			desc := types.StringNull()
+			if !item.JSON.Description.IsNull() {
+				desc = types.StringValue(item.Description)
+			}
+			items = append(items, &ZeroTrustListItemsModel{
+				Value:       types.StringValue(item.Value),
+				Description: desc,
+			})
+		}
+	}
+	data.Items = &items
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -213,8 +258,6 @@ func (r *ZeroTrustListResource) Delete(ctx context.Context, req resource.DeleteR
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *ZeroTrustListResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -251,7 +294,11 @@ func (r *ZeroTrustListResource) ImportState(ctx context.Context, req resource.Im
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
-	bytes, _ := io.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read http response body", err.Error())
+		return
+	}
 	err = apijson.Unmarshal(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
@@ -263,7 +310,9 @@ func (r *ZeroTrustListResource) ImportState(ctx context.Context, req resource.Im
 }
 
 func (r *ZeroTrustListResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	// Plan is null on destroy; state is null on first create. In both cases
+	// there is nothing to compare, so return early.
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
 		return
 	}
 
@@ -288,19 +337,20 @@ func (r *ZeroTrustListResource) ModifyPlan(ctx context.Context, req resource.Mod
 // nested object hashing (~70s for 2000 items). This hash-based approach takes
 // ~0.5ms for 5000 items, providing ~70,000x speedup for no-change plans.
 //
-// Items are sorted by value before hashing to ensure consistent results regardless
-// of set ordering. Both value and description are included in the hash.
+// Items are sorted before hashing to ensure consistent results regardless of set
+// ordering. Both value and description are included in the hash.
+//
+// Encoding: each item is serialised as "<len(value)>:<value>/<len(desc)>:<desc>"
+// using length-prefixed fields. This avoids separator-collision ambiguities that
+// would arise if value or description contained the separator character.
 func computeItemsHash(items []*ZeroTrustListItemsModel) [32]byte {
 	values := make([]string, len(items))
 	for i, item := range items {
-		val := ""
 		if item != nil {
-			val = item.Value.ValueString()
-			if desc := item.Description.ValueString(); desc != "" {
-				val += "\x00" + desc
-			}
+			v := item.Value.ValueString()
+			d := item.Description.ValueString()
+			values[i] = fmt.Sprintf("%d:%s/%d:%s", len(v), v, len(d), d)
 		}
-		values[i] = val
 	}
 	sort.Strings(values)
 

--- a/internal/services/zero_trust_list/resource.go
+++ b/internal/services/zero_trust_list/resource.go
@@ -5,6 +5,7 @@ package zero_trust_list
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/cloudflare/cloudflare-go/v6"
@@ -16,6 +17,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// readBody reads all bytes from an http.Response body.
+func readBody(res *http.Response) ([]byte, error) {
+	defer res.Body.Close()
+	return io.ReadAll(res.Body)
+}
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.ResourceWithConfigure = (*ZeroTrustListResource)(nil)

--- a/internal/services/zero_trust_list/resource.go
+++ b/internal/services/zero_trust_list/resource.go
@@ -7,10 +7,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
-	"sort"
-
 	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
@@ -19,7 +15,32 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"io"
+	"net/http"
+	"sort"
 )
+
+// readBody reads all bytes from an http.Response body.
+func readBody(res *http.Response) ([]byte, error) {
+	defer res.Body.Close()
+	return io.ReadAll(res.Body)
+}
+
+// is404 reports whether err is an API 404 response.
+func is404(err error) bool {
+	var apiErr *cloudflare.Error
+	return errors.As(err, &apiErr) && apiErr.StatusCode == 404
+}
+
+// itemDescription returns the description as a Terraform string value.
+// types.StringNull() is used when the field is absent in the API response
+// so state matches configs that omit the field entirely.
+func itemDescription(item zero_trust.GatewayItem) types.String {
+	if item.JSON.Description.IsNull() {
+		return types.StringNull()
+	}
+	return types.StringValue(item.Description)
+}
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.ResourceWithConfigure = (*ZeroTrustListResource)(nil)
@@ -87,7 +108,7 @@ func (r *ZeroTrustListResource) Create(ctx context.Context, req resource.CreateR
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
-	bytes, err := io.ReadAll(res.Body)
+	bytes, err := readBody(res)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to read http response body", err.Error())
 		return
@@ -140,7 +161,7 @@ func (r *ZeroTrustListResource) Update(ctx context.Context, req resource.UpdateR
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
-	bytes, err := io.ReadAll(res.Body)
+	bytes, err := readBody(res)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to read http response body", err.Error())
 		return
@@ -184,7 +205,7 @@ func (r *ZeroTrustListResource) Read(ctx context.Context, req resource.ReadReque
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
-	bytes, err := io.ReadAll(res.Body)
+	bytes, err := readBody(res)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to read http response body", err.Error())
 		return
@@ -206,8 +227,7 @@ func (r *ZeroTrustListResource) Read(ctx context.Context, req resource.ReadReque
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)
 	if err != nil {
-		var apiErr *cloudflare.Error
-		if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+		if is404(err) {
 			resp.Diagnostics.AddWarning("Resource not found", "The resource was not found when fetching items and will be removed from state.")
 			resp.State.RemoveResource(ctx)
 			return
@@ -220,15 +240,9 @@ func (r *ZeroTrustListResource) Read(ctx context.Context, req resource.ReadReque
 	var items []*ZeroTrustListItemsModel
 	if len(itemsPage.Result) > 0 {
 		for _, item := range itemsPage.Result[0] {
-			// Use StringNull() when description is absent/null in the API
-			// response so state matches configs that omit the field.
-			desc := types.StringNull()
-			if !item.JSON.Description.IsNull() {
-				desc = types.StringValue(item.Description)
-			}
 			items = append(items, &ZeroTrustListItemsModel{
 				Value:       types.StringValue(item.Value),
-				Description: desc,
+				Description: itemDescription(item),
 			})
 		}
 	}
@@ -294,7 +308,7 @@ func (r *ZeroTrustListResource) ImportState(ctx context.Context, req resource.Im
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
-	bytes, err := io.ReadAll(res.Body)
+	bytes, err := readBody(res)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to read http response body", err.Error())
 		return

--- a/internal/services/zero_trust_list/resource_test.go
+++ b/internal/services/zero_trust_list/resource_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -38,11 +38,11 @@ func testSweepCloudflareZeroTrustList(r string) error {
 	ctx := context.Background()
 	client := acctest.SharedClient()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	
+
 	if accountID == "" {
 		return nil
 	}
-	
+
 	// List all zero trust lists
 	page, err := client.ZeroTrust.Gateway.Lists.List(ctx, zero_trust.GatewayListListParams{
 		AccountID: cfv6.F(accountID),
@@ -158,6 +158,45 @@ func TestAccCloudflareTeamsList_LottaListItems(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
 				ImportStateVerifyIgnore: []string{"list_count"},
+			},
+		},
+	})
+}
+
+// TestAccCloudflareTeamsList_LargeListNoChangePlan verifies that planning a large
+// list with no changes completes quickly (regression test for performance optimization).
+func TestAccCloudflareTeamsList_LargeListNoChangePlan(t *testing.T) {
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_list.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareTeamsListDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create list with 2000 items
+				Config: testAccCloudflareTeamsListConfig2000Items(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("items"), knownvalue.SetSizeExact(2000)),
+				},
+			},
+			{
+				// Re-apply same config - should produce no changes and complete quickly
+				Config: testAccCloudflareTeamsListConfig2000Items(rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -638,6 +677,14 @@ func testAccCloudflareTeamsListConfigBigItemCount(rnd, accountID string) string 
 		items = append(items, `{value = "example-`+strconv.Itoa(i)+`"}`)
 	}
 
+	return acctest.LoadTestCase("teamslistconfigbigitemcount.tf", rnd, accountID, strings.Join(items, ","))
+}
+
+func testAccCloudflareTeamsListConfig2000Items(rnd, accountID string) string {
+	items := make([]string, 2000)
+	for i := 0; i < 2000; i++ {
+		items[i] = fmt.Sprintf(`{value = "serial-%d"}`, i)
+	}
 	return acctest.LoadTestCase("teamslistconfigbigitemcount.tf", rnd, accountID, strings.Join(items, ","))
 }
 

--- a/internal/services/zero_trust_list/resource_test.go
+++ b/internal/services/zero_trust_list/resource_test.go
@@ -100,7 +100,7 @@ func TestAccCloudflareTeamsList_Basic(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("SERIAL")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("My description")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("items"), knownvalue.ListExact([]knownvalue.Check{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("items"), knownvalue.SetExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"description": knownvalue.Null(),
 							"value":       knownvalue.StringExact("asdf-1234"),
@@ -149,7 +149,7 @@ func TestAccCloudflareTeamsList_LottaListItems(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("SERIAL")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("My description")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("items"), knownvalue.ListSizeExact(1000)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("items"), knownvalue.SetSizeExact(1000)),
 				},
 			},
 			{
@@ -165,7 +165,19 @@ func TestAccCloudflareTeamsList_LottaListItems(t *testing.T) {
 
 // TestAccCloudflareTeamsList_LargeListNoChangePlan verifies that planning a large
 // list with no changes completes quickly (regression test for performance optimization).
+//
+// NOTE: This test exercises the hash-based ModifyPlan optimization. If the optimization
+// were accidentally removed, this test would still pass — just much more slowly (~70s
+// for 2000 items vs ~0.5ms). The performance guarantee is not enforced by an assertion.
+//
+// NOTE: Items are fetched separately via GET /gateway/lists/{id}/items on each Read,
+// so external drift (changes outside Terraform) will be detected on the next plan/refresh.
+// The hash-based ModifyPlan optimization only suppresses diffs when config and refreshed
+// state items are semantically identical (same values and descriptions, regardless of order).
 func TestAccCloudflareTeamsList_LargeListNoChangePlan(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
 	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
 		t.Setenv("CLOUDFLARE_API_TOKEN", "")
 	}
@@ -224,7 +236,7 @@ func TestAccCloudflareTeamsList_Reordered(t *testing.T) {
 			{
 				Config: testAccCloudflareTeamsListConfigBasic(rnd, accountID),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("items"), knownvalue.ListExact([]knownvalue.Check{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("items"), knownvalue.SetExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"description": knownvalue.Null(),
 							"value":       knownvalue.StringExact("asdf-1234"),
@@ -244,7 +256,7 @@ func TestAccCloudflareTeamsList_Reordered(t *testing.T) {
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("items"), knownvalue.ListExact([]knownvalue.Check{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("items"), knownvalue.SetExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"description": knownvalue.Null(),
 							"value":       knownvalue.StringExact("asdf-1234"),
@@ -288,30 +300,51 @@ func TestAccCloudflareTeamsList_Update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudflareTeamsListConfigReorderedItems(rnd, accountID),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
-					resource.TestCheckResourceAttr(resourceName, "name", rnd),
-					resource.TestCheckResourceAttr(resourceName, "description", "My description"),
-					resource.TestCheckResourceAttr(resourceName, "type", "SERIAL"),
-					resource.TestCheckResourceAttr(resourceName, "items.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "items.0.value", "asdf-1234"),
-					resource.TestCheckResourceAttr(resourceName, "items.1.value", "asdf-5678"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("My description")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("SERIAL")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("items"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"value":       knownvalue.StringExact("asdf-1234"),
+							"description": knownvalue.Null(),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"value":       knownvalue.StringExact("asdf-5678"),
+							"description": knownvalue.Null(),
+						}),
+					})),
+				},
 			},
 			{
 				Config: testAccCloudflareTeamsListConfigReorderedItemsUpdate(rnd, accountID),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
-					resource.TestCheckResourceAttr(resourceName, "name", rnd),
-					resource.TestCheckResourceAttr(resourceName, "description", "My description update"),
-					resource.TestCheckResourceAttr(resourceName, "type", "SERIAL"),
-					resource.TestCheckResourceAttr(resourceName, "items.#", "3"),
-					resource.TestCheckResourceAttr(resourceName, "items.0.value", "asdf-1234"),
-					resource.TestCheckResourceAttr(resourceName, "items.1.value", "bsdf-5678"),
-					resource.TestCheckResourceAttr(resourceName, "items.2.value", "csdf-5678"),
-				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("My description update")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("SERIAL")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("items"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"value":       knownvalue.StringExact("asdf-1234"),
+							"description": knownvalue.Null(),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"value":       knownvalue.StringExact("bsdf-5678"),
+							"description": knownvalue.Null(),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"value":       knownvalue.StringExact("csdf-5678"),
+							"description": knownvalue.Null(),
+						}),
+					})),
+				},
 			},
-
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
@@ -685,7 +718,7 @@ func testAccCloudflareTeamsListConfig2000Items(rnd, accountID string) string {
 	for i := 0; i < 2000; i++ {
 		items[i] = fmt.Sprintf(`{value = "serial-%d"}`, i)
 	}
-	return acctest.LoadTestCase("teamslistconfigbigitemcount.tf", rnd, accountID, strings.Join(items, ","))
+	return acctest.LoadTestCase("teamslistconfig2000items.tf", rnd, accountID, strings.Join(items, ","))
 }
 
 func testAccCloudflareTeamsListConfigReorderedItems(rnd, accountID string) string {

--- a/internal/services/zero_trust_list/testdata/teamslistconfig2000items.tf
+++ b/internal/services/zero_trust_list/testdata/teamslistconfig2000items.tf
@@ -1,0 +1,8 @@
+
+resource "cloudflare_zero_trust_list" "%[1]s" {
+	account_id  = "%[2]s"
+	name        = "%[1]s"
+	description = "Large list for no-change plan performance test"
+	type        = "SERIAL"
+	items       = [%[3]s]
+}


### PR DESCRIPTION
ZT Lists with 2000+ items were taking 70+ seconds to plan due to Terraform's expensive set comparison for nested objects. This optimization:

We have to use set for lists to make sure we don;t have duplicates. But set comparison is painfully slower than list comparison in terraform. The comparison is happening in the set internals library, same place as the performance bottleneck is observed. We do not want to make them list and introduce bugs. Instead we are suggesting a new modifyPlan with hash based comparison of the items.

1. In Read(): Preserve state items instead of replacing with API items
2. In ModifyPlan(): Compare items using fast SHA256 hash (~0.5ms for 5000 items) instead of Terraform's set diff (~70s for 2000 items)

Performance improvement: ~70,000x faster for no-change plans on large lists.

Trade-off: External drift detection on individual items is reduced, but Terraform config remains the source of truth.

Tests added. I can add an acceptance test ASAP
