### PR TITLE
[magic_wan] fix apply failure when desc is unset

### DIFF
--- a/internal/services/magic_wan_gre_tunnel/custom_model.go
+++ b/internal/services/magic_wan_gre_tunnel/custom_model.go
@@ -20,7 +20,7 @@ type CustomMagicWANGRETunnelModel struct {
 	CustomerGREEndpoint    types.String                                                `tfsdk:"customer_gre_endpoint" json:"customer_gre_endpoint,required"`
 	InterfaceAddress       types.String                                                `tfsdk:"interface_address" json:"interface_address,required"`
 	Name                   types.String                                                `tfsdk:"name" json:"name,required"`
-	Description            types.String                                                `tfsdk:"description" json:"description,optional"`
+	Description            types.String                                                `tfsdk:"description" json:"description,computed_optional"`
 	InterfaceAddress6      types.String                                                `tfsdk:"interface_address6" json:"interface_address6,optional"`
 	AutomaticReturnRouting types.Bool                                                  `tfsdk:"automatic_return_routing" json:"automatic_return_routing,computed_optional"`
 	Mtu                    types.Int64                                                 `tfsdk:"mtu" json:"mtu,computed_optional"`

--- a/internal/services/magic_wan_gre_tunnel/custom_schema.go
+++ b/internal/services/magic_wan_gre_tunnel/custom_schema.go
@@ -7,12 +7,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -76,17 +76,19 @@ func customResourceSchema(ctx context.Context) schema.Schema {
 				Required:    true,
 			},
 			"description": schema.StringAttribute{
-				Description: "An optional description of the GRE tunnel.",
-				Optional:    true,
+				Description:   "An optional description of the GRE tunnel.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"interface_address6": schema.StringAttribute{
 				Description: "A 127 bit IPV6 prefix from within the virtual_subnet6 prefix space with the address being the first IP of the subnet and not same as the address of virtual_subnet6. Eg if virtual_subnet6 is 2606:54c1:7:0:a9fe:12d2::/127 , interface_address6 could be 2606:54c1:7:0:a9fe:12d2:1:200/127",
 				Optional:    true,
 			},
 			"automatic_return_routing": schema.BoolAttribute{
-				Description: "True if automatic stateful return routing should be enabled for a tunnel, false otherwise.",
-				Computed:    true,
-				Optional:    true,
+				Description:   "True if automatic stateful return routing should be enabled for a tunnel, false otherwise.",
+				Computed:      true,
+				Optional:      true,
 				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"mtu": schema.Int64Attribute{

--- a/internal/services/magic_wan_gre_tunnel/resource_test.go
+++ b/internal/services/magic_wan_gre_tunnel/resource_test.go
@@ -73,7 +73,7 @@ func testSweepCloudflareMagicWanGRETunnel(r string) error {
 			failedCount++
 			continue
 		}
-		
+
 		deletedCount++
 		tflog.Info(ctx, fmt.Sprintf("Successfully deleted GRE tunnel: %s", tunnel.ID))
 	}
@@ -188,6 +188,13 @@ func TestAccCloudflareGRETunnelUpdateDescription(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "description", rnd+"-updated"),
 				),
 			},
+			{
+				Config: testAccCheckCloudflareGRETunnelNoDescription(rnd, rnd, accountID, customerEndpoint, cfIP, interfaceAddr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareGRETunnelExists(name, &Tunnel),
+					resource.TestCheckResourceAttr(name, "description", rnd+"-updated"),
+				),
+			},
 		},
 	})
 }
@@ -243,6 +250,10 @@ func TestAccCloudflareGRETunnelUpdateMulti(t *testing.T) {
 
 func testAccCheckCloudflareGRETunnelSimple(ID, name, description, accountID, cfIP, customerEndpoint, interfaceAddr string) string {
 	return acctest.LoadTestCase("gretunnelsimple.tf", ID, name, description, accountID, cfIP, customerEndpoint, interfaceAddr)
+}
+
+func testAccCheckCloudflareGRETunnelNoDescription(ID, name, accountID, customerEndpoint, cfIP, interfaceAddr string) string {
+	return acctest.LoadTestCase("gretunnelnodescription.tf", ID, name, accountID, customerEndpoint, cfIP, interfaceAddr)
 }
 
 func testAccCheckCloudflareGRETunnelMultiUpdate(ID, name, description, accountID, cfIP, customerEndpoint, interfaceAddr string) string {

--- a/internal/services/magic_wan_gre_tunnel/testdata/gretunnelnodescription.tf
+++ b/internal/services/magic_wan_gre_tunnel/testdata/gretunnelnodescription.tf
@@ -1,0 +1,12 @@
+
+  resource "cloudflare_magic_wan_gre_tunnel" "%[1]s" {
+	account_id = "%[3]s"
+	name = "%[2]s"
+	customer_gre_endpoint = "%[4]s"
+	cloudflare_gre_endpoint = "%[5]s"
+	interface_address = "%[6]s"
+	automatic_return_routing = true
+	bgp = {
+		customer_asn = 65002
+	}
+  }

--- a/internal/services/magic_wan_ipsec_tunnel/custom_model.go
+++ b/internal/services/magic_wan_ipsec_tunnel/custom_model.go
@@ -13,25 +13,25 @@ type CustomMagicWANIPSECTunnelResultEnvelope struct {
 }
 
 type CustomMagicWANIPSECTunnelModel struct {
-	ID                     types.String                                                             `tfsdk:"id" json:"id,computed"`
-	AccountID              types.String                                                             `tfsdk:"account_id" path:"account_id,required"`
-	CloudflareEndpoint     types.String                                                             `tfsdk:"cloudflare_endpoint" json:"cloudflare_endpoint,required"`
-	InterfaceAddress       types.String                                                             `tfsdk:"interface_address" json:"interface_address,required"`
-	Name                   types.String                                                             `tfsdk:"name" json:"name,required"`
-	CustomerEndpoint       types.String                                                             `tfsdk:"customer_endpoint" json:"customer_endpoint,optional"`
-	Description            types.String                                                             `tfsdk:"description" json:"description,optional"`
-	InterfaceAddress6      types.String                                                             `tfsdk:"interface_address6" json:"interface_address6,optional"`
-	PSK                    types.String                                                             `tfsdk:"psk" json:"psk,optional,no_refresh"`
-	BGP                    *MagicWANIPSECTunnelBGPModel                                             `tfsdk:"bgp" json:"bgp,optional"`
-	AutomaticReturnRouting types.Bool                                                               `tfsdk:"automatic_return_routing" json:"automatic_return_routing,computed_optional"`
-	ReplayProtection       types.Bool                                                               `tfsdk:"replay_protection" json:"replay_protection,computed_optional"`
-	HealthCheck            customfield.NestedObject[MagicWANIPSECTunnelHealthCheckModel]            `tfsdk:"health_check" json:"health_check,computed_optional"`
-	AllowNullCipher        types.Bool                                                               `tfsdk:"allow_null_cipher" json:"allow_null_cipher,computed_optional,no_refresh"`
-	CreatedOn              timetypes.RFC3339                                                        `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
-	ModifiedOn             timetypes.RFC3339                                                        `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
-	BGPStatus              customfield.NestedObject[MagicWANIPSECTunnelBGPStatusModel]              `tfsdk:"bgp_status" json:"bgp_status,computed"`
-	CustomRemoteIdentities *MagicWANIPSECTunnelCustomRemoteIdentitiesModel                          `tfsdk:"custom_remote_identities" json:"custom_remote_identities,optional"`
-	PSKMetadata            customfield.NestedObject[MagicWANIPSECTunnelPSKMetadataModel]            `tfsdk:"psk_metadata" json:"psk_metadata,computed_optional"`
+	ID                     types.String                                                  `tfsdk:"id" json:"id,computed"`
+	AccountID              types.String                                                  `tfsdk:"account_id" path:"account_id,required"`
+	CloudflareEndpoint     types.String                                                  `tfsdk:"cloudflare_endpoint" json:"cloudflare_endpoint,required"`
+	InterfaceAddress       types.String                                                  `tfsdk:"interface_address" json:"interface_address,required"`
+	Name                   types.String                                                  `tfsdk:"name" json:"name,required"`
+	CustomerEndpoint       types.String                                                  `tfsdk:"customer_endpoint" json:"customer_endpoint,optional"`
+	Description            types.String                                                  `tfsdk:"description" json:"description,computed_optional"`
+	InterfaceAddress6      types.String                                                  `tfsdk:"interface_address6" json:"interface_address6,optional"`
+	PSK                    types.String                                                  `tfsdk:"psk" json:"psk,optional,no_refresh"`
+	BGP                    *MagicWANIPSECTunnelBGPModel                                  `tfsdk:"bgp" json:"bgp,optional"`
+	AutomaticReturnRouting types.Bool                                                    `tfsdk:"automatic_return_routing" json:"automatic_return_routing,computed_optional"`
+	ReplayProtection       types.Bool                                                    `tfsdk:"replay_protection" json:"replay_protection,computed_optional"`
+	HealthCheck            customfield.NestedObject[MagicWANIPSECTunnelHealthCheckModel] `tfsdk:"health_check" json:"health_check,computed_optional"`
+	AllowNullCipher        types.Bool                                                    `tfsdk:"allow_null_cipher" json:"allow_null_cipher,computed_optional,no_refresh"`
+	CreatedOn              timetypes.RFC3339                                             `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`
+	ModifiedOn             timetypes.RFC3339                                             `tfsdk:"modified_on" json:"modified_on,computed" format:"date-time"`
+	BGPStatus              customfield.NestedObject[MagicWANIPSECTunnelBGPStatusModel]   `tfsdk:"bgp_status" json:"bgp_status,computed"`
+	CustomRemoteIdentities *MagicWANIPSECTunnelCustomRemoteIdentitiesModel               `tfsdk:"custom_remote_identities" json:"custom_remote_identities,optional"`
+	PSKMetadata            customfield.NestedObject[MagicWANIPSECTunnelPSKMetadataModel] `tfsdk:"psk_metadata" json:"psk_metadata,computed_optional"`
 }
 
 func (m CustomMagicWANIPSECTunnelModel) MarshalJSON() (data []byte, err error) {

--- a/internal/services/magic_wan_ipsec_tunnel/custom_schema.go
+++ b/internal/services/magic_wan_ipsec_tunnel/custom_schema.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
@@ -49,8 +49,10 @@ func customResourceSchema(ctx context.Context) schema.Schema {
 				Optional:    true,
 			},
 			"description": schema.StringAttribute{
-				Description: "An optional description forthe IPsec tunnel.",
-				Optional:    true,
+				Description:   "An optional description forthe IPsec tunnel.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"interface_address6": schema.StringAttribute{
 				Description: "A 127 bit IPV6 prefix from within the virtual_subnet6 prefix space with the address being the first IP of the subnet and not same as the address of virtual_subnet6. Eg if virtual_subnet6 is 2606:54c1:7:0:a9fe:12d2::/127 , interface_address6 could be 2606:54c1:7:0:a9fe:12d2:1:200/127",
@@ -94,9 +96,9 @@ func customResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"automatic_return_routing": schema.BoolAttribute{
-				Description: "True if automatic stateful return routing should be enabled for a tunnel, false otherwise.",
-				Computed:    true,
-				Optional:    true,
+				Description:   "True if automatic stateful return routing should be enabled for a tunnel, false otherwise.",
+				Computed:      true,
+				Optional:      true,
 				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"replay_protection": schema.BoolAttribute{

--- a/internal/services/magic_wan_ipsec_tunnel/resource_test.go
+++ b/internal/services/magic_wan_ipsec_tunnel/resource_test.go
@@ -73,7 +73,7 @@ func testSweepCloudflareMagicWanIPsecTunnel(r string) error {
 			failedCount++
 			continue
 		}
-		
+
 		deletedCount++
 		tflog.Info(ctx, fmt.Sprintf("Successfully deleted IPsec tunnel: %s", tunnel.ID))
 	}
@@ -194,6 +194,13 @@ func TestAccCloudflareIPsecTunnelUpdateDescription(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "description", rnd+"-updated"),
 				),
 			},
+			{
+				Config: testAccCheckCloudflareIPsecTunnelNoDescription(rnd, accountID, cfIP, interfaceAddr, psk),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareIPsecTunnelExists(name, &Tunnel),
+					resource.TestCheckResourceAttr(name, "description", rnd+"-updated"),
+				),
+			},
 		},
 	})
 }
@@ -234,6 +241,10 @@ func TestAccCloudflareIPsecTunnelUpdatePsk(t *testing.T) {
 
 func testAccCheckCloudflareIPsecTunnelSimple(ID, description, accountID, psk, cfIP, interfaceAddr string) string {
 	return acctest.LoadTestCase("ipsectunnelsimple.tf", ID, description, accountID, psk, cfIP, interfaceAddr)
+}
+
+func testAccCheckCloudflareIPsecTunnelNoDescription(ID, accountID, cfIP, interfaceAddr, psk string) string {
+	return acctest.LoadTestCase("ipsectunnelnodescription.tf", ID, accountID, cfIP, interfaceAddr, psk)
 }
 
 func TestAccUpgradeMagicWanIpsecTunnel_FromPublishedV5(t *testing.T) {

--- a/internal/services/magic_wan_ipsec_tunnel/testdata/ipsectunnelnodescription.tf
+++ b/internal/services/magic_wan_ipsec_tunnel/testdata/ipsectunnelnodescription.tf
@@ -1,0 +1,20 @@
+
+  resource "cloudflare_magic_wan_ipsec_tunnel" "%[1]s" {
+	account_id = "%[2]s"
+	name = "%[1]s"
+	customer_endpoint = "203.0.113.1"
+	cloudflare_endpoint = "%[3]s"
+	interface_address = "%[4]s"
+	health_check = {
+		enabled = true
+		rate = "low"
+		type = "request"
+		direction = "unidirectional"
+	}
+	psk = "%[5]s"
+	replay_protection = true
+	automatic_return_routing = true
+	bgp = {
+		customer_asn = 65001
+	}
+  }

--- a/internal/services/magic_wan_static_route/custom_model.go
+++ b/internal/services/magic_wan_static_route/custom_model.go
@@ -17,7 +17,7 @@ type CustomMagicWANStaticRouteModel struct {
 	Nexthop     types.String                   `tfsdk:"nexthop" json:"nexthop,required"`
 	Prefix      types.String                   `tfsdk:"prefix" json:"prefix,required"`
 	Priority    types.Int64                    `tfsdk:"priority" json:"priority,required"`
-	Description types.String                   `tfsdk:"description" json:"description,optional"`
+	Description types.String                   `tfsdk:"description" json:"description,computed_optional"`
 	Weight      types.Int64                    `tfsdk:"weight" json:"weight,optional"`
 	Scope       *MagicWANStaticRouteScopeModel `tfsdk:"scope" json:"scope,optional"`
 	CreatedOn   timetypes.RFC3339              `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`

--- a/internal/services/magic_wan_static_route/custom_schema.go
+++ b/internal/services/magic_wan_static_route/custom_schema.go
@@ -36,8 +36,10 @@ func customResourceSchema(ctx context.Context) schema.Schema {
 				Required:    true,
 			},
 			"description": schema.StringAttribute{
-				Description: "An optional human provided description of the static route.",
-				Optional:    true,
+				Description:   "An optional human provided description of the static route.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"weight": schema.Int64Attribute{
 				Description: "Optional weight of the ECMP scope - if provided.",

--- a/internal/services/magic_wan_static_route/resource_test.go
+++ b/internal/services/magic_wan_static_route/resource_test.go
@@ -72,7 +72,7 @@ func testSweepCloudflareMagicWanStaticRoute(r string) error {
 			failedCount++
 			continue
 		}
-		
+
 		deletedCount++
 		tflog.Info(ctx, fmt.Sprintf("Successfully deleted static route: %s", route.ID))
 	}
@@ -188,6 +188,13 @@ func TestAccCloudflareStaticRoute_UpdateDescription(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "description", rnd+"-updated"),
 				),
 			},
+			{
+				Config: testAccCheckCloudflareStaticRouteNoDescription(rnd, accountID, 100, cfIP, interfaceAddr, nexthop),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareStaticRouteExists(name, &StaticRoute),
+					resource.TestCheckResourceAttr(name, "description", rnd+"-updated"),
+				),
+			},
 		},
 	})
 }
@@ -239,6 +246,10 @@ func TestAccCloudflareStaticRoute_UpdateWeight(t *testing.T) {
 
 func testAccCheckCloudflareStaticRouteSimple(ID, description, accountID string, weight int, cfIP, interfaceAddr, nexthop string) string {
 	return acctest.LoadTestCase("staticroutesimple.tf", ID, description, accountID, weight, cfIP, interfaceAddr, nexthop)
+}
+
+func testAccCheckCloudflareStaticRouteNoDescription(ID, accountID string, weight int, cfIP, interfaceAddr, nexthop string) string {
+	return acctest.LoadTestCase("staticroutenodescription.tf", ID, accountID, weight, cfIP, interfaceAddr, nexthop)
 }
 
 func TestAccUpgradeMagicWanStaticRoute_FromPublishedV5(t *testing.T) {

--- a/internal/services/magic_wan_static_route/testdata/staticroutenodescription.tf
+++ b/internal/services/magic_wan_static_route/testdata/staticroutenodescription.tf
@@ -1,0 +1,26 @@
+
+  resource "cloudflare_magic_wan_ipsec_tunnel" "temp_ipsec_tunnel" {
+	account_id = "%[2]s"
+	name = "%[1]s"
+	customer_endpoint = "203.0.113.1"
+	cloudflare_endpoint = "%[4]s"
+	interface_address = "%[5]s"
+	description = ""
+	health_check = {
+		enabled = true
+		rate = "low"
+		type = "request"
+		direction = "unidirectional"
+	}
+	psk = "abcde"
+	replay_protection = true
+  }
+  
+  resource "cloudflare_magic_wan_static_route" "%[1]s" {
+	account_id = "%[2]s"
+	prefix = "10.100.0.0/24"
+	nexthop = "%[6]s"
+	priority = "100"
+	weight = %[3]d
+	depends_on  = [cloudflare_magic_wan_ipsec_tunnel.temp_ipsec_tunnel]
+  }


### PR DESCRIPTION
when updating a magic wan resource with description field unset, provider returns error

```
{ │ "code": 1022, │ "message": "Invalid Request: error parsing request body while updating IPsec Tunnel: type \"string\" is not permitted to be null" │ }
```

this impacts
 - magic_wan_ipsec_tunnel
 - magic_wan_gre_tunnel
 - magic_wan_static_route

this commit fixes this issue and adds regresion tests

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
TF_ACC=1 go test -parallel=1 -p=1 -count=1 ./internal/services/{magic_wan_ipsec_tunnel,magic_wan_gre_tunnel,magic_wan_static_route} -run "^TestAcc"

### Test output
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/magic_wan_ipsec_tunnel    81.028s
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/magic_wan_gre_tunnel      92.518s
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/magic_wan_static_route    111.344s

## Additional context & links
