### PR TITLE
ci: only run existing migration tests

### DIFF
--- a/scripts/run-ci-tests
+++ b/scripts/run-ci-tests
@@ -611,11 +611,17 @@ run_tests() {
         # Example: ./internal/services/dns_record/... -> ./internal/services/dns_record/migration/...
         test_path="${service%/...}/migration/..."
 
-        # Only run migration tests for services that have a v500 state upgrader
-        local migration_v500_dir="${service%/...}/migration/v500"
-        if [ ! -d "$migration_v500_dir" ]; then
-            log "${YELLOW}Skipping migration tests for $service (no migration/v500 directory)${NC}" > "$log_file"
-            log "Skipping migration tests for $service (no migration/v500 directory)"
+        # Skip services that define no migrations at all
+        local migration_dir="${service%/...}/migration"
+        local migration_test_file="${service%/...}/migration_test.go"
+        if [ -f "$migration_test_file" ]; then
+            log "${RED}FAIL: $service has migration_test.go which must be removed (migration tests belong in migration/ directory)${NC}" > "$log_file"
+            log "FAIL: $service has migration_test.go which must be removed (migration tests belong in migration/ directory)"
+            return 1
+        fi
+        if [ ! -d "$migration_dir" ]; then
+            log "${YELLOW}Skipping migration tests for $service (no migration/ directory)${NC}" > "$log_file"
+            log "Skipping migration tests for $service (no migration/ directory)"
             echo "TESTS_SKIPPED" >> "$log_file"
             return 0
         fi


### PR DESCRIPTION
## Summary

Updates the migration test runner (scripts/run-ci-tests) to enforce the new migration test structure.

## Changes to skip/fail logic:

- Fail if a service has migration_test.go — this file belongs to the old migration system and must be removed. Its presence means the resource has not been ported to the new migration/ directory structure.
- Skip if a service has no migration/ directory and no migration_test.go — the resource defines no migrations, nothing to test.
- Run if a service has a migration/ directory and no migration_test.go.

Previously, the runner would skip any service missing a migration/v500/ directory, silently hiding resources that still used the old pattern. The new behavior surfaces unported resources as CI failures, ensuring all migration tests are migrated to the new system before merging.