### PR TITLE
fix(page_rule): properly encode page_rule automatic_https_rewrites

### DIFF
--- a/internal/services/page_rule/custom.go
+++ b/internal/services/page_rule/custom.go
@@ -155,7 +155,7 @@ func (m *PageRuleActionsModel) Encode() (encoded []map[string]any, err error) {
 		encoded = append(encoded, map[string]any{"id": page_rules.PageRuleActionsIDAlwaysUseHTTPS})
 	}
 	if !m.AutomaticHTTPSRewrites.IsNull() {
-		encoded = append(encoded, map[string]any{"id": page_rules.PageRuleActionsIDAutomaticHTTPSRewrites, "value": m.AutomaticHTTPSRewrites.String()})
+		encoded = append(encoded, map[string]any{"id": page_rules.PageRuleActionsIDAutomaticHTTPSRewrites, "value": m.AutomaticHTTPSRewrites.ValueString()})
 	}
 	if !m.BrowserCacheTTL.IsNull() {
 		encoded = append(encoded, map[string]any{"id": page_rules.PageRuleActionsIDBrowserCacheTTL, "value": m.BrowserCacheTTL.ValueInt64()})

--- a/internal/services/page_rule/resource_test.go
+++ b/internal/services/page_rule/resource_test.go
@@ -817,6 +817,85 @@ func TestAccCloudflarePageRule_BrowserCheckOnOff(t *testing.T) {
 	})
 }
 
+func TestAccCloudflarePageRule_AutomaticHTTPSRewritesOnOff(t *testing.T) {
+	var pageRule cloudflare.PageRule
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_page_rule." + rnd
+	target := fmt.Sprintf("%s.%s", rnd, domain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflarePageRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflarePageRuleConfigString(rnd, zoneID, target, "automatic_https_rewrites", "on"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "target", fmt.Sprintf("%s", target)),
+					resource.TestCheckResourceAttr(resourceName, "actions.automatic_https_rewrites", "on"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflarePageRuleConfigString(rnd, zoneID, target, "automatic_https_rewrites", "on"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "target", fmt.Sprintf("%s", target)),
+					resource.TestCheckResourceAttr(resourceName, "actions.automatic_https_rewrites", "on"),
+				),
+				PlanOnly: true,
+			},
+			{
+				ResourceName: resourceName,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					rs, ok := state.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s/%s", zoneID, rs.Primary.ID), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCheckCloudflarePageRuleConfigString(rnd, zoneID, target, "automatic_https_rewrites", "off"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "target", fmt.Sprintf("%s", target)),
+					resource.TestCheckResourceAttr(resourceName, "actions.automatic_https_rewrites", "off"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflarePageRuleConfigString(rnd, zoneID, target, "automatic_https_rewrites", "off"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflarePageRuleExists(resourceName, &pageRule),
+					resource.TestCheckResourceAttr(resourceName, consts.ZoneIDSchemaKey, zoneID),
+					resource.TestCheckResourceAttr(resourceName, "target", fmt.Sprintf("%s", target)),
+					resource.TestCheckResourceAttr(resourceName, "actions.automatic_https_rewrites", "off"),
+				),
+				PlanOnly: true,
+			},
+			{
+				ResourceName: resourceName,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					rs, ok := state.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s/%s", zoneID, rs.Primary.ID), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCloudflarePageRule_CacheByDeviceTypeOnOff(t *testing.T) {
 	var pageRule cloudflare.PageRule
 	domain := os.Getenv("CLOUDFLARE_DOMAIN")


### PR DESCRIPTION
https://github.com/cloudflare/terraform-provider-cloudflare/issues/6090

Fixed an issue where we were getting API validation errors on an improperly encoded attribute `page_rule` `automatic_https_rewrites`. This attribute was unrepresented in the acceptance tests so adds a new `TestAccCloudflarePageRule_AutomaticHTTPSRewritesOnOff` test to confirm the attribute is getting applied properly. 
```
=== RUN   TestAccCloudflarePageRule_Basic
--- PASS: TestAccCloudflarePageRule_Basic (3.83s)
=== RUN   TestAccCloudflarePageRule_FullySpecified
--- PASS: TestAccCloudflarePageRule_FullySpecified (4.45s)
=== RUN   TestAccCloudflarePageRule_AlwaysUseHTTPS
    resource_test.go:191: unable to set always_use_https
--- SKIP: TestAccCloudflarePageRule_AlwaysUseHTTPS (0.00s)
=== RUN   TestAccCloudflarePageRule_DisableApps
--- PASS: TestAccCloudflarePageRule_DisableApps (6.71s)
=== RUN   TestAccCloudflarePageRule_DisablePerformance
--- PASS: TestAccCloudflarePageRule_DisablePerformance (6.39s)
=== RUN   TestAccCloudflarePageRule_DisableSecurity
--- PASS: TestAccCloudflarePageRule_DisableSecurity (8.20s)
=== RUN   TestAccCloudflarePageRule_DisableZaraz
--- PASS: TestAccCloudflarePageRule_DisableZaraz (5.38s)
=== RUN   TestAccCloudflarePageRule_ForwardingOnly
--- PASS: TestAccCloudflarePageRule_ForwardingOnly (3.74s)
=== RUN   TestAccCloudflarePageRule_ForwardingAndOthers
--- PASS: TestAccCloudflarePageRule_ForwardingAndOthers (0.73s)
=== RUN   TestAccCloudflarePageRule_Updated
--- PASS: TestAccCloudflarePageRule_Updated (6.60s)
=== RUN   TestAccCloudflarePageRule_CreateAfterManualDestroy
    resource_test.go:607: test is attempting to cleanup the page rules after running the manual delete causing failures before the next step
--- SKIP: TestAccCloudflarePageRule_CreateAfterManualDestroy (0.00s)
=== RUN   TestAccCloudflarePageRule_UpdatingZoneForcesNewResource
--- PASS: TestAccCloudflarePageRule_UpdatingZoneForcesNewResource (8.65s)
=== RUN   TestAccCloudflarePageRule_BrowserCheckOnOff
--- PASS: TestAccCloudflarePageRule_BrowserCheckOnOff (7.64s)
=== RUN   TestAccCloudflarePageRule_CacheByDeviceTypeOnOff
--- PASS: TestAccCloudflarePageRule_CacheByDeviceTypeOnOff (6.98s)
=== RUN   TestAccCloudflarePageRule_CacheDeceptionArmorOnOff
--- PASS: TestAccCloudflarePageRule_CacheDeceptionArmorOnOff (6.73s)
=== RUN   TestAccCloudflarePageRule_EmailObfuscationOnOff
--- PASS: TestAccCloudflarePageRule_EmailObfuscationOnOff (8.96s)
=== RUN   TestAccCloudflarePageRule_ExplicitCacheControlOnOff
--- PASS: TestAccCloudflarePageRule_ExplicitCacheControlOnOff (15.33s)
=== RUN   TestAccCloudflarePageRule_IPGeolocationOnOff
--- PASS: TestAccCloudflarePageRule_IPGeolocationOnOff (8.04s)
=== RUN   TestAccCloudflarePageRule_MirageOnOff
--- PASS: TestAccCloudflarePageRule_MirageOnOff (8.66s)
=== RUN   TestAccCloudflarePageRule_OpportunisticEncryptionOnOff
    resource_test.go:1295: unable to set opportunistic encryption
--- SKIP: TestAccCloudflarePageRule_OpportunisticEncryptionOnOff (0.00s)
=== RUN   TestAccCloudflarePageRule_OriginErrorPagePassThruOnOff
--- PASS: TestAccCloudflarePageRule_OriginErrorPagePassThruOnOff (7.01s)
=== RUN   TestAccCloudflarePageRule_RespectStrongEtagOnOff
--- PASS: TestAccCloudflarePageRule_RespectStrongEtagOnOff (6.71s)
=== RUN   TestAccCloudflarePageRule_ResponseBufferingOnOff
--- PASS: TestAccCloudflarePageRule_ResponseBufferingOnOff (6.58s)
=== RUN   TestAccCloudflarePageRule_RocketLoaderOnOff
--- PASS: TestAccCloudflarePageRule_RocketLoaderOnOff (8.48s)
=== RUN   TestAccCloudflarePageRule_SortQueryStringForCacheOnOff
--- PASS: TestAccCloudflarePageRule_SortQueryStringForCacheOnOff (13.00s)
=== RUN   TestAccCloudflarePageRule_TrueClientIPHeaderOnOff
--- PASS: TestAccCloudflarePageRule_TrueClientIPHeaderOnOff (10.86s)
=== RUN   TestAccCloudflarePageRule_WAFOnOff
--- PASS: TestAccCloudflarePageRule_WAFOnOff (20.65s)
=== RUN   TestAccCloudflarePageRule_BypassCacheOnCookie_String
--- PASS: TestAccCloudflarePageRule_BypassCacheOnCookie_String (7.80s)
=== RUN   TestAccCloudflarePageRule_CacheLevel_String
--- PASS: TestAccCloudflarePageRule_CacheLevel_String (33.81s)
=== RUN   TestAccCloudflarePageRule_CacheOnCookie_String
--- PASS: TestAccCloudflarePageRule_CacheOnCookie_String (5.36s)
=== RUN   TestAccCloudflarePageRule_HostHeaderOverride_String
--- PASS: TestAccCloudflarePageRule_HostHeaderOverride_String (4.27s)
=== RUN   TestAccCloudflarePageRule_Polish_String
--- PASS: TestAccCloudflarePageRule_Polish_String (15.99s)
=== RUN   TestAccCloudflarePageRule_ResolveOverride_String
--- PASS: TestAccCloudflarePageRule_ResolveOverride_String (18.00s)
=== RUN   TestAccCloudflarePageRule_SSL_String
--- PASS: TestAccCloudflarePageRule_SSL_String (61.73s)
=== RUN   TestAccCloudflarePageRule_SecurityLevel_String
--- PASS: TestAccCloudflarePageRule_SecurityLevel_String (18.26s)
=== RUN   TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues
--- PASS: TestAccCloudflarePageRule_CreatesBrowserCacheTTLIntegerValues (3.48s)
=== RUN   TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders
--- PASS: TestAccCloudflarePageRule_CreatesBrowserCacheTTLThatRespectsExistingHeaders (3.53s)
=== RUN   TestAccCloudflarePageRule_UpdatesBrowserCacheTTLToSameValue
--- PASS: TestAccCloudflarePageRule_UpdatesBrowserCacheTTLToSameValue (5.38s)
=== RUN   TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders
--- PASS: TestAccCloudflarePageRule_UpdatesBrowserCacheTTLThatRespectsExistingHeaders (5.53s)
=== RUN   TestAccCloudflarePageRule_DeletesBrowserCacheTTLThatRespectsExistingHeaders
--- PASS: TestAccCloudflarePageRule_DeletesBrowserCacheTTLThatRespectsExistingHeaders (5.77s)
=== RUN   TestAccCloudflarePageRule_EdgeCacheTTLNotClobbered
--- PASS: TestAccCloudflarePageRule_EdgeCacheTTLNotClobbered (7.07s)
=== RUN   TestAccCloudflarePageRule_CacheKeyFieldsBasic
--- PASS: TestAccCloudflarePageRule_CacheKeyFieldsBasic (3.65s)
=== RUN   TestAccCloudflarePageRule_CacheKeyFieldsIgnoreQueryStringOrdering
--- PASS: TestAccCloudflarePageRule_CacheKeyFieldsIgnoreQueryStringOrdering (5.70s)
=== RUN   TestAccCloudflarePageRule_CacheKeyFieldsExcludeAllQueryString
--- PASS: TestAccCloudflarePageRule_CacheKeyFieldsExcludeAllQueryString (3.55s)
=== RUN   TestAccCloudflarePageRule_CacheKeyFieldsExcludeMultipleValuesQueryString
--- PASS: TestAccCloudflarePageRule_CacheKeyFieldsExcludeMultipleValuesQueryString (3.98s)
=== RUN   TestAccCloudflarePageRule_CacheKeyFieldsNoQueryStringValuesDefined
--- PASS: TestAccCloudflarePageRule_CacheKeyFieldsNoQueryStringValuesDefined (3.39s)
=== RUN   TestAccCloudflarePageRule_CacheKeyFieldsIncludeAllQueryStringValues
--- PASS: TestAccCloudflarePageRule_CacheKeyFieldsIncludeAllQueryStringValues (3.70s)
=== RUN   TestAccCloudflarePageRule_CacheKeyFieldsIncludeMultipleValuesQueryString
--- PASS: TestAccCloudflarePageRule_CacheKeyFieldsIncludeMultipleValuesQueryString (3.22s)
=== RUN   TestAccCloudflarePageRule_EmptyCookie
--- PASS: TestAccCloudflarePageRule_EmptyCookie (3.79s)
=== RUN   TestAccCloudflarePageRule_CacheTTLByStatus
--- PASS: TestAccCloudflarePageRule_CacheTTLByStatus (3.24s)
=== RUN   TestAccCloudflarePageRule_CacheTTLByStatusEmptyBlockExpectAPIError
--- PASS: TestAccCloudflarePageRule_CacheTTLByStatusEmptyBlockExpectAPIError (1.18s)
=== RUN   TestAccUpgradePageRule_FromPublishedV5
--- PASS: TestAccUpgradePageRule_FromPublishedV5 (22.80s)
PASS
ok      command-line-arguments  445.869s
```