### PR TITLE
fix: cascading deletions with malformed refreshed zone ID

### DIFF
--- a/internal/services/zone/custom_test.go
+++ b/internal/services/zone/custom_test.go
@@ -1,0 +1,615 @@
+package zone_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/zone"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ---------------------------------------------------------------------------
+// Resource helpers
+// ---------------------------------------------------------------------------
+
+// makeZoneState builds a tfsdk.State whose ID field is set to id. All other
+// fields are null so that State.Get succeeds without real API data.
+func makeZoneState(t *testing.T, ctx context.Context, id types.String) tfsdk.State {
+	t.Helper()
+
+	model := zone.ZoneModel{
+		ID:                  id,
+		Name:                types.StringValue("example.com"),
+		Account:             &zone.ZoneAccountModel{ID: types.StringValue("account-123")},
+		Paused:              types.BoolValue(false),
+		Type:                types.StringValue("full"),
+		VanityNameServers:   customfield.NullList[types.String](ctx),
+		ActivatedOn:         timetypes.NewRFC3339Null(),
+		CNAMESuffix:         types.StringNull(),
+		CreatedOn:           timetypes.NewRFC3339Null(),
+		DevelopmentMode:     types.Float64Null(),
+		ModifiedOn:          timetypes.NewRFC3339Null(),
+		OriginalDnshost:     types.StringNull(),
+		OriginalRegistrar:   types.StringNull(),
+		Status:              types.StringNull(),
+		VerificationKey:     types.StringNull(),
+		NameServers:         customfield.NullList[types.String](ctx),
+		OriginalNameServers: customfield.NullList[types.String](ctx),
+		Permissions:         customfield.NullList[types.String](ctx),
+		Meta:                customfield.NullObject[zone.ZoneMetaModel](ctx),
+		Owner:               customfield.NullObject[zone.ZoneOwnerModel](ctx),
+		Plan:                customfield.NullObject[zone.ZonePlanModel](ctx),
+		Tenant:              customfield.NullObject[zone.ZoneTenantModel](ctx),
+		TenantUnit:          customfield.NullObject[zone.ZoneTenantUnitModel](ctx),
+	}
+
+	schema := zone.ResourceSchema(ctx)
+	state := tfsdk.State{Schema: schema}
+	if diags := state.Set(ctx, &model); diags.HasError() {
+		t.Fatalf("makeZoneState: failed to set state: %v", diags)
+	}
+	return state
+}
+
+// newZoneResource returns a ZoneResource whose cloudflare client is pointed at
+// baseURL. Pass an empty string to leave the client nil (safe when the guard
+// under test fires before any API call is attempted).
+func newZoneResource(t *testing.T, baseURL string) *zone.ZoneResource {
+	t.Helper()
+	r := zone.NewResource().(*zone.ZoneResource)
+	if baseURL == "" {
+		return r
+	}
+	client := cloudflare.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIToken("test-token"),
+	)
+	req := resource.ConfigureRequest{ProviderData: client}
+	resp := &resource.ConfigureResponse{}
+	r.Configure(context.Background(), req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("newZoneResource: Configure failed: %v", resp.Diagnostics)
+	}
+	return r
+}
+
+// ---------------------------------------------------------------------------
+// Data source helpers
+// ---------------------------------------------------------------------------
+
+// makeZoneDataSourceConfig builds a tfsdk.Config whose ZoneID field is set to
+// zoneID. All other fields are null and Filter is nil.
+func makeZoneDataSourceConfig(t *testing.T, ctx context.Context, zoneID types.String) tfsdk.Config {
+	t.Helper()
+
+	model := zone.ZoneDataSourceModel{
+		ID:                  types.StringNull(),
+		ZoneID:              zoneID,
+		ActivatedOn:         timetypes.NewRFC3339Null(),
+		CNAMESuffix:         types.StringNull(),
+		CreatedOn:           timetypes.NewRFC3339Null(),
+		DevelopmentMode:     types.Float64Null(),
+		ModifiedOn:          timetypes.NewRFC3339Null(),
+		Name:                types.StringNull(),
+		OriginalDnshost:     types.StringNull(),
+		OriginalRegistrar:   types.StringNull(),
+		Paused:              types.BoolNull(),
+		Status:              types.StringNull(),
+		Type:                types.StringNull(),
+		VerificationKey:     types.StringNull(),
+		NameServers:         customfield.NullList[types.String](ctx),
+		OriginalNameServers: customfield.NullList[types.String](ctx),
+		Permissions:         customfield.NullList[types.String](ctx),
+		VanityNameServers:   customfield.NullList[types.String](ctx),
+		Account:             customfield.NullObject[zone.ZoneAccountDataSourceModel](ctx),
+		Meta:                customfield.NullObject[zone.ZoneMetaDataSourceModel](ctx),
+		Owner:               customfield.NullObject[zone.ZoneOwnerDataSourceModel](ctx),
+		Plan:                customfield.NullObject[zone.ZonePlanDataSourceModel](ctx),
+		Tenant:              customfield.NullObject[zone.ZoneTenantDataSourceModel](ctx),
+		TenantUnit:          customfield.NullObject[zone.ZoneTenantUnitDataSourceModel](ctx),
+		Filter:              nil,
+	}
+
+	// tfsdk.Config has no Set method; use tfsdk.State (which does) with the
+	// data source schema as a proxy to obtain the raw tftypes.Value.
+	dsSchema := zone.DataSourceSchema(ctx)
+	state := tfsdk.State{Schema: dsSchema}
+	if diags := state.Set(ctx, &model); diags.HasError() {
+		t.Fatalf("makeZoneDataSourceConfig: failed to set state: %v", diags)
+	}
+	return tfsdk.Config{Schema: dsSchema, Raw: state.Raw}
+}
+
+// newZoneDataSource returns a ZoneDataSource whose cloudflare client is pointed
+// at baseURL.
+func newZoneDataSource(t *testing.T, baseURL string) *zone.ZoneDataSource {
+	t.Helper()
+	d := zone.NewZoneDataSource().(*zone.ZoneDataSource)
+	if baseURL == "" {
+		return d
+	}
+	client := cloudflare.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIToken("test-token"),
+	)
+	req := datasource.ConfigureRequest{ProviderData: client}
+	resp := &datasource.ConfigureResponse{}
+	d.Configure(context.Background(), req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("newZoneDataSource: Configure failed: %v", resp.Diagnostics)
+	}
+	return d
+}
+
+// ---------------------------------------------------------------------------
+// ZoneResource — ModifyPlan
+// ---------------------------------------------------------------------------
+
+func TestZoneResource_ModifyPlan_EmptyID_FailsPlan(t *testing.T) {
+	ctx := context.Background()
+	r := newZoneResource(t, "") // ModifyPlan never touches the client
+
+	req := resource.ModifyPlanRequest{State: makeZoneState(t, ctx, types.StringValue(""))}
+	resp := &resource.ModifyPlanResponse{}
+
+	r.ModifyPlan(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic for empty zone ID, got none")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != "Invalid zone state: empty or null zone ID" {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+// During a Create the prior state is null — the guard must not fire.
+func TestZoneResource_ModifyPlan_NullPriorState_Passes(t *testing.T) {
+	ctx := context.Background()
+	r := newZoneResource(t, "")
+
+	schema := zone.ResourceSchema(ctx)
+	// tfsdk.State with zero-value Raw: IsNull() returns true (value == nil).
+	req := resource.ModifyPlanRequest{State: tfsdk.State{Schema: schema}}
+	resp := &resource.ModifyPlanResponse{}
+
+	r.ModifyPlan(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("expected no error for null prior state (create path), got: %v", resp.Diagnostics)
+	}
+}
+
+func TestZoneResource_ModifyPlan_ValidID_Passes(t *testing.T) {
+	ctx := context.Background()
+	r := newZoneResource(t, "")
+
+	req := resource.ModifyPlanRequest{State: makeZoneState(t, ctx, types.StringValue("valid-zone-id-abc123"))}
+	resp := &resource.ModifyPlanResponse{}
+
+	r.ModifyPlan(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("expected no error for valid zone ID, got: %v", resp.Diagnostics)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ZoneResource — Read (prior state guard)
+// ---------------------------------------------------------------------------
+
+func TestZoneResource_Read_EmptyID_FailsWithoutAPICall(t *testing.T) {
+	ctx := context.Background()
+
+	requestMade := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestMade = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	r := newZoneResource(t, ts.URL)
+	state := makeZoneState(t, ctx, types.StringValue(""))
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic for empty zone ID, got none")
+	}
+	if requestMade {
+		t.Error("no API request should have been made with empty zone ID, but one was")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != "Invalid zone state: empty or null zone ID" {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ZoneResource — Update (prior state guard)
+// ---------------------------------------------------------------------------
+
+func TestZoneResource_Update_EmptyID_FailsWithoutAPICall(t *testing.T) {
+	ctx := context.Background()
+
+	requestMade := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestMade = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	r := newZoneResource(t, ts.URL)
+	state := makeZoneState(t, ctx, types.StringValue(""))
+
+	// Plan carries the same (empty) ID as the prior state.
+	req := resource.UpdateRequest{
+		Plan:  tfsdk.Plan{Schema: state.Schema, Raw: state.Raw},
+		State: state,
+	}
+	resp := &resource.UpdateResponse{State: state}
+
+	r.Update(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic for empty zone ID, got none")
+	}
+	if requestMade {
+		t.Error("no API request should have been made with empty zone ID, but one was")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != "Invalid zone state: empty or null zone ID" {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ZoneResource — Delete (prior state guard)
+// ---------------------------------------------------------------------------
+
+func TestZoneResource_Delete_EmptyID_FailsWithoutAPICall(t *testing.T) {
+	ctx := context.Background()
+
+	requestMade := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestMade = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	r := newZoneResource(t, ts.URL)
+	state := makeZoneState(t, ctx, types.StringValue(""))
+
+	resp := &resource.DeleteResponse{}
+	r.Delete(ctx, resource.DeleteRequest{State: state}, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic for empty zone ID, got none")
+	}
+	if requestMade {
+		t.Error("no API request should have been made with empty zone ID, but one was")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != "Invalid zone state: empty or null zone ID" {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ZoneDataSource — Read (empty zone_id guard)
+// ---------------------------------------------------------------------------
+
+func TestZoneDataSource_Read_EmptyZoneID_FailsWithoutAPICall(t *testing.T) {
+	ctx := context.Background()
+
+	requestMade := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestMade = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	d := newZoneDataSource(t, ts.URL)
+	cfg := makeZoneDataSourceConfig(t, ctx, types.StringValue(""))
+
+	resp := &datasource.ReadResponse{State: tfsdk.State{Schema: cfg.Schema}}
+	d.Read(ctx, datasource.ReadRequest{Config: cfg}, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic for empty zone_id, got none")
+	}
+	if requestMade {
+		t.Error("no API request should have been made with empty zone_id, but one was")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != "Invalid zone configuration: empty or null zone ID" {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ZoneResource — null ID prior-state tests
+// ---------------------------------------------------------------------------
+
+func TestZoneResource_ModifyPlan_NullID_FailsPlan(t *testing.T) {
+	ctx := context.Background()
+	r := newZoneResource(t, "")
+
+	req := resource.ModifyPlanRequest{State: makeZoneState(t, ctx, types.StringNull())}
+	resp := &resource.ModifyPlanResponse{}
+
+	r.ModifyPlan(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic for null zone ID, got none")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != "Invalid zone state: empty or null zone ID" {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+func TestZoneResource_Read_NullID_FailsWithoutAPICall(t *testing.T) {
+	ctx := context.Background()
+
+	requestMade := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestMade = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	r := newZoneResource(t, ts.URL)
+	state := makeZoneState(t, ctx, types.StringNull())
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic for null zone ID, got none")
+	}
+	if requestMade {
+		t.Error("no API request should have been made with null zone ID, but one was")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != "Invalid zone state: empty or null zone ID" {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+func TestZoneResource_Update_NullID_FailsWithoutAPICall(t *testing.T) {
+	ctx := context.Background()
+
+	requestMade := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestMade = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	r := newZoneResource(t, ts.URL)
+	state := makeZoneState(t, ctx, types.StringNull())
+
+	req := resource.UpdateRequest{
+		Plan:  tfsdk.Plan{Schema: state.Schema, Raw: state.Raw},
+		State: state,
+	}
+	resp := &resource.UpdateResponse{State: state}
+
+	r.Update(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic for null zone ID, got none")
+	}
+	if requestMade {
+		t.Error("no API request should have been made with null zone ID, but one was")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != "Invalid zone state: empty or null zone ID" {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+func TestZoneResource_Delete_NullID_FailsWithoutAPICall(t *testing.T) {
+	ctx := context.Background()
+
+	requestMade := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestMade = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	r := newZoneResource(t, ts.URL)
+	state := makeZoneState(t, ctx, types.StringNull())
+
+	resp := &resource.DeleteResponse{}
+	r.Delete(ctx, resource.DeleteRequest{State: state}, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic for null zone ID, got none")
+	}
+	if requestMade {
+		t.Error("no API request should have been made with null zone ID, but one was")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != "Invalid zone state: empty or null zone ID" {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ZoneDataSource — null zone_id prior-state test
+// ---------------------------------------------------------------------------
+
+func TestZoneDataSource_Read_NullZoneID_FailsWithoutAPICall(t *testing.T) {
+	ctx := context.Background()
+
+	requestMade := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestMade = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	d := newZoneDataSource(t, ts.URL)
+	cfg := makeZoneDataSourceConfig(t, ctx, types.StringNull())
+
+	resp := &datasource.ReadResponse{State: tfsdk.State{Schema: cfg.Schema}}
+	d.Read(ctx, datasource.ReadRequest{Config: cfg}, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic for null zone_id, got none")
+	}
+	if requestMade {
+		t.Error("no API request should have been made with null zone_id, but one was")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != "Invalid zone configuration: empty or null zone ID" {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Post-API response guard — API returns empty zone ID
+// ---------------------------------------------------------------------------
+
+// zoneAPIResponseWithID returns a minimal Cloudflare API JSON envelope that
+// will unmarshal into ZoneResultEnvelope with the given zone id value.
+func zoneAPIResponseWithID(id string) string {
+	return `{"result":{"id":"` + id + `","name":"example.com"},"success":true,"errors":[],"messages":[]}`
+}
+
+const wantAPIReturnedEmptyIDSummary = "Zone API returned empty or null zone ID"
+
+func TestZoneResource_Read_APIReturnsEmptyID_FailsWithoutWritingState(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(zoneAPIResponseWithID(""))) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	r := newZoneResource(t, ts.URL)
+	state := makeZoneState(t, ctx, types.StringValue("zone-abc123"))
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic when API returns empty zone ID, got none")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != wantAPIReturnedEmptyIDSummary {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+func TestZoneResource_Create_APIReturnsEmptyID_FailsWithoutWritingState(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(zoneAPIResponseWithID(""))) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	r := newZoneResource(t, ts.URL)
+
+	// Reuse makeZoneState as a convenient source of a fully-populated raw value
+	// for the plan. The guard fires after the API call, so the plan content
+	// does not need to carry a valid ID.
+	planState := makeZoneState(t, ctx, types.StringValue(""))
+	plan := tfsdk.Plan{Schema: planState.Schema, Raw: planState.Raw}
+
+	schema := zone.ResourceSchema(ctx)
+	resp := &resource.CreateResponse{State: tfsdk.State{Schema: schema}}
+	r.Create(ctx, resource.CreateRequest{Plan: plan}, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic when API returns empty zone ID on Create, got none")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != wantAPIReturnedEmptyIDSummary {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+func TestZoneResource_Update_APIReturnsEmptyID_FailsWithoutWritingState(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(zoneAPIResponseWithID(""))) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	r := newZoneResource(t, ts.URL)
+	// Prior state carries a valid ID so the prior-state guard passes.
+	state := makeZoneState(t, ctx, types.StringValue("zone-abc123"))
+	plan := tfsdk.Plan{Schema: state.Schema, Raw: state.Raw}
+
+	resp := &resource.UpdateResponse{State: state}
+	r.Update(ctx, resource.UpdateRequest{Plan: plan, State: state}, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic when API returns empty zone ID on Update, got none")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	if got := errs[0].Summary(); got != wantAPIReturnedEmptyIDSummary {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}

--- a/internal/services/zone/data_source.go
+++ b/internal/services/zone/data_source.go
@@ -87,6 +87,19 @@ func (d *ZoneDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		data.ZoneID = ts[0].ID
 	}
 
+	if data.ZoneID.IsNull() || data.ZoneID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"Invalid zone configuration: empty or null zone ID",
+			"zone_id resolved to an empty or null value. "+
+				"This can occur when zone_id references a cloudflare_zone resource whose ID is empty or null in state.\n\n"+
+				"If specifying zone_id directly, ensure it is not empty or null.\n"+
+				"If zone_id references a cloudflare_zone resource, re-import that zone:\n"+
+				"  terraform import cloudflare_zone.<name> <zone_id>\n"+
+				"then run terraform plan again.",
+		)
+		return
+	}
+
 	params, diags := data.toReadParams(ctx)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/services/zone/resource.go
+++ b/internal/services/zone/resource.go
@@ -90,6 +90,19 @@ func (r *ZoneResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 	data = &env.Result
 
+	if data.ID.IsNull() || data.ID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"Zone API returned empty or null zone ID",
+			"The Cloudflare API returned a zone response with an empty or null zone ID. "+
+				"This is unexpected and may indicate a transient API error.\n\n"+
+				"The provider is halting to prevent writing invalid state that could cause "+
+				"dependent zone-scoped resources to be incorrectly replaced or destroyed.\n\n"+
+				"Please try running the operation again. If the problem persists, "+
+				"contact Cloudflare support.",
+		)
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -107,6 +120,19 @@ func (r *ZoneResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.ID.IsNull() || state.ID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"Invalid zone state: empty or null zone ID",
+			"The cloudflare_zone resource has an empty or null ID in its Terraform state. "+
+				"This can occur when state becomes corrupted or a zone is removed from state manually.\n\n"+
+				"The provider is halting intentionally to avoid unsafe changes to dependent resources.\n\n"+
+				"To recover, re-import the zone:\n"+
+				"  terraform import cloudflare_zone.<name> <zone_id>\n"+
+				"then run terraform plan again.",
+		)
 		return
 	}
 
@@ -138,6 +164,19 @@ func (r *ZoneResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 	data = &env.Result
 
+	if data.ID.IsNull() || data.ID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"Zone API returned empty or null zone ID",
+			"The Cloudflare API returned a zone response with an empty or null zone ID. "+
+				"This is unexpected and may indicate a transient API error.\n\n"+
+				"The provider is halting to prevent writing invalid state that could cause "+
+				"dependent zone-scoped resources to be incorrectly replaced or destroyed.\n\n"+
+				"Please try running the operation again. If the problem persists, "+
+				"contact Cloudflare support.",
+		)
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -147,6 +186,19 @@ func (r *ZoneResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ID.IsNull() || data.ID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"Invalid zone state: empty or null zone ID",
+			"The cloudflare_zone resource has an empty or null ID in its Terraform state. "+
+				"This can occur when state becomes corrupted or a zone is removed from state manually.\n\n"+
+				"The provider is halting intentionally to avoid unsafe changes to dependent resources.\n\n"+
+				"To recover, re-import the zone:\n"+
+				"  terraform import cloudflare_zone.<name> <zone_id>\n"+
+				"then run terraform plan again.",
+		)
 		return
 	}
 
@@ -177,6 +229,19 @@ func (r *ZoneResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 	data = &env.Result
 
+	if data.ID.IsNull() || data.ID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"Zone API returned empty or null zone ID",
+			"The Cloudflare API returned a zone response with an empty or null zone ID. "+
+				"This is unexpected and may indicate a transient API error.\n\n"+
+				"The provider is halting to prevent writing invalid state that could cause "+
+				"dependent zone-scoped resources to be incorrectly replaced or destroyed.\n\n"+
+				"Please try running the operation again. If the problem persists, "+
+				"contact Cloudflare support.",
+		)
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -186,6 +251,19 @@ func (r *ZoneResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ID.IsNull() || data.ID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"Invalid zone state: empty or null zone ID",
+			"The cloudflare_zone resource has an empty or null ID in its Terraform state. "+
+				"This can occur when state becomes corrupted or a zone is removed from state manually.\n\n"+
+				"The provider is halting intentionally to avoid unsafe changes to dependent resources.\n\n"+
+				"To recover, re-import the zone:\n"+
+				"  terraform import cloudflare_zone.<name> <zone_id>\n"+
+				"then run terraform plan again.",
+		)
 		return
 	}
 
@@ -242,9 +320,45 @@ func (r *ZoneResource) ImportState(ctx context.Context, req resource.ImportState
 	}
 	data = &env.Result
 
+	if data.ID.IsNull() || data.ID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"Zone API returned empty or null zone ID",
+			"The Cloudflare API returned a zone response with an empty or null zone ID. "+
+				"This is unexpected and may indicate a transient API error.\n\n"+
+				"The provider is halting to prevent writing invalid state that could cause "+
+				"dependent zone-scoped resources to be incorrectly replaced or destroyed.\n\n"+
+				"Please try running the operation again. If the problem persists, "+
+				"contact Cloudflare support.",
+		)
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *ZoneResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, _ *resource.ModifyPlanResponse) {
+func (r *ZoneResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Skip during resource creation — prior state is null.
+	if req.State.Raw.IsNull() {
+		return
+	}
 
+	var state ZoneModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.ID.IsNull() || state.ID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"Invalid zone state: empty or null zone ID",
+			"The cloudflare_zone resource has an empty or null ID in its Terraform state. "+
+				"This can occur when state becomes corrupted or a zone is removed from state manually.\n\n"+
+				"Proceeding with an empty or null zone ID could allow dependent zone-scoped resources "+
+				"to be incorrectly replaced or destroyed.\n\n"+
+				"The provider is halting intentionally to avoid unsafe changes to dependent resources.\n\n"+
+				"To recover, re-import the zone:\n"+
+				"  terraform import cloudflare_zone.<name> <zone_id>\n"+
+				"then run terraform plan again.",
+		)
+	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
- Adds safeguards for when reading or writing an empty or null `cloudflare_zone` ID from state
- Adds unit tests with a mock server to test the plan failure and API response validation logic

## Context
We received a report that a malformed zone ID state value caused cascading deletions for all dependent zone-scoped resources. The tl;dr is that the zone ID being empty or null triggered all of the zone-scoped resources referencing that zone ID to get flagged as requiring replacement (i.e. `RequiresReplace`).

### Reproduction
1. `terraform apply` to create zone and zone_setting in new Terraform project
2. Use local proxy to edit the inbound zone ID to be empty
3. Observe cascading deletions when running `terraform apply -auto-approve`

### Pre-fix Plan Output
```
cloudflare_zone.main: Refreshing state... [id=38394ef6952794aa8285f1cc018d4720]
cloudflare_zone_setting.probe: Refreshing state... [id=always_use_https]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have affected this plan:

  # cloudflare_zone.main has changed
  ~ resource "cloudflare_zone" "main" {
      - id                    = "38394ef6952794aa8285f1cc018d4720" -> null
        name                  = "custesc62460repro.mjtest.com"
        # (17 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may
include actions to undo or respond to these changes.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # cloudflare_zone_setting.probe must be replaced
-/+ resource "cloudflare_zone_setting" "probe" {
      ~ editable       = true -> (known after apply)
      + enabled        = (known after apply)
      ~ id             = "always_use_https" -> (known after apply)
      ~ modified_on    = "2026-03-12T07:27:11Z" -> (known after apply)
      + time_remaining = (known after apply)
      - zone_id        = "38394ef6952794aa8285f1cc018d4720" -> null # forces replacement
        # (2 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  ~ zone_id = "38394ef6952794aa8285f1cc018d4720" -> ""
cloudflare_zone_setting.probe: Destroying... [id=always_use_https]
cloudflare_zone_setting.probe: Destruction complete after 0s
cloudflare_zone_setting.probe: Creating...
╷
│ Warning: Resource Destruction Considerations
│
│   with cloudflare_zone_setting.probe,
│   on main.tf line 14, in resource "cloudflare_zone_setting" "probe":
│   14: resource "cloudflare_zone_setting" "probe" {
│
│ This resource cannot be destroyed from Terraform. If you create this resource, it will be present in the API until manually deleted.
╵
╷
│ Error: failed to make http request
│
│   with cloudflare_zone_setting.probe,
│   on main.tf line 14, in resource "cloudflare_zone_setting" "probe":
│   14: resource "cloudflare_zone_setting" "probe" {
│
│ missing required zone_id parameter
```

### Post-fix Plan Output
```
Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - cloudflare/cloudflare in /Users/musa/cf-repos/github/terraform-provider-cloudflare

The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
published releases.
cloudflare_zone.main: Refreshing state... [id=38394ef6952794aa8285f1cc018d4720]

Planning failed. Terraform encountered an error while generating this plan.


Error: Zone API returned empty or null zone ID

  with cloudflare_zone.main,
  on main.tf line 1, in resource "cloudflare_zone" "main":
   1: resource "cloudflare_zone" "main" {

The Cloudflare API returned a zone response with an empty or null zone ID. This is unexpected and may indicate a transient API error.

The provider is halting to prevent writing invalid state that could cause dependent zone-scoped resources to be incorrectly replaced or destroyed.

Please try running the operation again. If the problem persists, contact Cloudflare support.
```

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
`TF_ACC=1 go test ./internal/services/zone -count=1 -v`

### Test output
```
=== RUN   TestZoneResource_ModifyPlan_EmptyID_FailsPlan
--- PASS: TestZoneResource_ModifyPlan_EmptyID_FailsPlan (0.00s)
=== RUN   TestZoneResource_ModifyPlan_NullPriorState_Passes
--- PASS: TestZoneResource_ModifyPlan_NullPriorState_Passes (0.00s)
=== RUN   TestZoneResource_ModifyPlan_ValidID_Passes
--- PASS: TestZoneResource_ModifyPlan_ValidID_Passes (0.00s)
=== RUN   TestZoneResource_Read_EmptyID_FailsWithoutAPICall
--- PASS: TestZoneResource_Read_EmptyID_FailsWithoutAPICall (0.00s)
=== RUN   TestZoneResource_Update_EmptyID_FailsWithoutAPICall
--- PASS: TestZoneResource_Update_EmptyID_FailsWithoutAPICall (0.00s)
=== RUN   TestZoneResource_Delete_EmptyID_FailsWithoutAPICall
--- PASS: TestZoneResource_Delete_EmptyID_FailsWithoutAPICall (0.00s)
=== RUN   TestZoneDataSource_Read_EmptyZoneID_FailsWithoutAPICall
--- PASS: TestZoneDataSource_Read_EmptyZoneID_FailsWithoutAPICall (0.00s)
=== RUN   TestZoneResource_ModifyPlan_NullID_FailsPlan
--- PASS: TestZoneResource_ModifyPlan_NullID_FailsPlan (0.00s)
=== RUN   TestZoneResource_Read_NullID_FailsWithoutAPICall
--- PASS: TestZoneResource_Read_NullID_FailsWithoutAPICall (0.00s)
=== RUN   TestZoneResource_Update_NullID_FailsWithoutAPICall
--- PASS: TestZoneResource_Update_NullID_FailsWithoutAPICall (0.00s)
=== RUN   TestZoneResource_Delete_NullID_FailsWithoutAPICall
--- PASS: TestZoneResource_Delete_NullID_FailsWithoutAPICall (0.00s)
=== RUN   TestZoneDataSource_Read_NullZoneID_FailsWithoutAPICall
--- PASS: TestZoneDataSource_Read_NullZoneID_FailsWithoutAPICall (0.00s)
=== RUN   TestZoneResource_Read_APIReturnsEmptyID_FailsWithoutWritingState
--- PASS: TestZoneResource_Read_APIReturnsEmptyID_FailsWithoutWritingState (0.00s)
=== RUN   TestZoneResource_Create_APIReturnsEmptyID_FailsWithoutWritingState
--- PASS: TestZoneResource_Create_APIReturnsEmptyID_FailsWithoutWritingState (0.00s)
=== RUN   TestZoneResource_Update_APIReturnsEmptyID_FailsWithoutWritingState
--- PASS: TestZoneResource_Update_APIReturnsEmptyID_FailsWithoutWritingState (0.00s)
=== RUN   TestZoneDataSourceModelSchemaParity
=== PAUSE TestZoneDataSourceModelSchemaParity
=== RUN   TestAccCloudflareZoneDataSource_ByZoneID
=== PAUSE TestAccCloudflareZoneDataSource_ByZoneID
=== RUN   TestAccCloudflareZoneDataSource_ByName
=== PAUSE TestAccCloudflareZoneDataSource_ByName
=== RUN   TestAccCloudflareZoneDataSource_ByNameWithFilter
=== PAUSE TestAccCloudflareZoneDataSource_ByNameWithFilter
=== RUN   TestAccCloudflareZoneDataSource_FilterByStatus
=== PAUSE TestAccCloudflareZoneDataSource_FilterByStatus
=== RUN   TestAccCloudflareZoneDataSource_FullZoneAttributes
=== PAUSE TestAccCloudflareZoneDataSource_FullZoneAttributes
=== RUN   TestAccCloudflareZone_NameLookup
=== PAUSE TestAccCloudflareZone_NameLookup
=== RUN   TestZonesDataSourceModelSchemaParity
=== PAUSE TestZonesDataSourceModelSchemaParity
=== RUN   TestAccCloudflareZonesDataSource_Basic
=== PAUSE TestAccCloudflareZonesDataSource_Basic
=== RUN   TestAccCloudflareZonesDataSource_FilterByName
=== PAUSE TestAccCloudflareZonesDataSource_FilterByName
=== RUN   TestAccCloudflareZonesDataSource_FilterByStatus
=== PAUSE TestAccCloudflareZonesDataSource_FilterByStatus
=== RUN   TestAccCloudflareZonesDataSource_FilterByNamePattern
=== PAUSE TestAccCloudflareZonesDataSource_FilterByNamePattern
=== RUN   TestAccCloudflareZonesDataSource_OrderAndDirection
=== PAUSE TestAccCloudflareZonesDataSource_OrderAndDirection
=== RUN   TestAccCloudflareZonesDataSource_MaxItems
=== PAUSE TestAccCloudflareZonesDataSource_MaxItems
=== RUN   TestAccCloudflareZonesDataSource_MatchAny
=== PAUSE TestAccCloudflareZonesDataSource_MatchAny
=== RUN   TestAccCloudflareZonesDataSource_CompleteZoneAttributes
=== PAUSE TestAccCloudflareZonesDataSource_CompleteZoneAttributes
=== RUN   TestZoneModelSchemaParity
    resource_schema_test.go:14: need investigation: currently broken
--- SKIP: TestZoneModelSchemaParity (0.00s)
=== RUN   TestAccCloudflareZone_Basic
--- PASS: TestAccCloudflareZone_Basic (11.66s)
=== RUN   TestAccCloudflareZone_PartialSetup
--- PASS: TestAccCloudflareZone_PartialSetup (5.63s)
=== RUN   TestAccCloudflareZone_FullSetup
--- PASS: TestAccCloudflareZone_FullSetup (5.31s)
=== RUN   TestAccZoneWithUnicodeIsStoredAsUnicode
--- PASS: TestAccZoneWithUnicodeIsStoredAsUnicode (4.51s)
=== RUN   TestAccZoneWithoutUnicodeIsStoredAsUnicode
    resource_test.go:218: unicode translation not working correctly
--- SKIP: TestAccZoneWithoutUnicodeIsStoredAsUnicode (0.00s)
=== RUN   TestAccZonePerformsUnicodeComparison
    resource_test.go:245: unicode translation not working correctly
--- SKIP: TestAccZonePerformsUnicodeComparison (0.00s)
=== RUN   TestAccCloudflareZone_WithEnterprisePlanVanityNameServers
    acctest.go:242: Skipping acceptance test for default account (f037e56e89293a057740de681ac9abbe). Need working zone_subscription to create enterprise plan before setting vanity name servers
--- SKIP: TestAccCloudflareZone_WithEnterprisePlanVanityNameServers (0.00s)
=== RUN   TestAccCloudflareZone_Secondary
--- PASS: TestAccCloudflareZone_Secondary (4.38s)
=== RUN   TestAccCloudflareZone_SecondaryWithVanityNameServers
    acctest.go:242: Skipping acceptance test for default account (f037e56e89293a057740de681ac9abbe). Need working zone_subscription to create enterprise plan before setting vanity name servers
--- SKIP: TestAccCloudflareZone_SecondaryWithVanityNameServers (0.00s)
=== RUN   TestAccCloudflareZone_TogglePaused
--- PASS: TestAccCloudflareZone_TogglePaused (8.74s)
=== RUN   TestAccCloudflareZone_SetType
--- PASS: TestAccCloudflareZone_SetType (6.61s)
=== RUN   TestAccUpgradeZone_FromPublishedV5
    resource_test.go:457: Failed to marshal state to json: schema version 0 in state does not match version 1 from the provider
--- SKIP: TestAccUpgradeZone_FromPublishedV5 (0.00s)
=== CONT  TestZoneDataSourceModelSchemaParity
=== CONT  TestAccCloudflareZonesDataSource_Basic
=== CONT  TestAccCloudflareZoneDataSource_FilterByStatus
=== CONT  TestAccCloudflareZonesDataSource_OrderAndDirection
=== CONT  TestAccCloudflareZonesDataSource_FilterByStatus
=== CONT  TestAccCloudflareZone_NameLookup
=== CONT  TestZonesDataSourceModelSchemaParity
--- PASS: TestZoneDataSourceModelSchemaParity (0.00s)
=== CONT  TestAccCloudflareZoneDataSource_ByName
=== CONT  TestAccCloudflareZonesDataSource_FilterByName
=== CONT  TestAccCloudflareZoneDataSource_FullZoneAttributes
--- PASS: TestZonesDataSourceModelSchemaParity (0.00s)
=== CONT  TestAccCloudflareZoneDataSource_ByNameWithFilter
=== CONT  TestAccCloudflareZonesDataSource_MatchAny
=== CONT  TestAccCloudflareZonesDataSource_CompleteZoneAttributes
=== CONT  TestAccCloudflareZonesDataSource_MaxItems
--- PASS: TestAccCloudflareZoneDataSource_FullZoneAttributes (3.04s)
=== CONT  TestAccCloudflareZoneDataSource_ByZoneID
--- PASS: TestAccCloudflareZonesDataSource_MaxItems (3.42s)
=== CONT  TestAccCloudflareZonesDataSource_FilterByNamePattern
--- PASS: TestAccCloudflareZoneDataSource_ByNameWithFilter (4.08s)
--- PASS: TestAccCloudflareZonesDataSource_FilterByName (4.28s)
--- PASS: TestAccCloudflareZoneDataSource_FilterByStatus (4.45s)
--- PASS: TestAccCloudflareZonesDataSource_CompleteZoneAttributes (4.48s)
--- PASS: TestAccCloudflareZone_NameLookup (4.49s)
--- PASS: TestAccCloudflareZonesDataSource_FilterByStatus (4.67s)
--- PASS: TestAccCloudflareZoneDataSource_ByName (4.86s)
--- PASS: TestAccCloudflareZonesDataSource_Basic (4.91s)
--- PASS: TestAccCloudflareZonesDataSource_OrderAndDirection (5.00s)
--- PASS: TestAccCloudflareZoneDataSource_ByZoneID (3.07s)
--- PASS: TestAccCloudflareZonesDataSource_FilterByNamePattern (3.79s)
--- PASS: TestAccCloudflareZonesDataSource_MatchAny (10.91s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zone	59.886s
```


