### PR TITLE
feat: bump all remaining resources to schema version 500

### DIFF
--- a/internal/services/account_dns_settings/migrations.go
+++ b/internal/services/account_dns_settings/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*AccountDNSSettingsResource)(nil)
 
 func (r *AccountDNSSettingsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/account_dns_settings/schema.go
+++ b/internal/services/account_dns_settings/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*AccountDNSSettingsResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/account_dns_settings_internal_view/migrations.go
+++ b/internal/services/account_dns_settings_internal_view/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*AccountDNSSettingsInternalViewResource)(nil)
 
 func (r *AccountDNSSettingsInternalViewResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/account_dns_settings_internal_view/schema.go
+++ b/internal/services/account_dns_settings_internal_view/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*AccountDNSSettingsInternalViewRe
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/account_subscription/migrations.go
+++ b/internal/services/account_subscription/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*AccountSubscriptionResource)(nil)
 
 func (r *AccountSubscriptionResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/account_subscription/schema.go
+++ b/internal/services/account_subscription/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*AccountSubscriptionResource)(nil
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Subscription identifier tag.",

--- a/internal/services/ai_search_instance/migrations.go
+++ b/internal/services/ai_search_instance/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*AISearchInstanceResource)(nil)
 
 func (r *AISearchInstanceResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/ai_search_instance/schema.go
+++ b/internal/services/ai_search_instance/schema.go
@@ -26,6 +26,7 @@ var _ resource.ResourceWithConfigValidators = (*AISearchInstanceResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Use your AI Search ID.",

--- a/internal/services/ai_search_token/migrations.go
+++ b/internal/services/ai_search_token/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*AISearchTokenResource)(nil)
 
 func (r *AISearchTokenResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/ai_search_token/schema.go
+++ b/internal/services/ai_search_token/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*AISearchTokenResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,

--- a/internal/services/api_shield_discovery_operation/migrations.go
+++ b/internal/services/api_shield_discovery_operation/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*APIShieldDiscoveryOperationResource)(nil)
 
 func (r *APIShieldDiscoveryOperationResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/api_shield_discovery_operation/schema.go
+++ b/internal/services/api_shield_discovery_operation/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*APIShieldDiscoveryOperationResou
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		DeprecationMessage: "This resource is no longer supported. It cannot be imported.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/services/api_shield_operation_schema_validation_settings/migrations.go
+++ b/internal/services/api_shield_operation_schema_validation_settings/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*APIShieldOperationSchemaValidationSettingsResource)(nil)
 
 func (r *APIShieldOperationSchemaValidationSettingsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/api_shield_operation_schema_validation_settings/schema.go
+++ b/internal/services/api_shield_operation_schema_validation_settings/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*APIShieldOperationSchemaValidati
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		DeprecationMessage: "Please use the `cloudflare_schema_validation_operation_settings` resource instead",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/services/api_shield_schema/migrations.go
+++ b/internal/services/api_shield_schema/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*APIShieldSchemaResource)(nil)
 
 func (r *APIShieldSchemaResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/api_shield_schema/schema.go
+++ b/internal/services/api_shield_schema/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*APIShieldSchemaResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		DeprecationMessage: "Please use the `cloudflare_schema_validation_schemas` resource instead",
 		Attributes: map[string]schema.Attribute{
 			"zone_id": schema.StringAttribute{

--- a/internal/services/api_shield_schema_validation_settings/migrations.go
+++ b/internal/services/api_shield_schema_validation_settings/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*APIShieldSchemaValidationSettingsResource)(nil)
 
 func (r *APIShieldSchemaValidationSettingsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/api_shield_schema_validation_settings/schema.go
+++ b/internal/services/api_shield_schema_validation_settings/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*APIShieldSchemaValidationSetting
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/calls_sfu_app/migrations.go
+++ b/internal/services/calls_sfu_app/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*CallsSFUAppResource)(nil)
 
 func (r *CallsSFUAppResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/calls_sfu_app/schema.go
+++ b/internal/services/calls_sfu_app/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*CallsSFUAppResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The account identifier tag.",

--- a/internal/services/calls_turn_app/migrations.go
+++ b/internal/services/calls_turn_app/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*CallsTURNAppResource)(nil)
 
 func (r *CallsTURNAppResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/calls_turn_app/schema.go
+++ b/internal/services/calls_turn_app/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*CallsTURNAppResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The account identifier tag.",

--- a/internal/services/certificate_authorities_hostname_associations/migrations.go
+++ b/internal/services/certificate_authorities_hostname_associations/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*CertificateAuthoritiesHostnameAssociationsResource)(nil)
 
 func (r *CertificateAuthoritiesHostnameAssociationsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/certificate_authorities_hostname_associations/schema.go
+++ b/internal/services/certificate_authorities_hostname_associations/schema.go
@@ -16,6 +16,7 @@ var _ resource.ResourceWithConfigValidators = (*CertificateAuthoritiesHostnameAs
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/client_certificate/migrations.go
+++ b/internal/services/client_certificate/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ClientCertificateResource)(nil)
 
 func (r *ClientCertificateResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/client_certificate/schema.go
+++ b/internal/services/client_certificate/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*ClientCertificateResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/cloud_connector_rules/migrations.go
+++ b/internal/services/cloud_connector_rules/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*CloudConnectorRulesResource)(nil)
 
 func (r *CloudConnectorRulesResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/cloud_connector_rules/schema.go
+++ b/internal/services/cloud_connector_rules/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*CloudConnectorRulesResource)(nil
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/cloudforce_one_request/migrations.go
+++ b/internal/services/cloudforce_one_request/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*CloudforceOneRequestResource)(nil)
 
 func (r *CloudforceOneRequestResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/cloudforce_one_request/schema.go
+++ b/internal/services/cloudforce_one_request/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*CloudforceOneRequestResource)(ni
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "UUID.",

--- a/internal/services/cloudforce_one_request_asset/migrations.go
+++ b/internal/services/cloudforce_one_request_asset/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*CloudforceOneRequestAssetResource)(nil)
 
 func (r *CloudforceOneRequestAssetResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/cloudforce_one_request_asset/schema.go
+++ b/internal/services/cloudforce_one_request_asset/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*CloudforceOneRequestAssetResourc
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.Int64Attribute{
 				Description:   "Asset ID.",

--- a/internal/services/cloudforce_one_request_message/migrations.go
+++ b/internal/services/cloudforce_one_request_message/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*CloudforceOneRequestMessageResource)(nil)
 
 func (r *CloudforceOneRequestMessageResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/cloudforce_one_request_message/schema.go
+++ b/internal/services/cloudforce_one_request_message/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*CloudforceOneRequestMessageResou
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.Int64Attribute{
 				Description:   "Message ID.",

--- a/internal/services/cloudforce_one_request_priority/migrations.go
+++ b/internal/services/cloudforce_one_request_priority/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*CloudforceOneRequestPriorityResource)(nil)
 
 func (r *CloudforceOneRequestPriorityResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/cloudforce_one_request_priority/schema.go
+++ b/internal/services/cloudforce_one_request_priority/schema.go
@@ -19,6 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*CloudforceOneRequestPriorityReso
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "UUID.",

--- a/internal/services/connectivity_directory_service/migrations.go
+++ b/internal/services/connectivity_directory_service/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ConnectivityDirectoryServiceResource)(nil)
 
 func (r *ConnectivityDirectoryServiceResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/connectivity_directory_service/schema.go
+++ b/internal/services/connectivity_directory_service/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*ConnectivityDirectoryServiceReso
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,

--- a/internal/services/content_scanning/migrations.go
+++ b/internal/services/content_scanning/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ContentScanningResource)(nil)
 
 func (r *ContentScanningResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/content_scanning/schema.go
+++ b/internal/services/content_scanning/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*ContentScanningResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"zone_id": schema.StringAttribute{
 				Description:   "Defines an identifier.",

--- a/internal/services/content_scanning_expression/migrations.go
+++ b/internal/services/content_scanning_expression/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ContentScanningExpressionResource)(nil)
 
 func (r *ContentScanningExpressionResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/content_scanning_expression/schema.go
+++ b/internal/services/content_scanning_expression/schema.go
@@ -16,6 +16,7 @@ var _ resource.ResourceWithConfigValidators = (*ContentScanningExpressionResourc
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "defines the unique ID for this custom scan expression.",

--- a/internal/services/custom_origin_trust_store/migrations.go
+++ b/internal/services/custom_origin_trust_store/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*CustomOriginTrustStoreResource)(nil)
 
 func (r *CustomOriginTrustStoreResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/custom_origin_trust_store/schema.go
+++ b/internal/services/custom_origin_trust_store/schema.go
@@ -19,6 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*CustomOriginTrustStoreResource)(
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/d1_database/migrations.go
+++ b/internal/services/d1_database/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*D1DatabaseResource)(nil)
 
 func (r *D1DatabaseResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/d1_database/schema.go
+++ b/internal/services/d1_database/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*D1DatabaseResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "D1 database identifier (UUID).",

--- a/internal/services/dns_firewall/migrations.go
+++ b/internal/services/dns_firewall/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*DNSFirewallResource)(nil)
 
 func (r *DNSFirewallResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/dns_firewall/schema.go
+++ b/internal/services/dns_firewall/schema.go
@@ -22,6 +22,7 @@ var _ resource.ResourceWithConfigValidators = (*DNSFirewallResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/dns_zone_transfers_acl/migrations.go
+++ b/internal/services/dns_zone_transfers_acl/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*DNSZoneTransfersACLResource)(nil)
 
 func (r *DNSZoneTransfersACLResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/dns_zone_transfers_acl/schema.go
+++ b/internal/services/dns_zone_transfers_acl/schema.go
@@ -15,6 +15,7 @@ var _ resource.ResourceWithConfigValidators = (*DNSZoneTransfersACLResource)(nil
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,

--- a/internal/services/dns_zone_transfers_incoming/migrations.go
+++ b/internal/services/dns_zone_transfers_incoming/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*DNSZoneTransfersIncomingResource)(nil)
 
 func (r *DNSZoneTransfersIncomingResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/dns_zone_transfers_incoming/schema.go
+++ b/internal/services/dns_zone_transfers_incoming/schema.go
@@ -19,6 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*DNSZoneTransfersIncomingResource
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,

--- a/internal/services/dns_zone_transfers_outgoing/migrations.go
+++ b/internal/services/dns_zone_transfers_outgoing/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*DNSZoneTransfersOutgoingResource)(nil)
 
 func (r *DNSZoneTransfersOutgoingResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/dns_zone_transfers_outgoing/schema.go
+++ b/internal/services/dns_zone_transfers_outgoing/schema.go
@@ -16,6 +16,7 @@ var _ resource.ResourceWithConfigValidators = (*DNSZoneTransfersOutgoingResource
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,

--- a/internal/services/dns_zone_transfers_peer/migrations.go
+++ b/internal/services/dns_zone_transfers_peer/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*DNSZoneTransfersPeerResource)(nil)
 
 func (r *DNSZoneTransfersPeerResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/dns_zone_transfers_peer/schema.go
+++ b/internal/services/dns_zone_transfers_peer/schema.go
@@ -15,6 +15,7 @@ var _ resource.ResourceWithConfigValidators = (*DNSZoneTransfersPeerResource)(ni
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,

--- a/internal/services/dns_zone_transfers_tsig/migrations.go
+++ b/internal/services/dns_zone_transfers_tsig/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*DNSZoneTransfersTSIGResource)(nil)
 
 func (r *DNSZoneTransfersTSIGResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/dns_zone_transfers_tsig/schema.go
+++ b/internal/services/dns_zone_transfers_tsig/schema.go
@@ -15,6 +15,7 @@ var _ resource.ResourceWithConfigValidators = (*DNSZoneTransfersTSIGResource)(ni
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,

--- a/internal/services/email_routing_dns/migrations.go
+++ b/internal/services/email_routing_dns/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*EmailRoutingDNSResource)(nil)
 
 func (r *EmailRoutingDNSResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/email_routing_dns/schema.go
+++ b/internal/services/email_routing_dns/schema.go
@@ -21,6 +21,7 @@ var _ resource.ResourceWithConfigValidators = (*EmailRoutingDNSResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/email_security_block_sender/migrations.go
+++ b/internal/services/email_security_block_sender/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*EmailSecurityBlockSenderResource)(nil)
 
 func (r *EmailSecurityBlockSenderResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/email_security_block_sender/schema.go
+++ b/internal/services/email_security_block_sender/schema.go
@@ -19,6 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*EmailSecurityBlockSenderResource
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.Int64Attribute{
 				Description:   "The unique identifier for the allow policy.",

--- a/internal/services/email_security_impersonation_registry/migrations.go
+++ b/internal/services/email_security_impersonation_registry/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*EmailSecurityImpersonationRegistryResource)(nil)
 
 func (r *EmailSecurityImpersonationRegistryResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/email_security_impersonation_registry/schema.go
+++ b/internal/services/email_security_impersonation_registry/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*EmailSecurityImpersonationRegist
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.Int64Attribute{
 				Computed:      true,

--- a/internal/services/email_security_trusted_domains/migrations.go
+++ b/internal/services/email_security_trusted_domains/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*EmailSecurityTrustedDomainsResource)(nil)
 
 func (r *EmailSecurityTrustedDomainsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/email_security_trusted_domains/schema.go
+++ b/internal/services/email_security_trusted_domains/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*EmailSecurityTrustedDomainsResou
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.Int64Attribute{
 				Description:   "The unique identifier for the trusted domain.",

--- a/internal/services/hostname_tls_setting/migrations.go
+++ b/internal/services/hostname_tls_setting/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*HostnameTLSSettingResource)(nil)
 
 func (r *HostnameTLSSettingResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/hostname_tls_setting/schema.go
+++ b/internal/services/hostname_tls_setting/schema.go
@@ -19,6 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*HostnameTLSSettingResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The TLS Setting name. The value type depends on the setting:\n- `ciphers`: value is an array of cipher suite strings (e.g., `[\"ECDHE-RSA-AES128-GCM-SHA256\", \"AES128-GCM-SHA256\"]`)\n- `min_tls_version`: value is a TLS version string (`\"1.0\"`, `\"1.1\"`, `\"1.2\"`, or `\"1.3\"`)\n- `http2`: value is `\"on\"` or `\"off\"`\nAvailable values: \"ciphers\", \"min_tls_version\", \"http2\".",

--- a/internal/services/hyperdrive_config/migrations.go
+++ b/internal/services/hyperdrive_config/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*HyperdriveConfigResource)(nil)
 
 func (r *HyperdriveConfigResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/hyperdrive_config/schema.go
+++ b/internal/services/hyperdrive_config/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*HyperdriveConfigResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Define configurations using a unique string identifier.",

--- a/internal/services/image/migrations.go
+++ b/internal/services/image/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ImageResource)(nil)
 
 func (r *ImageResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/image/schema.go
+++ b/internal/services/image/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*ImageResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "An optional custom unique identifier for your image.",

--- a/internal/services/keyless_certificate/migrations.go
+++ b/internal/services/keyless_certificate/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*KeylessCertificateResource)(nil)
 
 func (r *KeylessCertificateResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/keyless_certificate/schema.go
+++ b/internal/services/keyless_certificate/schema.go
@@ -22,6 +22,7 @@ var _ resource.ResourceWithConfigValidators = (*KeylessCertificateResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Keyless certificate identifier tag.",

--- a/internal/services/magic_network_monitoring_configuration/migrations.go
+++ b/internal/services/magic_network_monitoring_configuration/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*MagicNetworkMonitoringConfigurationResource)(nil)
 
 func (r *MagicNetworkMonitoringConfigurationResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/magic_network_monitoring_configuration/schema.go
+++ b/internal/services/magic_network_monitoring_configuration/schema.go
@@ -19,6 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*MagicNetworkMonitoringConfigurat
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Required:      true,

--- a/internal/services/magic_network_monitoring_rule/migrations.go
+++ b/internal/services/magic_network_monitoring_rule/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*MagicNetworkMonitoringRuleResource)(nil)
 
 func (r *MagicNetworkMonitoringRuleResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/magic_network_monitoring_rule/schema.go
+++ b/internal/services/magic_network_monitoring_rule/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*MagicNetworkMonitoringRuleResour
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "The id of the rule. Must be unique.",

--- a/internal/services/magic_transit_connector/migrations.go
+++ b/internal/services/magic_transit_connector/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*MagicTransitConnectorResource)(nil)
 
 func (r *MagicTransitConnectorResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/magic_transit_connector/schema.go
+++ b/internal/services/magic_transit_connector/schema.go
@@ -16,6 +16,7 @@ var _ resource.ResourceWithConfigValidators = (*MagicTransitConnectorResource)(n
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,

--- a/internal/services/magic_transit_site/migrations.go
+++ b/internal/services/magic_transit_site/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*MagicTransitSiteResource)(nil)
 
 func (r *MagicTransitSiteResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/magic_transit_site/schema.go
+++ b/internal/services/magic_transit_site/schema.go
@@ -16,6 +16,7 @@ var _ resource.ResourceWithConfigValidators = (*MagicTransitSiteResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier",

--- a/internal/services/magic_transit_site_acl/migrations.go
+++ b/internal/services/magic_transit_site_acl/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*MagicTransitSiteACLResource)(nil)
 
 func (r *MagicTransitSiteACLResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/magic_transit_site_acl/schema.go
+++ b/internal/services/magic_transit_site_acl/schema.go
@@ -19,6 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*MagicTransitSiteACLResource)(nil
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier",

--- a/internal/services/magic_transit_site_lan/migrations.go
+++ b/internal/services/magic_transit_site_lan/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*MagicTransitSiteLANResource)(nil)
 
 func (r *MagicTransitSiteLANResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/magic_transit_site_lan/schema.go
+++ b/internal/services/magic_transit_site_lan/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*MagicTransitSiteLANResource)(nil
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier",

--- a/internal/services/magic_transit_site_wan/migrations.go
+++ b/internal/services/magic_transit_site_wan/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*MagicTransitSiteWANResource)(nil)
 
 func (r *MagicTransitSiteWANResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/magic_transit_site_wan/schema.go
+++ b/internal/services/magic_transit_site_wan/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*MagicTransitSiteWANResource)(nil
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier",

--- a/internal/services/organization/migrations.go
+++ b/internal/services/organization/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*OrganizationResource)(nil)
 
 func (r *OrganizationResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/organization/schema.go
+++ b/internal/services/organization/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*OrganizationResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,

--- a/internal/services/organization_profile/migrations.go
+++ b/internal/services/organization_profile/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*OrganizationProfileResource)(nil)
 
 func (r *OrganizationProfileResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/organization_profile/schema.go
+++ b/internal/services/organization_profile/schema.go
@@ -15,6 +15,7 @@ var _ resource.ResourceWithConfigValidators = (*OrganizationProfileResource)(nil
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"organization_id": schema.StringAttribute{
 				Required:      true,

--- a/internal/services/page_shield_policy/migrations.go
+++ b/internal/services/page_shield_policy/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*PageShieldPolicyResource)(nil)
 
 func (r *PageShieldPolicyResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/page_shield_policy/schema.go
+++ b/internal/services/page_shield_policy/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*PageShieldPolicyResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier",

--- a/internal/services/pipeline/migrations.go
+++ b/internal/services/pipeline/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*PipelineResource)(nil)
 
 func (r *PipelineResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/pipeline/schema.go
+++ b/internal/services/pipeline/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*PipelineResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Indicates a unique identifier for this pipeline.",

--- a/internal/services/pipeline_sink/migrations.go
+++ b/internal/services/pipeline_sink/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*PipelineSinkResource)(nil)
 
 func (r *PipelineSinkResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/pipeline_sink/schema.go
+++ b/internal/services/pipeline_sink/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*PipelineSinkResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Indicates a unique identifier for this sink.",

--- a/internal/services/pipeline_stream/migrations.go
+++ b/internal/services/pipeline_stream/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*PipelineStreamResource)(nil)
 
 func (r *PipelineStreamResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/pipeline_stream/schema.go
+++ b/internal/services/pipeline_stream/schema.go
@@ -22,6 +22,7 @@ var _ resource.ResourceWithConfigValidators = (*PipelineStreamResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Indicates a unique identifier for this stream.",

--- a/internal/services/r2_bucket_cors/migrations.go
+++ b/internal/services/r2_bucket_cors/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*R2BucketCORSResource)(nil)
 
 func (r *R2BucketCORSResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/r2_bucket_cors/schema.go
+++ b/internal/services/r2_bucket_cors/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*R2BucketCORSResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Account ID.",

--- a/internal/services/r2_bucket_event_notification/migrations.go
+++ b/internal/services/r2_bucket_event_notification/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*R2BucketEventNotificationResource)(nil)
 
 func (r *R2BucketEventNotificationResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/r2_bucket_event_notification/schema.go
+++ b/internal/services/r2_bucket_event_notification/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*R2BucketEventNotificationResourc
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Account ID.",

--- a/internal/services/r2_bucket_lifecycle/migrations.go
+++ b/internal/services/r2_bucket_lifecycle/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*R2BucketLifecycleResource)(nil)
 
 func (r *R2BucketLifecycleResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/r2_bucket_lifecycle/schema.go
+++ b/internal/services/r2_bucket_lifecycle/schema.go
@@ -19,6 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*R2BucketLifecycleResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Account ID.",

--- a/internal/services/r2_bucket_lock/migrations.go
+++ b/internal/services/r2_bucket_lock/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*R2BucketLockResource)(nil)
 
 func (r *R2BucketLockResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/r2_bucket_lock/schema.go
+++ b/internal/services/r2_bucket_lock/schema.go
@@ -19,6 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*R2BucketLockResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Account ID.",

--- a/internal/services/r2_bucket_sippy/migrations.go
+++ b/internal/services/r2_bucket_sippy/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*R2BucketSippyResource)(nil)
 
 func (r *R2BucketSippyResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/r2_bucket_sippy/schema.go
+++ b/internal/services/r2_bucket_sippy/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*R2BucketSippyResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Account ID.",

--- a/internal/services/r2_custom_domain/migrations.go
+++ b/internal/services/r2_custom_domain/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*R2CustomDomainResource)(nil)
 
 func (r *R2CustomDomainResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/r2_custom_domain/schema.go
+++ b/internal/services/r2_custom_domain/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*R2CustomDomainResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Account ID.",

--- a/internal/services/r2_data_catalog/migrations.go
+++ b/internal/services/r2_data_catalog/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*R2DataCatalogResource)(nil)
 
 func (r *R2DataCatalogResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/r2_data_catalog/schema.go
+++ b/internal/services/r2_data_catalog/schema.go
@@ -19,6 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*R2DataCatalogResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Use this to uniquely identify the activated catalog.",

--- a/internal/services/r2_managed_domain/migrations.go
+++ b/internal/services/r2_managed_domain/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*R2ManagedDomainResource)(nil)
 
 func (r *R2ManagedDomainResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/r2_managed_domain/schema.go
+++ b/internal/services/r2_managed_domain/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*R2ManagedDomainResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Account ID.",

--- a/internal/services/registrar_domain/migrations.go
+++ b/internal/services/registrar_domain/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*RegistrarDomainResource)(nil)
 
 func (r *RegistrarDomainResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/registrar_domain/schema.go
+++ b/internal/services/registrar_domain/schema.go
@@ -15,6 +15,7 @@ var _ resource.ResourceWithConfigValidators = (*RegistrarDomainResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier",

--- a/internal/services/schema_validation_operation_settings/migrations.go
+++ b/internal/services/schema_validation_operation_settings/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*SchemaValidationOperationSettingsResource)(nil)
 
 func (r *SchemaValidationOperationSettingsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/schema_validation_operation_settings/schema.go
+++ b/internal/services/schema_validation_operation_settings/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*SchemaValidationOperationSetting
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"operation_id": schema.StringAttribute{
 				Description:   "UUID.",

--- a/internal/services/schema_validation_schemas/migrations.go
+++ b/internal/services/schema_validation_schemas/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*SchemaValidationSchemasResource)(nil)
 
 func (r *SchemaValidationSchemasResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/schema_validation_schemas/schema.go
+++ b/internal/services/schema_validation_schemas/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*SchemaValidationSchemasResource)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "A unique identifier of this schema",

--- a/internal/services/schema_validation_settings/migrations.go
+++ b/internal/services/schema_validation_settings/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*SchemaValidationSettingsResource)(nil)
 
 func (r *SchemaValidationSettingsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/schema_validation_settings/schema.go
+++ b/internal/services/schema_validation_settings/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*SchemaValidationSettingsResource
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/snippets/migrations.go
+++ b/internal/services/snippets/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*SnippetsResource)(nil)
 
 func (r *SnippetsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/snippets/schema.go
+++ b/internal/services/snippets/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*SnippetsResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		DeprecationMessage: "The `snippets` resource has been deprecated. Use `snippet` instead.",
 		Attributes: map[string]schema.Attribute{
 			"snippet_name": schema.StringAttribute{

--- a/internal/services/sso_connector/migrations.go
+++ b/internal/services/sso_connector/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*SSOConnectorResource)(nil)
 
 func (r *SSOConnectorResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/sso_connector/schema.go
+++ b/internal/services/sso_connector/schema.go
@@ -21,6 +21,7 @@ var _ resource.ResourceWithConfigValidators = (*SSOConnectorResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "SSO Connector identifier tag.",

--- a/internal/services/stream/migrations.go
+++ b/internal/services/stream/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*StreamResource)(nil)
 
 func (r *StreamResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/stream/schema.go
+++ b/internal/services/stream/schema.go
@@ -26,6 +26,7 @@ var _ resource.ResourceWithConfigValidators = (*StreamResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The account identifier tag.",

--- a/internal/services/stream_audio_track/migrations.go
+++ b/internal/services/stream_audio_track/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*StreamAudioTrackResource)(nil)
 
 func (r *StreamAudioTrackResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/stream_audio_track/schema.go
+++ b/internal/services/stream_audio_track/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*StreamAudioTrackResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The account identifier tag.",

--- a/internal/services/stream_caption_language/migrations.go
+++ b/internal/services/stream_caption_language/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*StreamCaptionLanguageResource)(nil)
 
 func (r *StreamCaptionLanguageResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/stream_caption_language/schema.go
+++ b/internal/services/stream_caption_language/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*StreamCaptionLanguageResource)(n
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/stream_download/migrations.go
+++ b/internal/services/stream_download/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*StreamDownloadResource)(nil)
 
 func (r *StreamDownloadResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/stream_download/schema.go
+++ b/internal/services/stream_download/schema.go
@@ -15,6 +15,7 @@ var _ resource.ResourceWithConfigValidators = (*StreamDownloadResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/stream_key/migrations.go
+++ b/internal/services/stream_key/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*StreamKeyResource)(nil)
 
 func (r *StreamKeyResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/stream_key/schema.go
+++ b/internal/services/stream_key/schema.go
@@ -16,6 +16,7 @@ var _ resource.ResourceWithConfigValidators = (*StreamKeyResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/stream_live_input/migrations.go
+++ b/internal/services/stream_live_input/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*StreamLiveInputResource)(nil)
 
 func (r *StreamLiveInputResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/stream_live_input/schema.go
+++ b/internal/services/stream_live_input/schema.go
@@ -25,6 +25,7 @@ var _ resource.ResourceWithConfigValidators = (*StreamLiveInputResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/stream_watermark/migrations.go
+++ b/internal/services/stream_watermark/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*StreamWatermarkResource)(nil)
 
 func (r *StreamWatermarkResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/stream_watermark/schema.go
+++ b/internal/services/stream_watermark/schema.go
@@ -21,6 +21,7 @@ var _ resource.ResourceWithConfigValidators = (*StreamWatermarkResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The account identifier tag.",

--- a/internal/services/stream_webhook/migrations.go
+++ b/internal/services/stream_webhook/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*StreamWebhookResource)(nil)
 
 func (r *StreamWebhookResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/stream_webhook/schema.go
+++ b/internal/services/stream_webhook/schema.go
@@ -15,6 +15,7 @@ var _ resource.ResourceWithConfigValidators = (*StreamWebhookResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The account identifier tag.",

--- a/internal/services/token_validation_config/migrations.go
+++ b/internal/services/token_validation_config/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*TokenValidationConfigResource)(nil)
 
 func (r *TokenValidationConfigResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/token_validation_config/schema.go
+++ b/internal/services/token_validation_config/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*TokenValidationConfigResource)(n
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "UUID.",

--- a/internal/services/token_validation_rules/migrations.go
+++ b/internal/services/token_validation_rules/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*TokenValidationRulesResource)(nil)
 
 func (r *TokenValidationRulesResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/token_validation_rules/schema.go
+++ b/internal/services/token_validation_rules/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*TokenValidationRulesResource)(ni
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "UUID.",

--- a/internal/services/universal_ssl_setting/migrations.go
+++ b/internal/services/universal_ssl_setting/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*UniversalSSLSettingResource)(nil)
 
 func (r *UniversalSSLSettingResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/universal_ssl_setting/schema.go
+++ b/internal/services/universal_ssl_setting/schema.go
@@ -15,6 +15,7 @@ var _ resource.ResourceWithConfigValidators = (*UniversalSSLSettingResource)(nil
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/user/migrations.go
+++ b/internal/services/user/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*UserResource)(nil)
 
 func (r *UserResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/user/schema.go
+++ b/internal/services/user/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*UserResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier of the user.",

--- a/internal/services/web_analytics_rule/migrations.go
+++ b/internal/services/web_analytics_rule/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*WebAnalyticsRuleResource)(nil)
 
 func (r *WebAnalyticsRuleResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/web_analytics_rule/schema.go
+++ b/internal/services/web_analytics_rule/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*WebAnalyticsRuleResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "The Web Analytics rule identifier.",

--- a/internal/services/web_analytics_site/migrations.go
+++ b/internal/services/web_analytics_site/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*WebAnalyticsSiteResource)(nil)
 
 func (r *WebAnalyticsSiteResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/web_analytics_site/schema.go
+++ b/internal/services/web_analytics_site/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*WebAnalyticsSiteResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "The Web Analytics site identifier.",

--- a/internal/services/worker/migrations.go
+++ b/internal/services/worker/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*WorkerResource)(nil)
 
 func (r *WorkerResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/worker/schema.go
+++ b/internal/services/worker/schema.go
@@ -23,6 +23,7 @@ var _ resource.ResourceWithConfigValidators = (*WorkerResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Immutable ID of the Worker.",

--- a/internal/services/workers_deployment/migrations.go
+++ b/internal/services/workers_deployment/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*WorkersDeploymentResource)(nil)
 
 func (r *WorkersDeploymentResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/workers_deployment/schema.go
+++ b/internal/services/workers_deployment/schema.go
@@ -22,6 +22,7 @@ var _ resource.ResourceWithConfigValidators = (*WorkersDeploymentResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,

--- a/internal/services/workers_script_subdomain/migrations.go
+++ b/internal/services/workers_script_subdomain/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*WorkersScriptSubdomainResource)(nil)
 
 func (r *WorkersScriptSubdomainResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/workers_script_subdomain/schema.go
+++ b/internal/services/workers_script_subdomain/schema.go
@@ -15,6 +15,7 @@ var _ resource.ResourceWithConfigValidators = (*WorkersScriptSubdomainResource)(
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier for the resource.",

--- a/internal/services/workflow/migrations.go
+++ b/internal/services/workflow/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*WorkflowResource)(nil)
 
 func (r *WorkflowResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/workflow/schema.go
+++ b/internal/services/workflow/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*WorkflowResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/migrations.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustAccessAIControlsMcpPortalResource)(nil)
 
 func (r *ZeroTrustAccessAIControlsMcpPortalResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/schema.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustAccessAIControlsMcpPort
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "portal id",

--- a/internal/services/zero_trust_access_ai_controls_mcp_server/migrations.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_server/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustAccessAIControlsMcpServerResource)(nil)
 
 func (r *ZeroTrustAccessAIControlsMcpServerResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_access_ai_controls_mcp_server/schema.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_server/schema.go
@@ -21,6 +21,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustAccessAIControlsMcpServ
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "server id",

--- a/internal/services/zero_trust_access_custom_page/migrations.go
+++ b/internal/services/zero_trust_access_custom_page/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustAccessCustomPageResource)(nil)
 
 func (r *ZeroTrustAccessCustomPageResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_access_custom_page/schema.go
+++ b/internal/services/zero_trust_access_custom_page/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustAccessCustomPageResourc
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "UUID.",

--- a/internal/services/zero_trust_access_infrastructure_target/migrations.go
+++ b/internal/services/zero_trust_access_infrastructure_target/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustAccessInfrastructureTargetResource)(nil)
 
 func (r *ZeroTrustAccessInfrastructureTargetResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_access_infrastructure_target/schema.go
+++ b/internal/services/zero_trust_access_infrastructure_target/schema.go
@@ -16,6 +16,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustAccessInfrastructureTar
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Target identifier",

--- a/internal/services/zero_trust_access_tag/migrations.go
+++ b/internal/services/zero_trust_access_tag/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustAccessTagResource)(nil)
 
 func (r *ZeroTrustAccessTagResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_access_tag/schema.go
+++ b/internal/services/zero_trust_access_tag/schema.go
@@ -15,6 +15,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustAccessTagResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "The name of the tag",

--- a/internal/services/zero_trust_device_ip_profile/migrations.go
+++ b/internal/services/zero_trust_device_ip_profile/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustDeviceIPProfileResource)(nil)
 
 func (r *ZeroTrustDeviceIPProfileResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_device_ip_profile/schema.go
+++ b/internal/services/zero_trust_device_ip_profile/schema.go
@@ -16,6 +16,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustDeviceIPProfileResource
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "The ID of the Device IP profile.",

--- a/internal/services/zero_trust_device_settings/migrations.go
+++ b/internal/services/zero_trust_device_settings/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustDeviceSettingsResource)(nil)
 
 func (r *ZeroTrustDeviceSettingsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_device_settings/schema.go
+++ b/internal/services/zero_trust_device_settings/schema.go
@@ -15,6 +15,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustDeviceSettingsResource)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Required:      true,

--- a/internal/services/zero_trust_device_subnet/migrations.go
+++ b/internal/services/zero_trust_device_subnet/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustDeviceSubnetResource)(nil)
 
 func (r *ZeroTrustDeviceSubnetResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_device_subnet/schema.go
+++ b/internal/services/zero_trust_device_subnet/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustDeviceSubnetResource)(n
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "The UUID of the subnet.",

--- a/internal/services/zero_trust_dex_rule/migrations.go
+++ b/internal/services/zero_trust_dex_rule/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustDEXRuleResource)(nil)
 
 func (r *ZeroTrustDEXRuleResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_dex_rule/schema.go
+++ b/internal/services/zero_trust_dex_rule/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustDEXRuleResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "API Resource UUID tag.",

--- a/internal/services/zero_trust_dlp_dataset/migrations.go
+++ b/internal/services/zero_trust_dlp_dataset/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustDLPDatasetResource)(nil)
 
 func (r *ZeroTrustDLPDatasetResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_dlp_dataset/schema.go
+++ b/internal/services/zero_trust_dlp_dataset/schema.go
@@ -22,6 +22,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustDLPDatasetResource)(nil
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Required:      true,

--- a/internal/services/zero_trust_dlp_entry/migrations.go
+++ b/internal/services/zero_trust_dlp_entry/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustDLPEntryResource)(nil)
 
 func (r *ZeroTrustDLPEntryResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_dlp_entry/schema.go
+++ b/internal/services/zero_trust_dlp_entry/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustDLPEntryResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		DeprecationMessage: "This resource is no longer used but has been split into `zero_trust_dlp_custom_entry`, `zero_trust_dlp_predefined_entry`, and `zero_trust_dlp_integration_entry`",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/services/zero_trust_gateway_pacfile/migrations.go
+++ b/internal/services/zero_trust_gateway_pacfile/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustGatewayPacfileResource)(nil)
 
 func (r *ZeroTrustGatewayPacfileResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_gateway_pacfile/schema.go
+++ b/internal/services/zero_trust_gateway_pacfile/schema.go
@@ -16,6 +16,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustGatewayPacfileResource)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,

--- a/internal/services/zero_trust_network_hostname_route/migrations.go
+++ b/internal/services/zero_trust_network_hostname_route/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustNetworkHostnameRouteResource)(nil)
 
 func (r *ZeroTrustNetworkHostnameRouteResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_network_hostname_route/schema.go
+++ b/internal/services/zero_trust_network_hostname_route/schema.go
@@ -16,6 +16,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustNetworkHostnameRouteRes
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "The hostname route ID.",

--- a/internal/services/zero_trust_risk_behavior/migrations.go
+++ b/internal/services/zero_trust_risk_behavior/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustRiskBehaviorResource)(nil)
 
 func (r *ZeroTrustRiskBehaviorResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_risk_behavior/schema.go
+++ b/internal/services/zero_trust_risk_behavior/schema.go
@@ -17,6 +17,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustRiskBehaviorResource)(n
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Required:      true,

--- a/internal/services/zero_trust_risk_scoring_integration/migrations.go
+++ b/internal/services/zero_trust_risk_scoring_integration/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustRiskScoringIntegrationResource)(nil)
 
 func (r *ZeroTrustRiskScoringIntegrationResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_risk_scoring_integration/schema.go
+++ b/internal/services/zero_trust_risk_scoring_integration/schema.go
@@ -18,6 +18,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustRiskScoringIntegrationR
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "The id of the integration, a UUIDv4.",

--- a/internal/services/zero_trust_tunnel_warp_connector/migrations.go
+++ b/internal/services/zero_trust_tunnel_warp_connector/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustTunnelWARPConnectorResource)(nil)
 
 func (r *ZeroTrustTunnelWARPConnectorResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zero_trust_tunnel_warp_connector/schema.go
+++ b/internal/services/zero_trust_tunnel_warp_connector/schema.go
@@ -20,6 +20,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustTunnelWARPConnectorReso
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "UUID of the tunnel.",

--- a/internal/services/zone_cache_reserve/migrations.go
+++ b/internal/services/zone_cache_reserve/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZoneCacheReserveResource)(nil)
 
 func (r *ZoneCacheReserveResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zone_cache_reserve/schema.go
+++ b/internal/services/zone_cache_reserve/schema.go
@@ -19,6 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*ZoneCacheReserveResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/zone_dns_settings/migrations.go
+++ b/internal/services/zone_dns_settings/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZoneDNSSettingsResource)(nil)
 
 func (r *ZoneDNSSettingsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zone_dns_settings/schema.go
+++ b/internal/services/zone_dns_settings/schema.go
@@ -19,6 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*ZoneDNSSettingsResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",

--- a/internal/services/zone_hold/migrations.go
+++ b/internal/services/zone_hold/migrations.go
@@ -11,5 +11,13 @@ import (
 var _ resource.ResourceWithUpgradeState = (*ZoneHoldResource)(nil)
 
 func (r *ZoneHoldResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	targetSchema := ResourceSchema(ctx)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &targetSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				resp.State.Raw = req.State.Raw
+			},
+		},
+	}
 }

--- a/internal/services/zone_hold/schema.go
+++ b/internal/services/zone_hold/schema.go
@@ -16,6 +16,7 @@ var _ resource.ResourceWithConfigValidators = (*ZoneHoldResource)(nil)
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		Version: 500,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Identifier.",


### PR DESCRIPTION
All v5 resources now declare Version: 500 in their schema and have a no-op state upgrader from version 0, enabling Terraform to upgrade existing state without data loss.

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
