### PR TITLE
fix: guard against nil SSH field in connection_rules JSON decoding

### DIFF
--- a/internal/sdkv2provider/resource_cloudflare_access_policy.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_policy.go
@@ -98,16 +98,18 @@ func apiAccessPolicyConnectionRulesToSchema(connectionRules *cloudflare.AccessIn
 	}
 
 	var connectionRulesSchema []interface{}
-	var sshArgList []map[string]interface{}
 
-	sshArgMap := map[string]interface{}{
-		"usernames":         connectionRules.SSH.Usernames,
-		"allow_email_alias": connectionRules.SSH.AllowEmailAlias,
+	if connectionRules.SSH != nil {
+		var sshArgList []map[string]interface{}
+		sshArgMap := map[string]interface{}{
+			"usernames":         connectionRules.SSH.Usernames,
+			"allow_email_alias": connectionRules.SSH.AllowEmailAlias,
+		}
+		sshArgList = append(sshArgList, sshArgMap)
+		connectionRulesSchema = append(connectionRulesSchema, map[string]interface{}{
+			"ssh": sshArgList,
+		})
 	}
-	sshArgList = append(sshArgList, sshArgMap)
-	connectionRulesSchema = append(connectionRulesSchema, map[string]interface{}{
-		"ssh": sshArgList,
-	})
 
 	return connectionRulesSchema
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

When the Cloudflare API returns a `connection_rules` object without an `ssh` sub-field, the provider would panic with a nil pointer dereference accessing `connectionRules.SSH.Usernames`.

Fix: Wraps the `SSH` field access in a `nil` guard so the function returns an empty schema block instead of crashing.

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
