### PR TITLE
fix: force recreation of access_mtls_certificate when certificate con…

### DIFF
--- a/.changelog/6916.txt
+++ b/.changelog/6916.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_zero_trust_access_mtls_certificate: changing `certificate` now correctly forces recreation of the resource instead of a silent no-op update
+```

--- a/docs/resources/access_mutual_tls_certificate.md
+++ b/docs/resources/access_mutual_tls_certificate.md
@@ -5,8 +5,8 @@ description: |-
   Provides a Cloudflare Access Mutual TLS Certificate resource.
   Mutual TLS authentication ensures that the traffic is secure and
   trusted in both directions between a client and server and can be
-   used with Access to only allows requests from devices with a
-   corresponding client certificate.
+  used with Access to only allows requests from devices with a
+  corresponding client certificate.
 ---
 
 # cloudflare_access_mutual_tls_certificate (Resource)
@@ -44,7 +44,7 @@ resource "cloudflare_access_mutual_tls_certificate" "my_cert" {
 
 - `account_id` (String) The account identifier to target for the resource. Conflicts with `zone_id`.
 - `associated_hostnames` (Set of String) The hostnames that will be prompted for this certificate.
-- `certificate` (String) The Root CA for your certificates.
+- `certificate` (String) The Root CA for your certificates. **Modifying this attribute will force creation of a new resource.**
 - `zone_id` (String) The zone identifier to target for the resource. Conflicts with `account_id`.
 
 ### Read-Only

--- a/docs/resources/zero_trust_access_mtls_certificate.md
+++ b/docs/resources/zero_trust_access_mtls_certificate.md
@@ -5,8 +5,8 @@ description: |-
   Provides a Cloudflare Access Mutual TLS Certificate resource.
   Mutual TLS authentication ensures that the traffic is secure and
   trusted in both directions between a client and server and can be
-   used with Access to only allows requests from devices with a
-   corresponding client certificate.
+  used with Access to only allows requests from devices with a
+  corresponding client certificate.
 ---
 
 # cloudflare_zero_trust_access_mtls_certificate (Resource)
@@ -44,7 +44,7 @@ resource "cloudflare_zero_trust_access_mtls_certificate" "my_cert" {
 
 - `account_id` (String) The account identifier to target for the resource. Conflicts with `zone_id`.
 - `associated_hostnames` (Set of String) The hostnames that will be prompted for this certificate.
-- `certificate` (String) The Root CA for your certificates.
+- `certificate` (String) The Root CA for your certificates. **Modifying this attribute will force creation of a new resource.**
 - `zone_id` (String) The zone identifier to target for the resource. Conflicts with `account_id`.
 
 ### Read-Only

--- a/internal/sdkv2provider/resource_cloudflare_access_mutual_tls_certificate_test.go
+++ b/internal/sdkv2provider/resource_cloudflare_access_mutual_tls_certificate_test.go
@@ -178,6 +178,102 @@ func testAccCheckCloudflareAccessMutualTLSCertificateDestroy(s *terraform.State)
 	return nil
 }
 
+func TestAccCloudflareAccessMutualTLSCertificateForceNew(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN if it is set as the Access
+	// service does not yet support the API tokens and it results in
+	// misleading state error messages.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	rnd := generateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_zero_trust_access_mtls_certificate.%s", rnd)
+	cert := os.Getenv("CLOUDFLARE_MUTUAL_TLS_CERTIFICATE")
+	// Adding a newline is technically changing the cert string, to it should be marked for recreation
+	cert2 := cert + "\\n"
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+
+	if cert == "" {
+		t.Fatal("CLOUDFLARE_MUTUAL_TLS_CERTIFICATE must be set for this acceptance test")
+	}
+
+	var beforeCert, afterCert cloudflare.AccessMutualTLSCertificate
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAccount(t)
+		},
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckCloudflareAccessMutualTLSCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccessMutualTLSCertificateConfigBasic(rnd, cloudflare.AccountIdentifier(accountID), cert, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareAccessMutualTLSCertificateExists(name, &beforeCert),
+					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttrSet(name, "certificate"),
+				),
+			},
+			{
+				Config: testAccessMutualTLSCertificateConfigBasic(rnd, cloudflare.AccountIdentifier(accountID), cert2, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudflareAccessMutualTLSCertificateExists(name, &afterCert),
+					testAccCheckCloudflareAccessMutualTLSCertificateRecreated(&beforeCert, &afterCert),
+					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttrSet(name, "certificate"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareAccessMutualTLSCertificateExists(n string, cert *cloudflare.AccessMutualTLSCertificate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No AccessMutualTLSCertificate ID is set")
+		}
+
+		client := testAccProvider.Meta().(*cloudflare.API)
+
+		var identifier *cloudflare.ResourceContainer
+		if rs.Primary.Attributes[consts.AccountIDSchemaKey] != "" {
+			identifier = cloudflare.AccountIdentifier(rs.Primary.Attributes[consts.AccountIDSchemaKey])
+		} else {
+			identifier = cloudflare.ZoneIdentifier(rs.Primary.Attributes[consts.ZoneIDSchemaKey])
+		}
+
+		foundCert, err := client.GetAccessMutualTLSCertificate(context.Background(), identifier, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if foundCert.ID != rs.Primary.ID {
+			return fmt.Errorf("AccessMutualTLSCertificate not found")
+		}
+
+		*cert = foundCert
+
+		return nil
+	}
+}
+
+func testAccCheckCloudflareAccessMutualTLSCertificateRecreated(before, after *cloudflare.AccessMutualTLSCertificate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before.ID == after.ID {
+			return fmt.Errorf("expected AccessMutualTLSCertificate to be recreated, but both had ID %s", before.ID)
+		}
+		return nil
+	}
+}
+
 func testAccessMutualTLSCertificateConfigBasic(rnd string, identifier *cloudflare.ResourceContainer, cert, domain string) string {
 	return fmt.Sprintf(`
 resource "cloudflare_zero_trust_access_mtls_certificate" "%[1]s" {

--- a/internal/sdkv2provider/schema_cloudflare_access_mutual_tls_certificate.go
+++ b/internal/sdkv2provider/schema_cloudflare_access_mutual_tls_certificate.go
@@ -29,6 +29,7 @@ func resourceCloudflareAccessMutualTLSCertificateSchema() map[string]*schema.Sch
 		"certificate": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			ForceNew:    true,
 			Description: "The Root CA for your certificates.",
 		},
 		"associated_hostnames": {


### PR DESCRIPTION
## Changes being requested

The `certificate` field on the `cloudflare_zero_trust_access_mtls_certificate` resource currently allows in-place updates, but the API update endpoint does not accept the certificate content. This means changing a certificate silently updates Terraform state without actually replacing the cert on Cloudflare's side, leaving the old certificate active until it expires.

This adds `ForceNew: true` to the `certificate` schema field so Terraform correctly destroys and recreates the resource when the certificate content changes.

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

## Acceptance test run results

```bash
TF_ACC=1 go test ./internal/sdkv2provider/ -run "TestAccCloudflareAccessMutualTLS" -v -timeout 30m
Test output
=== RUN   TestAccCloudflareAccessMutualTLSBasic
--- PASS: TestAccCloudflareAccessMutualTLSBasic (26.35s)
=== RUN   TestAccCloudflareAccessMutualTLSBasicWithZoneID
--- PASS: TestAccCloudflareAccessMutualTLSBasicWithZoneID (32.43s)
=== RUN   TestAccCloudflareAccessMutualTLSCertificateForceNew
--- PASS: TestAccCloudflareAccessMutualTLSCertificateForceNew (37.52s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider	96.320s
```

## Additional context & links

- BUGS-1809: https://jira.cfdata.org/browse/BUGS-1809
- AUTH-8305: https://jira.cfdata.org/browse/AUTH-8305