### PR TITLE
fix(apijson): return empty object from MarshalForPatch when no fields are serialisable

### DIFF
--- a/internal/apijson/encoder.go
+++ b/internal/apijson/encoder.go
@@ -148,6 +148,10 @@ func (e *encoder) typeEncoder(t reflect.Type) encoderFunc {
 }
 
 func (e *encoder) newTypeEncoder(t reflect.Type) encoderFunc {
+	// Capture root before any mutation below (e.root is set to false at line 179
+	// before the switch dispatches to newStructTypeEncoder).
+	isRoot := e.root
+
 	// Check if type implements CustomMarshaler interface
 	customMarshalerType := reflect.TypeOf((*CustomMarshaler)(nil)).Elem()
 	if t.Implements(customMarshalerType) {
@@ -221,7 +225,7 @@ func (e *encoder) newTypeEncoder(t reflect.Type) encoderFunc {
 		if t.Implements(attrType) {
 			return e.newTerraformTypeEncoder(t)
 		}
-		return e.newStructTypeEncoder(t)
+		return e.newStructTypeEncoder(t, isRoot)
 	case reflect.Array:
 		fallthrough
 	case reflect.Slice:
@@ -567,7 +571,7 @@ func (e encoder) newTerraformTypeEncoder(t reflect.Type) encoderFunc {
 	}
 }
 
-func (e *encoder) newStructTypeEncoder(t reflect.Type) encoderFunc {
+func (e *encoder) newStructTypeEncoder(t reflect.Type, isRoot bool) encoderFunc {
 	encoderFields := []encoderField{}
 	extraEncoder := (*encoderField)(nil)
 
@@ -667,6 +671,16 @@ func (e *encoder) newStructTypeEncoder(t reflect.Type) encoderFunc {
 		}
 
 		if !someFieldsSet && e.patch {
+			// At the root level, return an empty object rather than nil so the
+			// caller always has a valid JSON body to send. This matters when all
+			// serialisable fields are either unchanged (omitted by patch diffing)
+			// or computed_optional unknowns (omitted by handleNullAndUndefined).
+			// Returning nil here would produce an empty request body which most
+			// APIs reject with 400. Nested sub-objects still return nil so they
+			// are omitted from the parent object as expected.
+			if isRoot {
+				return []byte("{}"), nil
+			}
 			return nil, nil
 		}
 

--- a/internal/apijson/json_test.go
+++ b/internal/apijson/json_test.go
@@ -1053,7 +1053,9 @@ var updateTests = map[string]struct {
 			},
 		},
 		`{"bool_value":true,"data":{"embedded_int":17,"embedded_string":"embedded_string_value"},"float_value":3.14,"optional_array":["hi","there"],"string_value":"string_value"}`,
-		``,
+		// MarshalForPatch returns {} (not nil) at the root when nothing changed,
+		// so the caller always has a valid JSON body to send.
+		`{}`,
 	},
 
 	"nested value changed in nested struct": {
@@ -1286,8 +1288,10 @@ var updateTests = map[string]struct {
 		},
 		// Expected result: only values with "encode_state_for_unknown" are encoded
 		`{"computed_optional_state_encode":"computed optional from state","computed_state_encode":"computed value 2"}`,
+		// MarshalForPatch returns {} (not nil) at the root when all fields are unknown,
+		// so the caller always has a valid JSON body to send.
 		// NOTE: force_encode should probably override patch behavior, but we don't support that for now
-		``,
+		`{}`,
 	},
 
 	"encode_state_for_unknown with known plan": {
@@ -1332,7 +1336,9 @@ var updateTests = map[string]struct {
 		},
 		// Don't copy null fields from state
 		`{}`,
-		``,
+		// MarshalForPatch returns {} (not nil) at the root when all fields are unknown,
+		// so the caller always has a valid JSON body to send.
+		`{}`,
 	},
 }
 
@@ -1358,6 +1364,46 @@ func TestUpdateEncoding(t *testing.T) {
 				}
 			})
 		})
+	}
+}
+
+// TestMarshalForPatch_AllFieldsUnknown tests that MarshalForPatch returns an
+// empty JSON object (not nil) when every serialisable field in the plan is
+// unknown. This situation arises during Terraform applies where the only
+// pending diff is a computed_optional field that is "known after apply" — no
+// real user change has been made, but Terraform still calls Update. Returning
+// nil bytes would produce an empty HTTP request body and cause a 400 from the
+// API. Returning "{}" lets the server treat it as a no-op PATCH.
+func TestMarshalForPatch_AllFieldsUnknown(t *testing.T) {
+	// EncodeStateForUnknownStruct has computed_optional fields (ComputedOptionalRegular,
+	// ComputedOptionalWithStateEncode) alongside a normal field and computed fields.
+	// Set every field to unknown in the plan, leaving the state with real values.
+	plan := EncodeStateForUnknownStruct{
+		NormalField:                     types.StringUnknown(),
+		ComputedWithForceEncode:         types.StringUnknown(),
+		ComputedWithStateEncode:         types.StringUnknown(),
+		ComputedOptionalWithStateEncode: types.StringUnknown(),
+		ComputedOptionalRegular:         types.StringUnknown(),
+		ComputedRegular:                 types.StringUnknown(),
+	}
+	state := EncodeStateForUnknownStruct{
+		NormalField:                     types.StringValue("old normal"),
+		ComputedWithForceEncode:         types.StringValue("old force"),
+		ComputedWithStateEncode:         types.StringValue("old state encode"),
+		ComputedOptionalWithStateEncode: types.StringValue("old opt state encode"),
+		ComputedOptionalRegular:         types.StringValue("old opt regular"),
+		ComputedRegular:                 types.StringValue("old computed"),
+	}
+
+	raw, err := MarshalForPatch(plan, state)
+	if err != nil {
+		t.Fatalf("MarshalForPatch failed: %v", err)
+	}
+	if raw == nil {
+		t.Fatal("MarshalForPatch returned nil; expected '{}' so the caller has a valid request body")
+	}
+	if string(raw) != "{}" {
+		t.Fatalf("expected '{}' but got %s", string(raw))
 	}
 }
 


### PR DESCRIPTION
When every serialisable field in a patch update is either unchanged (omitted by the diff check) or computed_optional unknown (omitted by handleNullAndUndefined), MarshalForPatch previously returned nil bytes. Passing nil bytes to option.WithRequestBody produced an empty HTTP body, which the Cloudflare API rejected with "400: invalid json request".

At the root encoder level, return []byte("{}") instead of nil so the caller always has a structurally valid JSON body to send. Nested sub-object encoders still return nil (causing them to be omitted from the parent object) so existing patch diffing behaviour is unaffected.

The isRoot flag is captured at the start of newTypeEncoder, before e.root is reset to false, and threaded into newStructTypeEncoder as a parameter so the closure reads the correct value at call time.

Fixes the 400 error observed on cloudflare_zero_trust_device_default_profile updates triggered by a moved block, where the only pending diff was include/exclude being "known after apply".
