### PR TITLE
fix(dlp_predefined_profile): eliminate migration drift

### DIFF
--- a/internal/services/zero_trust_dlp_predefined_profile/migration/v500/transform.go
+++ b/internal/services/zero_trust_dlp_predefined_profile/migration/v500/transform.go
@@ -52,6 +52,16 @@ func Transform(ctx context.Context, source SourceCloudflareDLPProfileModel) (*Ta
 }
 
 // extractEnabledEntryIDs collects the IDs of all enabled entries from v4 state.
+//
+// When the v4 state has entry blocks but none are enabled, this returns a pointer to
+// an empty slice (not nil). This is important for state upgrade correctness: the v5
+// config produced by tf-migrate writes `enabled_entries = []` for the all-disabled case,
+// and the upgraded state must match that exactly — a nil pointer would cause a one-time
+// plan diff of `+ enabled_entries = []` on the first plan after the moved block fires.
+//
+// When the v4 state has no entry blocks at all (len == 0), nil is returned because the
+// resource was never configured with entries and the user's config will not have
+// enabled_entries set.
 func extractEnabledEntryIDs(entries []SourceEntryModel) *[]types.String {
 	if len(entries) == 0 {
 		return nil
@@ -66,9 +76,11 @@ func extractEnabledEntryIDs(entries []SourceEntryModel) *[]types.String {
 		}
 	}
 
-	if len(enabledIDs) == 0 {
-		return nil
+	// Always return a non-nil pointer when v4 entry blocks existed. If none were
+	// enabled, return a pointer to an empty slice so the state matches `enabled_entries = []`
+	// in the migrated config, avoiding a spurious plan diff after state upgrade.
+	if enabledIDs == nil {
+		enabledIDs = []types.String{}
 	}
-
 	return &enabledIDs
 }

--- a/internal/services/zero_trust_dlp_predefined_profile/migration/v500/transform_test.go
+++ b/internal/services/zero_trust_dlp_predefined_profile/migration/v500/transform_test.go
@@ -1,0 +1,109 @@
+package v500_test
+
+import (
+	"context"
+	"testing"
+
+	v500 "github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_dlp_predefined_profile/migration/v500"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestTransform_AllEntriesDisabled verifies that when a v4 predefined profile has entry
+// blocks but all are disabled, the upgraded state has enabled_entries set to an empty
+// slice (not nil). This prevents a spurious `+ enabled_entries = []` plan diff on the
+// first terraform plan after the moved block fires the state upgrade.
+func TestTransform_AllEntriesDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	source := v500.SourceCloudflareDLPProfileModel{
+		ID:        types.StringValue("profile-uuid"),
+		AccountID: types.StringValue("account-uuid"),
+		Name:      types.StringValue("Credentials and Secrets"),
+		Type:      types.StringValue("predefined"),
+		Entry: []v500.SourceEntryModel{
+			{ID: types.StringValue("entry-1"), Name: types.StringValue("Entry 1"), Enabled: types.BoolValue(false), Pattern: nil},
+			{ID: types.StringValue("entry-2"), Name: types.StringValue("Entry 2"), Enabled: types.BoolValue(false), Pattern: nil},
+			{ID: types.StringValue("entry-3"), Name: types.StringValue("Entry 3"), Enabled: types.BoolValue(false), Pattern: nil},
+		},
+		AllowedMatchCount: types.Int64Value(0),
+		OCREnabled:        types.BoolValue(false),
+	}
+
+	result, diags := v500.Transform(ctx, source)
+	if diags.HasError() {
+		t.Fatalf("Transform returned unexpected errors: %v", diags)
+	}
+
+	// EnabledEntries must be a non-nil pointer to an empty slice — not nil.
+	// A nil pointer would cause `+ enabled_entries = []` drift on the first plan
+	// after state upgrade when the config has `enabled_entries = []`.
+	if result.EnabledEntries == nil {
+		t.Fatal("EnabledEntries is nil; expected a pointer to an empty slice for all-disabled case")
+	}
+	if len(*result.EnabledEntries) != 0 {
+		t.Fatalf("EnabledEntries should be empty; got %v", *result.EnabledEntries)
+	}
+}
+
+// TestTransform_SomeEntriesEnabled verifies that enabled entry IDs are correctly
+// extracted and disabled entries are omitted.
+func TestTransform_SomeEntriesEnabled(t *testing.T) {
+	ctx := context.Background()
+
+	source := v500.SourceCloudflareDLPProfileModel{
+		ID:        types.StringValue("profile-uuid"),
+		AccountID: types.StringValue("account-uuid"),
+		Name:      types.StringValue("Test Profile"),
+		Type:      types.StringValue("predefined"),
+		Entry: []v500.SourceEntryModel{
+			{ID: types.StringValue("entry-enabled-1"), Name: types.StringValue("E1"), Enabled: types.BoolValue(true), Pattern: nil},
+			{ID: types.StringValue("entry-disabled"), Name: types.StringValue("E2"), Enabled: types.BoolValue(false), Pattern: nil},
+			{ID: types.StringValue("entry-enabled-2"), Name: types.StringValue("E3"), Enabled: types.BoolValue(true), Pattern: nil},
+		},
+		AllowedMatchCount: types.Int64Value(0),
+		OCREnabled:        types.BoolValue(false),
+	}
+
+	result, diags := v500.Transform(ctx, source)
+	if diags.HasError() {
+		t.Fatalf("Transform returned unexpected errors: %v", diags)
+	}
+
+	if result.EnabledEntries == nil {
+		t.Fatal("EnabledEntries is nil; expected non-nil")
+	}
+	if len(*result.EnabledEntries) != 2 {
+		t.Fatalf("Expected 2 enabled entries, got %d: %v", len(*result.EnabledEntries), *result.EnabledEntries)
+	}
+	if (*result.EnabledEntries)[0].ValueString() != "entry-enabled-1" {
+		t.Errorf("First enabled entry should be 'entry-enabled-1', got %q", (*result.EnabledEntries)[0].ValueString())
+	}
+	if (*result.EnabledEntries)[1].ValueString() != "entry-enabled-2" {
+		t.Errorf("Second enabled entry should be 'entry-enabled-2', got %q", (*result.EnabledEntries)[1].ValueString())
+	}
+}
+
+// TestTransform_NoEntries verifies that when a v4 profile has no entry blocks at all,
+// EnabledEntries is nil (the resource was never configured with entries).
+func TestTransform_NoEntries(t *testing.T) {
+	ctx := context.Background()
+
+	source := v500.SourceCloudflareDLPProfileModel{
+		ID:                types.StringValue("profile-uuid"),
+		AccountID:         types.StringValue("account-uuid"),
+		Name:              types.StringValue("Empty Profile"),
+		Type:              types.StringValue("predefined"),
+		Entry:             nil,
+		AllowedMatchCount: types.Int64Value(0),
+		OCREnabled:        types.BoolValue(false),
+	}
+
+	result, diags := v500.Transform(ctx, source)
+	if diags.HasError() {
+		t.Fatalf("Transform returned unexpected errors: %v", diags)
+	}
+
+	if result.EnabledEntries != nil {
+		t.Fatalf("EnabledEntries should be nil when no entry blocks exist, got %v", *result.EnabledEntries)
+	}
+}

--- a/internal/services/zero_trust_dlp_predefined_profile/resource.go
+++ b/internal/services/zero_trust_dlp_predefined_profile/resource.go
@@ -12,8 +12,10 @@ import (
 	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -188,8 +190,18 @@ func (r *ZeroTrustDLPPredefinedProfileResource) Read(ctx context.Context, req re
 	data = &env.Result
 	data.ID = data.ProfileID
 
-	// Restore enabled_entries if API returned null but prior state had a value
-	if data.EnabledEntries == nil && priorEnabledEntries != nil {
+	// Restore enabled_entries from prior state when the API returns null or omits the field.
+	//
+	// The Cloudflare API returns "enabled_entries": null (or omits the field) for profiles
+	// where no entries are explicitly enabled. apijson.Unmarshal with Always update behaviour
+	// decodes a JSON null into a non-nil pointer to a nil slice (*[]types.String where *ptr
+	// is nil) — not a Go nil pointer. The Terraform Framework treats these differently: a
+	// non-nil pointer to a nil slice is not the same as an empty list [].
+	//
+	// We detect both cases (nil pointer and non-nil pointer-to-nil) and restore the prior
+	// state value so that config == state after every refresh cycle.
+	apiReturnedNullOrAbsent := data.EnabledEntries == nil || *data.EnabledEntries == nil
+	if apiReturnedNullOrAbsent && priorEnabledEntries != nil {
 		data.EnabledEntries = priorEnabledEntries
 	}
 
@@ -268,6 +280,48 @@ func (r *ZeroTrustDLPPredefinedProfileResource) ImportState(ctx context.Context,
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *ZeroTrustDLPPredefinedProfileResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, _ *resource.ModifyPlanResponse) {
+func (r *ZeroTrustDLPPredefinedProfileResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Suppress drift on the deprecated `entries` attribute when the user has not set it
+	// in their config (i.e. they are using `enabled_entries` instead, which is the correct
+	// v5 approach).
+	//
+	// Background: the Cloudflare API always returns the full entries list on every GET.
+	// Because `entries` is Computed+Optional, Terraform diffs state (API value) against
+	// config (null/absent) and plans to remove the entries on every plan cycle — perpetual
+	// drift. Users who do set `entries` explicitly in their config are unaffected: when
+	// config is non-null, we leave the plan unchanged so their intent is respected.
+	//
+	// This hook runs at plan time (before apply), so it does not affect what is written
+	// to state — it only prevents Terraform from proposing a removal it would immediately
+	// undo on the next refresh.
+	if req.Plan.Raw.IsNull() {
+		// Resource is being destroyed — don't interfere.
+		return
+	}
 
+	var configEntries, stateEntries customfield.NestedObjectList[ZeroTrustDLPPredefinedProfileEntriesModel]
+
+	// Read config value for entries. If config is null/absent (user omitted entries),
+	// copy the state value into the plan to suppress the spurious removal diff.
+	configDiags := req.Config.GetAttribute(ctx, path.Root("entries"), &configEntries)
+	resp.Diagnostics.Append(configDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !configEntries.IsNull() {
+		// User has entries in their config — respect it, don't interfere.
+		return
+	}
+
+	// Config omits entries. Copy whatever is in state into the plan so Terraform
+	// sees no diff for this attribute.
+	stateDiags := req.State.GetAttribute(ctx, path.Root("entries"), &stateEntries)
+	resp.Diagnostics.Append(stateDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	setPlanDiags := resp.Plan.SetAttribute(ctx, path.Root("entries"), stateEntries)
+	resp.Diagnostics.Append(setPlanDiags...)
 }

--- a/internal/services/zero_trust_dlp_predefined_profile/schema.go
+++ b/internal/services/zero_trust_dlp_predefined_profile/schema.go
@@ -66,7 +66,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"entries": schema.ListNestedAttribute{
 				Computed:           true,
 				Optional:           true,
-				DeprecationMessage: "This attribute is deprecated.",
+				DeprecationMessage: "This attribute is deprecated. Use enabled_entries instead.",
 				CustomType:         customfield.NewNestedObjectListType[ZeroTrustDLPPredefinedProfileEntriesModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -98,4 +98,3 @@ func (r *ZeroTrustDLPPredefinedProfileResource) Schema(ctx context.Context, req 
 func (r *ZeroTrustDLPPredefinedProfileResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{}
 }
-


### PR DESCRIPTION
## Fix perpetual drift for `cloudflare_zero_trust_dlp_predefined_profile`

### Problem

Users migrating from v4 to v5 with `tf-migrate` experienced three distinct drift issues on `cloudflare_zero_trust_dlp_predefined_profile`, all causing `terraform plan` to show changes that could never be permanently resolved:

**1. Perpetual `entries -> null` (ongoing after every apply)**
The Cloudflare API always returns the full `entries` list on every GET response. Because `entries` is `Computed+Optional`, Terraform diffed the API-populated state value against the absent config value (users correctly use `enabled_entries` in v5) and proposed removing the entries on every plan cycle. Running `terraform apply` didn't help — the API repopulated them on the next refresh.

**2. Perpetual `enabled_entries = []` (ongoing after every apply)**
The existing restore guard in `Read` checked `data.EnabledEntries == nil`, but `apijson.Unmarshal` decodes a JSON `null` field as a **non-nil pointer to a nil slice** — not a Go nil pointer. The condition never fired, so `enabled_entries` was silently cleared from state after every refresh, causing the plan to perpetually propose adding it back.

**3. One-time `+ enabled_entries = []` (first plan after migration)**
`extractEnabledEntryIDs` returned `nil` when all v4 entries were disabled. The state upgrader wrote `enabled_entries = null` into the upgraded state, but `tf-migrate` correctly generates `enabled_entries = []` in the migrated config. The mismatch caused a spurious one-time diff on the first plan after the `moved` block triggered state upgrade.

### Solution

**`resource.go` — `ModifyPlan`**: When the user's config omits `entries` (the correct v5 pattern), copy the state value into the plan at plan time, so Terraform sees no diff. Users who explicitly set `entries` in their config are fully unaffected — the hook only fires when config is null. This is the correct mechanism for this case; `UseStateForUnknown` would not work here because it only acts when the plan value is _unknown_, not _null_.

**`resource.go` — Read restore guard**: Extended the `enabled_entries` nil check to cover both `data.EnabledEntries == nil` and `*data.EnabledEntries == nil`, catching the non-nil-pointer-to-nil-slice case that `apijson.Unmarshal` produces for JSON `null` fields.

**`migration/v500/transform.go`**: When v4 entry blocks existed but none were enabled, return `&[]types.String{}` instead of `nil`. Distinguishes "user had entries, all disabled" (→ `enabled_entries = []` in state, matching the migrated config) from "user had no entry blocks at all" (→ `nil`, no `enabled_entries` set).

**`schema.go`**: Updated `entries` deprecation message to explicitly point users to `enabled_entries`.

### No breaking changes

- `entries` remains `Computed+Optional` and fully writable
- `entries` remains readable from state
- The `ModifyPlan` hook is transparent to users who manage `entries` explicitly

### Tests

Added `migration/v500/transform_test.go` with three unit tests covering the Transform function: all-entries-disabled (verifies `&[]` not `nil`), some-entries-enabled, and no-entry-blocks.

---

```
========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ No material changes
    Result: 0 material changes
    Terraform: Plan: 0 to add, 1 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```
