### PR TITLE
Fix cloudflare_workers_cron_trigger documentation example to use schedules instead of body

### DIFF
--- a/docs/resources/workers_cron_trigger.md
+++ b/docs/resources/workers_cron_trigger.md
@@ -2,7 +2,7 @@
 page_title: "cloudflare_workers_cron_trigger Resource - Cloudflare"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # cloudflare_workers_cron_trigger (Resource)
@@ -15,7 +15,7 @@ description: |-
 resource "cloudflare_workers_cron_trigger" "example_workers_cron_trigger" {
   account_id = "023e105f4ecef8ad9ca31a8372d0c353"
   script_name = "this-is_my_script-01"
-  body = [{
+  schedules = [{
     cron = "*/30 * * * *"
   }]
 }

--- a/examples/resources/cloudflare_workers_cron_trigger/resource.tf
+++ b/examples/resources/cloudflare_workers_cron_trigger/resource.tf
@@ -1,7 +1,7 @@
 resource "cloudflare_workers_cron_trigger" "example_workers_cron_trigger" {
   account_id = "023e105f4ecef8ad9ca31a8372d0c353"
   script_name = "this-is_my_script-01"
-  body = [{
+  schedules = [{
     cron = "*/30 * * * *"
   }]
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->


- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
The docs for the cloudflare_workers_cron_trigger  resource were incorrectly displaying an example using the body attribute. The correct attribute that is used here is schedules.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
N/A, just a docs change

### Test output
<!-- Please paste the output of your acceptance test run below --> 
N/A, just a docs change

## Additional context & links
Issue below:
https://github.com/cloudflare/terraform-provider-cloudflare/issues/6952 