### PR TITLE
feat(ai_gateway): add cloudflare_ai_gateway resource

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_subscription"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_token"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/address_map"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/ai_gateway"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/ai_search_instance"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/ai_search_token"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_shield"
@@ -149,6 +150,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/snippet"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/snippet_rules"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/snippets"
+
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/spectrum_application"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/sso_connector"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/stream"
@@ -629,6 +631,7 @@ func (p *CloudflareProvider) Resources(ctx context.Context) []func() resource.Re
 		leaked_credential_check_rule.NewResource,
 		content_scanning.NewResource,
 		content_scanning_expression.NewResource,
+		ai_gateway.NewResource,
 		ai_search_instance.NewResource,
 		ai_search_token.NewResource,
 		custom_pages.NewResource,

--- a/internal/services/ai_gateway/model.go
+++ b/internal/services/ai_gateway/model.go
@@ -1,0 +1,68 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+package ai_gateway
+
+import (
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type AIGatewayResultEnvelope struct {
+	Result AIGatewayModel `json:"result"`
+}
+
+type AIGatewayModel struct {
+	ID                          types.String                                                `tfsdk:"id" json:"id,required"`
+	AccountID                   types.String                                                `tfsdk:"account_id" path:"account_id,required"`
+	CacheInvalidateOnUpdate      types.Bool                                                  `tfsdk:"cache_invalidate_on_update" json:"cache_invalidate_on_update,optional"`
+	CacheTTL                    types.Int64                                                 `tfsdk:"cache_ttl" json:"cache_ttl,optional"`
+	CollectLogs                 types.Bool                                                  `tfsdk:"collect_logs" json:"collect_logs,optional"`
+	CreatedAt                   timetypes.RFC3339                                           `tfsdk:"created_at" json:"created_at,computed"`
+	ModifiedAt                  timetypes.RFC3339                                           `tfsdk:"modified_at" json:"modified_at,computed"`
+	RateLimitingInterval        types.Int64                                                 `tfsdk:"rate_limiting_interval" json:"rate_limiting_interval,optional"`
+	RateLimitingLimit           types.Int64                                                 `tfsdk:"rate_limiting_limit" json:"rate_limiting_limit,optional"`
+	Authentication              types.Bool                                                  `tfsdk:"authentication" json:"authentication,optional"`
+	DLP                         *AIGatewayDLPModel                                         `tfsdk:"dlp" json:"dlp,optional"`
+	IsDefault                   types.Bool                                                  `tfsdk:"is_default" json:"is_default,computed_optional"`
+	LogManagement               types.Int64                                                 `tfsdk:"log_management" json:"log_management,optional"`
+	LogManagementStrategy       types.String                                                `tfsdk:"log_management_strategy" json:"log_management_strategy,optional"`
+	Logpush                     types.Bool                                                  `tfsdk:"logpush" json:"logpush,optional"`
+	LogpushPublicKey            types.String                                                `tfsdk:"logpush_public_key" json:"logpush_public_key,optional"`
+	OTel                        []AIGatewayOTelModel                                        `tfsdk:"otel" json:"otel,optional"`
+	RateLimitingTechnique       types.String                                                `tfsdk:"rate_limiting_technique" json:"rate_limiting_technique,optional"`
+	StoreID                     types.String                                                `tfsdk:"store_id" json:"store_id,optional"`
+	Stripe                      *AIGatewayStripeModel                                      `tfsdk:"stripe" json:"stripe,optional"`
+	WorkersAIBillingMode        types.String                                                `tfsdk:"workers_ai_billing_mode" json:"workers_ai_billing_mode,optional"`
+	ZDR                         types.Bool                                                  `tfsdk:"zdr" json:"zdr,optional"`
+}
+
+func (m AIGatewayModel) MarshalJSON() (data []byte, err error) {
+	return apijson.MarshalRoot(m)
+}
+
+func (m AIGatewayModel) MarshalJSONForUpdate(state AIGatewayModel) (data []byte, err error) {
+	return apijson.MarshalForUpdate(m, state)
+}
+
+type AIGatewayDLPModel struct {
+	Action   types.String  `tfsdk:"action" json:"action,optional"`
+	Enabled  types.Bool    `tfsdk:"enabled" json:"enabled,optional"`
+	Profiles []types.String `tfsdk:"profiles" json:"profiles,optional"`
+}
+
+type AIGatewayOTelModel struct {
+	Authorization types.String             `tfsdk:"authorization" json:"authorization,optional"`
+	Headers       *map[string]types.String `tfsdk:"headers" json:"headers,optional"`
+	URL          types.String              `tfsdk:"url" json:"url,optional"`
+	ContentType  types.String              `tfsdk:"content_type" json:"content_type,optional"`
+}
+
+type AIGatewayStripeModel struct {
+	Authorization types.String                     `tfsdk:"authorization" json:"authorization,optional"`
+	UsageEvents   []AIGatewayStripeUsageEventModel `tfsdk:"usage_events" json:"usage_events,optional"`
+}
+
+type AIGatewayStripeUsageEventModel struct {
+	Payload types.String `tfsdk:"payload" json:"payload,optional"`
+}

--- a/internal/services/ai_gateway/resource.go
+++ b/internal/services/ai_gateway/resource.go
@@ -1,0 +1,272 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+package ai_gateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/ai_gateway"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.ResourceWithConfigure = (*AIGatewayResource)(nil)
+var _ resource.ResourceWithImportState = (*AIGatewayResource)(nil)
+
+func NewResource() resource.Resource {
+	return &AIGatewayResource{}
+}
+
+type AIGatewayResource struct {
+	client *cloudflare.Client
+}
+
+func (r *AIGatewayResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_ai_gateway"
+}
+
+func (r *AIGatewayResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*cloudflare.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"unexpected resource configure type",
+			fmt.Sprintf("Expected *cloudflare.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *AIGatewayResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *AIGatewayModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	params := ai_gateway.AIGatewayNewParams{
+		AccountID:               cloudflare.F(data.AccountID.ValueString()),
+		ID:                      cloudflare.F(data.ID.ValueString()),
+		CacheInvalidateOnUpdate: cloudflare.F(data.CacheInvalidateOnUpdate.ValueBool()),
+		CacheTTL:                cloudflare.F(data.CacheTTL.ValueInt64()),
+		CollectLogs:             cloudflare.F(data.CollectLogs.ValueBool()),
+		RateLimitingInterval:    cloudflare.F(data.RateLimitingInterval.ValueInt64()),
+		RateLimitingLimit:       cloudflare.F(data.RateLimitingLimit.ValueInt64()),
+		RateLimitingTechnique:   cloudflare.F(ai_gateway.AIGatewayNewParamsRateLimitingTechnique(data.RateLimitingTechnique.ValueString())),
+		Authentication:          cloudflare.F(data.Authentication.ValueBool()),
+		IsDefault:               cloudflare.F(data.IsDefault.ValueBool()),
+		LogManagement:           cloudflare.F(data.LogManagement.ValueInt64()),
+		LogManagementStrategy:   cloudflare.F(ai_gateway.AIGatewayNewParamsLogManagementStrategy(data.LogManagementStrategy.ValueString())),
+		Logpush:                 cloudflare.F(data.Logpush.ValueBool()),
+		LogpushPublicKey:        cloudflare.F(data.LogpushPublicKey.ValueString()),
+		Zdr:                     cloudflare.F(data.ZDR.ValueBool()),
+	}
+
+	result, err := r.client.AIGateway.New(ctx, params)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create AI Gateway", err.Error())
+		return
+	}
+
+	data.ID = types.StringValue(result.ID)
+	data.AccountID = types.StringValue(result.AccountID)
+	data.CacheInvalidateOnUpdate = types.BoolValue(result.CacheInvalidateOnUpdate)
+	data.CacheTTL = types.Int64Value(result.CacheTTL)
+	data.CollectLogs = types.BoolValue(result.CollectLogs)
+	data.RateLimitingInterval = types.Int64Value(result.RateLimitingInterval)
+	data.RateLimitingLimit = types.Int64Value(result.RateLimitingLimit)
+	data.RateLimitingTechnique = types.StringValue(string(result.RateLimitingTechnique))
+	data.Authentication = types.BoolValue(result.Authentication)
+	data.IsDefault = types.BoolValue(result.IsDefault)
+	data.LogManagement = types.Int64Value(result.LogManagement)
+	data.LogManagementStrategy = types.StringValue(string(result.LogManagementStrategy))
+	data.Logpush = types.BoolValue(result.Logpush)
+	data.LogpushPublicKey = types.StringValue(result.LogpushPublicKey)
+	data.ZDR = types.BoolValue(result.Zdr)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AIGatewayResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *AIGatewayModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state *AIGatewayModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	params := ai_gateway.AIGatewayUpdateParams{
+		AccountID:               cloudflare.F(data.AccountID.ValueString()),
+		CacheInvalidateOnUpdate: cloudflare.F(data.CacheInvalidateOnUpdate.ValueBool()),
+		CacheTTL:                cloudflare.F(data.CacheTTL.ValueInt64()),
+		CollectLogs:             cloudflare.F(data.CollectLogs.ValueBool()),
+		RateLimitingInterval:    cloudflare.F(data.RateLimitingInterval.ValueInt64()),
+		RateLimitingLimit:       cloudflare.F(data.RateLimitingLimit.ValueInt64()),
+		RateLimitingTechnique:   cloudflare.F(ai_gateway.AIGatewayUpdateParamsRateLimitingTechnique(data.RateLimitingTechnique.ValueString())),
+		Authentication:          cloudflare.F(data.Authentication.ValueBool()),
+		IsDefault:               cloudflare.F(data.IsDefault.ValueBool()),
+		LogManagement:           cloudflare.F(data.LogManagement.ValueInt64()),
+		LogManagementStrategy:   cloudflare.F(ai_gateway.AIGatewayUpdateParamsLogManagementStrategy(data.LogManagementStrategy.ValueString())),
+		Logpush:                 cloudflare.F(data.Logpush.ValueBool()),
+		LogpushPublicKey:        cloudflare.F(data.LogpushPublicKey.ValueString()),
+		Zdr:                     cloudflare.F(data.ZDR.ValueBool()),
+	}
+
+	result, err := r.client.AIGateway.Update(ctx, data.ID.ValueString(), params)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to update AI Gateway", err.Error())
+		return
+	}
+
+	data.AccountID = types.StringValue(result.AccountID)
+	data.CacheInvalidateOnUpdate = types.BoolValue(result.CacheInvalidateOnUpdate)
+	data.CacheTTL = types.Int64Value(result.CacheTTL)
+	data.CollectLogs = types.BoolValue(result.CollectLogs)
+	data.RateLimitingInterval = types.Int64Value(result.RateLimitingInterval)
+	data.RateLimitingLimit = types.Int64Value(result.RateLimitingLimit)
+	data.RateLimitingTechnique = types.StringValue(string(result.RateLimitingTechnique))
+	data.Authentication = types.BoolValue(result.Authentication)
+	data.IsDefault = types.BoolValue(result.IsDefault)
+	data.LogManagement = types.Int64Value(result.LogManagement)
+	data.LogManagementStrategy = types.StringValue(string(result.LogManagementStrategy))
+	data.Logpush = types.BoolValue(result.Logpush)
+	data.LogpushPublicKey = types.StringValue(result.LogpushPublicKey)
+	data.ZDR = types.BoolValue(result.Zdr)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AIGatewayResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *AIGatewayModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	result, err := r.client.AIGateway.Get(
+		ctx,
+		data.ID.ValueString(),
+		ai_gateway.AIGatewayGetParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read AI Gateway", err.Error())
+		return
+	}
+
+	data.ID = types.StringValue(result.ID)
+	data.AccountID = types.StringValue(result.AccountID)
+	data.CacheInvalidateOnUpdate = types.BoolValue(result.CacheInvalidateOnUpdate)
+	data.CacheTTL = types.Int64Value(result.CacheTTL)
+	data.CollectLogs = types.BoolValue(result.CollectLogs)
+	data.RateLimitingInterval = types.Int64Value(result.RateLimitingInterval)
+	data.RateLimitingLimit = types.Int64Value(result.RateLimitingLimit)
+	data.RateLimitingTechnique = types.StringValue(string(result.RateLimitingTechnique))
+	data.Authentication = types.BoolValue(result.Authentication)
+	data.IsDefault = types.BoolValue(result.IsDefault)
+	data.LogManagement = types.Int64Value(result.LogManagement)
+	data.LogManagementStrategy = types.StringValue(string(result.LogManagementStrategy))
+	data.Logpush = types.BoolValue(result.Logpush)
+	data.LogpushPublicKey = types.StringValue(result.LogpushPublicKey)
+	data.ZDR = types.BoolValue(result.Zdr)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AIGatewayResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *AIGatewayModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := r.client.AIGateway.Delete(
+		ctx,
+		data.ID.ValueString(),
+		ai_gateway.AIGatewayDeleteParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to delete AI Gateway", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AIGatewayResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	var data = new(AIGatewayModel)
+
+	path_account_id := ""
+	path_id := ""
+	diags := importpath.ParseImportID(
+		req.ID,
+		"<account_id>/<id>",
+		&path_account_id,
+		&path_id,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.AccountID = types.StringValue(path_account_id)
+	data.ID = types.StringValue(path_id)
+
+	result, err := r.client.AIGateway.Get(
+		ctx,
+		path_id,
+		ai_gateway.AIGatewayGetParams{
+			AccountID: cloudflare.F(path_account_id),
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to import AI Gateway", err.Error())
+		return
+	}
+
+	data.ID = types.StringValue(result.ID)
+	data.AccountID = types.StringValue(result.AccountID)
+	data.CacheInvalidateOnUpdate = types.BoolValue(result.CacheInvalidateOnUpdate)
+	data.CacheTTL = types.Int64Value(result.CacheTTL)
+	data.CollectLogs = types.BoolValue(result.CollectLogs)
+	data.RateLimitingInterval = types.Int64Value(result.RateLimitingInterval)
+	data.RateLimitingLimit = types.Int64Value(result.RateLimitingLimit)
+	data.RateLimitingTechnique = types.StringValue(string(result.RateLimitingTechnique))
+	data.Authentication = types.BoolValue(result.Authentication)
+	data.IsDefault = types.BoolValue(result.IsDefault)
+	data.LogManagement = types.Int64Value(result.LogManagement)
+	data.LogManagementStrategy = types.StringValue(string(result.LogManagementStrategy))
+	data.Logpush = types.BoolValue(result.Logpush)
+	data.LogpushPublicKey = types.StringValue(result.LogpushPublicKey)
+	data.ZDR = types.BoolValue(result.Zdr)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/services/ai_gateway/schema.go
+++ b/internal/services/ai_gateway/schema.go
@@ -1,0 +1,223 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+package ai_gateway
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func ResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Version: 500,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description:   "AI Gateway identifier.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"account_id": schema.StringAttribute{
+				Description:   "The Account ID to use for the AI Gateway.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"cache_invalidate_on_update": schema.BoolAttribute{
+				Description: "Invalidate the cache on update.",
+				Optional:    true,
+				Computed:    true,
+				Default:    booldefault.StaticBool(false),
+			},
+			"cache_ttl": schema.Int64Attribute{
+				Description: "Cache TTL in seconds.",
+				Optional:    true,
+				Computed:    true,
+				Default:    int64default.StaticInt64(0),
+			},
+			"collect_logs": schema.BoolAttribute{
+				Description: "Collect logs from the gateway.",
+				Optional:    true,
+				Computed:    true,
+				Default:    booldefault.StaticBool(true),
+			},
+			"created_at": schema.StringAttribute{
+				Description:   "The timestamp when the AI Gateway was created.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"modified_at": schema.StringAttribute{
+				Description:   "The timestamp when the AI Gateway was last modified.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"rate_limiting_interval": schema.Int64Attribute{
+				Description: "Rate limiting interval in seconds.",
+				Optional:    true,
+				Computed:    true,
+				Default:    int64default.StaticInt64(0),
+			},
+			"rate_limiting_limit": schema.Int64Attribute{
+				Description: "Rate limiting limit.",
+				Optional:    true,
+				Computed:    true,
+				Default:    int64default.StaticInt64(0),
+			},
+			"authentication": schema.BoolAttribute{
+				Description: "Enable authentication on the gateway.",
+				Optional:    true,
+				Computed:    true,
+				Default:    booldefault.StaticBool(true),
+			},
+			"dlp": schema.SingleNestedAttribute{
+				Description: "Data Loss Prevention configuration.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"action": schema.StringAttribute{
+						Description:   `Available values: "BLOCK", "WARN".`,
+						Optional:      true,
+						Computed:      true,
+						Default:      stringdefault.StaticString("WARN"),
+						Validators: []validator.String{
+							stringvalidator.OneOfCaseInsensitive("BLOCK", "WARN"),
+						},
+					},
+					"enabled": schema.BoolAttribute{
+						Description: "Enable DLP.",
+						Optional:    true,
+						Computed:    true,
+						Default:    booldefault.StaticBool(false),
+					},
+					"profiles": schema.ListAttribute{
+						Description: "List of DLP profile IDs.",
+						Optional:    true,
+						ElementType: types.StringType,
+					},
+				},
+			},
+			"is_default": schema.BoolAttribute{
+				Description: "Whether this is the default gateway.",
+				Computed:    true,
+				Optional:    true,
+			},
+			"log_management": schema.Int64Attribute{
+				Description: "Log management setting.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"log_management_strategy": schema.StringAttribute{
+				Description:   `Available values: "STOP_INSERTING", "DROP_WHEN_FULL", "NO_SQL".`,
+				Optional:      true,
+				Computed:      true,
+				Validators: []validator.String{
+					stringvalidator.OneOfCaseInsensitive("STOP_INSERTING", "DROP_WHEN_FULL", "NO_SQL"),
+				},
+			},
+			"logpush": schema.BoolAttribute{
+				Description: "Enable logpush.",
+				Optional:    true,
+				Computed:    true,
+				Default:    booldefault.StaticBool(false),
+			},
+			"logpush_public_key": schema.StringAttribute{
+				Description: "Logpush public key.",
+				Computed:    true,
+				Optional:    true,
+			},
+			"otel": schema.ListNestedAttribute{
+				Description: "OpenTelemetry configuration.",
+				Optional:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"authorization": schema.StringAttribute{
+							Description: "Authorization header value.",
+							Optional:    true,
+						},
+						"headers": schema.MapAttribute{
+							Description: "Additional headers to include in OTEL requests.",
+							Optional:    true,
+							ElementType: types.StringType,
+						},
+						"url": schema.StringAttribute{
+							Description: "OTEL collector URL.",
+							Optional:    true,
+						},
+						"content_type": schema.StringAttribute{
+							Description:   `Available values: "json", "proto".`,
+							Optional:      true,
+							Computed:      true,
+							Default:      stringdefault.StaticString("json"),
+							Validators: []validator.String{
+								stringvalidator.OneOfCaseInsensitive("json", "proto"),
+							},
+						},
+					},
+				},
+			},
+			"rate_limiting_technique": schema.StringAttribute{
+				Description:   `Available values: "fixed", "sliding".`,
+				Optional:      true,
+				Computed:      true,
+				Default:      stringdefault.StaticString("fixed"),
+				Validators: []validator.String{
+					stringvalidator.OneOfCaseInsensitive("fixed", "sliding"),
+				},
+			},
+			"store_id": schema.StringAttribute{
+				Description: "Store ID for logs.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"stripe": schema.SingleNestedAttribute{
+				Description: "Stripe configuration for billing.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"authorization": schema.StringAttribute{
+						Description: "Stripe authorization token.",
+						Optional:    true,
+						Sensitive:   true,
+					},
+					"usage_events": schema.ListNestedAttribute{
+						Description: "Usage events configuration.",
+						Optional:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"payload": schema.StringAttribute{
+									Description: "Event payload.",
+									Optional:    true,
+								},
+							},
+						},
+					},
+				},
+			},
+			"workers_ai_billing_mode": schema.StringAttribute{
+				Description:   `Available values: "postpaid", "prepaid".`,
+				Optional:      true,
+				Computed:      true,
+				Default:      stringdefault.StaticString("postpaid"),
+				Validators: []validator.String{
+					stringvalidator.OneOfCaseInsensitive("postpaid", "prepaid"),
+				},
+			},
+			"zdr": schema.BoolAttribute{
+				Description: "Enable Zero Downtime Requirements.",
+				Optional:    true,
+				Computed:    true,
+				Default:    booldefault.StaticBool(false),
+			},
+		},
+	}
+}
+
+func (r *AIGatewayResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = ResourceSchema(ctx)
+}


### PR DESCRIPTION
## Summary

Implements cloudflare_ai_gateway resource for managing AI Gateway configurations via Terraform.

### Features
- Create, read, update, and delete AI Gateways
- Configure cache settings (cache_invalidate_on_update, cache_ttl)
- Configure logging (collect_logs, log_management, logpush)
- Configure rate limiting (rate_limiting_interval, rate_limiting_limit, rate_limiting_technique)
- Configure DLP settings (action, enabled, profiles)
- Configure OpenTelemetry (OTel) settings
- Configure Stripe billing
- Configure Workers AI billing mode

### Changes
This PR contains ONLY AI Gateway changes - no secrets_store or worker_builds modifications.

### Files Changed
- internal/services/ai_gateway/model.go
- internal/services/ai_gateway/resource.go
- internal/services/ai_gateway/schema.go
- docs/resources/ai_gateway.md

Resolves #6720