### PR TITLE
feat(secrets_store): add cloudflare_secrets_store resources

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -146,6 +146,8 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/schema_validation_operation_settings"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/schema_validation_schemas"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/schema_validation_settings"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/secrets_store"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/secrets_store_secret"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/snippet"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/snippet_rules"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/snippets"
@@ -622,6 +624,8 @@ func (p *CloudflareProvider) Resources(ctx context.Context) []func() resource.Re
 		cloudforce_one_request_message.NewResource,
 		cloudforce_one_request_priority.NewResource,
 		cloudforce_one_request_asset.NewResource,
+		secrets_store.NewResource,
+		secrets_store_secret.NewResource,
 		sso_connector.NewResource,
 		cloud_connector_rules.NewResource,
 		workflow.NewResource,

--- a/internal/services/secrets_store/model.go
+++ b/internal/services/secrets_store/model.go
@@ -1,0 +1,27 @@
+package secrets_store
+
+import (
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type SecretsStoreResultEnvelope struct {
+	Result SecretsStoreModel `json:"result"`
+}
+
+type SecretsStoreModel struct {
+	ID        types.String      `tfsdk:"id" json:"id,computed"`
+	AccountID types.String      `tfsdk:"account_id" path:"account_id,required"`
+	Name      types.String      `tfsdk:"name" json:"name,required"`
+	CreatedAt timetypes.RFC3339 `tfsdk:"created_at" json:"created_at,computed"`
+	ModifiedAt timetypes.RFC3339 `tfsdk:"modified_at" json:"modified_at,computed"`
+}
+
+func (m SecretsStoreModel) MarshalJSON() (data []byte, err error) {
+	return apijson.MarshalRoot(m)
+}
+
+func (m SecretsStoreModel) MarshalJSONForUpdate(state SecretsStoreModel) (data []byte, err error) {
+	return apijson.MarshalForUpdate(m, state)
+}

--- a/internal/services/secrets_store/resource.go
+++ b/internal/services/secrets_store/resource.go
@@ -1,0 +1,206 @@
+package secrets_store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/secrets_store"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.ResourceWithConfigure = (*SecretsStoreResource)(nil)
+var _ resource.ResourceWithImportState = (*SecretsStoreResource)(nil)
+
+func NewResource() resource.Resource {
+	return &SecretsStoreResource{}
+}
+
+type SecretsStoreResource struct {
+	client *cloudflare.Client
+}
+
+func (r *SecretsStoreResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_secrets_store"
+}
+
+func (r *SecretsStoreResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*cloudflare.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"unexpected resource configure type",
+			fmt.Sprintf("Expected *cloudflare.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *SecretsStoreResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *SecretsStoreModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	result, err := r.client.SecretsStore.Stores.New(
+		ctx,
+		secrets_store.StoreNewParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+			Body: []secrets_store.StoreNewParamsBody{
+				{
+					Name: cloudflare.F(data.Name.ValueString()),
+				},
+			},
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create secrets store", err.Error())
+		return
+	}
+
+	if len(result.Result) == 0 {
+		resp.Diagnostics.AddError("failed to create secrets store", "no store returned")
+		return
+	}
+
+	data.ID = types.StringValue(result.Result[0].ID)
+	data.Name = types.StringValue(result.Result[0].Name)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *SecretsStoreResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *SecretsStoreModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.AddError("updates not supported", "Secrets Store does not support updates. Please update the resource by using `terraform taint` and applying changes.")
+}
+
+func (r *SecretsStoreResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *SecretsStoreModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	stores, err := r.client.SecretsStore.Stores.List(
+		ctx,
+		secrets_store.StoreListParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to list secrets stores", err.Error())
+		return
+	}
+
+	found := false
+	for _, store := range stores.Result {
+		if store.ID == data.ID.ValueString() {
+			data.ID = types.StringValue(store.ID)
+			data.Name = types.StringValue(store.Name)
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		resp.Diagnostics.AddWarning("Resource not found", "The secrets store was not found on the server and will be removed from state.")
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *SecretsStoreResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *SecretsStoreModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := r.client.SecretsStore.Stores.Delete(
+		ctx,
+		data.ID.ValueString(),
+		secrets_store.StoreDeleteParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to delete secrets store", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *SecretsStoreResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	var data = new(SecretsStoreModel)
+
+	path_account_id := ""
+	path_id := ""
+	diags := importpath.ParseImportID(
+		req.ID,
+		"<account_id>/<id>",
+		&path_account_id,
+		&path_id,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.AccountID = types.StringValue(path_account_id)
+	data.ID = types.StringValue(path_id)
+
+	stores, err := r.client.SecretsStore.Stores.List(
+		ctx,
+		secrets_store.StoreListParams{
+			AccountID: cloudflare.F(path_account_id),
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to list secrets stores", err.Error())
+		return
+	}
+
+	found := false
+	for _, store := range stores.Result {
+		if store.ID == path_id {
+			data.ID = types.StringValue(store.ID)
+			data.Name = types.StringValue(store.Name)
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		resp.Diagnostics.AddWarning("Resource not found", "The secrets store was not found on the server and will be removed from state.")
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/services/secrets_store/schema.go
+++ b/internal/services/secrets_store/schema.go
@@ -1,0 +1,47 @@
+package secrets_store
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+func ResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Version: 500,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description:   "Secrets Store identifier.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"account_id": schema.StringAttribute{
+				Description:   "The Account ID to use for the Secrets Store.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"name": schema.StringAttribute{
+				Description:   "Name of the Secrets Store.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"created_at": schema.StringAttribute{
+				Description:   "The timestamp when the Secrets Store was created.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"modified_at": schema.StringAttribute{
+				Description:   "The timestamp when the Secrets Store was last modified.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+		},
+	}
+}
+
+func (r *SecretsStoreResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = ResourceSchema(ctx)
+}

--- a/internal/services/secrets_store_secret/model.go
+++ b/internal/services/secrets_store_secret/model.go
@@ -1,0 +1,32 @@
+package secrets_store_secret
+
+import (
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type SecretsStoreSecretResultEnvelope struct {
+	Result SecretsStoreSecretModel `json:"result"`
+}
+
+type SecretsStoreSecretModel struct {
+	ID        types.String      `tfsdk:"id" json:"id,computed"`
+	AccountID types.String      `tfsdk:"account_id" path:"account_id,required"`
+	StoreID   types.String      `tfsdk:"store_id" path:"store_id,required"`
+	Name      types.String      `tfsdk:"name" json:"name,required"`
+	SecretText types.String     `tfsdk:"secret_text" json:"value,required"`
+	Scopes    []types.String    `tfsdk:"scopes" json:"scopes,optional"`
+	Comment   types.String      `tfsdk:"comment" json:"comment,optional"`
+	Status    types.String      `tfsdk:"status" json:"status,computed"`
+	CreatedAt timetypes.RFC3339 `tfsdk:"created_at" json:"created_at,computed"`
+	ModifiedAt timetypes.RFC3339 `tfsdk:"modified_at" json:"modified_at,computed"`
+}
+
+func (m SecretsStoreSecretModel) MarshalJSON() (data []byte, err error) {
+	return apijson.MarshalRoot(m)
+}
+
+func (m SecretsStoreSecretModel) MarshalJSONForUpdate(state SecretsStoreSecretModel) (data []byte, err error) {
+	return apijson.MarshalForUpdate(m, state)
+}

--- a/internal/services/secrets_store_secret/resource.go
+++ b/internal/services/secrets_store_secret/resource.go
@@ -1,0 +1,256 @@
+package secrets_store_secret
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/secrets_store"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.ResourceWithConfigure = (*SecretsStoreSecretResource)(nil)
+var _ resource.ResourceWithImportState = (*SecretsStoreSecretResource)(nil)
+
+func NewResource() resource.Resource {
+	return &SecretsStoreSecretResource{}
+}
+
+type SecretsStoreSecretResource struct {
+	client *cloudflare.Client
+}
+
+func (r *SecretsStoreSecretResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_secrets_store_secret"
+}
+
+func (r *SecretsStoreSecretResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*cloudflare.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"unexpected resource configure type",
+			fmt.Sprintf("Expected *cloudflare.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *SecretsStoreSecretResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *SecretsStoreSecretModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var scopes []string
+	for _, s := range data.Scopes {
+		scopes = append(scopes, s.ValueString())
+	}
+
+	result, err := r.client.SecretsStore.Stores.Secrets.New(
+		ctx,
+		data.StoreID.ValueString(),
+		secrets_store.StoreSecretNewParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+			Body: []secrets_store.StoreSecretNewParamsBody{
+				{
+					Name:    cloudflare.F(data.Name.ValueString()),
+					Value:   cloudflare.F(data.SecretText.ValueString()),
+					Scopes:  cloudflare.F(scopes),
+					Comment: cloudflare.F(data.Comment.ValueString()),
+				},
+			},
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create secrets store secret", err.Error())
+		return
+	}
+
+	if len(result.Result) == 0 {
+		resp.Diagnostics.AddError("failed to create secrets store secret", "no secret returned")
+		return
+	}
+
+	data.ID = types.StringValue(result.Result[0].ID)
+	data.Name = types.StringValue(result.Result[0].Name)
+	data.Status = types.StringValue(string(result.Result[0].Status))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *SecretsStoreSecretResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *SecretsStoreSecretModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state *SecretsStoreSecretModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var scopes []string
+	for _, s := range data.Scopes {
+		scopes = append(scopes, s.ValueString())
+	}
+
+	result, err := r.client.SecretsStore.Stores.Secrets.Edit(
+		ctx,
+		state.StoreID.ValueString(),
+		state.ID.ValueString(),
+		secrets_store.StoreSecretEditParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+			Comment:   cloudflare.F(data.Comment.ValueString()),
+			Scopes:    cloudflare.F(scopes),
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to update secrets store secret", err.Error())
+		return
+	}
+
+	data.ID = types.StringValue(result.ID)
+	data.Name = types.StringValue(result.Name)
+	data.Status = types.StringValue(string(result.Status))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *SecretsStoreSecretResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *SecretsStoreSecretModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	secrets, err := r.client.SecretsStore.Stores.Secrets.List(
+		ctx,
+		data.StoreID.ValueString(),
+		secrets_store.StoreSecretListParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to list secrets store secrets", err.Error())
+		return
+	}
+
+	found := false
+	for _, secret := range secrets.Result {
+		if secret.ID == data.ID.ValueString() {
+			data.ID = types.StringValue(secret.ID)
+			data.Name = types.StringValue(secret.Name)
+			data.Status = types.StringValue(string(secret.Status))
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		resp.Diagnostics.AddWarning("Resource not found", "The secrets store secret was not found on the server and will be removed from state.")
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *SecretsStoreSecretResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *SecretsStoreSecretModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := r.client.SecretsStore.Stores.Secrets.Delete(
+		ctx,
+		data.StoreID.ValueString(),
+		data.ID.ValueString(),
+		secrets_store.StoreSecretDeleteParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to delete secrets store secret", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *SecretsStoreSecretResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	var data = new(SecretsStoreSecretModel)
+
+	path_account_id := ""
+	path_store_id := ""
+	path_id := ""
+	diags := importpath.ParseImportID(
+		req.ID,
+		"<account_id>/<store_id>/<id>",
+		&path_account_id,
+		&path_store_id,
+		&path_id,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.AccountID = types.StringValue(path_account_id)
+	data.StoreID = types.StringValue(path_store_id)
+	data.ID = types.StringValue(path_id)
+
+	secrets, err := r.client.SecretsStore.Stores.Secrets.List(
+		ctx,
+		path_store_id,
+		secrets_store.StoreSecretListParams{
+			AccountID: cloudflare.F(path_account_id),
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to list secrets store secrets", err.Error())
+		return
+	}
+
+	found := false
+	for _, secret := range secrets.Result {
+		if secret.ID == path_id {
+			data.ID = types.StringValue(secret.ID)
+			data.Name = types.StringValue(secret.Name)
+			data.Status = types.StringValue(string(secret.Status))
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		resp.Diagnostics.AddWarning("Resource not found", "The secrets store secret was not found on the server and will be removed from state.")
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/services/secrets_store_secret/schema.go
+++ b/internal/services/secrets_store_secret/schema.go
@@ -1,0 +1,72 @@
+package secrets_store_secret
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func ResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Version: 500,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description:   "Secrets Store Secret identifier.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"account_id": schema.StringAttribute{
+				Description:   "The Account ID to use for the Secrets Store Secret.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"store_id": schema.StringAttribute{
+				Description:   "The ID of the Secrets Store.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"name": schema.StringAttribute{
+				Description:   "Name of the secret.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"secret_text": schema.StringAttribute{
+				Description: "The secret value.",
+				Required:    true,
+				Sensitive:   true,
+			},
+			"scopes": schema.SetAttribute{
+				Description: "List of scopes for the secret.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"comment": schema.StringAttribute{
+				Description: "Comment describing the secret.",
+				Optional:    true,
+			},
+			"status": schema.StringAttribute{
+				Description:   "Status of the secret.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"created_at": schema.StringAttribute{
+				Description:   "The timestamp when the secret was created.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"modified_at": schema.StringAttribute{
+				Description:   "The timestamp when the secret was last modified.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+		},
+	}
+}
+
+func (r *SecretsStoreSecretResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = ResourceSchema(ctx)
+}


### PR DESCRIPTION
## Summary

Implements cloudflare_secrets_store and cloudflare_secrets_store_secret resource types for managing Secrets Store resources via Terraform.

### Features
- Create and manage Secrets Store containers
- Add, update, and remove secrets within a store
- Support CI/CD pipelines using Terraform for secret management

### Changes
This PR contains ONLY Secrets Store changes - no ai_gateway or worker_builds modifications.

### Files Changed
- internal/services/secrets_store/model.go
- internal/services/secrets_store/resource.go
- internal/services/secrets_store/schema.go
- internal/services/secrets_store_secret/model.go
- internal/services/secrets_store_secret/resource.go
- internal/services/secrets_store_secret/schema.go
- docs/resources/secrets_store.md
- docs/resources/secrets_store_secret.md

Resolves #6939