### PR TITLE
fix: mark provider credential fields as sensitive and update validation

### DIFF
--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/service/zero_trust_infrastructure_access_target"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/service/zero_trust_risk_behavior"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/service/zero_trust_risk_score_integration"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/framework/validators"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/sdkv2provider"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -108,11 +109,12 @@ func (p *CloudflareProvider) Schema(ctx context.Context, req provider.SchemaRequ
 
 			consts.APIKeySchemaKey: schema.StringAttribute{
 				Optional:            true,
+				Sensitive:           true,
 				MarkdownDescription: fmt.Sprintf("The API key for operations. Alternatively, can be configured using the `%s` environment variable. API keys are [now considered legacy by Cloudflare](https://developers.cloudflare.com/fundamentals/api/get-started/keys/#limitations), API tokens should be used instead. Must provide only one of `api_key`, `api_token`, `api_user_service_key`.", consts.APIKeyEnvVarKey),
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						regexp.MustCompile(`[0-9a-f]{37}`),
-						"API key must be 37 characters long and only contain characters 0-9 and a-f (all lowercased)",
+					validators.NewSensitiveRegexMatchesValidator(
+						regexp.MustCompile(`^[0-9A-Za-z\-_]{37,60}$`),
+						"API key must only contain characters 0-9, a-z, A-Z, hyphens and underscores",
 					),
 					stringvalidator.AlsoRequires(path.Expressions{
 						path.MatchRoot(consts.EmailSchemaKey),
@@ -122,17 +124,19 @@ func (p *CloudflareProvider) Schema(ctx context.Context, req provider.SchemaRequ
 
 			consts.APITokenSchemaKey: schema.StringAttribute{
 				Optional:            true,
+				Sensitive:           true,
 				MarkdownDescription: fmt.Sprintf("The API Token for operations. Alternatively, can be configured using the `%s` environment variable. Must provide only one of `api_key`, `api_token`, `api_user_service_key`.", consts.APITokenEnvVarKey),
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						regexp.MustCompile(`[A-Za-z0-9-_]{40}`),
-						"API tokens must be 40 characters long and only contain characters a-z, A-Z, 0-9, hyphens and underscores",
+					validators.NewSensitiveRegexMatchesValidator(
+						regexp.MustCompile(`^[0-9A-Za-z\-_]{40,80}$`),
+						"API tokens must only contain characters a-z, A-Z, 0-9, hyphens and underscores",
 					),
 				},
 			},
 
 			consts.APIUserServiceKeySchemaKey: schema.StringAttribute{
 				Optional:            true,
+				Sensitive:           true,
 				MarkdownDescription: fmt.Sprintf("A special Cloudflare API key good for a restricted set of endpoints. Alternatively, can be configured using the `%s` environment variable. Must provide only one of `api_key`, `api_token`, `api_user_service_key`.", consts.APIUserServiceKeyEnvVarKey),
 			},
 

--- a/internal/framework/validators/sensitive_regex.go
+++ b/internal/framework/validators/sensitive_regex.go
@@ -1,0 +1,55 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// SensitiveRegexMatches validates that a string attribute matches the given
+// regex pattern, but unlike stringvalidator.RegexMatches, it does NOT include
+// the raw attribute value in validation error messages. This is critical for
+// sensitive fields like API keys and tokens where leaking the value in error
+// output would be a security concern.
+type SensitiveRegexMatches struct {
+	regexp  *regexp.Regexp
+	message string
+}
+
+func (v SensitiveRegexMatches) Description(ctx context.Context) string {
+	if v.message != "" {
+		return v.message
+	}
+	return fmt.Sprintf("value must match regular expression '%s'", v.regexp)
+}
+
+func (v SensitiveRegexMatches) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v SensitiveRegexMatches) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := req.ConfigValue.ValueString()
+
+	if !v.regexp.MatchString(value) {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Attribute Value",
+			fmt.Sprintf("Attribute %s %s", req.Path, v.Description(ctx)),
+		)
+	}
+}
+
+// NewSensitiveRegexMatchesValidator returns a validator that checks the string
+// matches the given regex, without leaking the raw value in error messages.
+func NewSensitiveRegexMatchesValidator(r *regexp.Regexp, message string) validator.String {
+	return SensitiveRegexMatches{
+		regexp:  r,
+		message: message,
+	}
+}

--- a/internal/framework/validators/sensitive_regex_test.go
+++ b/internal/framework/validators/sensitive_regex_test.go
@@ -1,0 +1,179 @@
+package validators
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSensitiveRegexMatches_ValidateString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		value       types.String
+		regex       *regexp.Regexp
+		message     string
+		expectError bool
+	}{
+		{
+			name:        "matching value passes",
+			value:       types.StringValue("abc123"),
+			regex:       regexp.MustCompile(`^[a-z0-9]+$`),
+			message:     "must be lowercase alphanumeric",
+			expectError: false,
+		},
+		{
+			name:        "non-matching value fails",
+			value:       types.StringValue("ABC!@#"),
+			regex:       regexp.MustCompile(`^[a-z0-9]+$`),
+			message:     "must be lowercase alphanumeric",
+			expectError: true,
+		},
+		{
+			name:        "null value skips validation",
+			value:       types.StringNull(),
+			regex:       regexp.MustCompile(`^[a-z]+$`),
+			message:     "must be lowercase",
+			expectError: false,
+		},
+		{
+			name:        "unknown value skips validation",
+			value:       types.StringUnknown(),
+			regex:       regexp.MustCompile(`^[a-z]+$`),
+			message:     "must be lowercase",
+			expectError: false,
+		},
+		{
+			name:        "old format api key passes",
+			value:       types.StringValue("fake0key000000000000000000000000000000"),
+			regex:       regexp.MustCompile(`^[0-9A-Za-z\-_]{37,60}$`),
+			message:     "API key must only contain characters 0-9, a-z, A-Z, hyphens and underscores",
+			expectError: false,
+		},
+		{
+			name:        "new prefixed api key passes",
+			value:       types.StringValue("test_fake0key0aaaa0bbbb0cccc0dddd0eeee0ffff0gggg0hhhh"),
+			regex:       regexp.MustCompile(`^[0-9A-Za-z\-_]{37,60}$`),
+			message:     "API key must only contain characters 0-9, a-z, A-Z, hyphens and underscores",
+			expectError: false,
+		},
+		{
+			name:        "api key too short fails",
+			value:       types.StringValue("tooshort"),
+			regex:       regexp.MustCompile(`^[0-9A-Za-z\-_]{37,60}$`),
+			message:     "API key must only contain characters 0-9, a-z, A-Z, hyphens and underscores",
+			expectError: true,
+		},
+		{
+			name:        "api key with invalid characters fails",
+			value:       types.StringValue("this-has-special!chars@that#fail$regex00000000000"),
+			regex:       regexp.MustCompile(`^[0-9A-Za-z\-_]{37,60}$`),
+			message:     "API key must only contain characters 0-9, a-z, A-Z, hyphens and underscores",
+			expectError: true,
+		},
+		{
+			name:        "old format api token passes",
+			value:       types.StringValue("fake0token0FAKE0TOKEN0aaa0bbb0ccc0ddd0eee"),
+			regex:       regexp.MustCompile(`^[0-9A-Za-z\-_]{40,80}$`),
+			message:     "API tokens must only contain characters a-z, A-Z, 0-9, hyphens and underscores",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := NewSensitiveRegexMatchesValidator(tc.regex, tc.message)
+
+			req := validator.StringRequest{
+				Path:        path.Root("test_attr"),
+				ConfigValue: tc.value,
+			}
+			resp := &validator.StringResponse{}
+
+			v.ValidateString(context.Background(), req, resp)
+
+			if tc.expectError && !resp.Diagnostics.HasError() {
+				t.Error("expected validation error but got none")
+			}
+			if !tc.expectError && resp.Diagnostics.HasError() {
+				t.Errorf("expected no error but got: %s", resp.Diagnostics.Errors())
+			}
+		})
+	}
+}
+
+func TestSensitiveRegexMatches_ErrorDoesNotContainValue(t *testing.T) {
+	t.Parallel()
+
+	sensitiveValue := "test_FAKE_sensitive_value_0000000000000000"
+	v := NewSensitiveRegexMatchesValidator(
+		regexp.MustCompile(`^[a-z]{10}$`),
+		"must be exactly 10 lowercase letters",
+	)
+
+	req := validator.StringRequest{
+		Path:        path.Root("api_key"),
+		ConfigValue: types.StringValue(sensitiveValue),
+	}
+	resp := &validator.StringResponse{}
+
+	v.ValidateString(context.Background(), req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected validation error but got none")
+	}
+
+	for _, d := range resp.Diagnostics.Errors() {
+		if strings.Contains(d.Summary(), sensitiveValue) {
+			t.Errorf("error summary contains the sensitive value: %s", d.Summary())
+		}
+		if strings.Contains(d.Detail(), sensitiveValue) {
+			t.Errorf("error detail contains the sensitive value: %s", d.Detail())
+		}
+	}
+}
+
+func TestSensitiveRegexMatches_Description(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("custom message", func(t *testing.T) {
+		t.Parallel()
+
+		v := SensitiveRegexMatches{
+			regexp:  regexp.MustCompile(`^[a-z]+$`),
+			message: "must be lowercase letters",
+		}
+
+		expected := "must be lowercase letters"
+		if got := v.Description(ctx); got != expected {
+			t.Errorf("Description() = %q, want %q", got, expected)
+		}
+		if got := v.MarkdownDescription(ctx); got != expected {
+			t.Errorf("MarkdownDescription() = %q, want %q", got, expected)
+		}
+	})
+
+	t.Run("default message", func(t *testing.T) {
+		t.Parallel()
+
+		v := SensitiveRegexMatches{
+			regexp:  regexp.MustCompile(`^[a-z]+$`),
+			message: "",
+		}
+
+		expected := "value must match regular expression '^[a-z]+$'"
+		if got := v.Description(ctx); got != expected {
+			t.Errorf("Description() = %q, want %q", got, expected)
+		}
+	})
+}

--- a/internal/sdkv2provider/provider.go
+++ b/internal/sdkv2provider/provider.go
@@ -99,20 +99,23 @@ func New(version string) func() *schema.Provider {
 				consts.APIKeySchemaKey: {
 					Type:         schema.TypeString,
 					Optional:     true,
+					Sensitive:    true,
 					Description:  fmt.Sprintf("The API key for operations. Alternatively, can be configured using the `%s` environment variable. API keys are [now considered legacy by Cloudflare](https://developers.cloudflare.com/fundamentals/api/get-started/keys/#limitations), API tokens should be used instead. Must provide only one of `api_key`, `api_token`, `api_user_service_key`.", consts.APIKeyEnvVarKey),
-					ValidateFunc: validation.StringMatch(regexp.MustCompile("[0-9a-f]{37}"), "API key must be 37 characters long and only contain characters 0-9 and a-f (all lowercased)"),
+					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z\-_]{37,60}$`), "API key must only contain characters 0-9, a-z, A-Z, hyphens and underscores"),
 				},
 
 				consts.APITokenSchemaKey: {
 					Type:         schema.TypeString,
 					Optional:     true,
+					Sensitive:    true,
 					Description:  fmt.Sprintf("The API Token for operations. Alternatively, can be configured using the `%s` environment variable. Must provide only one of `api_key`, `api_token`, `api_user_service_key`.", consts.APITokenEnvVarKey),
-					ValidateFunc: validation.StringMatch(regexp.MustCompile("[A-Za-z0-9-_]{40}"), "API tokens must be 40 characters long and only contain characters a-z, A-Z, 0-9, hyphens and underscores"),
+					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z\-_]{40,80}$`), "API tokens must only contain characters a-z, A-Z, 0-9, hyphens and underscores"),
 				},
 
 				consts.APIUserServiceKeySchemaKey: {
 					Type:        schema.TypeString,
 					Optional:    true,
+					Sensitive:   true,
 					Description: fmt.Sprintf("A special Cloudflare API key good for a restricted set of endpoints. Alternatively, can be configured using the `%s` environment variable. Must provide only one of `api_key`, `api_token`, `api_user_service_key`.", consts.APIUserServiceKeyEnvVarKey),
 				},
 


### PR DESCRIPTION
## Summary
- Marks `api_key`, `api_token`, and `api_user_service_key` provider fields as `Sensitive` in both the framework and SDKv2 schemas
- Replaces `stringvalidator.RegexMatches` with a custom `SensitiveRegexMatches` validator that omits raw values from error messages
- Updates validation regexes to accept new prefixed key/token formats (`api_key`: 37-60 chars, `api_token`: 40-80 chars)
## Problem
When provider credential validation failed, the raw API key or token was printed in the error output. The built-in `stringvalidator.RegexMatches` unconditionally appends `got: <value>` to error messages, and the credential fields were not marked as sensitive. Additionally, server-side changes to key formats (new prefixes extending the length) caused validation to reject valid credentials.
## Changes
- `internal/framework/validators/sensitive_regex.go` — new custom validator implementing `validator.String` that performs regex matching without including the raw value in error diagnostics
- `internal/framework/provider/provider.go` — added `Sensitive: true` to all three credential fields, switched to custom validator, updated regexes
- `internal/sdkv2provider/provider.go` — added `Sensitive: true` to all three credential fields, updated regexes
## Tests
`go test ./internal/framework/validators/ -v`

### Output
```
=== RUN   TestSensitiveRegexMatches_ValidateString
=== PAUSE TestSensitiveRegexMatches_ValidateString
=== RUN   TestSensitiveRegexMatches_ErrorDoesNotContainValue
=== PAUSE TestSensitiveRegexMatches_ErrorDoesNotContainValue
=== RUN   TestSensitiveRegexMatches_Description
=== PAUSE TestSensitiveRegexMatches_Description
=== CONT  TestSensitiveRegexMatches_ValidateString
=== CONT  TestSensitiveRegexMatches_Description
=== RUN   TestSensitiveRegexMatches_Description/custom_message
=== PAUSE TestSensitiveRegexMatches_Description/custom_message
=== RUN   TestSensitiveRegexMatches_Description/default_message
=== PAUSE TestSensitiveRegexMatches_Description/default_message
=== CONT  TestSensitiveRegexMatches_Description/custom_message
=== CONT  TestSensitiveRegexMatches_ErrorDoesNotContainValue
--- PASS: TestSensitiveRegexMatches_ErrorDoesNotContainValue (0.00s)
=== CONT  TestSensitiveRegexMatches_Description/default_message
=== RUN   TestSensitiveRegexMatches_ValidateString/matching_value_passes
=== PAUSE TestSensitiveRegexMatches_ValidateString/matching_value_passes
=== RUN   TestSensitiveRegexMatches_ValidateString/non-matching_value_fails
=== PAUSE TestSensitiveRegexMatches_ValidateString/non-matching_value_fails
=== RUN   TestSensitiveRegexMatches_ValidateString/null_value_skips_validation
--- PASS: TestSensitiveRegexMatches_Description (0.00s)
    --- PASS: TestSensitiveRegexMatches_Description/custom_message (0.00s)
    --- PASS: TestSensitiveRegexMatches_Description/default_message (0.00s)
=== PAUSE TestSensitiveRegexMatches_ValidateString/null_value_skips_validation
=== RUN   TestSensitiveRegexMatches_ValidateString/unknown_value_skips_validation
=== PAUSE TestSensitiveRegexMatches_ValidateString/unknown_value_skips_validation
=== RUN   TestSensitiveRegexMatches_ValidateString/old_format_api_key_passes
=== PAUSE TestSensitiveRegexMatches_ValidateString/old_format_api_key_passes
=== RUN   TestSensitiveRegexMatches_ValidateString/new_prefixed_api_key_passes
=== PAUSE TestSensitiveRegexMatches_ValidateString/new_prefixed_api_key_passes
=== RUN   TestSensitiveRegexMatches_ValidateString/api_key_too_short_fails
=== PAUSE TestSensitiveRegexMatches_ValidateString/api_key_too_short_fails
=== RUN   TestSensitiveRegexMatches_ValidateString/api_key_with_invalid_characters_fails
=== PAUSE TestSensitiveRegexMatches_ValidateString/api_key_with_invalid_characters_fails
=== RUN   TestSensitiveRegexMatches_ValidateString/old_format_api_token_passes
=== PAUSE TestSensitiveRegexMatches_ValidateString/old_format_api_token_passes
=== CONT  TestSensitiveRegexMatches_ValidateString/matching_value_passes
=== CONT  TestSensitiveRegexMatches_ValidateString/old_format_api_token_passes
=== CONT  TestSensitiveRegexMatches_ValidateString/unknown_value_skips_validation
=== CONT  TestSensitiveRegexMatches_ValidateString/null_value_skips_validation
=== CONT  TestSensitiveRegexMatches_ValidateString/old_format_api_key_passes
=== CONT  TestSensitiveRegexMatches_ValidateString/non-matching_value_fails
=== CONT  TestSensitiveRegexMatches_ValidateString/new_prefixed_api_key_passes
=== CONT  TestSensitiveRegexMatches_ValidateString/api_key_with_invalid_characters_fails
=== CONT  TestSensitiveRegexMatches_ValidateString/api_key_too_short_fails
--- PASS: TestSensitiveRegexMatches_ValidateString (0.00s)
    --- PASS: TestSensitiveRegexMatches_ValidateString/matching_value_passes (0.00s)
    --- PASS: TestSensitiveRegexMatches_ValidateString/old_format_api_token_passes (0.00s)
    --- PASS: TestSensitiveRegexMatches_ValidateString/unknown_value_skips_validation (0.00s)
    --- PASS: TestSensitiveRegexMatches_ValidateString/null_value_skips_validation (0.00s)
    --- PASS: TestSensitiveRegexMatches_ValidateString/old_format_api_key_passes (0.00s)
    --- PASS: TestSensitiveRegexMatches_ValidateString/non-matching_value_fails (0.00s)
    --- PASS: TestSensitiveRegexMatches_ValidateString/new_prefixed_api_key_passes (0.00s)
    --- PASS: TestSensitiveRegexMatches_ValidateString/api_key_with_invalid_characters_fails (0.00s)
    --- PASS: TestSensitiveRegexMatches_ValidateString/api_key_too_short_fails (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/framework/validators	0.572s
```