### PR TITLE
fix(zero_trust_gateway_policy): make filters Computed+Optional to pre…

### DIFF
--- a/internal/services/zero_trust_gateway_policy/model.go
+++ b/internal/services/zero_trust_gateway_policy/model.go
@@ -19,7 +19,7 @@ type ZeroTrustGatewayPolicyModel struct {
 	Action        types.String                                                      `tfsdk:"action" json:"action,required"`
 	Name          types.String                                                      `tfsdk:"name" json:"name,required"`
 	Description   types.String                                                      `tfsdk:"description" json:"description,optional"`
-	Filters       *[]types.String                                                   `tfsdk:"filters" json:"filters,optional"`
+	Filters       customfield.List[types.String]                                    `tfsdk:"filters" json:"filters,computed_optional"`
 	DevicePosture types.String                                                      `tfsdk:"device_posture" json:"device_posture,computed_optional"`
 	Enabled       types.Bool                                                        `tfsdk:"enabled" json:"enabled,computed_optional"`
 	Identity      types.String                                                      `tfsdk:"identity" json:"identity,computed_optional"`

--- a/internal/services/zero_trust_gateway_policy/resource.go
+++ b/internal/services/zero_trust_gateway_policy/resource.go
@@ -155,9 +155,6 @@ func (r *ZeroTrustGatewayPolicyResource) Read(ctx context.Context, req resource.
 		return
 	}
 
-	// Store prior state for preserving config values not returned by API
-	priorFilters := data.Filters
-
 	res := new(http.Response)
 	env := ZeroTrustGatewayPolicyResultEnvelope{*data}
 	_, err := r.client.ZeroTrust.Gateway.Rules.Get(
@@ -185,12 +182,6 @@ func (r *ZeroTrustGatewayPolicyResource) Read(ctx context.Context, req resource.
 		return
 	}
 	data = &env.Result
-
-	// Preserve filters from prior state if API returns null
-	// The API doesn't return filters in the response, causing drift
-	if data.Filters == nil && priorFilters != nil {
-		data.Filters = priorFilters
-	}
 
 	// Normalize duration strings to prevent drift from API returning verbose formats
 	normalizeRuleSettingsDurations(ctx, data)

--- a/internal/services/zero_trust_gateway_policy/schema.go
+++ b/internal/services/zero_trust_gateway_policy/schema.go
@@ -69,7 +69,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"filters": schema.ListAttribute{
 				Description: "Specify the protocol or layer to evaluate the traffic, identity, and device posture expressions. Can only contain a single value.",
+				Computed:    true,
 				Optional:    true,
+				CustomType:  customfield.NewListType[types.String](ctx),
 				Validators: []validator.List{
 					listvalidator.ValueStringsAre(
 						stringvalidator.OneOfCaseInsensitive(


### PR DESCRIPTION
### Problem

The `filters` attribute on `cloudflare_zero_trust_gateway_policy` was declared as `Optional`-only in the schema. The Cloudflare API always returns a value for `filters` in its response (e.g. `["dns"]`), but when a user doesn't explicitly set `filters` in their config, the v5 provider would plan to remove it on every `terraform plan` and re-read it from the API on every `terraform apply` — making the resource permanently unstable:

```
~ resource "cloudflare_zero_trust_gateway_policy" "example" {
    ~ filters = [
        - "dns",
      ] -> null
```

A previous workaround had been added in `Read()` to manually copy `filters` from prior state back to the response when the API returned null — but this was fragile and insufficient, and broke when the field type was corrected.

### Root cause

`filters` needed to be `Computed+Optional`:
- **`Computed`** — the provider reads the value back from the API and stores it in state, so a missing config value doesn't plan as a removal
- **`Optional`** — users can still explicitly set `filters` in config when they want to

Additionally, the Go field type `*[]types.String` cannot represent the **unknown** state that the Terraform framework sends during planning for `Computed+Optional` fields. This caused a hard apply error:

```
Error: Value Conversion Error
  Received unknown value, however the target type cannot handle unknown values.
  Path: filters
  Target Type: *[]basetypes.StringValue
  Suggested Type: basetypes.ListValue
```

### Changes

**`schema.go`**
- Added `Computed: true` to the `filters` attribute
- Added `CustomType: customfield.NewListType[types.String](ctx)` — required so the framework can represent the field as unknown during planning before the API responds. Follows the same pattern as `override_ips` in the same schema.

**`model.go`**
- Changed `Filters` from `*[]types.String` to `customfield.List[types.String]` to match the `customfield.NewListType` in the schema and correctly handle null/unknown values

**`resource.go`**
- Removed the manual `priorFilters` preservation workaround in `Read()`. This was a band-aid for the missing `Computed` flag — with `Computed+Optional` + `customfield.List`, the framework handles the full null/unknown/known lifecycle correctly at the type system level

### Testing

Verified via the `tf-migrate` e2e test suite against a real Cloudflare account: gateway policy resources with API-assigned `filters` values now plan with no drift after migration from v4, and achieve stable state after apply.

---

