### PR TITLE
fix(zone_setting): pass `--yes` to tf-migrate in migration test harness

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1022,6 +1022,7 @@ func RunMigrationV2Command(t *testing.T, v4Config string, tmpDir string, sourceV
 		"--config-dir", tmpDir,
 		"--source-version", sourceVersion,
 		"--target-version", targetVersion,
+		"--yes", // skip phased migration prompts — state cleanup is handled by the test harness
 	}
 
 	// Add debug logging if TF_LOG is set


### PR DESCRIPTION
## PR Description

**fix(zone_setting): pass `--yes` to tf-migrate in migration test harness**

---

### Problem

tf-migrate recently gained a phased migration flow for `cloudflare_zone_settings_override`. On the first run (without `--yes`), it auto-detects the resource, replaces the resource blocks with `removed {}` blocks, prints instructions, and exits — it does **not** run the full v5 migration. This is the correct behavior for real users in Atlantis-managed workspaces.

However, `RunMigrationV2Command` in the provider test harness was calling tf-migrate without `--yes`, so all `from_v4_latest` migration tests for zone settings started getting only the phase-1 output (a file with `removed {}` blocks and no v5 resources). The subsequent `terraform apply` found nothing to create, and the state checks failed with:

```
state does not contain any state values
```

### Fix

Add `--yes` to the tf-migrate invocation in `RunMigrationV2Command`. This bypasses phase detection and runs the full migration directly — which is the correct behavior for the test harness, since it already handles state cleanup itself via `RunStateRmForObsoleteTypes`.

### Change

One line in `internal/acctest/acctest.go`:

```go
args := []string{
    "migrate",
    "--config-dir", tmpDir,
    "--source-version", sourceVersion,
    "--target-version", targetVersion,
    "--yes", // skip phased migration prompts — state cleanup is handled by the test harness
}
```

---