### PR TITLE
fix(zero_trust_access_policy): set PriorSchema nil for v4 state upgrade (TKT-007)

### DIFF
--- a/internal/services/zero_trust_access_policy/migration/v500/migrations_test.go
+++ b/internal/services/zero_trust_access_policy/migration/v500/migrations_test.go
@@ -42,6 +42,9 @@ var v4ServiceTokenConfig string
 //go:embed testdata/v4_unsupported.tf
 var v4UnsupportedConfig string
 
+//go:embed testdata/v4_connection_rules.tf
+var v4ConnectionRulesConfig string
+
 //go:embed testdata/v5_basic.tf
 var v5BasicConfig string
 
@@ -743,6 +746,55 @@ func TestMigrateZeroTrustAccessPolicyEmailDomainTransformation(t *testing.T) {
 					tfjsonpath.New("include").AtSliceIndex(0).AtMapKey("email_domain").AtMapKey("domain"),
 					knownvalue.StringExact(domain),
 				),
+			}),
+		},
+	})
+}
+
+// TestMigrateZeroTrustAccessPolicyConnectionRules tests that connection_rules
+// with application_id and precedence are correctly migrated from v4 to v5.
+// Reproduces TKT-007: connection_rules stored as JSON array [] in v4 state
+// causes "invalid JSON, expected '{', got '['" error during state upgrade.
+// Reported by research team (terraform-cfaccounts MR !7756).
+func TestMigrateZeroTrustAccessPolicyConnectionRules(t *testing.T) {
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_zero_trust_access_policy." + rnd
+	tmpDir := t.TempDir()
+
+	v4Config := fmt.Sprintf(v4ConnectionRulesConfig, rnd, accountID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create with v4 provider
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "~> 4.52.1",
+					},
+				},
+				Config: v4Config,
+			},
+			// Step 2: Run migration and verify state
+			// With the PriorSchema: nil fix, state upgrade succeeds
+			// The key success is that we don't get: "AttributeName("connection_rules"): invalid JSON, expected "{", got "[""
+			acctest.MigrationV2TestStep(t, v4Config, tmpDir, "4.52.1", "v4", "v5", []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("decision"), knownvalue.StringExact("allow")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("session_duration"), knownvalue.StringExact("24h")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+				// Verify include was transformed correctly
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("include"), knownvalue.ListSizeExact(1)),
 			}),
 		},
 	})

--- a/internal/services/zero_trust_access_policy/migration/v500/testdata/v4_connection_rules.tf
+++ b/internal/services/zero_trust_access_policy/migration/v500/testdata/v4_connection_rules.tf
@@ -1,0 +1,17 @@
+resource "cloudflare_access_policy" "%[1]s" {
+  account_id       = "%[2]s"
+  name             = "%[1]s"
+  decision         = "allow"
+  session_duration = "24h"
+
+  include {
+    any_valid_service_token = true
+  }
+
+  connection_rules {
+    ssh {
+      usernames         = ["root", "admin"]
+      allow_email_alias = true
+    }
+  }
+}

--- a/internal/services/zero_trust_access_policy/migrations.go
+++ b/internal/services/zero_trust_access_policy/migrations.go
@@ -40,11 +40,12 @@ func (r *ZeroTrustAccessPolicyResource) UpgradeState(ctx context.Context) map[in
 	v5Schema := ResourceSchema(ctx)
 
 	return map[int64]resource.StateUpgrader{
-		// Handle early v5 state with schema_version=0 (v5.12-v5.15)
-		// Uses v5Schema - only works for v5 format, NOT v4
-		// v4 migration must use `moved` blocks which go through MoveState
+		// Handle early v5 state with schema_version=0 (v5.12-v5.15) AND v4 state
+		// PriorSchema is nil to allow raw JSON unmarshaling in handler
+		// Handler detects v4 format (application_id/precedence/connection_rules=[])
+		// and transforms using v4 source schema, or passes v5 state through unchanged
 		0: {
-			PriorSchema:   &v5Schema,
+			PriorSchema:   nil,
 			StateUpgrader: v500.UpgradeFromSchemaV0,
 		},
 		// Handle upgrades from v5 with schema_version=1


### PR DESCRIPTION
The Terraform Plugin Framework's PriorSchema-based state deserialization fails when v4 SDKv2 state encoding is incompatible with Plugin Framework schema types. Specifically, connection_rules stored as JSON array [] by SDKv2 cannot be parsed by Plugin Framework which expects an object {}.

Fix: Set PriorSchema: nil in UpgradeState registration for schema_version=0 to allow the handler to unmarshal raw JSON directly using the v4 source schema type system. This bypasses the framework's schema validation and uses the same approach as other working migrations.

The handler (v500.UpgradeFromSchemaV0) now:
- Detects v4 format by checking for application_id, precedence, or connection_rules=[]
- If v4: unmarshals using v4 source schema, transforms to v5
- If v5: passes state through unchanged

This completes the fix started in commit 0e93ea652 which updated the handler logic but missed updating the migrations.go registration.

Resolves: AttributeName("connection_rules"): invalid JSON, expected "{", got "["
Reported by: Research team (terraform-cfaccounts MR !7756)
Test: TestMigrateZeroTrustAccessPolicyConnectionRules

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
