### PR TITLE
fix(CI): pin go releaser

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6.0.0
         with:
-          version: latest
+          version: v2.15.0
           args: "release --clean --timeout 3h -p 3"
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6.0.0
         with:
-          version: v2.15.0
+          version: v2.15.2
           args: "release --clean --timeout 3h -p 3"
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
https://github.com/goreleaser/goreleaser/releases/tag/v2.15.1 . A bug was introduced that added an extra file to the SHA256SUMS file. It added an entry for the SHA256SUMS.sig file, which lead to an error. Every filename in SHA256SUMS must correspond to a platform asset, or the manifest file. Therefore the registry side validation failed causing the last release to not be published. 

See these issues raised:
- https://github.com/goreleaser/goreleaser/issues/6514
- https://github.com/goreleaser/goreleaser/issues/6508


## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
```
NA
```
