### PR TITLE
feat(origin_cloud_region): Add resource for origin cloud region mappings

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -116,6 +116,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/organization"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/organization_profile"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/origin_ca_certificate"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/origin_cloud_regions"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/page_rule"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/page_shield_connections"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/page_shield_cookies"
@@ -425,6 +426,7 @@ func (p *CloudflareProvider) Resources(ctx context.Context) []func() resource.Re
 		organization.NewResource,
 		organization_profile.NewResource,
 		origin_ca_certificate.NewResource,
+		origin_cloud_regions.NewResource,
 		user.NewResource,
 		api_token.NewResource,
 		zone.NewResource,

--- a/internal/services/origin_cloud_regions/model.go
+++ b/internal/services/origin_cloud_regions/model.go
@@ -1,0 +1,48 @@
+package origin_cloud_regions
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// OriginCloudRegionsResultEnvelope wraps the standard Cloudflare v4 API envelope.
+type OriginCloudRegionsResultEnvelope struct {
+	Result OriginCloudRegionsResult `json:"result"`
+}
+
+// OriginCloudRegionsResult is the top-level result object returned by
+// GET /zones/:zone_id/cache/origin_public_cloud_region.
+type OriginCloudRegionsResult struct {
+	ID         string                   `json:"id"`
+	Value      []OriginCloudRegionEntry `json:"value"`
+	ModifiedOn string                   `json:"modified_on"`
+	Editable   bool                     `json:"editable"`
+}
+
+// OriginCloudRegionEntry is one IP→vendor:region mapping in the value array.
+type OriginCloudRegionEntry struct {
+	OriginIP   string `json:"origin-ip"`
+	Vendor     string `json:"vendor"`
+	Region     string `json:"region"`
+	ModifiedOn string `json:"modified_on,omitempty"`
+}
+
+// OriginCloudRegionMappingModel is the Terraform model for a single mapping block.
+type OriginCloudRegionMappingModel struct {
+	OriginIP types.String `tfsdk:"origin_ip"`
+	Vendor   types.String `tfsdk:"vendor"`
+	Region   types.String `tfsdk:"region"`
+}
+
+// OriginCloudRegionsModel is the Terraform resource model.
+type OriginCloudRegionsModel struct {
+	ID       types.String                    `tfsdk:"id"`
+	ZoneID   types.String                    `tfsdk:"zone_id"`
+	Mappings []OriginCloudRegionMappingModel `tfsdk:"mappings"`
+}
+
+// OriginCloudRegionUpsertRequest is the POST/PATCH request body.
+type OriginCloudRegionUpsertRequest struct {
+	IP     string `json:"ip"`
+	Vendor string `json:"vendor"`
+	Region string `json:"region"`
+}

--- a/internal/services/origin_cloud_regions/resource.go
+++ b/internal/services/origin_cloud_regions/resource.go
@@ -1,0 +1,248 @@
+package origin_cloud_regions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const apiPath = "/zones/%s/cache/origin_public_cloud_region"
+const apiPathWithIP = "/zones/%s/cache/origin_public_cloud_region/%s"
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.ResourceWithConfigure = (*OriginCloudRegionsResource)(nil)
+var _ resource.ResourceWithImportState = (*OriginCloudRegionsResource)(nil)
+
+type OriginCloudRegionsResource struct {
+	client *cloudflare.Client
+}
+
+func NewResource() resource.Resource {
+	return &OriginCloudRegionsResource{}
+}
+
+func (r *OriginCloudRegionsResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_origin_cloud_regions"
+}
+
+func (r *OriginCloudRegionsResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*cloudflare.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"unexpected resource configure type",
+			fmt.Sprintf("Expected *cloudflare.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+}
+
+func (r *OriginCloudRegionsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data OriginCloudRegionsModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	zoneID := data.ZoneID.ValueString()
+	for _, m := range data.Mappings {
+		body := OriginCloudRegionUpsertRequest{
+			IP:     m.OriginIP.ValueString(),
+			Vendor: m.Vendor.ValueString(),
+			Region: m.Region.ValueString(),
+		}
+		if err := r.patchMapping(ctx, zoneID, body); err != nil {
+			resp.Diagnostics.AddError("failed to create origin cloud region mapping", err.Error())
+			return
+		}
+	}
+
+	data.ID = types.StringValue(zoneID)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *OriginCloudRegionsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data OriginCloudRegionsModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	mappings, err := r.readMappings(ctx, data.ZoneID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read origin cloud region mappings", err.Error())
+		return
+	}
+
+	data.Mappings = mappings
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *OriginCloudRegionsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state OriginCloudRegionsModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	zoneID := plan.ZoneID.ValueString()
+
+	// Index desired state by IP — reused for both upsert and delete passes.
+	planByIP := make(map[string]OriginCloudRegionMappingModel, len(plan.Mappings))
+	for _, m := range plan.Mappings {
+		planByIP[m.OriginIP.ValueString()] = m
+	}
+
+	// Index current state by IP — used to detect new vs changed entries.
+	stateByIP := make(map[string]OriginCloudRegionMappingModel, len(state.Mappings))
+	for _, m := range state.Mappings {
+		stateByIP[m.OriginIP.ValueString()] = m
+	}
+
+	// PATCH new and changed entries — PATCH upserts (creates if not exists, updates if exists).
+	for ip, pm := range planByIP {
+		sm, exists := stateByIP[ip]
+		if !exists || sm.Vendor != pm.Vendor || sm.Region != pm.Region {
+			body := OriginCloudRegionUpsertRequest{
+				IP:     ip,
+				Vendor: pm.Vendor.ValueString(),
+				Region: pm.Region.ValueString(),
+			}
+			if err := r.patchMapping(ctx, zoneID, body); err != nil {
+				resp.Diagnostics.AddError("failed to upsert origin cloud region mapping", err.Error())
+				return
+			}
+		}
+	}
+
+	// DELETE removed entries — planByIP reused here.
+	for _, m := range state.Mappings {
+		if _, exists := planByIP[m.OriginIP.ValueString()]; !exists {
+			if err := r.deleteMapping(ctx, zoneID, m.OriginIP.ValueString()); err != nil {
+				resp.Diagnostics.AddError("failed to delete origin cloud region mapping", err.Error())
+				return
+			}
+		}
+	}
+
+	plan.ID = state.ID
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *OriginCloudRegionsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data OriginCloudRegionsModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	zoneID := data.ZoneID.ValueString()
+	for _, m := range data.Mappings {
+		if err := r.deleteMapping(ctx, zoneID, m.OriginIP.ValueString()); err != nil {
+			resp.Diagnostics.AddError("failed to delete origin cloud region mapping", err.Error())
+			return
+		}
+	}
+}
+
+func (r *OriginCloudRegionsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	var data OriginCloudRegionsModel
+
+	path := ""
+	diags := importpath.ParseImportID(req.ID, "<zone_id>", &path)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.ZoneID = types.StringValue(path)
+
+	mappings, err := r.readMappings(ctx, path)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read origin cloud region mappings during import", err.Error())
+		return
+	}
+
+	data.ID = data.ZoneID
+	data.Mappings = mappings
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// readMappings fetches the current list of mappings from the API.
+func (r *OriginCloudRegionsResource) readMappings(ctx context.Context, zoneID string) ([]OriginCloudRegionMappingModel, error) {
+	res := new(http.Response)
+	err := r.client.Get(
+		ctx,
+		fmt.Sprintf(apiPath, zoneID),
+		nil,
+		&res,
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var env OriginCloudRegionsResultEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, fmt.Errorf("failed to deserialize response: %w", err)
+	}
+
+	mappings := make([]OriginCloudRegionMappingModel, 0, len(env.Result.Value))
+	for _, entry := range env.Result.Value {
+		mappings = append(mappings, OriginCloudRegionMappingModel{
+			OriginIP: types.StringValue(entry.OriginIP),
+			Vendor:   types.StringValue(entry.Vendor),
+			Region:   types.StringValue(entry.Region),
+		})
+	}
+	return mappings, nil
+}
+
+// patchMapping issues a PATCH for an existing mapping.
+func (r *OriginCloudRegionsResource) patchMapping(ctx context.Context, zoneID string, body OriginCloudRegionUpsertRequest) error {
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	return r.client.Patch(
+		ctx,
+		fmt.Sprintf(apiPath, zoneID),
+		nil,
+		nil,
+		option.WithRequestBody("application/json", bytes.NewReader(bodyBytes)),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+}
+
+// deleteMapping issues DELETE for a single IP entry.
+func (r *OriginCloudRegionsResource) deleteMapping(ctx context.Context, zoneID, ip string) error {
+	return r.client.Delete(
+		ctx,
+		fmt.Sprintf(apiPathWithIP, zoneID, ip),
+		nil,
+		nil,
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+}

--- a/internal/services/origin_cloud_regions/resource_schema_test.go
+++ b/internal/services/origin_cloud_regions/resource_schema_test.go
@@ -1,0 +1,17 @@
+package origin_cloud_regions_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/origin_cloud_regions"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/test_helpers"
+)
+
+func TestOriginCloudRegionsModelSchemaParity(t *testing.T) {
+	t.Parallel()
+	model := (*origin_cloud_regions.OriginCloudRegionsModel)(nil)
+	schema := origin_cloud_regions.ResourceSchema(context.TODO())
+	errs := test_helpers.ValidateResourceModelSchemaIntegrity(model, schema)
+	errs.Report(t)
+}

--- a/internal/services/origin_cloud_regions/resource_test.go
+++ b/internal/services/origin_cloud_regions/resource_test.go
@@ -1,0 +1,275 @@
+package origin_cloud_regions_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func init() {
+	resource.AddTestSweepers("cloudflare_origin_cloud_regions", &resource.Sweeper{
+		Name: "cloudflare_origin_cloud_regions",
+		F:    testSweepCloudflareOriginCloudRegions,
+	})
+}
+
+func testSweepCloudflareOriginCloudRegions(r string) error {
+	ctx := context.Background()
+	// origin_cloud_regions is a zone-level collection managed per-entry.
+	// Acceptance tests clean up via destroy; no sweep required.
+	tflog.Info(ctx, "origin_cloud_regions does not require sweeping")
+	return nil
+}
+
+func testOriginCloudRegionsConfig(rnd, zoneID string) string {
+	return acctest.LoadTestCase("basic.tf", rnd, zoneID)
+}
+
+func testOriginCloudRegionsConfigUpdated(rnd, zoneID string) string {
+	return acctest.LoadTestCase("updated.tf", rnd, zoneID)
+}
+
+func testOriginCloudRegionsConfigVendorChanged(rnd, zoneID string) string {
+	return acctest.LoadTestCase("vendor_changed.tf", rnd, zoneID)
+}
+
+func testOriginCloudRegionsConfigEntryRemoved(rnd, zoneID string) string {
+	return acctest.LoadTestCase("entry_removed.tf", rnd, zoneID)
+}
+
+func testAccCheckOriginCloudRegionsDestroy(s *terraform.State) error {
+	client := acctest.SharedClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_origin_cloud_regions" {
+			continue
+		}
+
+		zoneID := rs.Primary.Attributes[consts.ZoneIDSchemaKey]
+
+		res := new(http.Response)
+		err := client.Get(
+			context.Background(),
+			fmt.Sprintf("/zones/%s/cache/origin_public_cloud_region", zoneID),
+			nil,
+			&res,
+		)
+		if err != nil {
+			continue
+		}
+
+		body, _ := io.ReadAll(res.Body)
+
+		var envelope struct {
+			Result struct {
+				Value []interface{} `json:"value"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal(body, &envelope); err != nil {
+			continue
+		}
+
+		if len(envelope.Result.Value) > 0 {
+			return fmt.Errorf("origin cloud region mappings still exist for zone %s", zoneID)
+		}
+	}
+
+	return nil
+}
+
+func TestAccCloudflareOriginCloudRegions_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_origin_cloud_regions." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckOriginCloudRegionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testOriginCloudRegionsConfig(rnd, zoneID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("mappings"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("mappings"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"origin_ip": knownvalue.StringExact("192.0.2.1"),
+							"vendor":    knownvalue.StringExact("aws"),
+							"region":    knownvalue.StringExact("us-east-1"),
+						}),
+					})),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareOriginCloudRegions_AddEntry(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_origin_cloud_regions." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckOriginCloudRegionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testOriginCloudRegionsConfig(rnd, zoneID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("mappings"), knownvalue.SetSizeExact(1)),
+				},
+			},
+			{
+				Config: testOriginCloudRegionsConfigUpdated(rnd, zoneID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("mappings"), knownvalue.SetSizeExact(2)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("mappings"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"origin_ip": knownvalue.StringExact("192.0.2.1"),
+							"vendor":    knownvalue.StringExact("aws"),
+							"region":    knownvalue.StringExact("us-west-2"),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"origin_ip": knownvalue.StringExact("2001:db8::1"),
+							"vendor":    knownvalue.StringExact("gcp"),
+							"region":    knownvalue.StringExact("us-central1"),
+						}),
+					})),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareOriginCloudRegions_ChangeVendor(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_origin_cloud_regions." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckOriginCloudRegionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Start: 192.0.2.1 → aws/us-east-1
+				Config: testOriginCloudRegionsConfig(rnd, zoneID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("mappings"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"origin_ip": knownvalue.StringExact("192.0.2.1"),
+							"vendor":    knownvalue.StringExact("aws"),
+							"region":    knownvalue.StringExact("us-east-1"),
+						}),
+					})),
+				},
+			},
+			{
+				// Change: 192.0.2.1 → gcp/us-central1
+				Config: testOriginCloudRegionsConfigVendorChanged(rnd, zoneID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("mappings"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("mappings"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"origin_ip": knownvalue.StringExact("192.0.2.1"),
+							"vendor":    knownvalue.StringExact("gcp"),
+							"region":    knownvalue.StringExact("us-central1"),
+						}),
+					})),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareOriginCloudRegions_DeleteEntry(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_origin_cloud_regions." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckOriginCloudRegionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Start: two entries
+				Config: testOriginCloudRegionsConfigUpdated(rnd, zoneID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("mappings"), knownvalue.SetSizeExact(2)),
+				},
+			},
+			{
+				// Remove 2001:db8::1, leaving only 192.0.2.1 → aws/us-east-1
+				Config: testOriginCloudRegionsConfigEntryRemoved(rnd, zoneID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("mappings"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("mappings"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"origin_ip": knownvalue.StringExact("192.0.2.1"),
+							"vendor":    knownvalue.StringExact("aws"),
+							"region":    knownvalue.StringExact("us-east-1"),
+						}),
+					})),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/services/origin_cloud_regions/schema.go
+++ b/internal/services/origin_cloud_regions/schema.go
@@ -1,0 +1,62 @@
+package origin_cloud_regions
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ resource.ResourceWithConfigValidators = (*OriginCloudRegionsResource)(nil)
+
+func ResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description:   "Identifier.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"zone_id": schema.StringAttribute{
+				Description:   "Identifier.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"mappings": schema.SetNestedAttribute{
+				Description: "Set of origin IP to public cloud vendor and region mappings. Up to 3,500 entries per zone.",
+				Required:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"origin_ip": schema.StringAttribute{
+							Description: "Origin server IP address (IPv4 or IPv6).",
+							Required:    true,
+						},
+						"vendor": schema.StringAttribute{
+							Description: "Cloud vendor.\nAvailable values: \"aws\", \"azure\", \"gcp\", \"oci\".",
+							Required:    true,
+							Validators: []validator.String{
+								stringvalidator.OneOfCaseInsensitive("aws", "azure", "gcp", "oci"),
+							},
+						},
+						"region": schema.StringAttribute{
+							Description: "Cloud region identifier (e.g. \"us-east-1\" for AWS).",
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *OriginCloudRegionsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = ResourceSchema(ctx)
+}
+
+func (r *OriginCloudRegionsResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{}
+}

--- a/internal/services/origin_cloud_regions/testdata/basic.tf
+++ b/internal/services/origin_cloud_regions/testdata/basic.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_origin_cloud_regions" "%[1]s" {
+  zone_id = "%[2]s"
+  mappings = [
+    {
+      origin_ip = "192.0.2.1"
+      vendor    = "aws"
+      region    = "us-east-1"
+    },
+  ]
+}

--- a/internal/services/origin_cloud_regions/testdata/entry_removed.tf
+++ b/internal/services/origin_cloud_regions/testdata/entry_removed.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_origin_cloud_regions" "%[1]s" {
+  zone_id = "%[2]s"
+  mappings = [
+    {
+      origin_ip = "192.0.2.1"
+      vendor    = "aws"
+      region    = "us-east-1"
+    },
+  ]
+}

--- a/internal/services/origin_cloud_regions/testdata/updated.tf
+++ b/internal/services/origin_cloud_regions/testdata/updated.tf
@@ -1,0 +1,15 @@
+resource "cloudflare_origin_cloud_regions" "%[1]s" {
+  zone_id = "%[2]s"
+  mappings = [
+    {
+      origin_ip = "192.0.2.1"
+      vendor    = "aws"
+      region    = "us-west-2"
+    },
+    {
+      origin_ip = "2001:db8::1"
+      vendor    = "gcp"
+      region    = "us-central1"
+    },
+  ]
+}

--- a/internal/services/origin_cloud_regions/testdata/vendor_changed.tf
+++ b/internal/services/origin_cloud_regions/testdata/vendor_changed.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_origin_cloud_regions" "%[1]s" {
+  zone_id = "%[2]s"
+  mappings = [
+    {
+      origin_ip = "192.0.2.1"
+      vendor    = "gcp"
+      region    = "us-central1"
+    },
+  ]
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [ x] I have added or updated acceptance tests for my changes
- [ x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
1.) Created api token with correct permissions for resources
2.) Set environment variables for api token and set TF_ACC=1
3.) Ran `go test -v -timeout 180s -run TestAccCloudflareOriginCloudRegions ./internal/services/origin_cloud_regions/ 2>&1`

### Test output
<!-- Please paste the output of your acceptance test run below --> 
=== RUN   TestAccCloudflareOriginCloudRegions_Basic
--- PASS: TestAccCloudflareOriginCloudRegions_Basic (9.99s)
=== RUN   TestAccCloudflareOriginCloudRegions_AddEntry
--- PASS: TestAccCloudflareOriginCloudRegions_AddEntry (10.42s)
=== RUN   TestAccCloudflareOriginCloudRegions_ChangeVendor
--- PASS: TestAccCloudflareOriginCloudRegions_ChangeVendor (10.09s)
=== RUN   TestAccCloudflareOriginCloudRegions_DeleteEntry
--- PASS: TestAccCloudflareOriginCloudRegions_DeleteEntry (10.46s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/origin_cloud_regions        40.979s

## Additional context & links
