### PR TITLE
fix: ci acceptance tests

### DIFF
--- a/internal/services/dns_record/model.go
+++ b/internal/services/dns_record/model.go
@@ -23,7 +23,7 @@ type DNSRecordModel struct {
 	Content           types.String                                     `tfsdk:"content" json:"content,computed_optional"`
 	Priority          types.Float64                                    `tfsdk:"priority" json:"priority,optional"`
 	Data              *DNSRecordDataModel                              `tfsdk:"data" json:"data,optional"`
-	PrivateRouting    types.Bool                                       `tfsdk:"private_routing" json:"private_routing,computed_optional"`
+	PrivateRouting    types.Bool                                       `tfsdk:"private_routing" json:"private_routing,optional"`
 	Proxied           types.Bool                                       `tfsdk:"proxied" json:"proxied,computed_optional"`
 	TTL               types.Float64                                    `tfsdk:"ttl" json:"ttl,required"`
 	Tags              customfield.Set[types.String]                    `tfsdk:"tags" json:"tags,computed_optional"`

--- a/internal/services/dns_record/schema.go
+++ b/internal/services/dns_record/schema.go
@@ -328,9 +328,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"private_routing": schema.BoolAttribute{
 				Description: "Enables private network routing to the origin.",
-				Computed:    true,
 				Optional:    true,
-				Default:     booldefault.StaticBool(false),
 			},
 			"proxied": schema.BoolAttribute{
 				Description: "Whether the record is receiving the performance and security benefits of Cloudflare.",

--- a/internal/services/logpush_job/migration/v500/model.go
+++ b/internal/services/logpush_job/migration/v500/model.go
@@ -35,19 +35,18 @@ type SourceCloudflareLogpushJobModel struct {
 // SourceLogpushJobOutputOptionsModel represents the source output_options nested structure.
 // In the legacy provider, this is stored as a TypeList with MaxItems: 1, hence the array in parent model.
 type SourceLogpushJobOutputOptionsModel struct {
-	BatchPrefix      types.String    `tfsdk:"batch_prefix"`
-	BatchSuffix      types.String    `tfsdk:"batch_suffix"`
-	Cve20214428      types.Bool      `tfsdk:"cve20214428"` // Renamed to cve_2021_44228 in target
-	FieldDelimiter   types.String    `tfsdk:"field_delimiter"`
-	FieldNames       *[]types.String `tfsdk:"field_names"`
-	MergeSubrequests types.Bool      `tfsdk:"merge_subrequests"`
-	OutputType       types.String    `tfsdk:"output_type"`
-	RecordDelimiter  types.String    `tfsdk:"record_delimiter"`
-	RecordPrefix     types.String    `tfsdk:"record_prefix"`
-	RecordSuffix     types.String    `tfsdk:"record_suffix"`
-	RecordTemplate   types.String    `tfsdk:"record_template"`
-	SampleRate       types.Float64   `tfsdk:"sample_rate"`
-	TimestampFormat  types.String    `tfsdk:"timestamp_format"`
+	BatchPrefix     types.String    `tfsdk:"batch_prefix"`
+	BatchSuffix     types.String    `tfsdk:"batch_suffix"`
+	Cve20214428     types.Bool      `tfsdk:"cve20214428"` // Renamed to cve_2021_44228 in target
+	FieldDelimiter  types.String    `tfsdk:"field_delimiter"`
+	FieldNames      *[]types.String `tfsdk:"field_names"`
+	OutputType      types.String    `tfsdk:"output_type"`
+	RecordDelimiter types.String    `tfsdk:"record_delimiter"`
+	RecordPrefix    types.String    `tfsdk:"record_prefix"`
+	RecordSuffix    types.String    `tfsdk:"record_suffix"`
+	RecordTemplate  types.String    `tfsdk:"record_template"`
+	SampleRate      types.Float64   `tfsdk:"sample_rate"`
+	TimestampFormat types.String    `tfsdk:"timestamp_format"`
 }
 
 // ============================================================================

--- a/internal/services/logpush_job/migration/v500/transform.go
+++ b/internal/services/logpush_job/migration/v500/transform.go
@@ -48,13 +48,13 @@ func Transform(ctx context.Context, source SourceCloudflareLogpushJobModel) (*Ta
 
 	// Step 3: Initialize target with direct copies
 	target := &TargetLogpushJobModel{
-		ID:              targetID,
-		AccountID:       source.AccountID,
-		ZoneID:          source.ZoneID,
-		Dataset:         source.Dataset,
-		DestinationConf: source.DestinationConf,
-		Enabled:         source.Enabled,
-		Frequency:       source.Frequency,
+		ID:                 targetID,
+		AccountID:          source.AccountID,
+		ZoneID:             source.ZoneID,
+		Dataset:            source.Dataset,
+		DestinationConf:    source.DestinationConf,
+		Enabled:            source.Enabled,
+		Frequency:          source.Frequency,
 		OwnershipChallenge: source.OwnershipChallenge,
 	}
 
@@ -122,6 +122,9 @@ func transformOutputOptions(ctx context.Context, source SourceLogpushJobOutputOp
 	target.RecordPrefix = preserveV4Default(source.RecordPrefix, "{")
 	target.RecordSuffix = preserveV4Default(source.RecordSuffix, "}\n")
 	target.TimestampFormat = preserveV4Default(source.TimestampFormat, "unixnano")
+
+	// Set default for merge_subrequests (not present in v4 state, default is false)
+	target.MergeSubrequests = types.BoolValue(false)
 
 	// cve_2021_44228 has default false in both v4 and v5, so no special handling needed
 	// sample_rate has default 1.0 in v4, but we preserve the actual value from state

--- a/internal/services/worker/data_source_test.go
+++ b/internal/services/worker/data_source_test.go
@@ -37,9 +37,17 @@ func TestAccCloudflareWorkerDataSource_Basic(t *testing.T) {
 						"enabled":            knownvalue.Bool(false),
 						"head_sampling_rate": knownvalue.Float64Exact(1),
 						"logs": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"destinations":       knownvalue.ListExact([]knownvalue.Check{}),
 							"enabled":            knownvalue.Bool(false),
 							"head_sampling_rate": knownvalue.Float64Exact(1),
 							"invocation_logs":    knownvalue.Bool(true),
+							"persist":            knownvalue.Bool(true),
+						}),
+						"traces": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"destinations":       knownvalue.ListExact([]knownvalue.Check{}),
+							"enabled":            knownvalue.Bool(false),
+							"head_sampling_rate": knownvalue.Float64Exact(1),
+							"persist":            knownvalue.Bool(true),
 						}),
 					})),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subdomain"), knownvalue.ObjectExact(map[string]knownvalue.Check{
@@ -59,9 +67,17 @@ func TestAccCloudflareWorkerDataSource_Basic(t *testing.T) {
 						"enabled":            knownvalue.Bool(false),
 						"head_sampling_rate": knownvalue.Float64Exact(1),
 						"logs": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"destinations":       knownvalue.ListExact([]knownvalue.Check{}),
 							"enabled":            knownvalue.Bool(false),
 							"head_sampling_rate": knownvalue.Float64Exact(1),
 							"invocation_logs":    knownvalue.Bool(true),
+							"persist":            knownvalue.Bool(true),
+						}),
+						"traces": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"destinations":       knownvalue.ListExact([]knownvalue.Check{}),
+							"enabled":            knownvalue.Bool(false),
+							"head_sampling_rate": knownvalue.Float64Exact(1),
+							"persist":            knownvalue.Bool(true),
 						}),
 					})),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("subdomain"), knownvalue.ObjectExact(map[string]knownvalue.Check{

--- a/internal/services/worker/resource_test.go
+++ b/internal/services/worker/resource_test.go
@@ -106,9 +106,17 @@ func TestAccCloudflareWorker_Basic(t *testing.T) {
 						"enabled":            knownvalue.Bool(false),
 						"head_sampling_rate": knownvalue.Float64Exact(1),
 						"logs": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"destinations":       knownvalue.ListExact([]knownvalue.Check{}),
 							"enabled":            knownvalue.Bool(false),
 							"head_sampling_rate": knownvalue.Float64Exact(1),
 							"invocation_logs":    knownvalue.Bool(true),
+							"persist":            knownvalue.Bool(true),
+						}),
+						"traces": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"destinations":       knownvalue.ListExact([]knownvalue.Check{}),
+							"enabled":            knownvalue.Bool(false),
+							"head_sampling_rate": knownvalue.Float64Exact(1),
+							"persist":            knownvalue.Bool(true),
 						}),
 					})),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("subdomain"), knownvalue.ObjectExact(map[string]knownvalue.Check{
@@ -133,9 +141,17 @@ func TestAccCloudflareWorker_Basic(t *testing.T) {
 						"enabled":            knownvalue.Bool(false),
 						"head_sampling_rate": knownvalue.Float64Exact(1),
 						"logs": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"destinations":       knownvalue.ListExact([]knownvalue.Check{}),
 							"enabled":            knownvalue.Bool(false),
 							"head_sampling_rate": knownvalue.Float64Exact(1),
 							"invocation_logs":    knownvalue.Bool(true),
+							"persist":            knownvalue.Bool(true),
+						}),
+						"traces": knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"destinations":       knownvalue.ListExact([]knownvalue.Check{}),
+							"enabled":            knownvalue.Bool(false),
+							"head_sampling_rate": knownvalue.Float64Exact(1),
+							"persist":            knownvalue.Bool(true),
 						}),
 					})),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("subdomain"), knownvalue.ObjectExact(map[string]knownvalue.Check{

--- a/internal/services/worker/schema.go
+++ b/internal/services/worker/schema.go
@@ -12,7 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -58,6 +60,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:    true,
 				Optional:    true,
 				CustomType:  customfield.NewNestedObjectType[WorkerObservabilityModel](ctx),
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"enabled": schema.BoolAttribute{
 						Description: "Whether observability is enabled for the Worker.",
@@ -79,6 +84,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Computed:    true,
 						Optional:    true,
 						CustomType:  customfield.NewNestedObjectType[WorkerObservabilityLogsModel](ctx),
+						PlanModifiers: []planmodifier.Object{
+							objectplanmodifier.UseStateForUnknown(),
+						},
 						Attributes: map[string]schema.Attribute{
 							"destinations": schema.ListAttribute{
 								Description: "A list of destinations where logs will be exported to.",
@@ -86,6 +94,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Optional:    true,
 								CustomType:  customfield.NewListType[types.String](ctx),
 								ElementType: types.StringType,
+								PlanModifiers: []planmodifier.List{
+									listplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"enabled": schema.BoolAttribute{
 								Description: "Whether logs are enabled for the Worker.",
@@ -121,6 +132,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Computed:    true,
 						Optional:    true,
 						CustomType:  customfield.NewNestedObjectType[WorkerObservabilityTracesModel](ctx),
+						PlanModifiers: []planmodifier.Object{
+							objectplanmodifier.UseStateForUnknown(),
+						},
 						Attributes: map[string]schema.Attribute{
 							"destinations": schema.ListAttribute{
 								Description: "A list of destinations where traces will be exported to.",
@@ -128,6 +142,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Optional:    true,
 								CustomType:  customfield.NewListType[types.String](ctx),
 								ElementType: types.StringType,
+								PlanModifiers: []planmodifier.List{
+									listplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"enabled": schema.BoolAttribute{
 								Description: "Whether traces are enabled for the Worker.",
@@ -148,10 +165,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Default:     booldefault.StaticBool(true),
 							},
 						},
-						Default: objectdefault.StaticValue(customfield.NewObjectMust(ctx, &WorkerObservabilityLogsModel{
+						Default: objectdefault.StaticValue(customfield.NewObjectMust(ctx, &WorkerObservabilityTracesModel{
 							Enabled:          types.BoolValue(false),
 							HeadSamplingRate: types.Float64Value(1),
-							InvocationLogs:   types.BoolValue(true),
+							Persist:          types.BoolValue(true),
+							Destinations:     customfield.NewListMust[types.String](ctx, nil),
 						}).ObjectValue),
 					},
 				},
@@ -162,6 +180,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Enabled:          types.BoolValue(false),
 						HeadSamplingRate: types.Float64Value(1),
 						InvocationLogs:   types.BoolValue(true),
+						Persist:          types.BoolValue(true),
+						Destinations:     customfield.NewListMust[types.String](ctx, nil),
+					}),
+					Traces: customfield.NewObjectMust(ctx, &WorkerObservabilityTracesModel{
+						Enabled:          types.BoolValue(false),
+						HeadSamplingRate: types.Float64Value(1),
+						Persist:          types.BoolValue(true),
+						Destinations:     customfield.NewListMust[types.String](ctx, nil),
 					}),
 				}).ObjectValue),
 			},
@@ -221,6 +247,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description: "When the Worker's most recent deployment was created. `null` if the Worker has never been deployed.",
 				Computed:    true,
 				CustomType:  timetypes.RFC3339Type{},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_on": schema.StringAttribute{
 				Description: "When the Worker was most recently updated.",

--- a/internal/services/workers_custom_domain/migration/v500/migrations_test.go
+++ b/internal/services/workers_custom_domain/migration/v500/migrations_test.go
@@ -174,7 +174,7 @@ func TestMigrateWorkersCustomDomain_WithoutEnvironment(t *testing.T) {
 					ExpectNonEmptyPlan:       true,
 					ConfigPlanChecks: resource.ConfigPlanChecks{
 						PostApplyPostRefresh: []plancheck.PlanCheck{
-							plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+							plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
 						},
 					},
 				}
@@ -227,7 +227,7 @@ func migrationStepExpectEnvironmentReplacement(t *testing.T, cfg string, tmpDir 
 				acctest.DebugNonEmptyPlan,
 			},
 			PostApplyPostRefresh: []plancheck.PlanCheck{
-				plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+				plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
 			},
 		},
 		ConfigStateChecks: stateChecks,

--- a/internal/services/workers_custom_domain/migration/v500/migrations_test.go
+++ b/internal/services/workers_custom_domain/migration/v500/migrations_test.go
@@ -171,7 +171,6 @@ func TestMigrateWorkersCustomDomain_WithoutEnvironment(t *testing.T) {
 				firstStep = resource.TestStep{
 					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 					Config:                   testConfig,
-					ExpectNonEmptyPlan:       true,
 					ConfigPlanChecks: resource.ConfigPlanChecks{
 						PostApplyPostRefresh: []plancheck.PlanCheck{
 							plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
@@ -221,7 +220,7 @@ func migrationStepExpectEnvironmentReplacement(t *testing.T, cfg string, tmpDir 
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		ConfigDirectory:          config.StaticDirectory(tmpDir),
-		ExpectNonEmptyPlan:       true,
+		ExpectNonEmptyPlan:       false,
 		ConfigPlanChecks: resource.ConfigPlanChecks{
 			PreApply: []plancheck.PlanCheck{
 				acctest.DebugNonEmptyPlan,

--- a/internal/services/workers_custom_domain/resource.go
+++ b/internal/services/workers_custom_domain/resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/option"
@@ -16,6 +17,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -157,8 +159,18 @@ func (r *WorkersCustomDomainResource) Delete(ctx context.Context, req resource.D
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("failed to make http request", err.Error())
-		return
+		// The API may return an empty content-type for DELETE responses which causes
+		// the SDK to fail with a content-type handling error. Treat this as success
+		// since DELETE is idempotent and a response indicates the server processed it.
+		errStr := err.Error()
+		if strings.Contains(errStr, "expected destination type") && strings.Contains(errStr, "content-type") {
+			tflog.Warn(ctx, "Delete operation returned non-JSON response, assuming success", map[string]interface{}{
+				"id": data.ID.ValueString(),
+			})
+		} else {
+			resp.Diagnostics.AddError("failed to make http request", errStr)
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/services/zero_trust_access_policy/migration/v500/handler.go
+++ b/internal/services/zero_trust_access_policy/migration/v500/handler.go
@@ -81,7 +81,18 @@ func UpgradeFromSchemaV0(ctx context.Context, req resource.UpgradeStateRequest, 
 
 	// Early v5 state (v5.12-v5.15) — pass through unchanged
 	tflog.Info(ctx, "Detected v5 format in schema_version=0 state, no-op upgrade")
-	resp.State.Raw = req.State.Raw
+
+	// When PriorSchema is nil (as set in migrations.go for v4 compatibility),
+	// req.State is nil and only req.RawState is available. We need to unmarshal
+	// the raw state using the target schema type.
+	v5Type := resp.State.Schema.Type().TerraformType(ctx)
+	rawValue, err := req.RawState.Unmarshal(v5Type)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to unmarshal v5 state during upgrade",
+			fmt.Sprintf("Could not parse state as v5 format: %s", err))
+		return
+	}
+	resp.State.Raw = rawValue
 }
 
 // UpgradeFromSchemaV1 handles state upgrades from schema_version=1 to current version.


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Fix CI tests

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Test output
```
~/c/github/terraform-provider-cloudflare vaishak/ci-acceptance *1 !3 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/logpush_job/... -run "Test"       04:50:56 PM
=== RUN   TestLogpushJobDataSourceModelSchemaParity
=== PAUSE TestLogpushJobDataSourceModelSchemaParity
=== RUN   TestLogpushJobsDataSourceModelSchemaParity
=== PAUSE TestLogpushJobsDataSourceModelSchemaParity
=== RUN   TestLogpushJobModelSchemaParity
=== PAUSE TestLogpushJobModelSchemaParity
=== RUN   TestAccCloudflareLogpushJob_Basic
--- PASS: TestAccCloudflareLogpushJob_Basic (10.62s)
=== RUN   TestAccCloudflareLogpushJob_BasicOutputOptions
--- PASS: TestAccCloudflareLogpushJob_BasicOutputOptions (8.72s)
=== RUN   TestAccCloudflareLogpushJob_Full
--- PASS: TestAccCloudflareLogpushJob_Full (8.31s)
=== RUN   TestAccCloudflareLogpushJob_BasicToFull
--- PASS: TestAccCloudflareLogpushJob_BasicToFull (8.50s)
=== RUN   TestAccCloudflareLogpushJob_Update
--- PASS: TestAccCloudflareLogpushJob_Update (9.50s)
=== RUN   TestAccCloudflareLogpushJob_ImmutableFields
--- PASS: TestAccCloudflareLogpushJob_ImmutableFields (8.51s)
=== RUN   TestAccCloudflareLogpushJob_OmitemptyField
--- PASS: TestAccCloudflareLogpushJob_OmitemptyField (12.59s)
=== RUN   TestAccUpgradeLogpushJob_FromPublishedV5
--- PASS: TestAccUpgradeLogpushJob_FromPublishedV5 (22.64s)
=== CONT  TestLogpushJobDataSourceModelSchemaParity
=== CONT  TestLogpushJobModelSchemaParity
=== CONT  TestLogpushJobsDataSourceModelSchemaParity
--- PASS: TestLogpushJobModelSchemaParity (0.00s)
--- PASS: TestLogpushJobDataSourceModelSchemaParity (0.00s)
--- PASS: TestLogpushJobsDataSourceModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/logpush_job	91.293s
=== RUN   TestLogpushJobMigrationModelSchemaParity
=== PAUSE TestLogpushJobMigrationModelSchemaParity
=== RUN   TestMigrateLogpushJobBasic
=== RUN   TestMigrateLogpushJobBasic/from_v4_latest
=== RUN   TestMigrateLogpushJobBasic/from_v5
--- PASS: TestMigrateLogpushJobBasic (33.18s)
    --- PASS: TestMigrateLogpushJobBasic/from_v4_latest (20.57s)
    --- PASS: TestMigrateLogpushJobBasic/from_v5 (12.61s)
=== RUN   TestMigrateLogpushJobOutputOptions
=== RUN   TestMigrateLogpushJobOutputOptions/from_v4_latest
=== RUN   TestMigrateLogpushJobOutputOptions/from_v5
--- PASS: TestMigrateLogpushJobOutputOptions (26.39s)
    --- PASS: TestMigrateLogpushJobOutputOptions/from_v4_latest (19.48s)
    --- PASS: TestMigrateLogpushJobOutputOptions/from_v5 (6.91s)
=== RUN   TestMigrateLogpushJobInstantLogs
=== RUN   TestMigrateLogpushJobInstantLogs/from_v4_latest
=== RUN   TestMigrateLogpushJobInstantLogs/from_v5
--- PASS: TestMigrateLogpushJobInstantLogs (26.85s)
    --- PASS: TestMigrateLogpushJobInstantLogs/from_v4_latest (19.73s)
    --- PASS: TestMigrateLogpushJobInstantLogs/from_v5 (7.12s)
=== CONT  TestLogpushJobMigrationModelSchemaParity
--- PASS: TestLogpushJobMigrationModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/logpush_job/migration/v500	88.410s

```

```
~/cf-repos/github/terraform-provider-cloudflare next *1 +1 !6 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/worker/ -run "TestAcc"               43s 01:18:56 PM
=== RUN   TestAccCloudflareWorkerDataSource_Basic
--- PASS: TestAccCloudflareWorkerDataSource_Basic (7.87s)
=== RUN   TestAccCloudflareWorker_Basic
--- PASS: TestAccCloudflareWorker_Basic (10.04s)
=== RUN   TestAccCloudflareWorker_SubdomainDynamicDefault
--- PASS: TestAccCloudflareWorker_SubdomainDynamicDefault (8.46s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/worker	28.360s
```

```
~/cf-repos/github/terraform-provider-cloudflare next *1 +1 !6 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/dns_record/... -run "Test"               12:23:46 PM
=== RUN   TestDNSRecordDataSourceModelSchemaParity
=== PAUSE TestDNSRecordDataSourceModelSchemaParity
=== RUN   TestDNSRecordsDataSourceModelSchemaParity
=== PAUSE TestDNSRecordsDataSourceModelSchemaParity
=== RUN   TestModifyPlan_ModifiedOnPreservation
=== RUN   TestModifyPlan_ModifiedOnPreservation/no_changes_preserves_modified_on
    resource_modifyplan_test.go:136: Test case: When no fields change, modified_on should be preserved from state
    resource_modifyplan_test.go:137: Expect preserve modified_on: true
=== RUN   TestModifyPlan_ModifiedOnPreservation/content_change_updates_modified_on
    resource_modifyplan_test.go:136: Test case: When content changes, modified_on should remain unknown for API to update
    resource_modifyplan_test.go:137: Expect preserve modified_on: false
=== RUN   TestModifyPlan_ModifiedOnPreservation/empty_settings_no_drift
    resource_modifyplan_test.go:136: Test case: Empty settings {} should not cause drift
    resource_modifyplan_test.go:137: Expect preserve modified_on: true
--- PASS: TestModifyPlan_ModifiedOnPreservation (0.00s)
    --- PASS: TestModifyPlan_ModifiedOnPreservation/no_changes_preserves_modified_on (0.00s)
    --- PASS: TestModifyPlan_ModifiedOnPreservation/content_change_updates_modified_on (0.00s)
    --- PASS: TestModifyPlan_ModifiedOnPreservation/empty_settings_no_drift (0.00s)
=== RUN   TestModifyPlan_SettingsEmptyObject
=== RUN   TestModifyPlan_SettingsEmptyObject/null_state_empty_plan_no_drift
    resource_modifyplan_test.go:184: State settings: <nil>
    resource_modifyplan_test.go:185: Plan settings: map[]
    resource_modifyplan_test.go:186: Expect drift: false
=== RUN   TestModifyPlan_SettingsEmptyObject/defaults_state_empty_plan_no_drift
    resource_modifyplan_test.go:184: State settings: map[flatten_cname:false ipv4_only:false ipv6_only:false]
    resource_modifyplan_test.go:185: Plan settings: map[]
    resource_modifyplan_test.go:186: Expect drift: false
=== RUN   TestModifyPlan_SettingsEmptyObject/actual_values_state_empty_plan_has_drift
    resource_modifyplan_test.go:184: State settings: map[flatten_cname:false ipv4_only:true ipv6_only:false]
    resource_modifyplan_test.go:185: Plan settings: map[]
    resource_modifyplan_test.go:186: Expect drift: true
--- PASS: TestModifyPlan_SettingsEmptyObject (0.00s)
    --- PASS: TestModifyPlan_SettingsEmptyObject/null_state_empty_plan_no_drift (0.00s)
    --- PASS: TestModifyPlan_SettingsEmptyObject/defaults_state_empty_plan_no_drift (0.00s)
    --- PASS: TestModifyPlan_SettingsEmptyObject/actual_values_state_empty_plan_has_drift (0.00s)
=== RUN   TestDNSRecordModelSchemaParity
=== PAUSE TestDNSRecordModelSchemaParity
=== RUN   TestAccCloudflareRecord_Basic
--- PASS: TestAccCloudflareRecord_Basic (3.78s)
=== RUN   TestAccCloudflareRecord_Apex
--- PASS: TestAccCloudflareRecord_Apex (4.19s)
=== RUN   TestAccCloudflareRecord_LOC
--- PASS: TestAccCloudflareRecord_LOC (3.95s)
=== RUN   TestAccCloudflareRecord_SRV
--- PASS: TestAccCloudflareRecord_SRV (3.89s)
=== RUN   TestAccCloudflareRecord_CAA
--- PASS: TestAccCloudflareRecord_CAA (6.29s)
=== RUN   TestAccCloudflareRecord_Proxied
--- PASS: TestAccCloudflareRecord_Proxied (4.05s)
=== RUN   TestAccCloudflareRecord_Updated
--- PASS: TestAccCloudflareRecord_Updated (7.51s)
=== RUN   TestAccCloudflareRecord_typeForceNewRecord
--- PASS: TestAccCloudflareRecord_typeForceNewRecord (7.02s)
=== RUN   TestAccCloudflareRecord_TtlValidation
--- PASS: TestAccCloudflareRecord_TtlValidation (0.67s)
=== RUN   TestAccCloudflareRecord_ExplicitProxiedFalse
--- PASS: TestAccCloudflareRecord_ExplicitProxiedFalse (8.52s)
=== RUN   TestAccCloudflareRecord_MXWithPriorityZero
--- PASS: TestAccCloudflareRecord_MXWithPriorityZero (3.15s)
=== RUN   TestAccCloudflareRecord_HTTPS
--- PASS: TestAccCloudflareRecord_HTTPS (2.96s)
=== RUN   TestAccCloudflareRecord_SVCB
--- PASS: TestAccCloudflareRecord_SVCB (2.76s)
=== RUN   TestAccCloudflareRecord_MXNull
=== PAUSE TestAccCloudflareRecord_MXNull
=== RUN   TestAccCloudflareRecord_DNSKEY
    acctest.go:235: Skipping acceptance test for default zone (0da42c8d2132a9ddaf714f9e7c920711). Pending automating setup from https://developers.cloudflare.com/dns/dnssec/multi-signer-dnssec/.
--- SKIP: TestAccCloudflareRecord_DNSKEY (0.00s)
=== RUN   TestAccCloudflareRecord_ClearTags
--- PASS: TestAccCloudflareRecord_ClearTags (5.39s)
=== RUN   TestSuppressTrailingDots
=== PAUSE TestSuppressTrailingDots
=== RUN   TestAccCloudflareRecord_TagsDrift
--- PASS: TestAccCloudflareRecord_TagsDrift (10.91s)
=== RUN   TestAccCloudflareRecord_ComputedFieldsDrift
--- PASS: TestAccCloudflareRecord_ComputedFieldsDrift (9.92s)
=== RUN   TestAccCloudflareRecord_DriftIssue5517
--- PASS: TestAccCloudflareRecord_DriftIssue5517 (8.01s)
=== RUN   TestAccCloudflareRecord_ModifiedOnDrift6438
--- PASS: TestAccCloudflareRecord_ModifiedOnDrift6438 (10.17s)
=== RUN   TestAccCloudflareRecord_SettingsDrift
--- PASS: TestAccCloudflareRecord_SettingsDrift (7.51s)
=== RUN   TestAccCloudflareRecord_ComprehensiveDriftPrevention
--- PASS: TestAccCloudflareRecord_ComprehensiveDriftPrevention (20.99s)
=== RUN   TestAccCloudflareRecord_SimpleDrift
--- PASS: TestAccCloudflareRecord_SimpleDrift (3.65s)
=== RUN   TestAccCloudflareRecord_CNAMECase
--- PASS: TestAccCloudflareRecord_CNAMECase (3.38s)
=== RUN   TestAccCloudflareRecord_CommentModifiedOn
--- PASS: TestAccCloudflareRecord_CommentModifiedOn (6.28s)
=== RUN   TestAccCloudflareRecord_FQDNNormalize
--- PASS: TestAccCloudflareRecord_FQDNNormalize (4.74s)
=== RUN   TestAccCloudflareRecord_ModifiedOnDrift
--- PASS: TestAccCloudflareRecord_ModifiedOnDrift (8.15s)
=== RUN   TestAccCloudflareRecord_ModifiedOnConsistency
--- PASS: TestAccCloudflareRecord_ModifiedOnConsistency (13.41s)
=== RUN   TestAccUpgradeDNSRecord_FromPublishedV5
--- PASS: TestAccUpgradeDNSRecord_FromPublishedV5 (18.73s)
=== RUN   TestAccCloudflareRecord_ProxiedCNAMEUpdateSettingsDrift
--- PASS: TestAccCloudflareRecord_ProxiedCNAMEUpdateSettingsDrift (5.25s)
=== CONT  TestDNSRecordDataSourceModelSchemaParity
=== CONT  TestSuppressTrailingDots
=== CONT  TestDNSRecordModelSchemaParity
=== CONT  TestDNSRecordsDataSourceModelSchemaParity
--- PASS: TestSuppressTrailingDots (0.00s)
=== CONT  TestAccCloudflareRecord_MXNull
--- PASS: TestDNSRecordModelSchemaParity (0.00s)
--- PASS: TestDNSRecordDataSourceModelSchemaParity (0.00s)
--- PASS: TestDNSRecordsDataSourceModelSchemaParity (0.00s)
--- PASS: TestAccCloudflareRecord_MXNull (3.14s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/dns_record	200.270s
=== RUN   TestDNSRecordMigrationModelSchemaParity
=== PAUSE TestDNSRecordMigrationModelSchemaParity
=== RUN   TestMigrateDNSRecordBasicA
=== RUN   TestMigrateDNSRecordBasicA/from_v4_latest
=== RUN   TestMigrateDNSRecordBasicA/from_v5
--- PASS: TestMigrateDNSRecordBasicA (22.20s)
    --- PASS: TestMigrateDNSRecordBasicA/from_v4_latest (17.75s)
    --- PASS: TestMigrateDNSRecordBasicA/from_v5 (4.45s)
=== RUN   TestMigrateDNSRecordCAARecord
=== RUN   TestMigrateDNSRecordCAARecord/from_v4_latest
=== RUN   TestMigrateDNSRecordCAARecord/from_v5
--- PASS: TestMigrateDNSRecordCAARecord (19.99s)
    --- PASS: TestMigrateDNSRecordCAARecord/from_v4_latest (15.77s)
    --- PASS: TestMigrateDNSRecordCAARecord/from_v5 (4.22s)
=== RUN   TestMigrateDNSRecordMXRecord
=== RUN   TestMigrateDNSRecordMXRecord/from_v4_latest
=== RUN   TestMigrateDNSRecordMXRecord/from_v5
--- PASS: TestMigrateDNSRecordMXRecord (36.63s)
    --- PASS: TestMigrateDNSRecordMXRecord/from_v4_latest (29.69s)
    --- PASS: TestMigrateDNSRecordMXRecord/from_v5 (6.93s)
=== RUN   TestMigrateDNSRecordSRVRecord
=== RUN   TestMigrateDNSRecordSRVRecord/from_v4_latest
=== RUN   TestMigrateDNSRecordSRVRecord/from_v5
--- PASS: TestMigrateDNSRecordSRVRecord (22.32s)
    --- PASS: TestMigrateDNSRecordSRVRecord/from_v4_latest (16.54s)
    --- PASS: TestMigrateDNSRecordSRVRecord/from_v5 (5.78s)
=== RUN   TestMigrateDNSRecordTXTRecord
=== RUN   TestMigrateDNSRecordTXTRecord/from_v4_latest
=== RUN   TestMigrateDNSRecordTXTRecord/from_v5
--- PASS: TestMigrateDNSRecordTXTRecord (19.94s)
    --- PASS: TestMigrateDNSRecordTXTRecord/from_v4_latest (15.19s)
    --- PASS: TestMigrateDNSRecordTXTRecord/from_v5 (4.75s)
=== RUN   TestMigrateDNSRecordCNAMERecord
=== RUN   TestMigrateDNSRecordCNAMERecord/from_v4_latest
=== RUN   TestMigrateDNSRecordCNAMERecord/from_v5
--- PASS: TestMigrateDNSRecordCNAMERecord (20.07s)
    --- PASS: TestMigrateDNSRecordCNAMERecord/from_v4_latest (15.56s)
    --- PASS: TestMigrateDNSRecordCNAMERecord/from_v5 (4.52s)
=== RUN   TestMigrateDNSRecordWithAllowOverwrite
--- PASS: TestMigrateDNSRecordWithAllowOverwrite (17.84s)
=== RUN   TestMigrateDNSRecordMultipleRecords
--- PASS: TestMigrateDNSRecordMultipleRecords (19.44s)
=== RUN   TestMigrateDNSRecordAAAARecord
=== RUN   TestMigrateDNSRecordAAAARecord/from_v4_latest
=== RUN   TestMigrateDNSRecordAAAARecord/from_v5
--- PASS: TestMigrateDNSRecordAAAARecord (20.86s)
    --- PASS: TestMigrateDNSRecordAAAARecord/from_v4_latest (16.37s)
    --- PASS: TestMigrateDNSRecordAAAARecord/from_v5 (4.49s)
=== RUN   TestMigrateDNSRecordNSRecord
=== RUN   TestMigrateDNSRecordNSRecord/from_v4_latest
=== RUN   TestMigrateDNSRecordNSRecord/from_v5
--- PASS: TestMigrateDNSRecordNSRecord (21.16s)
    --- PASS: TestMigrateDNSRecordNSRecord/from_v4_latest (15.13s)
    --- PASS: TestMigrateDNSRecordNSRecord/from_v5 (6.02s)
=== RUN   TestMigrateDNSRecordWithTags
=== RUN   TestMigrateDNSRecordWithTags/from_v4_latest
=== RUN   TestMigrateDNSRecordWithTags/from_v5
--- PASS: TestMigrateDNSRecordWithTags (20.65s)
    --- PASS: TestMigrateDNSRecordWithTags/from_v4_latest (15.62s)
    --- PASS: TestMigrateDNSRecordWithTags/from_v5 (5.03s)
=== RUN   TestMigrateDNSRecordPTRRecord
=== RUN   TestMigrateDNSRecordPTRRecord/from_v4_latest
=== RUN   TestMigrateDNSRecordPTRRecord/from_v5
--- PASS: TestMigrateDNSRecordPTRRecord (21.30s)
    --- PASS: TestMigrateDNSRecordPTRRecord/from_v4_latest (16.67s)
    --- PASS: TestMigrateDNSRecordPTRRecord/from_v5 (4.63s)
=== RUN   TestMigrateDNSRecord_Issue6076
--- PASS: TestMigrateDNSRecord_Issue6076 (34.56s)
=== CONT  TestDNSRecordMigrationModelSchemaParity
--- PASS: TestDNSRecordMigrationModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/dns_record/migration/v500	298.882s
```

```
~/cf-repos/github/terraform-provider-cloudflare next *1 !6 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/zero_trust_access_policy/... -run "Test"        07:14:53 PM
=== RUN   TestZeroTrustAccessPolicyDataSourceModelSchemaParity
=== PAUSE TestZeroTrustAccessPolicyDataSourceModelSchemaParity
=== RUN   TestZeroTrustAccessPoliciesDataSourceModelSchemaParity
=== PAUSE TestZeroTrustAccessPoliciesDataSourceModelSchemaParity
=== RUN   TestZeroTrustAccessPolicyModelSchemaParity
    resource_schema_test.go:14: page rules has too much custom code to have parity
--- SKIP: TestZeroTrustAccessPolicyModelSchemaParity (0.00s)
=== RUN   TestAccCloudflareAccessPolicy_ServiceToken
--- PASS: TestAccCloudflareAccessPolicy_ServiceToken (13.48s)
=== RUN   TestAccCloudflareAccessPolicy_AnyServiceToken
--- PASS: TestAccCloudflareAccessPolicy_AnyServiceToken (11.66s)
=== RUN   TestAccCloudflareAccessPolicy_Group
--- PASS: TestAccCloudflareAccessPolicy_Group (11.78s)
=== RUN   TestAccCloudflareAccessPolicy_MTLS
--- PASS: TestAccCloudflareAccessPolicy_MTLS (7.96s)
=== RUN   TestAccCloudflareAccessPolicy_EmailDomain
--- PASS: TestAccCloudflareAccessPolicy_EmailDomain (13.25s)
=== RUN   TestAccCloudflareAccessPolicy_Emails
--- PASS: TestAccCloudflareAccessPolicy_Emails (12.76s)
=== RUN   TestAccCloudflareAccessPolicy_Everyone
--- PASS: TestAccCloudflareAccessPolicy_Everyone (6.02s)
=== RUN   TestAccCloudflareAccessPolicy_IPs
--- PASS: TestAccCloudflareAccessPolicy_IPs (6.04s)
=== RUN   TestAccCloudflareAccessPolicy_AuthMethod
--- PASS: TestAccCloudflareAccessPolicy_AuthMethod (5.99s)
=== RUN   TestAccCloudflareAccessPolicy_Geo
--- PASS: TestAccCloudflareAccessPolicy_Geo (6.31s)
=== RUN   TestAccCloudflareAccessPolicy_Okta
--- PASS: TestAccCloudflareAccessPolicy_Okta (13.64s)
=== RUN   TestAccCloudflareAccessPolicy_PurposeJustification
--- PASS: TestAccCloudflareAccessPolicy_PurposeJustification (6.25s)
=== RUN   TestAccCloudflareAccessPolicy_ApprovalGroup
--- PASS: TestAccCloudflareAccessPolicy_ApprovalGroup (6.40s)
=== RUN   TestAccCloudflareAccessPolicy_ExternalEvaluation
--- PASS: TestAccCloudflareAccessPolicy_ExternalEvaluation (6.27s)
=== RUN   TestAccCloudflareAccessPolicy_ExcludeRules
--- PASS: TestAccCloudflareAccessPolicy_ExcludeRules (5.80s)
=== RUN   TestAccCloudflareAccessPolicy_RequireRules
--- PASS: TestAccCloudflareAccessPolicy_RequireRules (6.89s)
=== RUN   TestAccCloudflareAccessPolicy_DecisionTypes
--- PASS: TestAccCloudflareAccessPolicy_DecisionTypes (7.19s)
=== RUN   TestAccCloudflareAccessPolicy_IsolationRequired
    resource_test.go:870: this test depends on zero trust gateway settings, which first must be modernized and patched
--- SKIP: TestAccCloudflareAccessPolicy_IsolationRequired (0.00s)
=== RUN   TestAccCloudflareAccessPolicy_DenyOnly
--- PASS: TestAccCloudflareAccessPolicy_DenyOnly (5.07s)
=== RUN   TestAccCloudflareAccessPolicy_BypassOnly
--- PASS: TestAccCloudflareAccessPolicy_BypassOnly (5.98s)
=== RUN   TestAccCloudflareAccessPolicy_OptionalBooleans
--- PASS: TestAccCloudflareAccessPolicy_OptionalBooleans (5.35s)
=== RUN   TestAccUpgradeZeroTrustAccessPolicy_FromPublishedV5
--- PASS: TestAccUpgradeZeroTrustAccessPolicy_FromPublishedV5 (25.10s)
=== CONT  TestZeroTrustAccessPolicyDataSourceModelSchemaParity
=== CONT  TestZeroTrustAccessPoliciesDataSourceModelSchemaParity
--- PASS: TestZeroTrustAccessPoliciesDataSourceModelSchemaParity (0.00s)
--- PASS: TestZeroTrustAccessPolicyDataSourceModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_access_policy	190.971s
=== RUN   TestTransformConditions_SkipsEmptyAuthMethodAndCommonName
--- PASS: TestTransformConditions_SkipsEmptyAuthMethodAndCommonName (0.00s)
=== RUN   TestTransformConditions_IncludesNonEmptyAuthMethodAndCommonName
--- PASS: TestTransformConditions_IncludesNonEmptyAuthMethodAndCommonName (0.00s)
=== RUN   TestZeroTrustAccessPolicyMigrationModelSchemaParity
=== PAUSE TestZeroTrustAccessPolicyMigrationModelSchemaParity
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4Basic
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4Basic (15.73s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4Complex
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4Complex (14.56s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4OAuthProviders
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4OAuthProviders (15.79s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_Allow
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_Deny
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_NonIdentity
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_Bypass
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes (65.48s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_Allow (25.93s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_Deny (12.48s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_NonIdentity (13.42s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_Bypass (13.65s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans/Boolean_Everyone
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans/Boolean_Certificate
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans/Boolean_AnyValidServiceToken
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans (48.54s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans/Boolean_Everyone (19.91s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans/Boolean_Certificate (14.34s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans/Boolean_AnyValidServiceToken (14.29s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4UnsupportedFeatures
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4UnsupportedFeatures (23.26s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4ServiceTokens
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4ServiceTokens (14.73s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4RemovedAttributes
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4RemovedAttributes (13.63s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_12
--- PASS: TestMigrateZeroTrustAccessPolicyFromV5_12 (17.18s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_14
--- PASS: TestMigrateZeroTrustAccessPolicyFromV5_14 (17.00s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_15
--- PASS: TestMigrateZeroTrustAccessPolicyFromV5_15 (16.96s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_12_Complex
--- PASS: TestMigrateZeroTrustAccessPolicyFromV5_12_Complex (14.37s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_Allow
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_Deny
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_NonIdentity
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_Bypass
--- PASS: TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes (61.33s)
    --- PASS: TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_Allow (15.30s)
    --- PASS: TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_Deny (15.76s)
    --- PASS: TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_NonIdentity (15.11s)
    --- PASS: TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_Bypass (15.16s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_15_WithConditionTypes
--- PASS: TestMigrateZeroTrustAccessPolicyFromV5_15_WithConditionTypes (24.65s)
=== RUN   TestMigrateZeroTrustAccessPolicyEmailDomainTransformation
--- PASS: TestMigrateZeroTrustAccessPolicyEmailDomainTransformation (14.36s)
=== RUN   TestMigrateZeroTrustAccessPolicyConnectionRules
--- PASS: TestMigrateZeroTrustAccessPolicyConnectionRules (12.94s)
=== RUN   TestMigrateZeroTrustAccessPolicyStateMvScenario
    migrations_test.go:943: Renamed cloudflare_access_policy.cftftestzoaknnirks to cloudflare_zero_trust_access_policy.cftftestzoaknnirks in state file
--- PASS: TestMigrateZeroTrustAccessPolicyStateMvScenario (12.26s)
=== CONT  TestZeroTrustAccessPolicyMigrationModelSchemaParity
--- PASS: TestZeroTrustAccessPolicyMigrationModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_access_policy/migration/v500	404.588s
```

## Additional context & links
