### PR TITLE
Fix(tokens): Switch from Set to List for policies and permission_groups

### DIFF
--- a/internal/services/account_token/custom.go
+++ b/internal/services/account_token/custom.go
@@ -2,6 +2,8 @@ package account_token
 
 import (
 	"encoding/json"
+	"sort"
+	"strings"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -43,6 +45,9 @@ func MarshalCustom(m AccountTokenModel) (data []byte, err error) {
 }
 
 func UnmarshalCustom(data []byte, model *AccountTokenResultEnvelope) (err error) {
+	// Snapshot prior policy order before apijson.Unmarshal overwrites the model
+	snap := snapshotPolicyOrder(model.Result.Policies)
+
 	if err = apijson.Unmarshal(data, model); err != nil {
 		return
 	}
@@ -67,18 +72,234 @@ func UnmarshalCustom(data []byte, model *AccountTokenResultEnvelope) (err error)
 		}
 		(*model.Result.Policies)[i].Resources = types.StringValue(string(policy["resources"]))
 	}
+
+	// Reorder to match prior state (or canonical sort if no prior)
+	reorderPoliciesFromSnapshot(model.Result.Policies, snap)
 	return
 }
 
 func UnmarshalComputedCustom(data []byte, model *AccountTokenResultEnvelope) (err error) {
+	// Snapshot prior policy order BEFORE UnmarshalComputed overwrites the model
+	snap := snapshotPolicyOrder(model.Result.Policies)
+
 	if err = apijson.UnmarshalComputed(data, model); err != nil {
 		return
 	}
-	forPoliciesOnly := AccountTokenResultEnvelope{}
-	err = UnmarshalCustom(data, &forPoliciesOnly)
-	if err != nil {
+	return unmarshalCustomWithSnapshot(data, model, snap)
+}
+
+// unmarshalCustomWithSnapshot is like UnmarshalCustom but uses a provided
+// snapshot instead of capturing its own. apijson.Unmarshal is NOT called
+// because the caller has already done the initial unmarshal.
+func unmarshalCustomWithSnapshot(data []byte, model *AccountTokenResultEnvelope, snap *policyOrderSnapshot) error {
+	// pull out the raw JSON values for each policy resource and map to the model
+	var base map[string]json.RawMessage
+	if err := json.Unmarshal(data, &base); err != nil {
 		return err
 	}
-	model.Result.Policies = forPoliciesOnly.Result.Policies
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(base["result"], &result); err != nil {
+		return err
+	}
+	var policyJsons []json.RawMessage
+	if err := json.Unmarshal(result["policies"], &policyJsons); err != nil {
+		return err
+	}
+	for i, policyJson := range policyJsons {
+		var policy map[string]json.RawMessage
+		if err := json.Unmarshal(policyJson, &policy); err != nil {
+			return err
+		}
+		(*model.Result.Policies)[i].Resources = types.StringValue(string(policy["resources"]))
+	}
+
+	// Reorder to match prior state (or canonical sort if no prior)
+	reorderPoliciesFromSnapshot(model.Result.Policies, snap)
 	return nil
+}
+
+// ============================================================================
+// Policy order snapshot and reordering
+// ============================================================================
+
+// policySnapshot captures a policy's identity as plain strings.
+type policySnapshot struct {
+	effect           string
+	resources        string
+	permissionGroups []string
+}
+
+// policyOrderSnapshot captures the full prior ordering of policies.
+type policyOrderSnapshot struct {
+	policies []policySnapshot
+}
+
+// snapshotPolicyOrder extracts the current policy order as plain strings.
+// Returns nil if there are no prior policies.
+func snapshotPolicyOrder(policies *[]*AccountTokenPoliciesModel) *policyOrderSnapshot {
+	if policies == nil || len(*policies) == 0 {
+		return nil
+	}
+	snap := &policyOrderSnapshot{
+		policies: make([]policySnapshot, len(*policies)),
+	}
+	for i, p := range *policies {
+		var pgIDs []string
+		if p.PermissionGroups != nil {
+			pgIDs = make([]string, len(*p.PermissionGroups))
+			for j, pg := range *p.PermissionGroups {
+				pgIDs[j] = pg.ID.ValueString()
+			}
+		}
+		snap.policies[i] = policySnapshot{
+			effect:           p.Effect.ValueString(),
+			resources:        p.Resources.ValueString(),
+			permissionGroups: pgIDs,
+		}
+	}
+	return snap
+}
+
+// policyFingerprint builds a unique key for a policy using effect + resources +
+// sorted permission group IDs, joined with "|".
+func policyFingerprint(effect, resources string, pgIDs []string) string {
+	sorted := make([]string, len(pgIDs))
+	copy(sorted, pgIDs)
+	sort.Strings(sorted)
+	return effect + "|" + resources + "|" + strings.Join(sorted, ",")
+}
+
+// policyFingerprintFromModel builds a fingerprint from a policy model.
+func policyFingerprintFromModel(p *AccountTokenPoliciesModel) string {
+	var pgIDs []string
+	if p.PermissionGroups != nil {
+		pgIDs = make([]string, len(*p.PermissionGroups))
+		for i, pg := range *p.PermissionGroups {
+			pgIDs[i] = pg.ID.ValueString()
+		}
+	}
+	return policyFingerprint(p.Effect.ValueString(), p.Resources.ValueString(), pgIDs)
+}
+
+// reorderPoliciesFromSnapshot reorders policies to match the prior snapshot.
+// If snap is nil (no prior state), falls back to canonical sort.
+func reorderPoliciesFromSnapshot(newPolicies *[]*AccountTokenPoliciesModel, snap *policyOrderSnapshot) {
+	if newPolicies == nil || len(*newPolicies) == 0 {
+		return
+	}
+
+	if snap == nil {
+		sortPolicies(newPolicies)
+		return
+	}
+
+	// Build index: fingerprint → desired position from prior snapshot
+	priorIndex := make(map[string]int, len(snap.policies))
+	for i, sp := range snap.policies {
+		fp := policyFingerprint(sp.effect, sp.resources, sp.permissionGroups)
+		priorIndex[fp] = i
+	}
+
+	policies := *newPolicies
+
+	// Stable sort: policies that match prior go to their prior position;
+	// unmatched policies sort after matched ones in canonical order.
+	sort.SliceStable(policies, func(i, j int) bool {
+		fpI := policyFingerprintFromModel(policies[i])
+		fpJ := policyFingerprintFromModel(policies[j])
+		posI, okI := priorIndex[fpI]
+		posJ, okJ := priorIndex[fpJ]
+
+		switch {
+		case okI && okJ:
+			return posI < posJ
+		case okI:
+			return true // matched before unmatched
+		case okJ:
+			return false
+		default:
+			// Both unmatched: canonical order
+			return canonicalPolicyLess(policies[i], policies[j])
+		}
+	})
+
+	// Reorder permission_groups within each policy to match prior
+	priorPGIndex := make(map[string]map[string]int, len(snap.policies))
+	for _, sp := range snap.policies {
+		fp := policyFingerprint(sp.effect, sp.resources, sp.permissionGroups)
+		pgIdx := make(map[string]int, len(sp.permissionGroups))
+		for j, pgID := range sp.permissionGroups {
+			pgIdx[pgID] = j
+		}
+		priorPGIndex[fp] = pgIdx
+	}
+
+	for _, p := range policies {
+		if p.PermissionGroups == nil || len(*p.PermissionGroups) == 0 {
+			continue
+		}
+		fp := policyFingerprintFromModel(p)
+		pgIdx, ok := priorPGIndex[fp]
+		if !ok {
+			// No prior — canonical sort by ID
+			pgs := *p.PermissionGroups
+			sort.SliceStable(pgs, func(i, j int) bool {
+				return pgs[i].ID.ValueString() < pgs[j].ID.ValueString()
+			})
+			continue
+		}
+
+		pgs := *p.PermissionGroups
+		sort.SliceStable(pgs, func(i, j int) bool {
+			idI := pgs[i].ID.ValueString()
+			idJ := pgs[j].ID.ValueString()
+			posI, okI := pgIdx[idI]
+			posJ, okJ := pgIdx[idJ]
+			switch {
+			case okI && okJ:
+				return posI < posJ
+			case okI:
+				return true
+			case okJ:
+				return false
+			default:
+				return idI < idJ
+			}
+		})
+	}
+}
+
+// sortPolicies applies canonical sort: permission_groups by ID within each
+// policy, then policies by effect then resources.
+func sortPolicies(policies *[]*AccountTokenPoliciesModel) {
+	if policies == nil || len(*policies) == 0 {
+		return
+	}
+	ps := *policies
+
+	// Sort permission groups within each policy
+	for _, p := range ps {
+		if p.PermissionGroups == nil || len(*p.PermissionGroups) == 0 {
+			continue
+		}
+		pgs := *p.PermissionGroups
+		sort.SliceStable(pgs, func(i, j int) bool {
+			return pgs[i].ID.ValueString() < pgs[j].ID.ValueString()
+		})
+	}
+
+	// Sort policies by effect, then resources
+	sort.SliceStable(ps, func(i, j int) bool {
+		return canonicalPolicyLess(ps[i], ps[j])
+	})
+}
+
+// canonicalPolicyLess defines the canonical ordering: by effect, then resources.
+func canonicalPolicyLess(a, b *AccountTokenPoliciesModel) bool {
+	ea := a.Effect.ValueString()
+	eb := b.Effect.ValueString()
+	if ea != eb {
+		return ea < eb
+	}
+	return a.Resources.ValueString() < b.Resources.ValueString()
 }

--- a/internal/services/account_token/custom_test.go
+++ b/internal/services/account_token/custom_test.go
@@ -97,6 +97,7 @@ func TestUnmarshalCustom(t *testing.T) {
 }
 
 func TestUnmarshalComputedCustom(t *testing.T) {
+	// API returns policies in [flat, nested_resources] order
 	data := json.RawMessage(`{
 		"result":{
 			"name":"name",
@@ -119,8 +120,7 @@ func TestUnmarshalComputedCustom(t *testing.T) {
 			ID: types.StringValue("permgroup1"),
 		},
 	}
-	// Policy order in client-side model is not the same as the server-side data
-	// model.
+	// Prior model has policies in [nested_resources, flat] order
 	policies := []*AccountTokenPoliciesModel{
 		{
 			Effect:           types.StringValue("effect"),
@@ -143,12 +143,94 @@ func TestUnmarshalComputedCustom(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The order of policies should be the same as the server-side data model
+	// With reorder-to-match-prior, result should be [nested_resources, flat] matching prior order
 	foundPolicies := env.Result.Policies
-	if (*foundPolicies)[0].Resources != types.StringValue("{\"com.cloudflare.api.account.123\":\"*\"}") {
-		t.Fatalf("expected %s, got %s", "{\"com.cloudflare.api.account.123\":\"*\"}", (*foundPolicies)[0].Resources)
+	if (*foundPolicies)[0].Resources != types.StringValue("{\"com.cloudflare.api.account.123\":{\"com.cloudflare.api.account.zone.*\":\"*\"}}") {
+		t.Fatalf("expected nested resources first, got %s", (*foundPolicies)[0].Resources)
 	}
-	if (*foundPolicies)[1].Resources != types.StringValue("{\"com.cloudflare.api.account.123\":{\"com.cloudflare.api.account.zone.*\":\"*\"}}") {
-		t.Fatalf("expected %s, got %s", "{\"com.cloudflare.api.account.123\":{\"com.cloudflare.api.account.zone.*\":\"*\"}}", (*foundPolicies)[0].Resources)
+	if (*foundPolicies)[1].Resources != types.StringValue("{\"com.cloudflare.api.account.123\":\"*\"}") {
+		t.Fatalf("expected flat resources second, got %s", (*foundPolicies)[1].Resources)
+	}
+}
+
+func TestSortPolicies_SortsPermissionGroupsByID(t *testing.T) {
+	pgs := []*AccountTokenPoliciesPermissionGroupsModel{
+		{ID: types.StringValue("ccc")},
+		{ID: types.StringValue("aaa")},
+		{ID: types.StringValue("bbb")},
+	}
+	policies := []*AccountTokenPoliciesModel{
+		{
+			Effect:           types.StringValue("allow"),
+			PermissionGroups: &pgs,
+			Resources:        types.StringValue("{}"),
+		},
+	}
+	sortPolicies(&policies)
+
+	sorted := *policies[0].PermissionGroups
+	expected := []string{"aaa", "bbb", "ccc"}
+	for i, exp := range expected {
+		got := sorted[i].ID.ValueString()
+		if got != exp {
+			t.Fatalf("permission_groups[%d]: expected %q, got %q", i, exp, got)
+		}
+	}
+}
+
+func TestSortPolicies_SortsPoliciesByEffectThenResources(t *testing.T) {
+	pg := []*AccountTokenPoliciesPermissionGroupsModel{{ID: types.StringValue("pg1")}}
+	policies := []*AccountTokenPoliciesModel{
+		{Effect: types.StringValue("deny"), PermissionGroups: &pg, Resources: types.StringValue("b")},
+		{Effect: types.StringValue("allow"), PermissionGroups: &pg, Resources: types.StringValue("z")},
+		{Effect: types.StringValue("allow"), PermissionGroups: &pg, Resources: types.StringValue("a")},
+	}
+	sortPolicies(&policies)
+
+	type expected struct {
+		effect    string
+		resources string
+	}
+	expectations := []expected{
+		{"allow", "a"},
+		{"allow", "z"},
+		{"deny", "b"},
+	}
+	for i, exp := range expectations {
+		got := policies[i]
+		if got.Effect.ValueString() != exp.effect || got.Resources.ValueString() != exp.resources {
+			t.Fatalf("policies[%d]: expected {%s, %s}, got {%s, %s}",
+				i, exp.effect, exp.resources, got.Effect.ValueString(), got.Resources.ValueString())
+		}
+	}
+}
+
+func TestUnmarshalCustom_SortsPermissionGroups(t *testing.T) {
+	// API returns permission groups in [zzz, aaa, mmm] order, no prior state
+	data := json.RawMessage(`{
+		"result":{
+			"name":"name",
+			"policies":[
+				{
+					"effect":"allow",
+					"permission_groups":[{"id":"zzz"},{"id":"aaa"},{"id":"mmm"}],
+					"resources":{"com.cloudflare.api.account.123":"*"}
+				}
+			]
+		}
+	}`)
+	env := AccountTokenResultEnvelope{}
+	err := UnmarshalCustom(data, &env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// With no prior state, canonical sort should order by ID: [aaa, mmm, zzz]
+	pgs := *(*env.Result.Policies)[0].PermissionGroups
+	expected := []string{"aaa", "mmm", "zzz"}
+	for i, exp := range expected {
+		got := pgs[i].ID.ValueString()
+		if got != exp {
+			t.Fatalf("permission_groups[%d]: expected %q, got %q", i, exp, got)
+		}
 	}
 }

--- a/internal/services/account_token/migration/v500/handler.go
+++ b/internal/services/account_token/migration/v500/handler.go
@@ -41,16 +41,18 @@ func UpgradeFromV0(ctx context.Context, req resource.UpgradeStateRequest, resp *
 
 // UpgradeFromV1 handles state upgrades from schema version 1 to version 500.
 //
-// This is a no-op upgrade — v1 schema is compatible with v500.
 // v1 is the "dormant" state version before migration activation.
-// When migrations are activated (schema version → 500), this handler
-// copies the state as-is.
+// The v1 schema uses Set types which must be deserialized and re-serialized
+// to produce state compatible with the target schema (which may use List types).
 func UpgradeFromV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	tflog.Info(ctx, "Upgrading account_token state from v1 to v500 (no-op)")
+	tflog.Info(ctx, "Upgrading account_token state from v1 to v500")
 
-	// CRITICAL: For no-op upgrades, copy raw state directly.
-	// This preserves all state data without any transformation.
-	resp.State.Raw = req.State.Raw
+	var state TargetAccountTokenModelV500
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 
 	tflog.Info(ctx, "State version bump from 1 to 500 completed")
 }

--- a/internal/services/account_token/migration/v501/handler.go
+++ b/internal/services/account_token/migration/v501/handler.go
@@ -1,0 +1,57 @@
+package v501
+
+import (
+	"context"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// UpgradeFromV500 handles state upgrades from schema version 500 to version 501.
+//
+// v500 state uses Set-typed policies and permission_groups. v501 switches to
+// List-typed with FastSetType for O(n) performance. This handler reads the v500
+// Set state, sorts policies and permission_groups canonically (for stable List
+// ordering), and writes back as List state.
+func UpgradeFromV500(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading account_token state from v500 to v501")
+
+	var state AccountTokenModelV500
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Sort policies and permission_groups canonically for stable List ordering
+	sortPolicies(state.Policies)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	tflog.Info(ctx, "State upgrade from v500 to v501 completed successfully")
+}
+
+// sortPolicies applies canonical sort: permission_groups by ID within each
+// policy, then policies by effect then resources.
+func sortPolicies(policies []PolicyV500) {
+	if len(policies) == 0 {
+		return
+	}
+
+	// Sort permission groups within each policy
+	for i := range policies {
+		pgs := policies[i].PermissionGroups
+		sort.SliceStable(pgs, func(a, b int) bool {
+			return pgs[a].ID.ValueString() < pgs[b].ID.ValueString()
+		})
+	}
+
+	// Sort policies by effect, then resources
+	sort.SliceStable(policies, func(i, j int) bool {
+		ei := policies[i].Effect.ValueString()
+		ej := policies[j].Effect.ValueString()
+		if ei != ej {
+			return ei < ej
+		}
+		return policies[i].Resources.ValueString() < policies[j].Resources.ValueString()
+	})
+}

--- a/internal/services/account_token/migration/v501/migrations_test.go
+++ b/internal/services/account_token/migration/v501/migrations_test.go
@@ -1,0 +1,131 @@
+package v501_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+//go:embed testdata/v501_multi_policy.tf
+var v501MultiPolicyConfig string
+
+//go:embed testdata/v501_multi_permgroups.tf
+var v501MultiPermgroupsConfig string
+
+// TestMigrateAccountTokenFromV500_MultiPolicy tests migration from v500 (Set-based,
+// schema_version=500 via v5.16.0) to v501 (List-based) with multiple policies.
+// This verifies that the Set→List migration properly converts policy collections
+// and that the provider can plan/apply without drift.
+func TestMigrateAccountTokenFromV500_MultiPolicy(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	tmpDir := t.TempDir()
+
+	config := fmt.Sprintf(v501MultiPolicyConfig, rnd, accountID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Create with v5.16.0 which has schema_version=500 (Set-based)
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "5.16.0",
+					},
+				},
+				Config: config,
+			},
+			{
+				// Migrate to current (v501, List-based) and verify no drift
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				Config:                   config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						fmt.Sprintf("cloudflare_account_token.%s", rnd),
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(rnd),
+					),
+					statecheck.ExpectKnownValue(
+						fmt.Sprintf("cloudflare_account_token.%s", rnd),
+						tfjsonpath.New("policies"),
+						knownvalue.ListSizeExact(2),
+					),
+				},
+			},
+		},
+	})
+}
+
+// TestMigrateAccountTokenFromV500_MultiPermGroups tests migration from v500
+// (Set-based) to v501 (List-based) with a policy that has multiple permission
+// groups. This is the scenario that triggers the O(n²) performance issue —
+// verifying that migration works correctly and produces no drift.
+func TestMigrateAccountTokenFromV500_MultiPermGroups(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	tmpDir := t.TempDir()
+
+	config := fmt.Sprintf(v501MultiPermgroupsConfig, rnd, accountID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Create with v5.16.0 which has schema_version=500 (Set-based)
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "5.16.0",
+					},
+				},
+				Config: config,
+			},
+			{
+				// Migrate to current (v501, List-based) and verify no drift
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				Config:                   config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						fmt.Sprintf("cloudflare_account_token.%s", rnd),
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(rnd),
+					),
+					statecheck.ExpectKnownValue(
+						fmt.Sprintf("cloudflare_account_token.%s", rnd),
+						tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"),
+						knownvalue.ListSizeExact(3),
+					),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/account_token/migration/v501/model.go
+++ b/internal/services/account_token/migration/v501/model.go
@@ -1,0 +1,46 @@
+package v501
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// AccountTokenModelV500 represents the full account_token state in v500.
+// Uses Go slices (not pointers) for compatibility with Set-based schema deserialization.
+type AccountTokenModelV500 struct {
+	AccountID  types.String      `tfsdk:"account_id"`
+	ID         types.String      `tfsdk:"id"`
+	IssuedOn   timetypes.RFC3339 `tfsdk:"issued_on"`
+	ModifiedOn timetypes.RFC3339 `tfsdk:"modified_on"`
+	Name       types.String      `tfsdk:"name"`
+	Policies   []PolicyV500      `tfsdk:"policies"`
+	Status     types.String      `tfsdk:"status"`
+	Value      types.String      `tfsdk:"value"`
+	NotBefore  timetypes.RFC3339 `tfsdk:"not_before"`
+	ExpiresOn  timetypes.RFC3339 `tfsdk:"expires_on"`
+	Condition  *ConditionV500    `tfsdk:"condition"`
+	LastUsedOn timetypes.RFC3339 `tfsdk:"last_used_on"`
+}
+
+// PolicyV500 represents a policy in v500 state.
+type PolicyV500 struct {
+	Effect           types.String          `tfsdk:"effect"`
+	PermissionGroups []PermissionGroupV500 `tfsdk:"permission_groups"`
+	Resources        types.String          `tfsdk:"resources"`
+}
+
+// PermissionGroupV500 represents a permission group in v500 state.
+type PermissionGroupV500 struct {
+	ID types.String `tfsdk:"id"`
+}
+
+// ConditionV500 represents the condition object in v500 state.
+type ConditionV500 struct {
+	RequestIP *ConditionRequestIPV500 `tfsdk:"request_ip"`
+}
+
+// ConditionRequestIPV500 represents the request_ip condition in v500 state.
+type ConditionRequestIPV500 struct {
+	In    []types.String `tfsdk:"in"`
+	NotIn []types.String `tfsdk:"not_in"`
+}

--- a/internal/services/account_token/migration/v501/schema.go
+++ b/internal/services/account_token/migration/v501/schema.go
@@ -1,0 +1,104 @@
+package v501
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// SourceSchemaV500 returns the schema for version 500 (Set-based policies).
+// Schema version: 500
+// Resource type: cloudflare_account_token
+//
+// This schema is used only for reading v500 state during migration to v501.
+// The key difference from v501 is that policies and permission_groups use
+// SetNestedAttribute instead of ListNestedAttribute.
+func SourceSchemaV500() schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"account_id": schema.StringAttribute{
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"id": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"issued_on": schema.StringAttribute{
+				Computed:   true,
+				CustomType: timetypes.RFC3339Type{},
+			},
+			"modified_on": schema.StringAttribute{
+				Computed:   true,
+				CustomType: timetypes.RFC3339Type{},
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"policies": schema.SetNestedAttribute{
+				Required: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"effect": schema.StringAttribute{
+							Required: true,
+						},
+						"permission_groups": schema.SetNestedAttribute{
+							Required: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"id": schema.StringAttribute{
+										Required: true,
+									},
+								},
+							},
+						},
+						"resources": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			"status": schema.StringAttribute{
+				Computed: true,
+				Optional: true,
+			},
+			"value": schema.StringAttribute{
+				Computed:      true,
+				Sensitive:     true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"not_before": schema.StringAttribute{
+				Optional:   true,
+				CustomType: timetypes.RFC3339Type{},
+			},
+			"expires_on": schema.StringAttribute{
+				Optional:   true,
+				CustomType: timetypes.RFC3339Type{},
+			},
+			"condition": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"request_ip": schema.SingleNestedAttribute{
+						Optional: true,
+						Attributes: map[string]schema.Attribute{
+							"in": schema.ListAttribute{
+								Optional:    true,
+								ElementType: types.StringType,
+							},
+							"not_in": schema.ListAttribute{
+								Optional:    true,
+								ElementType: types.StringType,
+							},
+						},
+					},
+				},
+			},
+			"last_used_on": schema.StringAttribute{
+				Computed:   true,
+				CustomType: timetypes.RFC3339Type{},
+			},
+		},
+	}
+}

--- a/internal/services/account_token/migration/v501/testdata/v501_multi_permgroups.tf
+++ b/internal/services/account_token/migration/v501/testdata/v501_multi_permgroups.tf
@@ -1,0 +1,18 @@
+resource "cloudflare_account_token" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+
+  policies = [
+    {
+      effect = "allow"
+      permission_groups = [
+        { id = "82e64a83756745bbbb1c9c2701bf816b" },
+        { id = "c8fed203ed3043cba015a93ad1616f1f" },
+        { id = "e199d584e69344eba202452019deafe3" }
+      ]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = "*"
+      })
+    }
+  ]
+}

--- a/internal/services/account_token/migration/v501/testdata/v501_multi_policy.tf
+++ b/internal/services/account_token/migration/v501/testdata/v501_multi_policy.tf
@@ -1,0 +1,25 @@
+resource "cloudflare_account_token" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+
+  policies = [
+    {
+      effect = "allow"
+      permission_groups = [{
+        id = "82e64a83756745bbbb1c9c2701bf816b"
+      }]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = "*"
+      })
+    },
+    {
+      effect = "allow"
+      permission_groups = [{
+        id = "c8fed203ed3043cba015a93ad1616f1f"
+      }]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = "*"
+      })
+    }
+  ]
+}

--- a/internal/services/account_token/migrations.go
+++ b/internal/services/account_token/migrations.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_token/migration/v500"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_token/migration/v501"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
@@ -13,17 +14,22 @@ var _ resource.ResourceWithUpgradeState = (*AccountTokenResource)(nil)
 
 // UpgradeState registers state upgraders for schema version changes.
 //
-// This handles two upgrade paths:
+// This handles three upgrade paths:
 //
-// 1. v0 state (schema_version=0) → v500: Full transformation
+// 1. v0 state (schema_version=0) → v501: Full transformation via v500
 //   - Converts policies[].resources from map to JSON string
 //   - Removes policies[].id (computed field)
 //   - Removes policies[].permission_groups[].meta and .name (computed fields)
 //
-// 2. v1 state (schema_version=1) → v500: No-op upgrade (version bump only)
+// 2. v1 state (schema_version=1) → v501: Deserialize/re-serialize via v500
+//   - Converts Set-typed state to List-compatible state
+//
+// 3. v500 state (schema_version=500) → v501: Set→List migration
+//   - Converts Set-typed policies and permission_groups to sorted Lists
 func (r *AccountTokenResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	v0Schema := v500.SourceSchemaV0()
 	v1Schema := v500.SourceSchemaV1()
+	v500Schema := v501.SourceSchemaV500()
 
 	return map[int64]resource.StateUpgrader{
 		// Handle state from early v5 releases (v5.10, v5.11) with map-based resources
@@ -32,10 +38,16 @@ func (r *AccountTokenResource) UpgradeState(ctx context.Context) map[int64]resou
 			StateUpgrader: v500.UpgradeFromV0,
 		},
 
-		// Handle state from dormant v5 (version=1) — no-op version bump
+		// Handle state from dormant v5 (version=1) — deserialize/re-serialize
 		1: {
 			PriorSchema:   &v1Schema,
 			StateUpgrader: v500.UpgradeFromV1,
+		},
+
+		// Handle state from v500 (Set-based) → v501 (List-based with FastSetType)
+		500: {
+			PriorSchema:   &v500Schema,
+			StateUpgrader: v501.UpgradeFromV500,
 		},
 	}
 }

--- a/internal/services/account_token/resource_test.go
+++ b/internal/services/account_token/resource_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -326,15 +325,61 @@ func TestAccAccountToken_TokenTTL(t *testing.T) {
 	})
 }
 
+// checkPermissionGroupIDsUnchanged verifies that the set of permission group
+// IDs at policies[policyIdx] matches expectedIDs regardless of order.
+// This replaces cross-step positional stability checks that assumed Set behavior.
+func checkPermissionGroupIDsUnchanged(resourceName string, policyIdx int, expectedIDs *[]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+
+		// Collect all permission_group IDs at this policy index
+		var actualIDs []string
+		for i := 0; ; i++ {
+			key := fmt.Sprintf("policies.%d.permission_groups.%d.id", policyIdx, i)
+			val, ok := rs.Primary.Attributes[key]
+			if !ok {
+				break
+			}
+			actualIDs = append(actualIDs, val)
+		}
+
+		// On first call, capture the IDs as the baseline
+		if len(*expectedIDs) == 0 {
+			*expectedIDs = make([]string, len(actualIDs))
+			copy(*expectedIDs, actualIDs)
+			return nil
+		}
+
+		// Compare as sets: same IDs regardless of order
+		if len(actualIDs) != len(*expectedIDs) {
+			return fmt.Errorf("permission_groups count changed: expected %d, got %d", len(*expectedIDs), len(actualIDs))
+		}
+		expected := make(map[string]bool, len(*expectedIDs))
+		for _, id := range *expectedIDs {
+			expected[id] = true
+		}
+		for _, id := range actualIDs {
+			if !expected[id] {
+				return fmt.Errorf("unexpected permission_group ID %s; expected one of %v", id, *expectedIDs)
+			}
+		}
+		return nil
+	}
+}
+
 func TestAccAccountToken_PermissionGroupOrder(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	resourceName := "cloudflare_account_token.test_account_token"
 
-	permgroup0_SAME := statecheck.CompareValue(compare.ValuesSame())
-	permgroup1_SAME := statecheck.CompareValue(compare.ValuesSame())
+	// Track the set of permission group IDs across steps (order-insensitive)
+	var permGroupIDs []string
 
-	// Test that permission group order doesn't affect plans
+	// Test that permission group order swap produces a benign update
+	// but the same set of IDs is preserved
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
@@ -345,17 +390,17 @@ func TestAccAccountToken_PermissionGroupOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"), knownvalue.ListSizeExact(2)),
-					permgroup0_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					permgroup1_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(1).AtMapKey("id")),
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDs),
 			},
 			{
 				Config: acctest.LoadTestCase("account_token-permissiongroup-order2.tf", rnd, accountID),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDs),
 			},
 			{
 				Config: acctest.LoadTestCase("account_token-permissiongroup-order2.tf", rnd+"-updated", accountID),
@@ -368,30 +413,33 @@ func TestAccAccountToken_PermissionGroupOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"), knownvalue.ListSizeExact(2)),
-					permgroup0_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					permgroup1_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(1).AtMapKey("id")),
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDs),
 			},
 			{
 				Config: acctest.LoadTestCase("account_token-permissiongroup-order1.tf", rnd+"-updated", accountID),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDs),
 			},
-			// Import step
+			// Import step — ignore policies ordering since import uses canonical
+			// sort (no prior state) which may differ from the last config order
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-				ImportStateVerifyIgnore: []string{"value"}, // API token value is not returned by the API
+				ImportStateVerifyIgnore: []string{"value", "policies"},
 			},
 		},
 	})
 
 	// Test the reverse order scenario
+	var permGroupIDsReverse []string
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
@@ -402,17 +450,17 @@ func TestAccAccountToken_PermissionGroupOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"), knownvalue.ListSizeExact(2)),
-					permgroup0_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					permgroup1_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(1).AtMapKey("id")),
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDsReverse),
 			},
 			{
 				Config: acctest.LoadTestCase("account_token-permissiongroup-order1.tf", rnd, accountID),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDsReverse),
 			},
 			{
 				Config: acctest.LoadTestCase("account_token-permissiongroup-order1.tf", rnd+"-updated", accountID),
@@ -425,34 +473,85 @@ func TestAccAccountToken_PermissionGroupOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"), knownvalue.ListSizeExact(2)),
-					permgroup0_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					permgroup1_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(1).AtMapKey("id")),
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDsReverse),
 			},
 			{
 				Config: acctest.LoadTestCase("account_token-permissiongroup-order2.tf", rnd+"-updated", accountID),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"), knownvalue.ListSizeExact(2)),
-					permgroup0_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					permgroup1_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(1).AtMapKey("id")),
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDsReverse),
 			},
-			// Import step
+			// Import step — ignore policies ordering since import uses canonical
+			// sort (no prior state) which may differ from the last config order
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-				ImportStateVerifyIgnore: []string{"value"}, // API token value is not returned by the API
+				ImportStateVerifyIgnore: []string{"value", "policies"},
 			},
 		},
 	})
+}
+
+// checkAllPolicyPermGroupIDsUnchanged verifies that the combined set of
+// permission group IDs across all policies is unchanged (order-insensitive).
+func checkAllPolicyPermGroupIDsUnchanged(resourceName string, expectedIDs *[]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+
+		// Collect all permission group IDs across all policies
+		var actualIDs []string
+		for pi := 0; ; pi++ {
+			found := false
+			for pgi := 0; ; pgi++ {
+				key := fmt.Sprintf("policies.%d.permission_groups.%d.id", pi, pgi)
+				val, ok := rs.Primary.Attributes[key]
+				if !ok {
+					break
+				}
+				found = true
+				actualIDs = append(actualIDs, val)
+			}
+			if !found {
+				break
+			}
+		}
+
+		// On first call, capture the IDs as the baseline
+		if len(*expectedIDs) == 0 {
+			*expectedIDs = make([]string, len(actualIDs))
+			copy(*expectedIDs, actualIDs)
+			return nil
+		}
+
+		// Compare as sets: same IDs regardless of order or which policy they're in
+		if len(actualIDs) != len(*expectedIDs) {
+			return fmt.Errorf("total permission_group count changed: expected %d, got %d", len(*expectedIDs), len(actualIDs))
+		}
+		expected := make(map[string]int, len(*expectedIDs))
+		for _, id := range *expectedIDs {
+			expected[id]++
+		}
+		for _, id := range actualIDs {
+			if expected[id] <= 0 {
+				return fmt.Errorf("unexpected permission_group ID %s; expected IDs: %v", id, *expectedIDs)
+			}
+			expected[id]--
+		}
+		return nil
+	}
 }
 
 // Test that policy group order doesn't affect plans. This test uses two
@@ -463,10 +562,11 @@ func TestAccAccountToken_PolicyOrder(t *testing.T) {
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	resourceName := "cloudflare_account_token.test_account_token"
 
-	policy1_permgroup_SAME := statecheck.CompareValue(compare.ValuesSame())
-	policy2_permgroup_SAME := statecheck.CompareValue(compare.ValuesSame())
+	// Track the combined set of permission group IDs across all policies
+	var allPermGroupIDs []string
 
-	// Test that policy order doesn't affect plans
+	// Test that policy order swap produces a benign update
+	// but the same set of permission group IDs is preserved
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
@@ -477,17 +577,17 @@ func TestAccAccountToken_PolicyOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(2)),
-					policy1_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					policy2_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(1).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDs),
 			},
 			{
 				Config: acctest.LoadTestCase("account_token-policy-order2.tf", rnd, accountID),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDs),
 			},
 			{
 				Config: acctest.LoadTestCase("account_token-policy-order2.tf", rnd+"-updated", accountID),
@@ -500,30 +600,33 @@ func TestAccAccountToken_PolicyOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(2)),
-					policy1_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					policy2_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(1).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDs),
 			},
 			{
 				Config: acctest.LoadTestCase("account_token-policy-order1.tf", rnd+"-updated", accountID),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDs),
 			},
-			// Import step
+			// Import step — ignore policies ordering since import uses canonical
+			// sort (no prior state) which may differ from the last config order
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-				ImportStateVerifyIgnore: []string{"value"}, // API token value is not returned by the API
+				ImportStateVerifyIgnore: []string{"value", "policies"},
 			},
 		},
 	})
 
 	// Test the reverse order scenario
+	var allPermGroupIDsReverse []string
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
@@ -534,17 +637,17 @@ func TestAccAccountToken_PolicyOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(2)),
-					policy1_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					policy2_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(1).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDsReverse),
 			},
 			{
 				Config: acctest.LoadTestCase("account_token-policy-order1.tf", rnd, accountID),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDsReverse),
 			},
 			{
 				Config: acctest.LoadTestCase("account_token-policy-order1.tf", rnd+"-updated", accountID),
@@ -557,31 +660,30 @@ func TestAccAccountToken_PolicyOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(2)),
-					policy1_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					policy2_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(1).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDsReverse),
 			},
 			{
 				Config: acctest.LoadTestCase("account_token-policy-order2.tf", rnd+"-updated", accountID),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(2)),
-					policy1_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					policy2_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(1).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDsReverse),
 			},
-			// Import step
+			// Import step — ignore policies ordering since import uses canonical
+			// sort (no prior state) which may differ from the last config order
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-				ImportStateVerifyIgnore: []string{"value"}, // API token value is not returned by the API
+				ImportStateVerifyIgnore: []string{"value", "policies"},
 			},
 		},
 	})
@@ -627,13 +729,14 @@ func TestAccAccountToken_ResourcesFlexible(t *testing.T) {
 					},
 				},
 			},
-			// Import step
+			// Import step — ignore policies ordering since import uses canonical
+			// sort (no prior state) which may differ from the last config order
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
-				ImportStateVerifyIgnore: []string{"value"}, // API token value is not returned by the API
+				ImportStateVerifyIgnore: []string{"value", "policies"},
 			},
 		},
 	})

--- a/internal/services/account_token/schema.go
+++ b/internal/services/account_token/schema.go
@@ -44,7 +44,7 @@ func (v ResourcesValidator) MarkdownDescription(context.Context) string {
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
-		Version: 500,
+		Version: 501,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Token identifier tag.",
@@ -60,7 +60,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description: "Token name.",
 				Required:    true,
 			},
-			"policies": schema.SetNestedAttribute{
+			"policies": schema.ListNestedAttribute{
 				Description: "Set of access policies assigned to the token.",
 				Required:    true,
 				NestedObject: schema.NestedAttributeObject{
@@ -72,7 +72,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								stringvalidator.OneOfCaseInsensitive("allow", "deny"),
 							},
 						},
-						"permission_groups": schema.SetNestedAttribute{
+						"permission_groups": schema.ListNestedAttribute{
 							Description: "A set of permission groups that are specified to the policy.",
 							Required:    true,
 							NestedObject: schema.NestedAttributeObject{

--- a/internal/services/api_token/custom.go
+++ b/internal/services/api_token/custom.go
@@ -2,6 +2,8 @@ package api_token
 
 import (
 	"encoding/json"
+	"sort"
+	"strings"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -43,6 +45,9 @@ func MarshalCustom(m APITokenModel) (data []byte, err error) {
 }
 
 func UnmarshalCustom(data []byte, model *APITokenResultEnvelope) (err error) {
+	// Snapshot prior policy order before apijson.Unmarshal overwrites the model
+	snap := snapshotPolicyOrder(model.Result.Policies)
+
 	if err = apijson.Unmarshal(data, model); err != nil {
 		return
 	}
@@ -67,18 +72,234 @@ func UnmarshalCustom(data []byte, model *APITokenResultEnvelope) (err error) {
 		}
 		(*model.Result.Policies)[i].Resources = types.StringValue(string(policy["resources"]))
 	}
+
+	// Reorder to match prior state (or canonical sort if no prior)
+	reorderPoliciesFromSnapshot(model.Result.Policies, snap)
 	return
 }
 
 func UnmarshalComputedCustom(data []byte, model *APITokenResultEnvelope) (err error) {
+	// Snapshot prior policy order BEFORE UnmarshalComputed overwrites the model
+	snap := snapshotPolicyOrder(model.Result.Policies)
+
 	if err = apijson.UnmarshalComputed(data, model); err != nil {
 		return
 	}
-	forPoliciesOnly := APITokenResultEnvelope{}
-	err = UnmarshalCustom(data, &forPoliciesOnly)
-	if err != nil {
+	return unmarshalCustomWithSnapshot(data, model, snap)
+}
+
+// unmarshalCustomWithSnapshot is like UnmarshalCustom but uses a provided
+// snapshot instead of capturing its own. apijson.Unmarshal is NOT called
+// because the caller has already done the initial unmarshal.
+func unmarshalCustomWithSnapshot(data []byte, model *APITokenResultEnvelope, snap *policyOrderSnapshot) error {
+	// pull out the raw JSON values for each policy resource and map to the model
+	var base map[string]json.RawMessage
+	if err := json.Unmarshal(data, &base); err != nil {
 		return err
 	}
-	model.Result.Policies = forPoliciesOnly.Result.Policies
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(base["result"], &result); err != nil {
+		return err
+	}
+	var policyJsons []json.RawMessage
+	if err := json.Unmarshal(result["policies"], &policyJsons); err != nil {
+		return err
+	}
+	for i, policyJson := range policyJsons {
+		var policy map[string]json.RawMessage
+		if err := json.Unmarshal(policyJson, &policy); err != nil {
+			return err
+		}
+		(*model.Result.Policies)[i].Resources = types.StringValue(string(policy["resources"]))
+	}
+
+	// Reorder to match prior state (or canonical sort if no prior)
+	reorderPoliciesFromSnapshot(model.Result.Policies, snap)
 	return nil
+}
+
+// ============================================================================
+// Policy order snapshot and reordering
+// ============================================================================
+
+// policySnapshot captures a policy's identity as plain strings.
+type policySnapshot struct {
+	effect           string
+	resources        string
+	permissionGroups []string
+}
+
+// policyOrderSnapshot captures the full prior ordering of policies.
+type policyOrderSnapshot struct {
+	policies []policySnapshot
+}
+
+// snapshotPolicyOrder extracts the current policy order as plain strings.
+// Returns nil if there are no prior policies.
+func snapshotPolicyOrder(policies *[]*APITokenPoliciesModel) *policyOrderSnapshot {
+	if policies == nil || len(*policies) == 0 {
+		return nil
+	}
+	snap := &policyOrderSnapshot{
+		policies: make([]policySnapshot, len(*policies)),
+	}
+	for i, p := range *policies {
+		var pgIDs []string
+		if p.PermissionGroups != nil {
+			pgIDs = make([]string, len(*p.PermissionGroups))
+			for j, pg := range *p.PermissionGroups {
+				pgIDs[j] = pg.ID.ValueString()
+			}
+		}
+		snap.policies[i] = policySnapshot{
+			effect:           p.Effect.ValueString(),
+			resources:        p.Resources.ValueString(),
+			permissionGroups: pgIDs,
+		}
+	}
+	return snap
+}
+
+// policyFingerprint builds a unique key for a policy using effect + resources +
+// sorted permission group IDs, joined with "|".
+func policyFingerprint(effect, resources string, pgIDs []string) string {
+	sorted := make([]string, len(pgIDs))
+	copy(sorted, pgIDs)
+	sort.Strings(sorted)
+	return effect + "|" + resources + "|" + strings.Join(sorted, ",")
+}
+
+// policyFingerprintFromModel builds a fingerprint from a policy model.
+func policyFingerprintFromModel(p *APITokenPoliciesModel) string {
+	var pgIDs []string
+	if p.PermissionGroups != nil {
+		pgIDs = make([]string, len(*p.PermissionGroups))
+		for i, pg := range *p.PermissionGroups {
+			pgIDs[i] = pg.ID.ValueString()
+		}
+	}
+	return policyFingerprint(p.Effect.ValueString(), p.Resources.ValueString(), pgIDs)
+}
+
+// reorderPoliciesFromSnapshot reorders policies to match the prior snapshot.
+// If snap is nil (no prior state), falls back to canonical sort.
+func reorderPoliciesFromSnapshot(newPolicies *[]*APITokenPoliciesModel, snap *policyOrderSnapshot) {
+	if newPolicies == nil || len(*newPolicies) == 0 {
+		return
+	}
+
+	if snap == nil {
+		sortPolicies(newPolicies)
+		return
+	}
+
+	// Build index: fingerprint -> desired position from prior snapshot
+	priorIndex := make(map[string]int, len(snap.policies))
+	for i, sp := range snap.policies {
+		fp := policyFingerprint(sp.effect, sp.resources, sp.permissionGroups)
+		priorIndex[fp] = i
+	}
+
+	policies := *newPolicies
+
+	// Stable sort: policies that match prior go to their prior position;
+	// unmatched policies sort after matched ones in canonical order.
+	sort.SliceStable(policies, func(i, j int) bool {
+		fpI := policyFingerprintFromModel(policies[i])
+		fpJ := policyFingerprintFromModel(policies[j])
+		posI, okI := priorIndex[fpI]
+		posJ, okJ := priorIndex[fpJ]
+
+		switch {
+		case okI && okJ:
+			return posI < posJ
+		case okI:
+			return true // matched before unmatched
+		case okJ:
+			return false
+		default:
+			// Both unmatched: canonical order
+			return canonicalPolicyLess(policies[i], policies[j])
+		}
+	})
+
+	// Reorder permission_groups within each policy to match prior
+	priorPGIndex := make(map[string]map[string]int, len(snap.policies))
+	for _, sp := range snap.policies {
+		fp := policyFingerprint(sp.effect, sp.resources, sp.permissionGroups)
+		pgIdx := make(map[string]int, len(sp.permissionGroups))
+		for j, pgID := range sp.permissionGroups {
+			pgIdx[pgID] = j
+		}
+		priorPGIndex[fp] = pgIdx
+	}
+
+	for _, p := range policies {
+		if p.PermissionGroups == nil || len(*p.PermissionGroups) == 0 {
+			continue
+		}
+		fp := policyFingerprintFromModel(p)
+		pgIdx, ok := priorPGIndex[fp]
+		if !ok {
+			// No prior — canonical sort by ID
+			pgs := *p.PermissionGroups
+			sort.SliceStable(pgs, func(i, j int) bool {
+				return pgs[i].ID.ValueString() < pgs[j].ID.ValueString()
+			})
+			continue
+		}
+
+		pgs := *p.PermissionGroups
+		sort.SliceStable(pgs, func(i, j int) bool {
+			idI := pgs[i].ID.ValueString()
+			idJ := pgs[j].ID.ValueString()
+			posI, okI := pgIdx[idI]
+			posJ, okJ := pgIdx[idJ]
+			switch {
+			case okI && okJ:
+				return posI < posJ
+			case okI:
+				return true
+			case okJ:
+				return false
+			default:
+				return idI < idJ
+			}
+		})
+	}
+}
+
+// sortPolicies applies canonical sort: permission_groups by ID within each
+// policy, then policies by effect then resources.
+func sortPolicies(policies *[]*APITokenPoliciesModel) {
+	if policies == nil || len(*policies) == 0 {
+		return
+	}
+	ps := *policies
+
+	// Sort permission groups within each policy
+	for _, p := range ps {
+		if p.PermissionGroups == nil || len(*p.PermissionGroups) == 0 {
+			continue
+		}
+		pgs := *p.PermissionGroups
+		sort.SliceStable(pgs, func(i, j int) bool {
+			return pgs[i].ID.ValueString() < pgs[j].ID.ValueString()
+		})
+	}
+
+	// Sort policies by effect, then resources
+	sort.SliceStable(ps, func(i, j int) bool {
+		return canonicalPolicyLess(ps[i], ps[j])
+	})
+}
+
+// canonicalPolicyLess defines the canonical ordering: by effect, then resources.
+func canonicalPolicyLess(a, b *APITokenPoliciesModel) bool {
+	ea := a.Effect.ValueString()
+	eb := b.Effect.ValueString()
+	if ea != eb {
+		return ea < eb
+	}
+	return a.Resources.ValueString() < b.Resources.ValueString()
 }

--- a/internal/services/api_token/custom_test.go
+++ b/internal/services/api_token/custom_test.go
@@ -97,6 +97,7 @@ func TestUnmarshalCustom(t *testing.T) {
 }
 
 func TestUnmarshalComputedCustom(t *testing.T) {
+	// API returns policies in [flat, nested_resources] order
 	data := json.RawMessage(`{
 		"result":{
 			"name":"name",
@@ -119,8 +120,7 @@ func TestUnmarshalComputedCustom(t *testing.T) {
 			ID: types.StringValue("permgroup1"),
 		},
 	}
-	// Policy order in client-side model is not the same as the server-side data
-	// model.
+	// Prior model has policies in [nested_resources, flat] order
 	policies := []*APITokenPoliciesModel{
 		{
 			Effect:           types.StringValue("effect"),
@@ -143,12 +143,94 @@ func TestUnmarshalComputedCustom(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The order of policies should be the same as the server-side data model
+	// With reorder-to-match-prior, result should be [nested_resources, flat] matching prior order
 	foundPolicies := env.Result.Policies
-	if (*foundPolicies)[0].Resources != types.StringValue("{\"com.cloudflare.api.account.123\":\"*\"}") {
-		t.Fatalf("expected %s, got %s", "{\"com.cloudflare.api.account.123\":\"*\"}", (*foundPolicies)[0].Resources)
+	if (*foundPolicies)[0].Resources != types.StringValue("{\"com.cloudflare.api.account.123\":{\"com.cloudflare.api.account.zone.*\":\"*\"}}") {
+		t.Fatalf("expected nested resources first, got %s", (*foundPolicies)[0].Resources)
 	}
-	if (*foundPolicies)[1].Resources != types.StringValue("{\"com.cloudflare.api.account.123\":{\"com.cloudflare.api.account.zone.*\":\"*\"}}") {
-		t.Fatalf("expected %s, got %s", "{\"com.cloudflare.api.account.123\":{\"com.cloudflare.api.account.zone.*\":\"*\"}}", (*foundPolicies)[0].Resources)
+	if (*foundPolicies)[1].Resources != types.StringValue("{\"com.cloudflare.api.account.123\":\"*\"}") {
+		t.Fatalf("expected flat resources second, got %s", (*foundPolicies)[1].Resources)
+	}
+}
+
+func TestSortPolicies_SortsPermissionGroupsByID(t *testing.T) {
+	pgs := []*APITokenPoliciesPermissionGroupsModel{
+		{ID: types.StringValue("ccc")},
+		{ID: types.StringValue("aaa")},
+		{ID: types.StringValue("bbb")},
+	}
+	policies := []*APITokenPoliciesModel{
+		{
+			Effect:           types.StringValue("allow"),
+			PermissionGroups: &pgs,
+			Resources:        types.StringValue("{}"),
+		},
+	}
+	sortPolicies(&policies)
+
+	sorted := *policies[0].PermissionGroups
+	expected := []string{"aaa", "bbb", "ccc"}
+	for i, exp := range expected {
+		got := sorted[i].ID.ValueString()
+		if got != exp {
+			t.Fatalf("permission_groups[%d]: expected %q, got %q", i, exp, got)
+		}
+	}
+}
+
+func TestSortPolicies_SortsPoliciesByEffectThenResources(t *testing.T) {
+	pg := []*APITokenPoliciesPermissionGroupsModel{{ID: types.StringValue("pg1")}}
+	policies := []*APITokenPoliciesModel{
+		{Effect: types.StringValue("deny"), PermissionGroups: &pg, Resources: types.StringValue("b")},
+		{Effect: types.StringValue("allow"), PermissionGroups: &pg, Resources: types.StringValue("z")},
+		{Effect: types.StringValue("allow"), PermissionGroups: &pg, Resources: types.StringValue("a")},
+	}
+	sortPolicies(&policies)
+
+	type expected struct {
+		effect    string
+		resources string
+	}
+	expectations := []expected{
+		{"allow", "a"},
+		{"allow", "z"},
+		{"deny", "b"},
+	}
+	for i, exp := range expectations {
+		got := policies[i]
+		if got.Effect.ValueString() != exp.effect || got.Resources.ValueString() != exp.resources {
+			t.Fatalf("policies[%d]: expected {%s, %s}, got {%s, %s}",
+				i, exp.effect, exp.resources, got.Effect.ValueString(), got.Resources.ValueString())
+		}
+	}
+}
+
+func TestUnmarshalCustom_SortsPermissionGroups(t *testing.T) {
+	// API returns permission groups in [zzz, aaa, mmm] order, no prior state
+	data := json.RawMessage(`{
+		"result":{
+			"name":"name",
+			"policies":[
+				{
+					"effect":"allow",
+					"permission_groups":[{"id":"zzz"},{"id":"aaa"},{"id":"mmm"}],
+					"resources":{"com.cloudflare.api.account.123":"*"}
+				}
+			]
+		}
+	}`)
+	env := APITokenResultEnvelope{}
+	err := UnmarshalCustom(data, &env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// With no prior state, canonical sort should order by ID: [aaa, mmm, zzz]
+	pgs := *(*env.Result.Policies)[0].PermissionGroups
+	expected := []string{"aaa", "mmm", "zzz"}
+	for i, exp := range expected {
+		got := pgs[i].ID.ValueString()
+		if got != exp {
+			t.Fatalf("permission_groups[%d]: expected %q, got %q", i, exp, got)
+		}
 	}
 }

--- a/internal/services/api_token/migration/v500/handler.go
+++ b/internal/services/api_token/migration/v500/handler.go
@@ -37,10 +37,18 @@ func UpgradeFromV4(ctx context.Context, req resource.UpgradeStateRequest, resp *
 
 // UpgradeFromV1 handles state upgrades from v5 Plugin Framework provider (version=1) to v5 (version=500).
 //
-// This is a no-op upgrade since the schema is compatible — just bumps the version.
-// This handler is only triggered.
+// v1 is the "dormant" state version before migration activation.
+// The v1 schema uses Set types which must be deserialized and re-serialized
+// to produce state compatible with the target schema (which may use List types).
 func UpgradeFromV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	tflog.Info(ctx, "Upgrading api_token state from version=1 to version=500 (no-op)")
-	resp.State.Raw = req.State.Raw
+	tflog.Info(ctx, "Upgrading api_token state from version=1 to version=500")
+
+	var state TargetAPITokenModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+
 	tflog.Info(ctx, "State version bump from 1 to 500 completed")
 }

--- a/internal/services/api_token/migration/v501/handler.go
+++ b/internal/services/api_token/migration/v501/handler.go
@@ -1,0 +1,57 @@
+package v501
+
+import (
+	"context"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// UpgradeFromV500 handles state upgrades from schema version 500 to version 501.
+//
+// v500 state uses Set-typed policies and permission_groups. v501 switches to
+// List-typed with FastSetType for O(n) performance. This handler reads the v500
+// Set state, sorts policies and permission_groups canonically (for stable List
+// ordering), and writes back as List state.
+func UpgradeFromV500(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading api_token state from v500 to v501")
+
+	var state APITokenModelV500
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Sort policies and permission_groups canonically for stable List ordering
+	sortPolicies(state.Policies)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	tflog.Info(ctx, "State upgrade from v500 to v501 completed successfully")
+}
+
+// sortPolicies applies canonical sort: permission_groups by ID within each
+// policy, then policies by effect then resources.
+func sortPolicies(policies []PolicyV500) {
+	if len(policies) == 0 {
+		return
+	}
+
+	// Sort permission groups within each policy
+	for i := range policies {
+		pgs := policies[i].PermissionGroups
+		sort.SliceStable(pgs, func(a, b int) bool {
+			return pgs[a].ID.ValueString() < pgs[b].ID.ValueString()
+		})
+	}
+
+	// Sort policies by effect, then resources
+	sort.SliceStable(policies, func(i, j int) bool {
+		ei := policies[i].Effect.ValueString()
+		ej := policies[j].Effect.ValueString()
+		if ei != ej {
+			return ei < ej
+		}
+		return policies[i].Resources.ValueString() < policies[j].Resources.ValueString()
+	})
+}

--- a/internal/services/api_token/migration/v501/migrations_test.go
+++ b/internal/services/api_token/migration/v501/migrations_test.go
@@ -1,0 +1,123 @@
+package v501_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+//go:embed testdata/v501_multi_policy.tf
+var v501MultiPolicyConfig string
+
+//go:embed testdata/v501_multi_permgroups.tf
+var v501MultiPermgroupsConfig string
+
+// TestMigrateAPITokenFromV500_MultiPolicy tests migration from v500 (Set-based,
+// schema_version=500 via v5.16.0) to v501 (List-based) with multiple policies.
+func TestMigrateAPITokenFromV500_MultiPolicy(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	tmpDir := t.TempDir()
+
+	config := fmt.Sprintf(v501MultiPolicyConfig, rnd, accountID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "5.16.0",
+					},
+				},
+				Config: config,
+			},
+			{
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				Config:                   config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						fmt.Sprintf("cloudflare_api_token.%s", rnd),
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(rnd),
+					),
+					statecheck.ExpectKnownValue(
+						fmt.Sprintf("cloudflare_api_token.%s", rnd),
+						tfjsonpath.New("policies"),
+						knownvalue.ListSizeExact(2),
+					),
+				},
+			},
+		},
+	})
+}
+
+// TestMigrateAPITokenFromV500_MultiPermGroups tests migration from v500
+// (Set-based) to v501 (List-based) with multiple permission groups.
+func TestMigrateAPITokenFromV500_MultiPermGroups(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	tmpDir := t.TempDir()
+
+	config := fmt.Sprintf(v501MultiPermgroupsConfig, rnd, accountID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "5.16.0",
+					},
+				},
+				Config: config,
+			},
+			{
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				Config:                   config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						fmt.Sprintf("cloudflare_api_token.%s", rnd),
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(rnd),
+					),
+					statecheck.ExpectKnownValue(
+						fmt.Sprintf("cloudflare_api_token.%s", rnd),
+						tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"),
+						knownvalue.ListSizeExact(3),
+					),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/api_token/migration/v501/model.go
+++ b/internal/services/api_token/migration/v501/model.go
@@ -1,0 +1,45 @@
+package v501
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// APITokenModelV500 represents the full api_token state in v500.
+// Uses Go slices (not pointers) for compatibility with Set-based schema deserialization.
+type APITokenModelV500 struct {
+	ID         types.String      `tfsdk:"id"`
+	IssuedOn   timetypes.RFC3339 `tfsdk:"issued_on"`
+	ModifiedOn timetypes.RFC3339 `tfsdk:"modified_on"`
+	Name       types.String      `tfsdk:"name"`
+	Policies   []PolicyV500      `tfsdk:"policies"`
+	Status     types.String      `tfsdk:"status"`
+	Value      types.String      `tfsdk:"value"`
+	NotBefore  timetypes.RFC3339 `tfsdk:"not_before"`
+	ExpiresOn  timetypes.RFC3339 `tfsdk:"expires_on"`
+	Condition  *ConditionV500    `tfsdk:"condition"`
+	LastUsedOn timetypes.RFC3339 `tfsdk:"last_used_on"`
+}
+
+// PolicyV500 represents a policy in v500 state.
+type PolicyV500 struct {
+	Effect           types.String          `tfsdk:"effect"`
+	PermissionGroups []PermissionGroupV500 `tfsdk:"permission_groups"`
+	Resources        types.String          `tfsdk:"resources"`
+}
+
+// PermissionGroupV500 represents a permission group in v500 state.
+type PermissionGroupV500 struct {
+	ID types.String `tfsdk:"id"`
+}
+
+// ConditionV500 represents the condition object in v500 state.
+type ConditionV500 struct {
+	RequestIP *ConditionRequestIPV500 `tfsdk:"request_ip"`
+}
+
+// ConditionRequestIPV500 represents the request_ip condition in v500 state.
+type ConditionRequestIPV500 struct {
+	In    []types.String `tfsdk:"in"`
+	NotIn []types.String `tfsdk:"not_in"`
+}

--- a/internal/services/api_token/migration/v501/schema.go
+++ b/internal/services/api_token/migration/v501/schema.go
@@ -1,0 +1,99 @@
+package v501
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// SourceSchemaV500 returns the schema for version 500 (Set-based policies).
+// Schema version: 500
+// Resource type: cloudflare_api_token
+//
+// This schema is used only for reading v500 state during migration to v501.
+// The key difference from v501 is that policies and permission_groups use
+// SetNestedAttribute instead of ListNestedAttribute.
+func SourceSchemaV500() schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"issued_on": schema.StringAttribute{
+				Computed:   true,
+				CustomType: timetypes.RFC3339Type{},
+			},
+			"modified_on": schema.StringAttribute{
+				Computed:   true,
+				CustomType: timetypes.RFC3339Type{},
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"policies": schema.SetNestedAttribute{
+				Required: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"effect": schema.StringAttribute{
+							Required: true,
+						},
+						"permission_groups": schema.SetNestedAttribute{
+							Required: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"id": schema.StringAttribute{
+										Required: true,
+									},
+								},
+							},
+						},
+						"resources": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			"status": schema.StringAttribute{
+				Computed: true,
+				Optional: true,
+			},
+			"value": schema.StringAttribute{
+				Computed:  true,
+				Sensitive: true,
+			},
+			"not_before": schema.StringAttribute{
+				Optional:   true,
+				CustomType: timetypes.RFC3339Type{},
+			},
+			"expires_on": schema.StringAttribute{
+				Optional:   true,
+				CustomType: timetypes.RFC3339Type{},
+			},
+			"condition": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"request_ip": schema.SingleNestedAttribute{
+						Optional: true,
+						Attributes: map[string]schema.Attribute{
+							"in": schema.ListAttribute{
+								Optional:    true,
+								ElementType: types.StringType,
+							},
+							"not_in": schema.ListAttribute{
+								Optional:    true,
+								ElementType: types.StringType,
+							},
+						},
+					},
+				},
+			},
+			"last_used_on": schema.StringAttribute{
+				Computed:   true,
+				CustomType: timetypes.RFC3339Type{},
+			},
+		},
+	}
+}

--- a/internal/services/api_token/migration/v501/testdata/v501_multi_permgroups.tf
+++ b/internal/services/api_token/migration/v501/testdata/v501_multi_permgroups.tf
@@ -1,0 +1,17 @@
+resource "cloudflare_api_token" "%[1]s" {
+  name = "%[1]s"
+
+  policies = [
+    {
+      effect = "allow"
+      permission_groups = [
+        { id = "82e64a83756745bbbb1c9c2701bf816b" },
+        { id = "c8fed203ed3043cba015a93ad1616f1f" },
+        { id = "e199d584e69344eba202452019deafe3" }
+      ]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = "*"
+      })
+    }
+  ]
+}

--- a/internal/services/api_token/migration/v501/testdata/v501_multi_policy.tf
+++ b/internal/services/api_token/migration/v501/testdata/v501_multi_policy.tf
@@ -1,0 +1,24 @@
+resource "cloudflare_api_token" "%[1]s" {
+  name = "%[1]s"
+
+  policies = [
+    {
+      effect = "allow"
+      permission_groups = [{
+        id = "82e64a83756745bbbb1c9c2701bf816b"
+      }]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = "*"
+      })
+    },
+    {
+      effect = "allow"
+      permission_groups = [{
+        id = "c8fed203ed3043cba015a93ad1616f1f"
+      }]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = "*"
+      })
+    }
+  ]
+}

--- a/internal/services/api_token/migrations.go
+++ b/internal/services/api_token/migrations.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_token/migration/v500"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_token/migration/v501"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -20,22 +21,26 @@ var _ resource.ResourceWithUpgradeState = (*APITokenResource)(nil)
 
 // UpgradeState registers state upgraders for schema version changes.
 //
-// This handles two modes:
+// This handles three upgrade paths:
 //
-// for early v5 users who still have schema_version=0.
+// 1. v0 state (schema_version=0) → v501: Full transformation via v500
+//   - Converts policy[] block to policies[] attribute
+//   - Converts permission_groups from strings to objects
+//   - Converts resources from map to JSON string
+//   - Converts condition/request_ip from arrays to single nested
 //
-// Test mode: Version=500, two upgraders:
-//   - Slot 0: v4 SDKv2 (schema_version=0) → v500: Full transformation
-//   - Slot 1: v5 current (schema_version=1) → v500: No-op version bump
+// 2. v1 state (schema_version=1) → v501: Deserialize/re-serialize via v500
+//   - Converts Set-typed state to List-compatible state
+//
+// 3. v500 state (schema_version=500) → v501: Set→List migration
+//   - Converts Set-typed policies and permission_groups to sorted Lists
 func (r *APITokenResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	targetSchema := ResourceSchema(ctx)
-
 	v4Schema := v500.SourceCloudflareAPITokenSchema()
 
 	v5SchemaVersion1 := ResourceSchema(ctx)
 	v5SchemaVersion1.Version = 1
 
-	_ = targetSchema // used indirectly via ResourceSchema
+	v500Schema := v501.SourceSchemaV500()
 
 	return map[int64]resource.StateUpgrader{
 		// Handle state from v4 SDKv2 provider (schema_version=0)
@@ -47,6 +52,11 @@ func (r *APITokenResource) UpgradeState(ctx context.Context) map[int64]resource.
 		1: {
 			PriorSchema:   &v5SchemaVersion1,
 			StateUpgrader: v500.UpgradeFromV1,
+		},
+		// Handle state from v500 (Set-based) → v501 (List-based with FastSetType)
+		500: {
+			PriorSchema:   &v500Schema,
+			StateUpgrader: v501.UpgradeFromV500,
 		},
 	}
 }

--- a/internal/services/api_token/resource_test.go
+++ b/internal/services/api_token/resource_test.go
@@ -10,9 +10,8 @@ import (
 	"github.com/cloudflare/cloudflare-go/v6/user"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
-	"github.com/hashicorp/terraform-plugin-testing/compare"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -38,7 +37,7 @@ func testSweepCloudflareAPIToken(r string) error {
 	// List all API tokens
 	tokens, err := client.User.Tokens.List(ctx, user.TokenListParams{})
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Failed to fetch API tokens: %s",err))
+		tflog.Error(ctx, fmt.Sprintf("Failed to fetch API tokens: %s", err))
 		return err
 	}
 	if len(tokens.Result) == 0 {
@@ -54,7 +53,7 @@ func testSweepCloudflareAPIToken(r string) error {
 		tflog.Info(ctx, fmt.Sprintf("Deleting API token: %s (%s)", token.Name, token.ID))
 		_, err := client.User.Tokens.Delete(ctx, token.ID)
 		if err != nil {
-			tflog.Error(ctx, fmt.Sprintf("Failed to delete API token %s (%s): %s", token.Name, token.ID,err))
+			tflog.Error(ctx, fmt.Sprintf("Failed to delete API token %s (%s): %s", token.Name, token.ID, err))
 			continue
 		}
 		tflog.Info(ctx, fmt.Sprintf("Deleted API token: %s (%s)", token.Name, token.ID))
@@ -301,20 +300,96 @@ func TestAccAPIToken_TokenTTL(t *testing.T) {
 	})
 }
 
-// Test that permission group order doesn't affect plans. This test uses two
-// corresponding .tf files that are identical except they swap the order of two
-// permission groups on the same policy. We use statecheck.CompareValue to
-// assert that permission group 0 never changes and permission group 1 never
-// changes despite changing the order of the permission groups and updating the
-// token name.
+// checkPermissionGroupIDsUnchanged verifies that the set of permission group
+// IDs at policies[policyIdx] matches expectedIDs regardless of order.
+func checkPermissionGroupIDsUnchanged(resourceName string, policyIdx int, expectedIDs *[]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		var actualIDs []string
+		for i := 0; ; i++ {
+			key := fmt.Sprintf("policies.%d.permission_groups.%d.id", policyIdx, i)
+			val, ok := rs.Primary.Attributes[key]
+			if !ok {
+				break
+			}
+			actualIDs = append(actualIDs, val)
+		}
+		if len(*expectedIDs) == 0 {
+			*expectedIDs = make([]string, len(actualIDs))
+			copy(*expectedIDs, actualIDs)
+			return nil
+		}
+		if len(actualIDs) != len(*expectedIDs) {
+			return fmt.Errorf("permission_groups count changed: expected %d, got %d", len(*expectedIDs), len(actualIDs))
+		}
+		expected := make(map[string]bool, len(*expectedIDs))
+		for _, id := range *expectedIDs {
+			expected[id] = true
+		}
+		for _, id := range actualIDs {
+			if !expected[id] {
+				return fmt.Errorf("unexpected permission_group ID %s; expected one of %v", id, *expectedIDs)
+			}
+		}
+		return nil
+	}
+}
+
+// checkAllPolicyPermGroupIDsUnchanged verifies that the combined set of
+// permission group IDs across all policies is unchanged (order-insensitive).
+func checkAllPolicyPermGroupIDsUnchanged(resourceName string, expectedIDs *[]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		var actualIDs []string
+		for pi := 0; ; pi++ {
+			found := false
+			for pgi := 0; ; pgi++ {
+				key := fmt.Sprintf("policies.%d.permission_groups.%d.id", pi, pgi)
+				val, ok := rs.Primary.Attributes[key]
+				if !ok {
+					break
+				}
+				found = true
+				actualIDs = append(actualIDs, val)
+			}
+			if !found {
+				break
+			}
+		}
+		if len(*expectedIDs) == 0 {
+			*expectedIDs = make([]string, len(actualIDs))
+			copy(*expectedIDs, actualIDs)
+			return nil
+		}
+		if len(actualIDs) != len(*expectedIDs) {
+			return fmt.Errorf("total permission_group count changed: expected %d, got %d", len(*expectedIDs), len(actualIDs))
+		}
+		expected := make(map[string]int, len(*expectedIDs))
+		for _, id := range *expectedIDs {
+			expected[id]++
+		}
+		for _, id := range actualIDs {
+			if expected[id] <= 0 {
+				return fmt.Errorf("unexpected permission_group ID %s; expected IDs: %v", id, *expectedIDs)
+			}
+			expected[id]--
+		}
+		return nil
+	}
+}
+
 func TestAccAPIToken_PermissionGroupOrder(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_api_token.test_account_token"
 
-	permgroup0_SAME := statecheck.CompareValue(compare.ValuesSame())
-	permgroup1_SAME := statecheck.CompareValue(compare.ValuesSame())
+	var permGroupIDs []string
 
-	// Test that permission group order doesn't affect plans
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
@@ -325,17 +400,17 @@ func TestAccAPIToken_PermissionGroupOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"), knownvalue.ListSizeExact(2)),
-					permgroup0_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					permgroup1_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(1).AtMapKey("id")),
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDs),
 			},
 			{
 				Config: acctest.LoadTestCase("api_token-permissiongroup-order2.tf", rnd),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDs),
 			},
 			{
 				Config: acctest.LoadTestCase("api_token-permissiongroup-order2.tf", rnd+"-updated"),
@@ -348,29 +423,31 @@ func TestAccAPIToken_PermissionGroupOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"), knownvalue.ListSizeExact(2)),
-					permgroup0_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					permgroup1_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(1).AtMapKey("id")),
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDs),
 			},
 			{
 				Config: acctest.LoadTestCase("api_token-permissiongroup-order1.tf", rnd+"-updated"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDs),
 			},
 			// Import step
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"value"}, // API token value is not returned by the API
+				ImportStateVerifyIgnore: []string{"value", "policies"},
 			},
 		},
 	})
 
 	// Test the reverse order scenario
+	var permGroupIDsReverse []string
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
@@ -381,17 +458,17 @@ func TestAccAPIToken_PermissionGroupOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"), knownvalue.ListSizeExact(2)),
-					permgroup0_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					permgroup1_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(1).AtMapKey("id")),
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDsReverse),
 			},
 			{
 				Config: acctest.LoadTestCase("api_token-permissiongroup-order1.tf", rnd),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDsReverse),
 			},
 			{
 				Config: acctest.LoadTestCase("api_token-permissiongroup-order1.tf", rnd+"-updated"),
@@ -404,46 +481,35 @@ func TestAccAPIToken_PermissionGroupOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"), knownvalue.ListSizeExact(2)),
-					permgroup0_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					permgroup1_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(1).AtMapKey("id")),
 				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDsReverse),
 			},
 			{
 				Config: acctest.LoadTestCase("api_token-permissiongroup-order2.tf", rnd+"-updated"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"), knownvalue.ListSizeExact(2)),
-					permgroup0_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					permgroup1_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(1).AtMapKey("id")),
-				},
+				Check: checkPermissionGroupIDsUnchanged(resourceName, 0, &permGroupIDsReverse),
 			},
 			// Import step
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"value"}, // API token value is not returned by the API
+				ImportStateVerifyIgnore: []string{"value", "policies"},
 			},
 		},
 	})
 }
 
-// Test that policy group order doesn't affect plans. This test uses two
-// corresponding .tf files that are identical except they swap the order of two
-// policies.
 func TestAccAPIToken_PolicyOrder(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_api_token.test_account_token"
 
-	policy1_permgroup_SAME := statecheck.CompareValue(compare.ValuesSame())
-	policy2_permgroup_SAME := statecheck.CompareValue(compare.ValuesSame())
+	var allPermGroupIDs []string
 
-	// Test that policy order doesn't affect plans
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
@@ -454,17 +520,17 @@ func TestAccAPIToken_PolicyOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(2)),
-					policy1_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					policy2_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(1).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDs),
 			},
 			{
 				Config: acctest.LoadTestCase("api_token-policy-order2.tf", rnd),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDs),
 			},
 			{
 				Config: acctest.LoadTestCase("api_token-policy-order2.tf", rnd+"-updated"),
@@ -477,29 +543,31 @@ func TestAccAPIToken_PolicyOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(2)),
-					policy1_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					policy2_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(1).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDs),
 			},
 			{
 				Config: acctest.LoadTestCase("api_token-policy-order1.tf", rnd+"-updated"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDs),
 			},
 			// Import step
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"value"}, // API token value is not returned by the API
+				ImportStateVerifyIgnore: []string{"value", "policies"},
 			},
 		},
 	})
 
 	// Test the reverse order scenario
+	var allPermGroupIDsReverse []string
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
@@ -510,17 +578,17 @@ func TestAccAPIToken_PolicyOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(2)),
-					policy1_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					policy2_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(1).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDsReverse),
 			},
 			{
 				Config: acctest.LoadTestCase("api_token-policy-order1.tf", rnd),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDsReverse),
 			},
 			{
 				Config: acctest.LoadTestCase("api_token-policy-order1.tf", rnd+"-updated"),
@@ -533,30 +601,24 @@ func TestAccAPIToken_PolicyOrder(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(2)),
-					policy1_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					policy2_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(1).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
 				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDsReverse),
 			},
 			{
 				Config: acctest.LoadTestCase("api_token-policy-order2.tf", rnd+"-updated"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(2)),
-					policy1_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-					policy2_permgroup_SAME.AddStateValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(1).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id")),
-				},
+				Check: checkAllPolicyPermGroupIDsUnchanged(resourceName, &allPermGroupIDsReverse),
 			},
 			// Import step
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"value"}, // API token value is not returned by the API
+				ImportStateVerifyIgnore: []string{"value", "policies"},
 			},
 		},
 	})
@@ -602,12 +664,13 @@ func TestAccAPIToken_ResourcesFlexible(t *testing.T) {
 					},
 				},
 			},
-			// Import step
+			// Import step — ignore policies ordering since import uses canonical
+			// sort (no prior state) which may differ from the last config order
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"value"}, // API token value is not returned by the API
+				ImportStateVerifyIgnore: []string{"value", "policies"},
 			},
 		},
 	})

--- a/internal/services/api_token/schema.go
+++ b/internal/services/api_token/schema.go
@@ -44,7 +44,7 @@ func (v ResourcesValidator) MarkdownDescription(context.Context) string {
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
-		Version: 500,
+		Version: 501,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "Token identifier tag.",
@@ -55,7 +55,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description: "Token name.",
 				Required:    true,
 			},
-			"policies": schema.SetNestedAttribute{
+			"policies": schema.ListNestedAttribute{
 				Description: "Set of access policies assigned to the token.",
 				Required:    true,
 				NestedObject: schema.NestedAttributeObject{
@@ -67,7 +67,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								stringvalidator.OneOfCaseInsensitive("allow", "deny"),
 							},
 						},
-						"permission_groups": schema.SetNestedAttribute{
+						"permission_groups": schema.ListNestedAttribute{
 							Description: "A set of permission groups that are specified to the policy.",
 							Required:    true,
 							NestedObject: schema.NestedAttributeObject{


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

### Problem
cloudflare_account_token and cloudflare_api_token have an O(n²) plan computation when a token has many permission groups. A token with ~150 permission groups takes ~23s to plan (up from ~3s before v5.13.0). Reported in #6917

### Solution
Switch back to ListNestedAttribute and handle ordering at the provider level:

Reorder API responses to match prior state/plan order — prevents the drift and apply errors that originally motivated the Set change. Uses fingerprinting (effect + resources + sorted permission group IDs) to match policies across API responses.
Canonical sort fallback — for ImportState and migrations where no prior state exists.
State migration v500→v501 — properly converts existing Set-typed state to List-typed state.

### Trade-off
Swapping the order of policies or permission_groups in a user's .tf config now produces a benign update (Terraform applies the same data in the new order). This is inherent to Lists — Terraform Core compares List elements positionally at the tftypes layer before any framework-level hook can intervene. With Sets this was invisible, but Sets have the O(n²) bug in terraform-plugin-go that cannot be worked around at the framework level.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
Ran tests as normal

### Test output
# account token acceptance tests
```
=== RUN   TestAccountTokenDataSourceModelSchemaParity
=== PAUSE TestAccountTokenDataSourceModelSchemaParity
=== RUN   TestAccountTokensDataSourceModelSchemaParity
=== PAUSE TestAccountTokensDataSourceModelSchemaParity
=== RUN   TestAccountTokenModelSchemaParity
=== PAUSE TestAccountTokenModelSchemaParity
=== RUN   TestAccAccountToken_Basic
--- PASS: TestAccAccountToken_Basic (9.78s)
=== RUN   TestAccAccountToken_SetIndividualCondition
--- PASS: TestAccAccountToken_SetIndividualCondition (5.64s)
=== RUN   TestAccAccountToken_SetAllCondition
--- PASS: TestAccAccountToken_SetAllCondition (5.72s)
=== RUN   TestAccAccountToken_TokenTTL
--- PASS: TestAccAccountToken_TokenTTL (8.56s)
=== RUN   TestAccAccountToken_PermissionGroupOrder
--- PASS: TestAccAccountToken_PermissionGroupOrder (29.31s)
=== RUN   TestAccAccountToken_PolicyOrder
--- PASS: TestAccAccountToken_PolicyOrder (38.64s)
=== RUN   TestAccAccountToken_ResourcesFlexible
--- PASS: TestAccAccountToken_ResourcesFlexible (9.85s)
=== RUN   TestAccAccountToken_CRUD
--- PASS: TestAccAccountToken_CRUD (8.79s)
=== RUN   TestAccUpgradeAccountToken_FromPublishedV5
--- PASS: TestAccUpgradeAccountToken_FromPublishedV5 (17.11s)
=== CONT  TestAccountTokenDataSourceModelSchemaParity
=== CONT  TestAccountTokenModelSchemaParity
=== CONT  TestAccountTokensDataSourceModelSchemaParity
--- PASS: TestAccountTokenModelSchemaParity (0.00s)
--- PASS: TestAccountTokenDataSourceModelSchemaParity (0.00s)
--- PASS: TestAccountTokensDataSourceModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_token	135.172s
```

# api token acceptance tests
```
=== RUN   TestAccCloudflareAPITokenData
=== PAUSE TestAccCloudflareAPITokenData
=== RUN   TestAccAPIToken_Basic
--- PASS: TestAccAPIToken_Basic (11.13s)
=== RUN   TestAccAPIToken_SetIndividualCondition
--- PASS: TestAccAPIToken_SetIndividualCondition (5.31s)
=== RUN   TestAccAPIToken_SetAllCondition
--- PASS: TestAccAPIToken_SetAllCondition (9.74s)
=== RUN   TestAccAPIToken_TokenTTL
--- PASS: TestAccAPIToken_TokenTTL (8.04s)
=== RUN   TestAccAPIToken_PermissionGroupOrder
--- PASS: TestAccAPIToken_PermissionGroupOrder (26.86s)
=== RUN   TestAccAPIToken_PolicyOrder
--- PASS: TestAccAPIToken_PolicyOrder (27.82s)
=== RUN   TestAccAPIToken_ResourcesFlexible
--- PASS: TestAccAPIToken_ResourcesFlexible (9.44s)
=== RUN   TestAccAPIToken_CRUD
--- PASS: TestAccAPIToken_CRUD (8.42s)
=== RUN   TestAccUpgradeApiToken_FromPublishedV5
--- PASS: TestAccUpgradeApiToken_FromPublishedV5 (22.43s)
=== CONT  TestAccCloudflareAPITokenData
--- PASS: TestAccCloudflareAPITokenData (2.78s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_token	133.568s
```

## Perf testing
Also did some performance testing before and after the changes to observe a time decrease from ~20 seconds to ~0.25 seconds
```
=== BASELINE (Sets, no changes) ===
terraform plan -var="account_id=$CLOUDFLARE_ACCOUNT_ID" -input=false 2>&1  23.09s user 2.94s system 131% cpu 19.741 total
tail -3  0.00s user 0.00s system 0% cpu 19.741 total

terraform plan -var="account_id=$CLOUDFLARE_ACCOUNT_ID" -input=false 2>&1  17.17s user 2.11s system 147% cpu 13.068 total
tail -3  0.00s user 0.00s system 0% cpu 13.068 total

terraform plan -var="account_id=$CLOUDFLARE_ACCOUNT_ID" -input=false 2>&1  22.95s user 2.81s system 148% cpu 17.393 total
tail -3  0.00s user 0.00s system 0% cpu 17.392 total

=== WITH FIX (Lists + reorder) ===
terraform plan -var="account_id=$CLOUDFLARE_ACCOUNT_ID" -input=false 2>&1  0.25s user 0.13s system 15% cpu 2.489 total
tail -3  0.00s user 0.00s system 0% cpu 2.489 total

terraform plan -var="account_id=$CLOUDFLARE_ACCOUNT_ID" -input=false 2>&1  0.26s user 0.09s system 35% cpu 1.004 total
tail -3  0.00s user 0.00s system 0% cpu 1.004 total

terraform plan -var="account_id=$CLOUDFLARE_ACCOUNT_ID" -input=false 2>&1  0.27s user 0.09s system 58% cpu 0.615 total
tail -3  0.00s user 0.00s system 0% cpu 0.615 total
```

## Additional context & links
- https://github.com/cloudflare/terraform-provider-cloudflare/issues/6917