### PR TITLE
test: add acceptance tests for custom_page_asset resource

### DIFF
--- a/internal/services/custom_page_asset/data_source_test.go
+++ b/internal/services/custom_page_asset/data_source_test.go
@@ -1,0 +1,39 @@
+package custom_page_asset_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareCustomPageAssetDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	dataSourceName := "data.cloudflare_custom_page_asset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomPageAssetDataSourceConfig(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("description"), knownvalue.StringExact("Data source test asset")),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("url"), knownvalue.StringExact("https://example.com/error.html")),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("id"), knownvalue.StringExact(rnd)),
+				},
+			},
+		},
+	})
+}
+
+func testAccCustomPageAssetDataSourceConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("datasource_basic.tf", rnd, accountID)
+}

--- a/internal/services/custom_page_asset/resource_test.go
+++ b/internal/services/custom_page_asset/resource_test.go
@@ -1,0 +1,93 @@
+package custom_page_asset_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareCustomPageAsset_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_custom_page_asset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomPageAssetConfig(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("Basic test asset")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("url"), knownvalue.StringExact("https://example.com/error.html")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(rnd)),
+				},
+			},
+			{
+				Config: testAccCustomPageAssetConfig(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("Basic test asset")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("url"), knownvalue.StringExact("https://example.com/error.html")),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: acctest.LogResourceDrift,
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
+				ImportStateVerifyIgnore: []string{"last_updated"},
+			},
+		},
+	})
+}
+
+func TestAccCloudflareCustomPageAsset_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_custom_page_asset." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomPageAssetConfig(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("Basic test asset")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("url"), knownvalue.StringExact("https://example.com/error.html")),
+				},
+			},
+			{
+				Config: testAccCustomPageAssetUpdateConfig(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("Updated test asset")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("url"), knownvalue.StringExact("https://example.com/updated-error.html")),
+				},
+			},
+		},
+	})
+}
+
+func testAccCustomPageAssetConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("basic.tf", rnd, accountID)
+}
+
+func testAccCustomPageAssetUpdateConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("update.tf", rnd, accountID)
+}

--- a/internal/services/custom_page_asset/testdata/basic.tf
+++ b/internal/services/custom_page_asset/testdata/basic.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_custom_page_asset" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "%[1]s"
+  description = "Basic test asset"
+  url         = "https://example.com/error.html"
+}

--- a/internal/services/custom_page_asset/testdata/datasource_basic.tf
+++ b/internal/services/custom_page_asset/testdata/datasource_basic.tf
@@ -1,0 +1,11 @@
+resource "cloudflare_custom_page_asset" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "%[1]s"
+  description = "Data source test asset"
+  url         = "https://example.com/error.html"
+}
+
+data "cloudflare_custom_page_asset" "%[1]s" {
+  account_id = "%[2]s"
+  asset_name = cloudflare_custom_page_asset.%[1]s.name
+}

--- a/internal/services/custom_page_asset/testdata/update.tf
+++ b/internal/services/custom_page_asset/testdata/update.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_custom_page_asset" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "%[1]s"
+  description = "Updated test asset"
+  url         = "https://example.com/updated-error.html"
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [ x ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [ x ] I have added or updated acceptance tests for my changes
- [ x ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
```bash
export TF_ACC=1
export CLOUDFLARE_API_TOKEN=<your_api_token>
export CLOUDFLARE_ACCOUNT_ID=<your_account_id>

TF_ACC=1 go test -count 1 ./internal/services/custom_page_asset/... -run "^TestAccCloudflare" -v

### Test output
=== RUN TestAccCloudflareCustomPageAssetDataSource_Basic 
--- PASS: TestAccCloudflareCustomPageAssetDataSource_Basic (9.73s) 
=== RUN TestAccCloudflareCustomPageAsset_Basic 
--- PASS: TestAccCloudflareCustomPageAsset_Basic (8.20s) 
=== RUN TestAccCloudflareCustomPageAsset_Update 
--- PASS: TestAccCloudflareCustomPageAsset_Update (7.92s) PASS 
ok github.com/cloudflare/terraform-provider-cloudflare/internal/services/custom_page_asset 27.407s

## Additional context & links
Merging to SDKs/Cloudflare Config staging 
https://gitlab.cfdata.org/cloudflare/sdks/cloudflare-config/-/merge_requests/509
Merging to SDKs/Cloudflare Config main
https://gitlab.cfdata.org/cloudflare/sdks/cloudflare-config/-/merge_requests/564