### PR TITLE
fix(tokens): Handle revoked and expired tokens

### DIFF
--- a/internal/services/account_token/read_auto_roll_test.go
+++ b/internal/services/account_token/read_auto_roll_test.go
@@ -1,0 +1,227 @@
+package account_token_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_token"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func newAccountTokenResource(t *testing.T, baseURL string) *account_token.AccountTokenResource {
+	t.Helper()
+	r := account_token.NewResource().(*account_token.AccountTokenResource)
+	if baseURL == "" {
+		return r
+	}
+	client := cloudflare.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIToken("test-token"),
+	)
+	req := resource.ConfigureRequest{ProviderData: client}
+	resp := &resource.ConfigureResponse{}
+	r.Configure(context.Background(), req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("newAccountTokenResource: Configure failed: %v", resp.Diagnostics)
+	}
+	return r
+}
+
+func makeAccountTokenState(t *testing.T, ctx context.Context, id, accountID, name, status, value string) tfsdk.State {
+	t.Helper()
+
+	permGroups := []*account_token.AccountTokenPoliciesPermissionGroupsModel{
+		{ID: types.StringValue("pg-1")},
+	}
+	policies := []*account_token.AccountTokenPoliciesModel{
+		{
+			Effect:           types.StringValue("allow"),
+			PermissionGroups: &permGroups,
+			Resources:        types.StringValue(`{"com.cloudflare.api.account.abc123":"*"}`),
+		},
+	}
+	model := account_token.AccountTokenModel{
+		ID:         types.StringValue(id),
+		AccountID:  types.StringValue(accountID),
+		Name:       types.StringValue(name),
+		Policies:   &policies,
+		ExpiresOn:  timetypes.NewRFC3339Null(),
+		NotBefore:  timetypes.NewRFC3339Null(),
+		Condition:  nil,
+		Status:     types.StringValue(status),
+		IssuedOn:   timetypes.NewRFC3339Null(),
+		LastUsedOn: timetypes.NewRFC3339Null(),
+		ModifiedOn: timetypes.NewRFC3339Null(),
+		Value:      types.StringValue(value),
+	}
+
+	schema := account_token.ResourceSchema(ctx)
+	state := tfsdk.State{Schema: schema}
+	if diags := state.Set(ctx, &model); diags.HasError() {
+		t.Fatalf("makeAccountTokenState: failed to set state: %v", diags)
+	}
+	return state
+}
+
+func accountTokenGetResponse(id, name, status string) string {
+	return fmt.Sprintf(`{
+		"success": true,
+		"errors": [],
+		"messages": [],
+		"result": {
+			"id": %q,
+			"name": %q,
+			"status": %q,
+			"policies": [
+				{
+					"effect": "allow",
+					"permission_groups": [{"id": "pg-1"}],
+					"resources": {"com.cloudflare.api.account.abc123": "*"}
+				}
+			]
+		}
+	}`, id, name, status)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestRead_ActiveAccountToken_PreservesState(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, accountTokenGetResponse("tok-123", "my-account-token", "active"))
+	}))
+	defer ts.Close()
+
+	r := newAccountTokenResource(t, ts.URL)
+	state := makeAccountTokenState(t, ctx, "tok-123", "acct-abc", "my-account-token", "active", "original-secret")
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+
+	var result account_token.AccountTokenModel
+	resp.State.Get(ctx, &result)
+	if result.Value.ValueString() != "original-secret" {
+		t.Errorf("expected value %q, got %q", "original-secret", result.Value.ValueString())
+	}
+}
+
+func TestRead_ExpiredAccountToken_RemovesFromState(t *testing.T) {
+	ctx := context.Background()
+	var rollCalled atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			rollCalled.Store(true)
+			t.Error("roll endpoint should not be called — expired tokens should be removed from state")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, accountTokenGetResponse("tok-123", "my-account-token", "expired"))
+	}))
+	defer ts.Close()
+
+	r := newAccountTokenResource(t, ts.URL)
+	state := makeAccountTokenState(t, ctx, "tok-123", "acct-abc", "my-account-token", "active", "old-secret")
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+	if rollCalled.Load() {
+		t.Error("roll endpoint was called — should not mutate during Read")
+	}
+
+	hasWarning := false
+	for _, d := range resp.Diagnostics.Warnings() {
+		if d.Summary() == "Token expired or revoked" {
+			hasWarning = true
+			break
+		}
+	}
+	if !hasWarning {
+		t.Error("expected warning diagnostic about token being expired")
+	}
+}
+
+func TestRead_RevokedExposedAccountToken_RemovesFromState(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, accountTokenGetResponse("tok-456", "exposed-token", "revoked (exposed)"))
+	}))
+	defer ts.Close()
+
+	r := newAccountTokenResource(t, ts.URL)
+	state := makeAccountTokenState(t, ctx, "tok-456", "acct-abc", "exposed-token", "active", "compromised-secret")
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+
+	hasWarning := false
+	for _, d := range resp.Diagnostics.Warnings() {
+		if d.Summary() == "Token expired or revoked" {
+			hasWarning = true
+			break
+		}
+	}
+	if !hasWarning {
+		t.Error("expected warning diagnostic about token being revoked")
+	}
+}
+
+func TestRead_DisabledAccountToken_PreservesState(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, accountTokenGetResponse("tok-dis", "disabled-token", "disabled"))
+	}))
+	defer ts.Close()
+
+	r := newAccountTokenResource(t, ts.URL)
+	state := makeAccountTokenState(t, ctx, "tok-dis", "acct-abc", "disabled-token", "disabled", "my-secret")
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+
+	var result account_token.AccountTokenModel
+	resp.State.Get(ctx, &result)
+	if result.Value.ValueString() != "my-secret" {
+		t.Errorf("expected value preserved for disabled token, got %q", result.Value.ValueString())
+	}
+}

--- a/internal/services/account_token/resource.go
+++ b/internal/services/account_token/resource.go
@@ -182,6 +182,21 @@ func (r *AccountTokenResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 	data = &env.Result
+
+	// If the token is expired or revoked-exposed, treat it as if the resource
+	// no longer exists. Terraform will plan a Create to replace it with a fresh
+	// token. This avoids mutating the token during Read (which runs during plan)
+	// and ensures the user explicitly approves the recreation via apply.
+	status := data.Status.ValueString()
+	if status == "expired" || status == "revoked (exposed)" {
+		resp.Diagnostics.AddWarning(
+			"Token expired or revoked",
+			fmt.Sprintf("Token %q is in %q status and is no longer usable. It will be removed from state and recreated on the next apply.", data.Name.ValueString(), status),
+		)
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Value = tokenValue
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/services/api_token/read_auto_roll_test.go
+++ b/internal/services/api_token/read_auto_roll_test.go
@@ -1,0 +1,255 @@
+package api_token_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_token"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func newAPITokenResource(t *testing.T, baseURL string) *api_token.APITokenResource {
+	t.Helper()
+	r := api_token.NewResource().(*api_token.APITokenResource)
+	if baseURL == "" {
+		return r
+	}
+	client := cloudflare.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIToken("test-token"),
+	)
+	req := resource.ConfigureRequest{ProviderData: client}
+	resp := &resource.ConfigureResponse{}
+	r.Configure(context.Background(), req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("newAPITokenResource: Configure failed: %v", resp.Diagnostics)
+	}
+	return r
+}
+
+func makeAPITokenState(t *testing.T, ctx context.Context, id, name, status, value string) tfsdk.State {
+	t.Helper()
+
+	permGroups := []*api_token.APITokenPoliciesPermissionGroupsModel{
+		{ID: types.StringValue("pg-1")},
+	}
+	policies := []*api_token.APITokenPoliciesModel{
+		{
+			Effect:           types.StringValue("allow"),
+			PermissionGroups: &permGroups,
+			Resources:        types.StringValue(`{"com.cloudflare.api.account.abc123":"*"}`),
+		},
+	}
+	model := api_token.APITokenModel{
+		ID:         types.StringValue(id),
+		Name:       types.StringValue(name),
+		Policies:   &policies,
+		ExpiresOn:  timetypes.NewRFC3339Null(),
+		NotBefore:  timetypes.NewRFC3339Null(),
+		Condition:  nil,
+		Status:     types.StringValue(status),
+		IssuedOn:   timetypes.NewRFC3339Null(),
+		LastUsedOn: timetypes.NewRFC3339Null(),
+		ModifiedOn: timetypes.NewRFC3339Null(),
+		Value:      types.StringValue(value),
+	}
+
+	schema := api_token.ResourceSchema(ctx)
+	state := tfsdk.State{Schema: schema}
+	if diags := state.Set(ctx, &model); diags.HasError() {
+		t.Fatalf("makeAPITokenState: failed to set state: %v", diags)
+	}
+	return state
+}
+
+func tokenGetResponse(id, name, status string) string {
+	return fmt.Sprintf(`{
+		"success": true,
+		"errors": [],
+		"messages": [],
+		"result": {
+			"id": %q,
+			"name": %q,
+			"status": %q,
+			"policies": [
+				{
+					"effect": "allow",
+					"permission_groups": [{"id": "pg-1"}],
+					"resources": {"com.cloudflare.api.account.abc123": "*"}
+				}
+			]
+		}
+	}`, id, name, status)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestRead_ActiveToken_PreservesState(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, tokenGetResponse("tok-123", "my-token", "active"))
+	}))
+	defer ts.Close()
+
+	r := newAPITokenResource(t, ts.URL)
+	state := makeAPITokenState(t, ctx, "tok-123", "my-token", "active", "original-secret")
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+
+	// Verify value is preserved from state
+	var result api_token.APITokenModel
+	resp.State.Get(ctx, &result)
+	if result.Value.ValueString() != "original-secret" {
+		t.Errorf("expected value %q, got %q", "original-secret", result.Value.ValueString())
+	}
+}
+
+func TestRead_ExpiredToken_RemovesFromState(t *testing.T) {
+	ctx := context.Background()
+	var rollCalled atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			rollCalled.Store(true)
+			t.Error("roll endpoint should not be called — expired tokens should be removed from state")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, tokenGetResponse("tok-123", "my-token", "expired"))
+	}))
+	defer ts.Close()
+
+	r := newAPITokenResource(t, ts.URL)
+	state := makeAPITokenState(t, ctx, "tok-123", "my-token", "active", "old-secret")
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+	if rollCalled.Load() {
+		t.Error("roll endpoint was called — should not mutate during Read")
+	}
+
+	// Verify a warning was emitted about the token being removed
+	hasWarning := false
+	for _, d := range resp.Diagnostics.Warnings() {
+		if d.Summary() == "Token expired or revoked" {
+			hasWarning = true
+			break
+		}
+	}
+	if !hasWarning {
+		t.Error("expected warning diagnostic about token being expired")
+	}
+
+	// Verify state was removed (resource will be recreated on next apply)
+	var result api_token.APITokenModel
+	diags := resp.State.Get(ctx, &result)
+	if !diags.HasError() && result.ID.ValueString() != "" {
+		t.Error("expected state to be removed for expired token")
+	}
+}
+
+func TestRead_RevokedExposedToken_RemovesFromState(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, tokenGetResponse("tok-456", "exposed-token", "revoked (exposed)"))
+	}))
+	defer ts.Close()
+
+	r := newAPITokenResource(t, ts.URL)
+	state := makeAPITokenState(t, ctx, "tok-456", "exposed-token", "active", "compromised-secret")
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+
+	hasWarning := false
+	for _, d := range resp.Diagnostics.Warnings() {
+		if d.Summary() == "Token expired or revoked" {
+			hasWarning = true
+			break
+		}
+	}
+	if !hasWarning {
+		t.Error("expected warning diagnostic about token being revoked")
+	}
+}
+
+func TestRead_DisabledToken_PreservesState(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, tokenGetResponse("tok-dis", "disabled-token", "disabled"))
+	}))
+	defer ts.Close()
+
+	r := newAPITokenResource(t, ts.URL)
+	state := makeAPITokenState(t, ctx, "tok-dis", "disabled-token", "disabled", "my-secret")
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+
+	var result api_token.APITokenModel
+	resp.State.Get(ctx, &result)
+	if result.Value.ValueString() != "my-secret" {
+		t.Errorf("expected value preserved for disabled token, got %q", result.Value.ValueString())
+	}
+}
+
+func TestRead_404_RemovesFromState(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"success":false,"errors":[{"code":1000,"message":"not found"}]}`)
+	}))
+	defer ts.Close()
+
+	r := newAPITokenResource(t, ts.URL)
+	state := makeAPITokenState(t, ctx, "tok-gone", "gone-token", "active", "secret")
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+}

--- a/internal/services/api_token/resource.go
+++ b/internal/services/api_token/resource.go
@@ -177,6 +177,21 @@ func (r *APITokenResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 	data = &env.Result
+
+	// If the token is expired or revoked-exposed, treat it as if the resource
+	// no longer exists. Terraform will plan a Create to replace it with a fresh
+	// token. This avoids mutating the token during Read (which runs during plan)
+	// and ensures the user explicitly approves the recreation via apply.
+	status := data.Status.ValueString()
+	if status == "expired" || status == "revoked (exposed)" {
+		resp.Diagnostics.AddWarning(
+			"Token expired or revoked",
+			fmt.Sprintf("Token %q is in %q status and is no longer usable. It will be removed from state and recreated on the next apply.", data.Name.ValueString(), status),
+		)
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Value = token
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Tokens can now be in an expired or revoked state. Terraform would not gracefully handle this however. Terraform relies on the API returning 404 when it plans to determine whether or not a token needs to be created. Revoked/expired tokens now being returned would mean terraform does not recreate the token, but the token as it exists would not work because of the state it is in.

To get around this, I have made it so terraform removes the token from its internal state if the API returns a token in either status.

### No acceptance tests were added because you cannot force a token into this state, it only can get into these states through automatic processes that happen async.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
Associated my CF account and an api token with the tests and ran them

### Test output
```
=== RUN   TestAccCloudflareAPITokenData
=== PAUSE TestAccCloudflareAPITokenData
=== RUN   TestAccAPIToken_Basic
--- PASS: TestAccAPIToken_Basic (10.17s)
=== RUN   TestAccAPIToken_SetIndividualCondition
--- PASS: TestAccAPIToken_SetIndividualCondition (5.14s)
=== RUN   TestAccAPIToken_SetAllCondition
--- PASS: TestAccAPIToken_SetAllCondition (5.12s)
=== RUN   TestAccAPIToken_TokenTTL
--- PASS: TestAccAPIToken_TokenTTL (7.95s)
=== RUN   TestAccAPIToken_PermissionGroupOrder
--- PASS: TestAccAPIToken_PermissionGroupOrder (34.50s)
=== RUN   TestAccAPIToken_PolicyOrder
--- PASS: TestAccAPIToken_PolicyOrder (30.23s)
=== RUN   TestAccAPIToken_ResourcesFlexible
--- PASS: TestAccAPIToken_ResourcesFlexible (9.59s)
=== RUN   TestAccAPIToken_CRUD
--- PASS: TestAccAPIToken_CRUD (12.32s)
=== RUN   TestAccUpgradeApiToken_FromPublishedV5
--- PASS: TestAccUpgradeApiToken_FromPublishedV5 (18.69s)
=== CONT  TestAccCloudflareAPITokenData
--- PASS: TestAccCloudflareAPITokenData (2.34s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_token 137.635s
```

```
=== RUN   TestAccountTokenDataSourceModelSchemaParity
=== PAUSE TestAccountTokenDataSourceModelSchemaParity
=== RUN   TestAccountTokensDataSourceModelSchemaParity
=== PAUSE TestAccountTokensDataSourceModelSchemaParity
=== RUN   TestAccountTokenModelSchemaParity
=== PAUSE TestAccountTokenModelSchemaParity
=== RUN   TestAccAccountToken_Basic
--- PASS: TestAccAccountToken_Basic (10.89s)
=== RUN   TestAccAccountToken_SetIndividualCondition
--- PASS: TestAccAccountToken_SetIndividualCondition (5.98s)
=== RUN   TestAccAccountToken_SetAllCondition
--- PASS: TestAccAccountToken_SetAllCondition (6.23s)
=== RUN   TestAccAccountToken_TokenTTL
--- PASS: TestAccAccountToken_TokenTTL (8.08s)
=== RUN   TestAccAccountToken_PermissionGroupOrder
--- PASS: TestAccAccountToken_PermissionGroupOrder (30.38s)
=== RUN   TestAccAccountToken_PolicyOrder
--- PASS: TestAccAccountToken_PolicyOrder (30.89s)
=== RUN   TestAccAccountToken_ResourcesFlexible
--- PASS: TestAccAccountToken_ResourcesFlexible (9.87s)
=== RUN   TestAccAccountToken_CRUD
--- PASS: TestAccAccountToken_CRUD (9.15s)
=== RUN   TestAccUpgradeAccountToken_FromPublishedV5
--- PASS: TestAccUpgradeAccountToken_FromPublishedV5 (15.78s)
=== CONT  TestAccountTokenDataSourceModelSchemaParity
=== CONT  TestAccountTokenModelSchemaParity
=== CONT  TestAccountTokensDataSourceModelSchemaParity
--- PASS: TestAccountTokenDataSourceModelSchemaParity (0.00s)
--- PASS: TestAccountTokenModelSchemaParity (0.00s)
--- PASS: TestAccountTokensDataSourceModelSchemaParity (0.00s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_token     128.826s
```

## Additional context & links
