### PR TITLE
fix(account_member): add UseStateForUnknown to status field to prevent drift

### DIFF
--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Download tf-migrate
         run: |
-          gh release download v1.0.0-beta.10 --repo cloudflare/tf-migrate --pattern 'tf-migrate_*_linux_amd64.tar.gz' --output tf-migrate.tar.gz
+          gh release download v1.0.0-beta.11 --repo cloudflare/tf-migrate --pattern 'tf-migrate_*_linux_amd64.tar.gz' --output tf-migrate.tar.gz
           tar -xzf tf-migrate.tar.gz tf-migrate
           chmod +x tf-migrate
         env:

--- a/internal/services/account_member/resource_test.go
+++ b/internal/services/account_member/resource_test.go
@@ -151,6 +151,64 @@ func TestAccCloudflareAccountMember_Basic(t *testing.T) {
 	})
 }
 
+// TestAccCloudflareAccountMember_StatusNoDrift verifies that when status is not
+// explicitly configured, the computed status value from the API does not cause
+// drift on subsequent plans. This validates the UseStateForUnknown plan modifier
+// on the status field.
+func TestAccCloudflareAccountMember_StatusNoDrift(t *testing.T) {
+	// Temporarily unset CLOUDFLARE_API_TOKEN as the API token won't have
+	// permission to manage account members.
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	email := fmt.Sprintf("%s@example.com", rnd)
+	resourceName := "cloudflare_account_member.test_member"
+
+	adminRoleID := getRoleId(t, accountID, "Administrator")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create member with roles but WITHOUT status in config
+				Config: testCloudflareAccountMemberRolesNoStatusConfig(email, accountID, adminRoleID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.StringExact("pending")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles").AtSliceIndex(0), knownvalue.StringExact(adminRoleID)),
+				},
+			},
+			{
+				// Step 2: Re-apply same config — should be a Noop (no drift from computed status)
+				Config: testCloudflareAccountMemberRolesNoStatusConfig(email, accountID, adminRoleID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.StringExact("pending")),
+				},
+			},
+		},
+	})
+}
+
+func testCloudflareAccountMemberRolesNoStatusConfig(emailAddress, accountID, roleID string) string {
+	return acctest.LoadTestCase("cloudflareaccountmemberrolesnostatus.tf", emailAddress, accountID, roleID)
+}
+
 func TestAccCloudflareAccountMember_Import(t *testing.T) {
 	// Temporarily unset CLOUDFLARE_API_TOKEN as the API token won't have
 	// permission to manage account members.

--- a/internal/services/account_member/schema.go
+++ b/internal/services/account_member/schema.go
@@ -46,7 +46,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive("accepted", "pending"),
 				},
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIfConfigured()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown(), stringplanmodifier.RequiresReplaceIfConfigured()},
 			},
 			"roles": schema.SetAttribute{
 				Description: "Set of roles associated with this member.",

--- a/internal/services/account_member/testdata/cloudflareaccountmemberrolesnostatus.tf
+++ b/internal/services/account_member/testdata/cloudflareaccountmemberrolesnostatus.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_account_member" "test_member" {
+  account_id = "%[2]s"
+  email      = "%[1]s"
+  roles      = ["%[3]s"]
+}


### PR DESCRIPTION
The status field was Computed+Optional but missing UseStateForUnknown(), causing every plan to show drift (status = "accepted" -> known after apply) when users didn't explicitly set status in their config. This forced users to add status = "accepted" which then caused API errors when creating new members not yet in the account.

```
TF_ACC=1 go test -v -run TestAccCloudflareAccountMember_StatusNoDrift ./internal/services/account_member/
=== RUN   TestAccCloudflareAccountMember_StatusNoDrift
--- PASS: TestAccCloudflareAccountMember_StatusNoDrift (6.74s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_member	8.870s
```
