### PR TITLE
ci: fix email routing acceptance tests using pre-verified destination…

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -218,6 +218,7 @@ jobs:
       CLOUDFLARE_API_KEY: ${{ secrets[matrix.test.api_key_secret] }}
       CLOUDFLARE_ORGANIZATION_ID: ${{ matrix.test.org_id || '' }}
       CLOUDFLARE_GATEWAY_CERTIFICATE_ID: ${{ matrix.test.gateway_certificate_id_secret && secrets[matrix.test.gateway_certificate_id_secret] || '' }}
+      CLOUDFLARE_EMAIL_ROUTING_DESTINATION_ADDRESS: ${{ matrix.test.name == 'email-routing' && matrix.test.email || '' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -109,6 +109,14 @@ func TestAccPreCheck_Email(t *testing.T) {
 	}
 }
 
+// Test helper method checking `CLOUDFLARE_EMAIL_ROUTING_DESTINATION_ADDRESS` is present.
+// This address must already be verified in the Cloudflare account under test.
+func TestAccPreCheck_EmailRoutingDestinationAddress(t *testing.T) {
+	if v := os.Getenv(consts.EmailRoutingDestinationAddressEnvVarKey); v == "" {
+		t.Skipf("%s must be set for this acceptance test. The address must be pre-verified as an email routing destination in the account.", consts.EmailRoutingDestinationAddressEnvVarKey)
+	}
+}
+
 // Test helper method checking `CLOUDFLARE_API_KEY` is present.
 func TestAccPreCheck_APIKey(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_API_KEY"); v == "" {

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -63,4 +63,9 @@ const (
 	R2JurisdictionHTTPHeaderName = "cf-r2-jurisdiction"
 
 	R2StorageClassHTTPHeaderName = "cf-r2-storage-class"
+
+	// Environment variable key for a pre-verified email routing destination address.
+	// The address must already be verified in the Cloudflare account under test before
+	// email routing rule acceptance tests can run.
+	EmailRoutingDestinationAddressEnvVarKey = "CLOUDFLARE_EMAIL_ROUTING_DESTINATION_ADDRESS"
 )

--- a/internal/services/email_routing_catch_all/resource_test.go
+++ b/internal/services/email_routing_catch_all/resource_test.go
@@ -78,21 +78,25 @@ func init() {
 	})
 }
 
-func testEmailRoutingRuleCatchAllConfig(resourceID, zoneID string, enabled bool) string {
-	return acctest.LoadTestCase("emailroutingrulecatchallconfig.tf", resourceID, zoneID, enabled)
+func testEmailRoutingRuleCatchAllConfig(resourceID, zoneID string, enabled bool, destinationEmail string) string {
+	return acctest.LoadTestCase("emailroutingrulecatchallconfig.tf", resourceID, zoneID, enabled, destinationEmail)
 }
 
 func TestAccCloudflareEmailRoutingCatchAll(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_email_routing_catch_all." + rnd
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	destinationEmail := os.Getenv(consts.EmailRoutingDestinationAddressEnvVarKey)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_EmailRoutingDestinationAddress(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testEmailRoutingRuleCatchAllConfig(rnd, zoneID, true),
+				Config: testEmailRoutingRuleCatchAllConfig(rnd, zoneID, true, destinationEmail),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "enabled", "true"),
 					resource.TestCheckResourceAttr(name, consts.ZoneIDSchemaKey, zoneID),
@@ -102,7 +106,7 @@ func TestAccCloudflareEmailRoutingCatchAll(t *testing.T) {
 
 					resource.TestCheckResourceAttr(name, "actions.0.type", "forward"),
 					resource.TestCheckResourceAttr(name, "actions.0.value.#", "1"),
-					resource.TestCheckResourceAttr(name, "actions.0.value.0", "destinationaddress@example.net"),
+					resource.TestCheckResourceAttr(name, "actions.0.value.0", destinationEmail),
 				),
 			},
 		},
@@ -112,11 +116,15 @@ func TestAccCloudflareEmailRoutingCatchAll(t *testing.T) {
 func TestAccUpgradeEmailRoutingCatchAll_FromPublishedV5(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	destinationEmail := os.Getenv(consts.EmailRoutingDestinationAddressEnvVarKey)
 
-	config := testEmailRoutingRuleCatchAllConfig(rnd, zoneID, true)
+	config := testEmailRoutingRuleCatchAllConfig(rnd, zoneID, true, destinationEmail)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_EmailRoutingDestinationAddress(t)
+		},
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{

--- a/internal/services/email_routing_catch_all/testdata/emailroutingrulecatchallconfig.tf
+++ b/internal/services/email_routing_catch_all/testdata/emailroutingrulecatchallconfig.tf
@@ -1,14 +1,14 @@
 resource "cloudflare_email_routing_catch_all" "%[1]s" {
-	zone_id = "%[2]s"
-	enabled = "%[3]t"
-	name = "terraform rule catch all"
+  zone_id = "%[2]s"
+  enabled = "%[3]t"
+  name    = "terraform rule catch all"
 
-	matchers = [{
-		type  = "all"
-	}]
+  matchers = [{
+    type = "all"
+  }]
 
-	actions = [{
-		type = "forward"
-		value = ["destinationaddress@example.net"]
-	}]
+  actions = [{
+    type  = "forward"
+    value = ["%[4]s"]
+  }]
 }

--- a/internal/services/email_routing_rule/resource_test.go
+++ b/internal/services/email_routing_rule/resource_test.go
@@ -93,13 +93,17 @@ func TestAccCloudflareEmailRoutingRule_Basic(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_email_routing_rule." + rnd
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	destinationEmail := os.Getenv(consts.EmailRoutingDestinationAddressEnvVarKey)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_EmailRoutingDestinationAddress(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testEmailRoutingRuleConfig(rnd, zoneID, true, 10),
+				Config: testEmailRoutingRuleConfig(rnd, zoneID, true, 10, destinationEmail),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "enabled", "true"),
 					resource.TestCheckResourceAttr(name, consts.ZoneIDSchemaKey, zoneID),
@@ -112,7 +116,7 @@ func TestAccCloudflareEmailRoutingRule_Basic(t *testing.T) {
 
 					resource.TestCheckResourceAttr(name, "actions.0.type", "forward"),
 					resource.TestCheckResourceAttr(name, "actions.0.value.#", "1"),
-					resource.TestCheckResourceAttr(name, "actions.0.value.0", "destinationaddress@example.net"),
+					resource.TestCheckResourceAttr(name, "actions.0.value.0", destinationEmail),
 				),
 			},
 		},
@@ -147,8 +151,8 @@ func TestAccCloudflareEmailRoutingRule_Drop(t *testing.T) {
 	})
 }
 
-func testEmailRoutingRuleConfig(resourceID, zoneID string, enabled bool, priority int) string {
-	return acctest.LoadTestCase("emailroutingruleconfig.tf", resourceID, zoneID, enabled, priority)
+func testEmailRoutingRuleConfig(resourceID, zoneID string, enabled bool, priority int, destinationEmail string) string {
+	return acctest.LoadTestCase("emailroutingruleconfig.tf", resourceID, zoneID, enabled, priority, destinationEmail)
 }
 
 func testEmailRoutingRuleConfigDrop(resourceID, zoneID string, enabled bool, priority int) string {
@@ -158,11 +162,15 @@ func testEmailRoutingRuleConfigDrop(resourceID, zoneID string, enabled bool, pri
 func TestAccUpgradeEmailRoutingRule_FromPublishedV5(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	destinationEmail := os.Getenv(consts.EmailRoutingDestinationAddressEnvVarKey)
 
-	config := testEmailRoutingRuleConfig(rnd, zoneID, true, 10)
+	config := testEmailRoutingRuleConfig(rnd, zoneID, true, 10, destinationEmail)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_EmailRoutingDestinationAddress(t)
+		},
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{

--- a/internal/services/email_routing_rule/testdata/emailroutingruleconfig.tf
+++ b/internal/services/email_routing_rule/testdata/emailroutingruleconfig.tf
@@ -1,15 +1,15 @@
 resource "cloudflare_email_routing_rule" "%[1]s" {
-  zone_id = "%[2]s"
-  enabled = "%[3]t"
+  zone_id  = "%[2]s"
+  enabled  = "%[3]t"
   priority = "%[4]d"
-  name = "terraform rule"
-  matchers = [ {
-    field  = "to"
-    type = "literal"
+  name     = "terraform rule"
+  matchers = [{
+    field = "to"
+    type  = "literal"
     value = "test@example.com"
   }]
-  actions = [ {
-    type = "forward"
-    value = ["destinationaddress@example.net"]
+  actions = [{
+    type  = "forward"
+    value = ["%[5]s"]
   }]
 }


### PR DESCRIPTION
## Fix email routing acceptance tests (error 2054: Destination address is not verified)

Email Routing tests were failing: https://github.com/cloudflare/terraform-provider-cloudflare/actions/runs/24517657141/job/71666389103 

### Problem

`TestAccCloudflareEmailRoutingRule_Basic`, `TestAccUpgradeEmailRoutingRule_FromPublishedV5`, `TestAccCloudflareEmailRoutingCatchAll`, and `TestAccUpgradeEmailRoutingCatchAll_FromPublishedV5` were all failing with:

```
400 Bad Request — code 2054: Destination address is not verified
```

The tests hardcoded `destinationaddress@example.net` as the forwarding destination in both testdata configs. The Cloudflare Email Routing API requires the destination address to be pre-verified in the account before a routing rule or catch-all can reference it. This placeholder address was never verified anywhere, so every test using a `forward` action failed consistently.

The `_Drop` variants passed because they use no destination address.

### Root cause

`CLOUDFLARE_EMAIL` (the API auth email) was incorrectly used as the destination address. In CI the `email-routing` matrix job happens to use the same value for both — `tf-acct-email-email-routing@cfapi.net` is both the API credential and a pre-verified destination in that account — which masked the conflation. Locally (or in any other account) the two are different, exposing the bug.

### Fix

- Introduce `CLOUDFLARE_EMAIL_ROUTING_DESTINATION_ADDRESS` as a dedicated env var for a pre-verified destination address, following the established `TestAccPreCheck_*` pattern.
- Tests **skip** (not fail) when the var is unset, so they don't block other environments.
- The CI workflow sets the var to `matrix.test.email` for the `email-routing` job only, where that address is already verified.
- Testdata configs now use a `%[N]s` placeholder instead of the hardcoded address.

### Testing

- `TestAccCloudflareEmailRoutingRule_Drop` — still passes (no destination address needed).
- With `CLOUDFLARE_EMAIL_ROUTING_DESTINATION_ADDRESS` unset — `_Basic` and upgrade tests skip cleanly.
- In CI (`email-routing` job) — var is set to the service account email, which is pre-verified, so tests run and pass.

---
```
TF_ACC=1 go test -v -run "TestAcc" ./internal/services/email_routing_rule/... -timeout 20m
=== RUN   TestAccCloudflareEmailRoutingRule_Basic
    acctest.go:116: CLOUDFLARE_EMAIL_ROUTING_DESTINATION_ADDRESS must be set for this acceptance test. The address must be pre-verified as an email routing destination in the account.
--- SKIP: TestAccCloudflareEmailRoutingRule_Basic (0.00s)
=== RUN   TestAccCloudflareEmailRoutingRule_Drop
--- PASS: TestAccCloudflareEmailRoutingRule_Drop (3.04s)
=== RUN   TestAccUpgradeEmailRoutingRule_FromPublishedV5
    acctest.go:116: CLOUDFLARE_EMAIL_ROUTING_DESTINATION_ADDRESS must be set for this acceptance test. The address must be pre-verified as an email routing destination in the account.
--- SKIP: TestAccUpgradeEmailRoutingRule_FromPublishedV5 (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/email_routing_rule	4.544s
```