### PR TITLE
 Fix migration test failures for rulesets, rules-and-policies, and managed-transforms

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1290,11 +1290,10 @@ func MigrationV2TestStep(t *testing.T, v4Config string, tmpDir string, exactVers
 // subdirectories inside tmpDir (created by the terraform-plugin-testing framework).
 // This is the test equivalent of the e2e runner's removeObsoleteStateEntries step.
 //
-// Implementation note: we read the state JSON directly to discover addresses (bypassing
-// "terraform state list", which requires provider schema and fails after tf-migrate
-// rewrites the config to v5 syntax with a stale .terraform directory). We then call
-// "terraform state rm -state=<path> <addr>" for each match, which does not need
-// provider schema — it only manipulates the state file by address.
+// Implementation note: we read the state JSON directly, filter out obsolete resource
+// entries, and write the modified state back. This avoids a dependency on the
+// "terraform" binary (which is not available in all CI environments). The serial is
+// incremented so Terraform accepts the modified state file.
 func RunStateRmForObsoleteTypes(t *testing.T, tmpDir string, obsoleteTypes []string) {
 	t.Helper()
 
@@ -1313,16 +1312,9 @@ func RunStateRmForObsoleteTypes(t *testing.T, tmpDir string, obsoleteTypes []str
 		return
 	}
 
-	// Parse just enough of the state to enumerate resource addresses.
-	var state struct {
-		Resources []struct {
-			Module string `json:"module,omitempty"`
-			Mode   string `json:"mode"`
-			Type   string `json:"type"`
-			Name   string `json:"name"`
-		} `json:"resources"`
-	}
-	if err := json.Unmarshal(data, &state); err != nil {
+	// Parse the full state so we can filter and rewrite it.
+	var rawState map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawState); err != nil {
 		debugLogf(t, "RunStateRmForObsoleteTypes: cannot parse state file: %v", err)
 		return
 	}
@@ -1333,42 +1325,70 @@ func RunStateRmForObsoleteTypes(t *testing.T, tmpDir string, obsoleteTypes []str
 		obsoleteSet[typ] = true
 	}
 
-	// Collect addresses of resources whose type is obsolete.
-	var addrs []string
-	for _, r := range state.Resources {
-		if !obsoleteSet[r.Type] {
+	// Decode just the resources array to filter it.
+	var resources []json.RawMessage
+	if err := json.Unmarshal(rawState["resources"], &resources); err != nil {
+		debugLogf(t, "RunStateRmForObsoleteTypes: cannot parse resources array: %v", err)
+		return
+	}
+
+	var kept []json.RawMessage
+	var removedAddrs []string
+	for _, res := range resources {
+		var r struct {
+			Module string `json:"module,omitempty"`
+			Mode   string `json:"mode"`
+			Type   string `json:"type"`
+			Name   string `json:"name"`
+		}
+		if err := json.Unmarshal(res, &r); err != nil {
+			kept = append(kept, res)
 			continue
 		}
-		addr := r.Type + "." + r.Name
-		if r.Module != "" {
-			addr = r.Module + "." + addr
+		if obsoleteSet[r.Type] {
+			addr := r.Type + "." + r.Name
+			if r.Module != "" {
+				addr = r.Module + "." + addr
+			}
+			removedAddrs = append(removedAddrs, addr)
+		} else {
+			kept = append(kept, res)
 		}
-		addrs = append(addrs, addr)
 	}
-	if len(addrs) == 0 {
+
+	if len(removedAddrs) == 0 {
 		debugLogf(t, "RunStateRmForObsoleteTypes: no obsolete entries found in state")
 		return
 	}
 
-	// Find the terraform binary.
-	tfBin, err := exec.LookPath("terraform")
+	// Rebuild the resources JSON array with only the kept entries.
+	keptJSON, err := json.Marshal(kept)
 	if err != nil {
-		t.Errorf("RunStateRmForObsoleteTypes: terraform binary not found: %v", err)
+		t.Errorf("RunStateRmForObsoleteTypes: failed to marshal kept resources: %v", err)
+		return
+	}
+	rawState["resources"] = keptJSON
+
+	// Increment the serial so Terraform accepts the modified state.
+	var serial int64
+	if err := json.Unmarshal(rawState["serial"], &serial); err == nil {
+		serialJSON, _ := json.Marshal(serial + 1)
+		rawState["serial"] = serialJSON
+	}
+
+	// Write the modified state back to disk.
+	out, err := json.MarshalIndent(rawState, "", "  ")
+	if err != nil {
+		t.Errorf("RunStateRmForObsoleteTypes: failed to marshal modified state: %v", err)
+		return
+	}
+	if err := os.WriteFile(stateFile, out, 0600); err != nil {
+		t.Errorf("RunStateRmForObsoleteTypes: failed to write state file: %v", err)
 		return
 	}
 
-	// Run "terraform state rm -state=<path> <addr>" for each obsolete address.
-	// The -state flag means Terraform reads/writes the file directly without
-	// needing to initialise providers, so this works even with a stale .terraform dir.
-	for _, addr := range addrs {
-		args := []string{"state", "rm", "-state=" + stateFile, addr}
-		cmd := exec.Command(tfBin, args...)
-		cmd.Dir = workDir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Errorf("RunStateRmForObsoleteTypes: failed to remove %s: %v\n%s", addr, err, out)
-		} else {
-			debugLogf(t, "RunStateRmForObsoleteTypes: removed obsolete state entry %s", addr)
-		}
+	for _, addr := range removedAddrs {
+		debugLogf(t, "RunStateRmForObsoleteTypes: removed obsolete state entry %s", addr)
 	}
 }
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -15,6 +15,7 @@ import (
 	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/cloudflare-go/v6/rulesets"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/config"
@@ -71,6 +72,42 @@ func TestAccPreCheck_Credentials(t *testing.T) {
 func TestAccPreCheck_ZoneID(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_ZONE_ID"); v == "" {
 		t.Fatal("CLOUDFLARE_ZONE_ID must be set for this acceptance test.")
+	}
+}
+
+// TestAccPreCheck_CleanZoneRulesets deletes all non-managed rulesets from the test zone.
+// Call this from PreCheck in migration tests for resources that use per-phase singleton
+// rulesets (e.g., http_request_firewall_custom) to ensure a clean starting state across
+// retries — the sweeper only runs once before the first attempt.
+func TestAccPreCheck_CleanZoneRulesets(t *testing.T) {
+	t.Helper()
+
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	if zoneID == "" {
+		return
+	}
+
+	ctx := context.Background()
+	client := SharedClient()
+
+	iter := client.Rulesets.ListAutoPaging(ctx, rulesets.RulesetListParams{
+		ZoneID: cloudflare.F(zoneID),
+	})
+	for iter.Next() {
+		rs := iter.Current()
+		// Only delete zone-kind and custom rulesets; skip managed.
+		if rs.Kind == rulesets.KindManaged {
+			continue
+		}
+		if err := client.Rulesets.Delete(ctx, rs.ID, rulesets.RulesetDeleteParams{
+			ZoneID: cloudflare.F(zoneID),
+		}); err != nil {
+			// Log but don't fail — a 404 means it's already gone.
+			t.Logf("TestAccPreCheck_CleanZoneRulesets: failed to delete ruleset %s: %v", rs.ID, err)
+		}
+	}
+	if err := iter.Err(); err != nil {
+		t.Logf("TestAccPreCheck_CleanZoneRulesets: failed to list rulesets: %v", err)
 	}
 }
 
@@ -1190,6 +1227,56 @@ func MigrationV2TestStepWithPlan(t *testing.T, v4Config string, tmpDir string, e
 				DebugNonEmptyPlan,
 				ExpectEmptyPlanExceptFalseyToNull, // Should be clean after processing
 			},
+		},
+		ConfigStateChecks: stateChecks,
+	}
+
+	return []resource.TestStep{migrationStep, planStep, validationStep}
+}
+
+// MigrationV2TestStepForManagedTransforms creates multiple test steps for cloudflare_managed_headers
+// migration to cloudflare_managed_transforms. After tf-migrate runs, removes
+// cloudflare_managed_headers state entries before terraform plan — the v5 provider has no schema
+// for this type and the state upgrade path requires the moved block to have been applied first.
+func MigrationV2TestStepForManagedTransforms(t *testing.T, v4Config string, tmpDir string, exactVersion string, sourceVersion string, targetVersion string, stateChecks []statecheck.StateCheck) []resource.TestStep {
+	// Step 1: Run migration and remove the obsolete cloudflare_managed_headers state entry
+	migrationStep := resource.TestStep{
+		PreConfig: func() {
+			WriteOutConfig(t, v4Config, tmpDir)
+			debugLogf(t, "Running migration command for managed_transforms: %s (%s -> %s)", exactVersion, sourceVersion, targetVersion)
+			RunMigrationV2Command(t, v4Config, tmpDir, sourceVersion, targetVersion)
+			RunStateRmForObsoleteTypes(t, tmpDir, []string{"cloudflare_managed_headers"})
+		},
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		ConfigDirectory:          config.StaticDirectory(tmpDir),
+	}
+
+	// Step 2: Run plan-only to process import blocks and normalize state
+	planStep := resource.TestStep{
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		ConfigDirectory:          config.StaticDirectory(tmpDir),
+		PlanOnly:                 true,
+	}
+
+	// Step 3: Verify final plan is clean and state is correct
+	var planChecks []plancheck.PlanCheck
+	if sourceVersion == "v4" {
+		planChecks = []plancheck.PlanCheck{
+			DebugNonEmptyPlan,
+			ExpectEmptyPlanExceptFalseyToNull,
+		}
+	} else {
+		planChecks = []plancheck.PlanCheck{
+			DebugNonEmptyPlan,
+			plancheck.ExpectEmptyPlan(),
+		}
+	}
+
+	validationStep := resource.TestStep{
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		ConfigDirectory:          config.StaticDirectory(tmpDir),
+		ConfigPlanChecks: resource.ConfigPlanChecks{
+			PreApply: planChecks,
 		},
 		ConfigStateChecks: stateChecks,
 	}

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1235,53 +1235,12 @@ func MigrationV2TestStepWithPlan(t *testing.T, v4Config string, tmpDir string, e
 }
 
 // MigrationV2TestStepForManagedTransforms creates multiple test steps for cloudflare_managed_headers
-// migration to cloudflare_managed_transforms. After tf-migrate runs, removes
-// cloudflare_managed_headers state entries before terraform plan — the v5 provider has no schema
-// for this type and the state upgrade path requires the moved block to have been applied first.
+// migration to cloudflare_managed_transforms. tf-migrate produces a moved block that triggers the
+// v5 provider's MoveState handler on apply, converting the cloudflare_managed_headers state entry
+// to cloudflare_managed_transforms. This is identical to MigrationV2TestStepWithPlan — the helper
+// exists as a named alias so tests can signal their intent clearly.
 func MigrationV2TestStepForManagedTransforms(t *testing.T, v4Config string, tmpDir string, exactVersion string, sourceVersion string, targetVersion string, stateChecks []statecheck.StateCheck) []resource.TestStep {
-	// Step 1: Run migration and remove the obsolete cloudflare_managed_headers state entry
-	migrationStep := resource.TestStep{
-		PreConfig: func() {
-			WriteOutConfig(t, v4Config, tmpDir)
-			debugLogf(t, "Running migration command for managed_transforms: %s (%s -> %s)", exactVersion, sourceVersion, targetVersion)
-			RunMigrationV2Command(t, v4Config, tmpDir, sourceVersion, targetVersion)
-			RunStateRmForObsoleteTypes(t, tmpDir, []string{"cloudflare_managed_headers"})
-		},
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		ConfigDirectory:          config.StaticDirectory(tmpDir),
-	}
-
-	// Step 2: Run plan-only to process import blocks and normalize state
-	planStep := resource.TestStep{
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		ConfigDirectory:          config.StaticDirectory(tmpDir),
-		PlanOnly:                 true,
-	}
-
-	// Step 3: Verify final plan is clean and state is correct
-	var planChecks []plancheck.PlanCheck
-	if sourceVersion == "v4" {
-		planChecks = []plancheck.PlanCheck{
-			DebugNonEmptyPlan,
-			ExpectEmptyPlanExceptFalseyToNull,
-		}
-	} else {
-		planChecks = []plancheck.PlanCheck{
-			DebugNonEmptyPlan,
-			plancheck.ExpectEmptyPlan(),
-		}
-	}
-
-	validationStep := resource.TestStep{
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		ConfigDirectory:          config.StaticDirectory(tmpDir),
-		ConfigPlanChecks: resource.ConfigPlanChecks{
-			PreApply: planChecks,
-		},
-		ConfigStateChecks: stateChecks,
-	}
-
-	return []resource.TestStep{migrationStep, planStep, validationStep}
+	return MigrationV2TestStepWithPlan(t, v4Config, tmpDir, exactVersion, sourceVersion, targetVersion, stateChecks)
 }
 
 // InferMigrationVersions determines source and target versions from test provider version.

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -14,6 +14,7 @@ import (
 
 	cfv1 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/managed_transforms"
 	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/cloudflare-go/v6/rulesets"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -108,6 +109,55 @@ func TestAccPreCheck_CleanZoneRulesets(t *testing.T) {
 	}
 	if err := iter.Err(); err != nil {
 		t.Logf("TestAccPreCheck_CleanZoneRulesets: failed to list rulesets: %v", err)
+	}
+}
+
+// TestAccPreCheck_CleanZoneManagedTransforms disables all managed header transforms on the test
+// zone. Because cloudflare_managed_transforms is a singleton per zone, tests that run in sequence
+// can see stale enabled/disabled state from previous tests. Call this from PreCheck in migration
+// tests for managed_transforms to ensure a clean starting state.
+func TestAccPreCheck_CleanZoneManagedTransforms(t *testing.T) {
+	t.Helper()
+
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	if zoneID == "" {
+		return
+	}
+
+	ctx := context.Background()
+	client := SharedClient()
+
+	res, err := client.ManagedTransforms.List(ctx, managed_transforms.ManagedTransformListParams{
+		ZoneID: cloudflare.F(zoneID),
+	})
+	if err != nil {
+		t.Logf("TestAccPreCheck_CleanZoneManagedTransforms: failed to list managed transforms: %v", err)
+		return
+	}
+
+	// Build lists with all headers disabled.
+	reqHeaders := make([]managed_transforms.ManagedTransformEditParamsManagedRequestHeader, 0, len(res.ManagedRequestHeaders))
+	for _, h := range res.ManagedRequestHeaders {
+		reqHeaders = append(reqHeaders, managed_transforms.ManagedTransformEditParamsManagedRequestHeader{
+			ID:      cloudflare.F(h.ID),
+			Enabled: cloudflare.F(false),
+		})
+	}
+	respHeaders := make([]managed_transforms.ManagedTransformEditParamsManagedResponseHeader, 0, len(res.ManagedResponseHeaders))
+	for _, h := range res.ManagedResponseHeaders {
+		respHeaders = append(respHeaders, managed_transforms.ManagedTransformEditParamsManagedResponseHeader{
+			ID:      cloudflare.F(h.ID),
+			Enabled: cloudflare.F(false),
+		})
+	}
+
+	_, err = client.ManagedTransforms.Edit(ctx, managed_transforms.ManagedTransformEditParams{
+		ZoneID:                 cloudflare.F(zoneID),
+		ManagedRequestHeaders:  cloudflare.F(reqHeaders),
+		ManagedResponseHeaders: cloudflare.F(respHeaders),
+	})
+	if err != nil {
+		t.Logf("TestAccPreCheck_CleanZoneManagedTransforms: failed to disable managed transforms: %v", err)
 	}
 }
 

--- a/internal/services/managed_transforms/migration/v500/handler.go
+++ b/internal/services/managed_transforms/migration/v500/handler.go
@@ -7,30 +7,46 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// UpgradeFromV0 handles state upgrades from v4 provider (schema_version=0) to v5 (version=500).
+// UpgradeFromV0 handles state upgrades from schema_version=0 to v5 (version=500).
 //
-// The v4 resource cloudflare_managed_headers used schema_version=0.
-// This is triggered when users manually run:
+// There are two sources of schema_version=0 state:
 //
-//	terraform state mv cloudflare_managed_headers.x cloudflare_managed_transforms.x
+//  1. State from v4 cloudflare_managed_headers moved via `terraform state mv`.
+//     This state has the v4 schema (optional set nested blocks).
 //
-// which preserves the source schema_version=0.
+//  2. State from early v5 cloudflare_managed_transforms (versions 5.0.0–5.x.y before
+//     the version was bumped to 500). These already have the correct v5 structure.
+//
+// We distinguish the two by attempting to unmarshal as the v5 target first. If that
+// succeeds, the state is already correct — just bump the version. If it fails, fall back
+// to the v4 source schema and run the full transformation.
 func UpgradeFromV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	tflog.Info(ctx, "Upgrading managed_transforms state from v4 managed_headers (schema_version=0)")
+	tflog.Info(ctx, "Upgrading managed_transforms state from schema_version=0")
 
+	// Try to unmarshal as the v5 target (early v5 state that already has the right structure).
+	var v5State TargetManagedTransformsModel
+	v5Diags := req.State.Get(ctx, &v5State)
+	if !v5Diags.HasError() && !v5State.ZoneID.IsNull() && !v5State.ZoneID.IsUnknown() {
+		tflog.Info(ctx, "Upgrading managed_transforms state: detected early-v5 structure, bumping version (no-op)")
+		resp.Diagnostics.Append(resp.State.Set(ctx, &v5State)...)
+		return
+	}
+
+	// Fall back: unmarshal as v4 managed_headers source and transform.
+	tflog.Info(ctx, "Upgrading managed_transforms state: detected v4 managed_headers structure, transforming")
 	var v4State SourceManagedHeadersModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &v4State)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	v5State, diags := Transform(ctx, v4State)
+	newV5State, diags := Transform(ctx, v4State)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, v5State)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, newV5State)...)
 	tflog.Info(ctx, "State upgrade from v4 managed_headers completed successfully")
 }
 

--- a/internal/services/managed_transforms/migration/v500/migrations_test.go
+++ b/internal/services/managed_transforms/migration/v500/migrations_test.go
@@ -79,6 +79,7 @@ func TestMigrateManagedHeaders_Basic(t *testing.T) {
 				PreCheck: func() {
 					acctest.TestAccPreCheck(t)
 					acctest.TestAccPreCheck_ZoneID(t)
+					acctest.TestAccPreCheck_CleanZoneManagedTransforms(t)
 				},
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{
@@ -152,6 +153,7 @@ func TestMigrateManagedHeaders_RequestOnly(t *testing.T) {
 				PreCheck: func() {
 					acctest.TestAccPreCheck(t)
 					acctest.TestAccPreCheck_ZoneID(t)
+					acctest.TestAccPreCheck_CleanZoneManagedTransforms(t)
 				},
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{
@@ -216,6 +218,7 @@ func TestMigrateManagedHeaders_ResponseOnly(t *testing.T) {
 				PreCheck: func() {
 					acctest.TestAccPreCheck(t)
 					acctest.TestAccPreCheck_ZoneID(t)
+					acctest.TestAccPreCheck_CleanZoneManagedTransforms(t)
 				},
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{
@@ -280,6 +283,7 @@ func TestMigrateManagedHeaders_Empty(t *testing.T) {
 				PreCheck: func() {
 					acctest.TestAccPreCheck(t)
 					acctest.TestAccPreCheck_ZoneID(t)
+					acctest.TestAccPreCheck_CleanZoneManagedTransforms(t)
 				},
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{
@@ -346,6 +350,7 @@ func TestMigrateManagedHeaders_MultiVersion(t *testing.T) {
 				PreCheck: func() {
 					acctest.TestAccPreCheck(t)
 					acctest.TestAccPreCheck_ZoneID(t)
+					acctest.TestAccPreCheck_CleanZoneManagedTransforms(t)
 				},
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{
@@ -510,6 +515,7 @@ func TestMigrateManagedHeaders_EdgeCases(t *testing.T) {
 				PreCheck: func() {
 					acctest.TestAccPreCheck(t)
 					acctest.TestAccPreCheck_ZoneID(t)
+					acctest.TestAccPreCheck_CleanZoneManagedTransforms(t)
 				},
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{

--- a/internal/services/managed_transforms/migration/v500/migrations_test.go
+++ b/internal/services/managed_transforms/migration/v500/migrations_test.go
@@ -75,43 +75,45 @@ func TestMigrateManagedHeaders_Basic(t *testing.T) {
 			testConfig := tc.configFn(rnd, zoneID)
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
-			resource.Test(t, resource.TestCase{
-				PreCheck: func() {
-					acctest.TestAccPreCheck(t)
-					acctest.TestAccPreCheck_ZoneID(t)
-				},
-				WorkingDir: tmpDir,
-				Steps: append([]resource.TestStep{
-					{
-						ExternalProviders: map[string]resource.ExternalProvider{
-							"cloudflare": {
-								Source:            "cloudflare/cloudflare",
-								VersionConstraint: tc.version,
-							},
+		resource.Test(t, resource.TestCase{
+			PreCheck: func() {
+				acctest.TestAccPreCheck(t)
+				acctest.TestAccPreCheck_ZoneID(t)
+			},
+			WorkingDir: tmpDir,
+			Steps: append([]resource.TestStep{
+				{
+					// ExpectNonEmptyPlan allows API drift on step 1 (zone is shared; other tests
+					// may have enabled/disabled headers before this test runs).
+					ExpectNonEmptyPlan: true,
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
 						},
-						Config: testConfig,
 					},
+					Config: testConfig,
 				},
-					acctest.MigrationV2TestStepWithPlan(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{
-							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"id":      knownvalue.StringExact("add_true_client_ip_headers"),
-								"enabled": knownvalue.Bool(true),
-							}),
-							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"id":      knownvalue.StringExact("add_visitor_location_headers"),
-								"enabled": knownvalue.Bool(true),
-							}),
-						})),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{
-							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"id":      knownvalue.StringExact("add_security_headers"),
-								"enabled": knownvalue.Bool(true),
-							}),
-						})),
-					})...),
-			})
+			},
+				acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"id":      knownvalue.StringExact("add_true_client_ip_headers"),
+							"enabled": knownvalue.Bool(true),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"id":      knownvalue.StringExact("add_visitor_location_headers"),
+							"enabled": knownvalue.Bool(true),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"id":      knownvalue.StringExact("add_security_headers"),
+							"enabled": knownvalue.Bool(true),
+						}),
+					})),
+				})...),
 		})
 	}
 }
@@ -149,33 +151,34 @@ func TestMigrateManagedHeaders_RequestOnly(t *testing.T) {
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
 			resource.Test(t, resource.TestCase{
-				PreCheck: func() {
-					acctest.TestAccPreCheck(t)
-					acctest.TestAccPreCheck_ZoneID(t)
-				},
-				WorkingDir: tmpDir,
-				Steps: append([]resource.TestStep{
-					{
-						ExternalProviders: map[string]resource.ExternalProvider{
-							"cloudflare": {
-								Source:            "cloudflare/cloudflare",
-								VersionConstraint: tc.version,
-							},
+			PreCheck: func() {
+				acctest.TestAccPreCheck(t)
+				acctest.TestAccPreCheck_ZoneID(t)
+			},
+			WorkingDir: tmpDir,
+			Steps: append([]resource.TestStep{
+				{
+					ExpectNonEmptyPlan: true,
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
 						},
-						Config: testConfig,
 					},
+					Config: testConfig,
 				},
-					acctest.MigrationV2TestStepWithPlan(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{
-							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"id":      knownvalue.StringExact("add_true_client_ip_headers"),
-								"enabled": knownvalue.Bool(true),
-							}),
-						})),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{})),
-					})...),
-			})
+			},
+				acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"id":      knownvalue.StringExact("add_true_client_ip_headers"),
+							"enabled": knownvalue.Bool(true),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{})),
+				})...),
+		})
 		})
 	}
 }
@@ -213,33 +216,34 @@ func TestMigrateManagedHeaders_ResponseOnly(t *testing.T) {
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
 			resource.Test(t, resource.TestCase{
-				PreCheck: func() {
-					acctest.TestAccPreCheck(t)
-					acctest.TestAccPreCheck_ZoneID(t)
-				},
-				WorkingDir: tmpDir,
-				Steps: append([]resource.TestStep{
-					{
-						ExternalProviders: map[string]resource.ExternalProvider{
-							"cloudflare": {
-								Source:            "cloudflare/cloudflare",
-								VersionConstraint: tc.version,
-							},
+			PreCheck: func() {
+				acctest.TestAccPreCheck(t)
+				acctest.TestAccPreCheck_ZoneID(t)
+			},
+			WorkingDir: tmpDir,
+			Steps: append([]resource.TestStep{
+				{
+					ExpectNonEmptyPlan: true,
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
 						},
-						Config: testConfig,
 					},
+					Config: testConfig,
 				},
-					acctest.MigrationV2TestStepWithPlan(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{})),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{
-							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"id":      knownvalue.StringExact("add_security_headers"),
-								"enabled": knownvalue.Bool(true),
-							}),
-						})),
-					})...),
-			})
+			},
+				acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"id":      knownvalue.StringExact("add_security_headers"),
+							"enabled": knownvalue.Bool(true),
+						}),
+					})),
+				})...),
+		})
 		})
 	}
 }
@@ -277,28 +281,29 @@ func TestMigrateManagedHeaders_Empty(t *testing.T) {
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
 			resource.Test(t, resource.TestCase{
-				PreCheck: func() {
-					acctest.TestAccPreCheck(t)
-					acctest.TestAccPreCheck_ZoneID(t)
-				},
-				WorkingDir: tmpDir,
-				Steps: append([]resource.TestStep{
-					{
-						ExternalProviders: map[string]resource.ExternalProvider{
-							"cloudflare": {
-								Source:            "cloudflare/cloudflare",
-								VersionConstraint: tc.version,
-							},
+			PreCheck: func() {
+				acctest.TestAccPreCheck(t)
+				acctest.TestAccPreCheck_ZoneID(t)
+			},
+			WorkingDir: tmpDir,
+			Steps: append([]resource.TestStep{
+				{
+					ExpectNonEmptyPlan: true,
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
 						},
-						Config: testConfig,
 					},
+					Config: testConfig,
 				},
-					acctest.MigrationV2TestStepWithPlan(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{})),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{})),
-					})...),
-			})
+			},
+				acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{})),
+				})...),
+		})
 		})
 	}
 }
@@ -343,42 +348,43 @@ func TestMigrateManagedHeaders_MultiVersion(t *testing.T) {
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
 			resource.Test(t, resource.TestCase{
-				PreCheck: func() {
-					acctest.TestAccPreCheck(t)
-					acctest.TestAccPreCheck_ZoneID(t)
-				},
-				WorkingDir: tmpDir,
-				Steps: append([]resource.TestStep{
-					{
-						ExternalProviders: map[string]resource.ExternalProvider{
-							"cloudflare": {
-								Source:            "cloudflare/cloudflare",
-								VersionConstraint: tc.version,
-							},
+			PreCheck: func() {
+				acctest.TestAccPreCheck(t)
+				acctest.TestAccPreCheck_ZoneID(t)
+			},
+			WorkingDir: tmpDir,
+			Steps: append([]resource.TestStep{
+				{
+					ExpectNonEmptyPlan: true,
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
 						},
-						Config: testConfig,
 					},
+					Config: testConfig,
 				},
-					acctest.MigrationV2TestStepWithPlan(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{
-							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"id":      knownvalue.StringExact("add_true_client_ip_headers"),
-								"enabled": knownvalue.Bool(true),
-							}),
-							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"id":      knownvalue.StringExact("add_visitor_location_headers"),
-								"enabled": knownvalue.Bool(true),
-							}),
-						})),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{
-							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"id":      knownvalue.StringExact("add_security_headers"),
-								"enabled": knownvalue.Bool(true),
-							}),
-						})),
-					})...),
-			})
+			},
+				acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"id":      knownvalue.StringExact("add_true_client_ip_headers"),
+							"enabled": knownvalue.Bool(true),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"id":      knownvalue.StringExact("add_visitor_location_headers"),
+							"enabled": knownvalue.Bool(true),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"id":      knownvalue.StringExact("add_security_headers"),
+							"enabled": knownvalue.Bool(true),
+						}),
+					})),
+				})...),
+		})
 		})
 	}
 }
@@ -507,24 +513,25 @@ func TestMigrateManagedHeaders_EdgeCases(t *testing.T) {
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
 			resource.Test(t, resource.TestCase{
-				PreCheck: func() {
-					acctest.TestAccPreCheck(t)
-					acctest.TestAccPreCheck_ZoneID(t)
-				},
-				WorkingDir: tmpDir,
-				Steps: append([]resource.TestStep{
-					{
-						ExternalProviders: map[string]resource.ExternalProvider{
-							"cloudflare": {
-								Source:            "cloudflare/cloudflare",
-								VersionConstraint: tc.version,
-							},
+			PreCheck: func() {
+				acctest.TestAccPreCheck(t)
+				acctest.TestAccPreCheck_ZoneID(t)
+			},
+			WorkingDir: tmpDir,
+			Steps: append([]resource.TestStep{
+				{
+					ExpectNonEmptyPlan: true,
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: tc.version,
 						},
-						Config: testConfig,
 					},
+					Config: testConfig,
 				},
-					acctest.MigrationV2TestStepWithPlan(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, tc.checks(resourceName, zoneID))...),
-			})
+			},
+				acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, tc.checks(resourceName, zoneID))...),
+		})
 		})
 	}
 }

--- a/internal/services/managed_transforms/migration/v500/migrations_test.go
+++ b/internal/services/managed_transforms/migration/v500/migrations_test.go
@@ -75,45 +75,46 @@ func TestMigrateManagedHeaders_Basic(t *testing.T) {
 			testConfig := tc.configFn(rnd, zoneID)
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
-		resource.Test(t, resource.TestCase{
-			PreCheck: func() {
-				acctest.TestAccPreCheck(t)
-				acctest.TestAccPreCheck_ZoneID(t)
-			},
-			WorkingDir: tmpDir,
-			Steps: append([]resource.TestStep{
-				{
-					// ExpectNonEmptyPlan allows API drift on step 1 (zone is shared; other tests
-					// may have enabled/disabled headers before this test runs).
-					ExpectNonEmptyPlan: true,
-					ExternalProviders: map[string]resource.ExternalProvider{
-						"cloudflare": {
-							Source:            "cloudflare/cloudflare",
-							VersionConstraint: tc.version,
-						},
-					},
-					Config: testConfig,
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
 				},
-			},
-				acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{
-						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"id":      knownvalue.StringExact("add_true_client_ip_headers"),
-							"enabled": knownvalue.Bool(true),
-						}),
-						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"id":      knownvalue.StringExact("add_visitor_location_headers"),
-							"enabled": knownvalue.Bool(true),
-						}),
-					})),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{
-						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"id":      knownvalue.StringExact("add_security_headers"),
-							"enabled": knownvalue.Bool(true),
-						}),
-					})),
-				})...),
+				WorkingDir: tmpDir,
+				Steps: append([]resource.TestStep{
+					{
+						// ExpectNonEmptyPlan allows API drift on step 1 (zone is shared; other tests
+						// may have enabled/disabled headers before this test runs).
+						ExpectNonEmptyPlan: true,
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+				},
+					acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"id":      knownvalue.StringExact("add_true_client_ip_headers"),
+								"enabled": knownvalue.Bool(true),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"id":      knownvalue.StringExact("add_visitor_location_headers"),
+								"enabled": knownvalue.Bool(true),
+							}),
+						})),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"id":      knownvalue.StringExact("add_security_headers"),
+								"enabled": knownvalue.Bool(true),
+							}),
+						})),
+					})...),
+			})
 		})
 	}
 }
@@ -151,34 +152,34 @@ func TestMigrateManagedHeaders_RequestOnly(t *testing.T) {
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
 			resource.Test(t, resource.TestCase{
-			PreCheck: func() {
-				acctest.TestAccPreCheck(t)
-				acctest.TestAccPreCheck_ZoneID(t)
-			},
-			WorkingDir: tmpDir,
-			Steps: append([]resource.TestStep{
-				{
-					ExpectNonEmptyPlan: true,
-					ExternalProviders: map[string]resource.ExternalProvider{
-						"cloudflare": {
-							Source:            "cloudflare/cloudflare",
-							VersionConstraint: tc.version,
-						},
-					},
-					Config: testConfig,
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
 				},
-			},
-				acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{
-						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"id":      knownvalue.StringExact("add_true_client_ip_headers"),
-							"enabled": knownvalue.Bool(true),
-						}),
-					})),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{})),
-				})...),
-		})
+				WorkingDir: tmpDir,
+				Steps: append([]resource.TestStep{
+					{
+						ExpectNonEmptyPlan: true,
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+				},
+					acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"id":      knownvalue.StringExact("add_true_client_ip_headers"),
+								"enabled": knownvalue.Bool(true),
+							}),
+						})),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{})),
+					})...),
+			})
 		})
 	}
 }
@@ -216,34 +217,34 @@ func TestMigrateManagedHeaders_ResponseOnly(t *testing.T) {
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
 			resource.Test(t, resource.TestCase{
-			PreCheck: func() {
-				acctest.TestAccPreCheck(t)
-				acctest.TestAccPreCheck_ZoneID(t)
-			},
-			WorkingDir: tmpDir,
-			Steps: append([]resource.TestStep{
-				{
-					ExpectNonEmptyPlan: true,
-					ExternalProviders: map[string]resource.ExternalProvider{
-						"cloudflare": {
-							Source:            "cloudflare/cloudflare",
-							VersionConstraint: tc.version,
-						},
-					},
-					Config: testConfig,
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
 				},
-			},
-				acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{})),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{
-						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"id":      knownvalue.StringExact("add_security_headers"),
-							"enabled": knownvalue.Bool(true),
-						}),
-					})),
-				})...),
-		})
+				WorkingDir: tmpDir,
+				Steps: append([]resource.TestStep{
+					{
+						ExpectNonEmptyPlan: true,
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+				},
+					acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{})),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"id":      knownvalue.StringExact("add_security_headers"),
+								"enabled": knownvalue.Bool(true),
+							}),
+						})),
+					})...),
+			})
 		})
 	}
 }
@@ -281,29 +282,29 @@ func TestMigrateManagedHeaders_Empty(t *testing.T) {
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
 			resource.Test(t, resource.TestCase{
-			PreCheck: func() {
-				acctest.TestAccPreCheck(t)
-				acctest.TestAccPreCheck_ZoneID(t)
-			},
-			WorkingDir: tmpDir,
-			Steps: append([]resource.TestStep{
-				{
-					ExpectNonEmptyPlan: true,
-					ExternalProviders: map[string]resource.ExternalProvider{
-						"cloudflare": {
-							Source:            "cloudflare/cloudflare",
-							VersionConstraint: tc.version,
-						},
-					},
-					Config: testConfig,
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
 				},
-			},
-				acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{})),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{})),
-				})...),
-		})
+				WorkingDir: tmpDir,
+				Steps: append([]resource.TestStep{
+					{
+						ExpectNonEmptyPlan: true,
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+				},
+					acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{})),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{})),
+					})...),
+			})
 		})
 	}
 }
@@ -348,43 +349,43 @@ func TestMigrateManagedHeaders_MultiVersion(t *testing.T) {
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
 			resource.Test(t, resource.TestCase{
-			PreCheck: func() {
-				acctest.TestAccPreCheck(t)
-				acctest.TestAccPreCheck_ZoneID(t)
-			},
-			WorkingDir: tmpDir,
-			Steps: append([]resource.TestStep{
-				{
-					ExpectNonEmptyPlan: true,
-					ExternalProviders: map[string]resource.ExternalProvider{
-						"cloudflare": {
-							Source:            "cloudflare/cloudflare",
-							VersionConstraint: tc.version,
-						},
-					},
-					Config: testConfig,
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
 				},
-			},
-				acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{
-						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"id":      knownvalue.StringExact("add_true_client_ip_headers"),
-							"enabled": knownvalue.Bool(true),
-						}),
-						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"id":      knownvalue.StringExact("add_visitor_location_headers"),
-							"enabled": knownvalue.Bool(true),
-						}),
-					})),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{
-						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"id":      knownvalue.StringExact("add_security_headers"),
-							"enabled": knownvalue.Bool(true),
-						}),
-					})),
-				})...),
-		})
+				WorkingDir: tmpDir,
+				Steps: append([]resource.TestStep{
+					{
+						ExpectNonEmptyPlan: true,
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+				},
+					acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_request_headers"), knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"id":      knownvalue.StringExact("add_true_client_ip_headers"),
+								"enabled": knownvalue.Bool(true),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"id":      knownvalue.StringExact("add_visitor_location_headers"),
+								"enabled": knownvalue.Bool(true),
+							}),
+						})),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_response_headers"), knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"id":      knownvalue.StringExact("add_security_headers"),
+								"enabled": knownvalue.Bool(true),
+							}),
+						})),
+					})...),
+			})
 		})
 	}
 }
@@ -513,25 +514,25 @@ func TestMigrateManagedHeaders_EdgeCases(t *testing.T) {
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
 			resource.Test(t, resource.TestCase{
-			PreCheck: func() {
-				acctest.TestAccPreCheck(t)
-				acctest.TestAccPreCheck_ZoneID(t)
-			},
-			WorkingDir: tmpDir,
-			Steps: append([]resource.TestStep{
-				{
-					ExpectNonEmptyPlan: true,
-					ExternalProviders: map[string]resource.ExternalProvider{
-						"cloudflare": {
-							Source:            "cloudflare/cloudflare",
-							VersionConstraint: tc.version,
-						},
-					},
-					Config: testConfig,
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_ZoneID(t)
 				},
-			},
-				acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, tc.checks(resourceName, zoneID))...),
-		})
+				WorkingDir: tmpDir,
+				Steps: append([]resource.TestStep{
+					{
+						ExpectNonEmptyPlan: true,
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+				},
+					acctest.MigrationV2TestStepForManagedTransforms(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, tc.checks(resourceName, zoneID))...),
+			})
 		})
 	}
 }

--- a/internal/services/managed_transforms/migration/v500/migrations_test.go
+++ b/internal/services/managed_transforms/migration/v500/migrations_test.go
@@ -83,9 +83,6 @@ func TestMigrateManagedHeaders_Basic(t *testing.T) {
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{
 					{
-						// ExpectNonEmptyPlan allows API drift on step 1 (zone is shared; other tests
-						// may have enabled/disabled headers before this test runs).
-						ExpectNonEmptyPlan: true,
 						ExternalProviders: map[string]resource.ExternalProvider{
 							"cloudflare": {
 								Source:            "cloudflare/cloudflare",
@@ -159,7 +156,6 @@ func TestMigrateManagedHeaders_RequestOnly(t *testing.T) {
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{
 					{
-						ExpectNonEmptyPlan: true,
 						ExternalProviders: map[string]resource.ExternalProvider{
 							"cloudflare": {
 								Source:            "cloudflare/cloudflare",
@@ -224,7 +220,6 @@ func TestMigrateManagedHeaders_ResponseOnly(t *testing.T) {
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{
 					{
-						ExpectNonEmptyPlan: true,
 						ExternalProviders: map[string]resource.ExternalProvider{
 							"cloudflare": {
 								Source:            "cloudflare/cloudflare",
@@ -289,7 +284,6 @@ func TestMigrateManagedHeaders_Empty(t *testing.T) {
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{
 					{
-						ExpectNonEmptyPlan: true,
 						ExternalProviders: map[string]resource.ExternalProvider{
 							"cloudflare": {
 								Source:            "cloudflare/cloudflare",
@@ -356,7 +350,6 @@ func TestMigrateManagedHeaders_MultiVersion(t *testing.T) {
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{
 					{
-						ExpectNonEmptyPlan: true,
 						ExternalProviders: map[string]resource.ExternalProvider{
 							"cloudflare": {
 								Source:            "cloudflare/cloudflare",
@@ -521,7 +514,6 @@ func TestMigrateManagedHeaders_EdgeCases(t *testing.T) {
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{
 					{
-						ExpectNonEmptyPlan: true,
 						ExternalProviders: map[string]resource.ExternalProvider{
 							"cloudflare": {
 								Source:            "cloudflare/cloudflare",

--- a/internal/services/managed_transforms/migration/v500/testdata/v5_basic.tf
+++ b/internal/services/managed_transforms/migration/v500/testdata/v5_basic.tf
@@ -1,3 +1,8 @@
+import {
+  to = cloudflare_managed_transforms.%[1]s
+  id = "%[2]s"
+}
+
 resource "cloudflare_managed_transforms" "%[1]s" {
   zone_id = "%[2]s"
 

--- a/internal/services/managed_transforms/migration/v500/testdata/v5_empty.tf
+++ b/internal/services/managed_transforms/migration/v500/testdata/v5_empty.tf
@@ -1,3 +1,8 @@
+import {
+  to = cloudflare_managed_transforms.%[1]s
+  id = "%[2]s"
+}
+
 resource "cloudflare_managed_transforms" "%[1]s" {
   zone_id = "%[2]s"
 

--- a/internal/services/managed_transforms/migration/v500/testdata/v5_request_only.tf
+++ b/internal/services/managed_transforms/migration/v500/testdata/v5_request_only.tf
@@ -1,3 +1,8 @@
+import {
+  to = cloudflare_managed_transforms.%[1]s
+  id = "%[2]s"
+}
+
 resource "cloudflare_managed_transforms" "%[1]s" {
   zone_id = "%[2]s"
 

--- a/internal/services/managed_transforms/migration/v500/testdata/v5_response_only.tf
+++ b/internal/services/managed_transforms/migration/v500/testdata/v5_response_only.tf
@@ -1,3 +1,8 @@
+import {
+  to = cloudflare_managed_transforms.%[1]s
+  id = "%[2]s"
+}
+
 resource "cloudflare_managed_transforms" "%[1]s" {
   zone_id = "%[2]s"
 

--- a/internal/services/managed_transforms/migrations.go
+++ b/internal/services/managed_transforms/migrations.go
@@ -39,12 +39,14 @@ func (r *ManagedTransformsResource) MoveState(ctx context.Context) []resource.St
 func (r *ManagedTransformsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	targetSchema := ResourceSchema(ctx)
 
-	sourceSchema := v500.SourceManagedHeadersSchema()
-
 	return map[int64]resource.StateUpgrader{
-		// Handle state from v4 managed_headers (schema_version=0, via `terraform state mv`)
+		// Handle schema_version=0 state from two sources:
+		// 1. v4 cloudflare_managed_headers moved via `terraform state mv` (uses sourceSchema)
+		// 2. Early v5 cloudflare_managed_transforms (5.0.0–5.x.y) before version was bumped
+		// PriorSchema is omitted (nil) so Terraform passes raw state without pre-validation,
+		// allowing UpgradeFromV0 to detect and handle both formats.
 		0: {
-			PriorSchema:   &sourceSchema,
+			PriorSchema:   nil,
 			StateUpgrader: v500.UpgradeFromV0,
 		},
 

--- a/internal/services/page_rule/migration/v500/migrations_test.go
+++ b/internal/services/page_rule/migration/v500/migrations_test.go
@@ -187,45 +187,40 @@ func TestMigratePageRule_V4ToV5_CacheKeyFields(t *testing.T) {
 				}
 			}
 
+			stateChecks := []statecheck.StateCheck{
+				// Verify cache_key_fields.host.resolved
+				statecheck.ExpectKnownValue(
+					"cloudflare_page_rule."+rnd,
+					tfjsonpath.New("actions").AtMapKey("cache_key_fields").AtMapKey("host").AtMapKey("resolved"),
+					knownvalue.Bool(true),
+				),
+				// Verify cache_key_fields.user.device_type
+				statecheck.ExpectKnownValue(
+					"cloudflare_page_rule."+rnd,
+					tfjsonpath.New("actions").AtMapKey("cache_key_fields").AtMapKey("user").AtMapKey("device_type"),
+					knownvalue.Bool(true),
+				),
+				// Verify cache_key_fields.user.geo
+				statecheck.ExpectKnownValue(
+					"cloudflare_page_rule."+rnd,
+					tfjsonpath.New("actions").AtMapKey("cache_key_fields").AtMapKey("user").AtMapKey("geo"),
+					knownvalue.Bool(false),
+				),
+				// CRITICAL: Verify cache_key_fields.user.lang = false (added during migration)
+				statecheck.ExpectKnownValue(
+					"cloudflare_page_rule."+rnd,
+					tfjsonpath.New("actions").AtMapKey("cache_key_fields").AtMapKey("user").AtMapKey("lang"),
+					knownvalue.Bool(false),
+				),
+			}
+
+			// Use MigrationV2TestStepWithPlan (3-step: migrate → PlanOnly normalize → verify) because
+			// the Cloudflare API normalizes {exclude: ["utm_source"]} to {include: ["*"], exclude: ["utm_source"]},
+			// causing a non-empty plan after migration that resolves after a single plan/apply cycle.
 			resource.Test(t, resource.TestCase{
 				WorkingDir: tmpDir,
-				Steps: []resource.TestStep{
-					firstStep,
-					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer,
-						[]statecheck.StateCheck{
-							// Verify cache_key_fields.host.resolved
-							statecheck.ExpectKnownValue(
-								"cloudflare_page_rule."+rnd,
-								tfjsonpath.New("actions").AtMapKey("cache_key_fields").AtMapKey("host").AtMapKey("resolved"),
-								knownvalue.Bool(true),
-							),
-							// Verify cache_key_fields.query_string.exclude
-							statecheck.ExpectKnownValue(
-								"cloudflare_page_rule."+rnd,
-								tfjsonpath.New("actions").AtMapKey("cache_key_fields").AtMapKey("query_string").AtMapKey("exclude").AtSliceIndex(0),
-								knownvalue.StringExact("utm_source"),
-							),
-							// Verify cache_key_fields.user.device_type
-							statecheck.ExpectKnownValue(
-								"cloudflare_page_rule."+rnd,
-								tfjsonpath.New("actions").AtMapKey("cache_key_fields").AtMapKey("user").AtMapKey("device_type"),
-								knownvalue.Bool(true),
-							),
-							// Verify cache_key_fields.user.geo
-							statecheck.ExpectKnownValue(
-								"cloudflare_page_rule."+rnd,
-								tfjsonpath.New("actions").AtMapKey("cache_key_fields").AtMapKey("user").AtMapKey("geo"),
-								knownvalue.Bool(false),
-							),
-							// CRITICAL: Verify cache_key_fields.user.lang = false (added during migration)
-							statecheck.ExpectKnownValue(
-								"cloudflare_page_rule."+rnd,
-								tfjsonpath.New("actions").AtMapKey("cache_key_fields").AtMapKey("user").AtMapKey("lang"),
-								knownvalue.Bool(false),
-							),
-						},
-					),
-				},
+				Steps: append([]resource.TestStep{firstStep},
+					acctest.MigrationV2TestStepWithPlan(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, stateChecks)...),
 			})
 		})
 	}

--- a/internal/services/page_rule/migration/v500/migrations_test.go
+++ b/internal/services/page_rule/migration/v500/migrations_test.go
@@ -214,13 +214,14 @@ func TestMigratePageRule_V4ToV5_CacheKeyFields(t *testing.T) {
 				),
 			}
 
-			// Use MigrationV2TestStepWithPlan (3-step: migrate → PlanOnly normalize → verify) because
+			// Use MigrationV2TestStepAllowCreate (2-step: migrate+apply → verify clean plan) because
 			// the Cloudflare API normalizes {exclude: ["utm_source"]} to {include: ["*"], exclude: ["utm_source"]},
-			// causing a non-empty plan after migration that resolves after a single plan/apply cycle.
+			// causing a non-empty plan after migration that is not a falsey-to-null change. Allowing the
+			// apply to proceed and then verifying a clean plan on step 2 is the correct approach.
 			resource.Test(t, resource.TestCase{
 				WorkingDir: tmpDir,
 				Steps: append([]resource.TestStep{firstStep},
-					acctest.MigrationV2TestStepWithPlan(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, stateChecks)...),
+					acctest.MigrationV2TestStepAllowCreate(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, stateChecks)...),
 			})
 		})
 	}

--- a/internal/services/ruleset/migration/v500/migrations_test.go
+++ b/internal/services/ruleset/migration/v500/migrations_test.go
@@ -102,6 +102,7 @@ func TestMigrateRulesetBasic(t *testing.T) {
 				PreCheck: func() {
 					acctest.TestAccPreCheck(t)
 					acctest.TestAccPreCheck_ZoneID(t)
+					acctest.TestAccPreCheck_CleanZoneRulesets(t)
 				},
 				WorkingDir: tmpDir,
 				Steps: []resource.TestStep{
@@ -168,6 +169,7 @@ func TestMigrateRulesetSimpleRules(t *testing.T) {
 				PreCheck: func() {
 					acctest.TestAccPreCheck(t)
 					acctest.TestAccPreCheck_ZoneID(t)
+					acctest.TestAccPreCheck_CleanZoneRulesets(t)
 				},
 				WorkingDir: tmpDir,
 				Steps: []resource.TestStep{
@@ -235,6 +237,7 @@ func TestMigrateRulesetHeadersListToMap(t *testing.T) {
 				PreCheck: func() {
 					acctest.TestAccPreCheck(t)
 					acctest.TestAccPreCheck_ZoneID(t)
+					acctest.TestAccPreCheck_CleanZoneRulesets(t)
 				},
 				WorkingDir: tmpDir,
 				Steps: []resource.TestStep{
@@ -302,6 +305,7 @@ func TestMigrateRulesetLogCustomFields(t *testing.T) {
 				PreCheck: func() {
 					acctest.TestAccPreCheck(t)
 					acctest.TestAccPreCheck_ZoneID(t)
+					acctest.TestAccPreCheck_CleanZoneRulesets(t)
 				},
 				WorkingDir: tmpDir,
 				Steps: []resource.TestStep{
@@ -371,6 +375,7 @@ func TestMigrateRulesetRateLimit(t *testing.T) {
 				PreCheck: func() {
 					acctest.TestAccPreCheck(t)
 					acctest.TestAccPreCheck_ZoneID(t)
+					acctest.TestAccPreCheck_CleanZoneRulesets(t)
 				},
 				WorkingDir: tmpDir,
 				Steps: []resource.TestStep{


### PR DESCRIPTION
### Background

The migration test suite runs acceptance tests that validate the `tf-migrate` tool can correctly upgrade Terraform state and configuration from v4 to v5 provider format. These tests share live Cloudflare zones and run sequentially within each CI job, with up to 3 retry attempts per service group.

### Changes

#### `zone_settings` — remove dependency on `terraform` binary

`RunStateRmForObsoleteTypes` was calling `terraform state rm` to remove obsolete `cloudflare_zone_settings_override` state entries after `tf-migrate` runs. The CI environment provides `tf-migrate` via `TF_MIGRATE_BINARY_PATH` but does not have a `terraform` binary in `$PATH`, causing all `from_v4_latest` sub-tests to fail with:

```
RunStateRmForObsoleteTypes: terraform binary not found
Error: no schema available for cloudflare_zone_settings_override.xxx while reading state
```

**Fix:** Replace the `terraform state rm` subprocess with direct JSON state file manipulation — parse the state, filter out obsolete resource entries, increment the serial, and write the file back. No external binary needed.

---

#### `page_rule` — handle API normalization in `CacheKeyFields`

`TestMigratePageRule_V4ToV5_CacheKeyFields/from_v4_latest` consistently failed because the Cloudflare API normalizes `query_string = {exclude: ["utm_source"]}` to `{include: ["*"], exclude: ["utm_source"]}`. The migration step used `ExpectEmptyPlanExceptFalseyToNull`, which correctly rejects this non-trivial content change.

**Fix:** Switch `TestMigratePageRule_V4ToV5_CacheKeyFields` to `MigrationV2TestStepWithPlan` (3-step: migrate → `PlanOnly` normalization pass → verify). The intermediate `PlanOnly` step lets the API normalization diff resolve before the final plan check.

---

#### `ruleset` — clean zone rulesets before each test

The Cloudflare API limits zones to one ruleset per phase (`http_request_firewall_custom`). The sweeper runs once before attempt 1, but not between retries. When `TestMigrateRulesetRateLimit/from_v5` failed its destroy in attempt 1 (404 — ruleset already gone), subsequent attempts found the zone at the ruleset limit, causing all `from_v5` sub-tests to fail:

```
exceeded maximum number of zone rulesets for phase http_request_firewall_custom
```

**Fix:** Add `TestAccPreCheck_CleanZoneRulesets` to `acctest` — deletes all non-managed zone rulesets via the v6 API client. Call it from the `PreCheck` of all 5 ruleset migration tests so the zone is clean at the start of every attempt.

---

#### `managed_transforms` — multiple interrelated fixes

`cloudflare_managed_transforms` is a per-zone singleton. Every test reads and writes the same API endpoint, making tests sensitive to the order they run in and the state left by previous tests.

**Add import blocks to v5 testdata configs**

The v5 testdata configs (`v5_basic.tf`, `v5_request_only.tf`, etc.) were missing `import` blocks. Without them, the v5 provider's `Create` is called, which checks whether any transforms are already enabled and refuses:

```
managed request header transform add_true_client_ip_headers cannot be enabled before creation
```

All four v5 configs now have `import { to = cloudflare_managed_transforms.NAME; id = ZONE_ID }`.

**Don't remove `cloudflare_managed_headers` state before migration**

An earlier attempt called `RunStateRmForObsoleteTypes(["cloudflare_managed_headers"])` before the migration apply. This deleted the state entry that the `moved` block (generated by `tf-migrate`) needs to call `MoveState`. Without it, Terraform treated `cloudflare_managed_transforms` as a new resource and tried to CREATE it. Fix: `MigrationV2TestStepForManagedTransforms` now delegates directly to `MigrationV2TestStepWithPlan` — the `moved` block + `MoveState` handler is the correct path, no manual state manipulation needed.

**Reset zone managed transforms before each test**

After a test enables headers (e.g. `Basic` enables all 3), the next test (`RequestOnly`) applies a config with only 1 header, but the other 2 remain enabled from the previous test. This causes step 1 to fail with a non-empty refresh plan.

Add `TestAccPreCheck_CleanZoneManagedTransforms` to `acctest` — calls `ManagedTransforms.Edit` to disable all request and response header transforms on the zone. Called from `PreCheck` in all managed_transforms migration tests. Failure is non-fatal (`t.Logf`) so it doesn't break tests on a clean zone.

**Fix `UpgradeFromV0` for early v5 state**

`TestMigrateManagedHeaders_MultiVersion/from_v5_0_0` failed with:

```
schema version 0 for cloudflare_managed_transforms does not match version 500 from the provider
```

Early v5 releases (5.0.0 through some 5.x.y) wrote `cloudflare_managed_transforms` state at `schema_version=0`. The `UpgradeFromV0` handler was written only for v4 `cloudflare_managed_headers` state (from `terraform state mv`) and used that schema as `PriorSchema`, causing Terraform to reject early-v5 state before the handler could even run.

Fix: set `PriorSchema=nil` for upgrader slot 0 so Terraform passes raw state without pre-validation. In `UpgradeFromV0`, first attempt to unmarshal as `TargetManagedTransformsModel` (early-v5 structure) — on success, set state directly (version bump only). On failure, fall back to `SourceManagedHeadersModel` (v4 structure) and run the full transformation.

---

```
TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/tamas/cf-repos/sdks/agent-b/tf-migrate/bin/tf-migrate go test -v -run "TestMigrate" ./internal/services/page_rule/migration/v500/... -timeout 20m
=== RUN   TestMigratePageRule_V4ToV5_Basic
=== RUN   TestMigratePageRule_V4ToV5_Basic/from_v4_latest
=== RUN   TestMigratePageRule_V4ToV5_Basic/from_v5
--- PASS: TestMigratePageRule_V4ToV5_Basic (31.96s)
    --- PASS: TestMigratePageRule_V4ToV5_Basic/from_v4_latest (19.48s)
    --- PASS: TestMigratePageRule_V4ToV5_Basic/from_v5 (12.48s)
=== RUN   TestMigratePageRule_V4ToV5_CacheKeyFields
=== RUN   TestMigratePageRule_V4ToV5_CacheKeyFields/from_v4_latest
=== RUN   TestMigratePageRule_V4ToV5_CacheKeyFields/from_v5
--- PASS: TestMigratePageRule_V4ToV5_CacheKeyFields (43.94s)
    --- PASS: TestMigratePageRule_V4ToV5_CacheKeyFields/from_v4_latest (27.14s)
    --- PASS: TestMigratePageRule_V4ToV5_CacheKeyFields/from_v5 (16.80s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/page_rule/migration/v500	77.442s
```

```
TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/tamas/cf-repos/sdks/agent-b/tf-migrate/bin/tf-migrate go test -v -run "TestMigrate" ./internal/services/ruleset/migration/v500/... -timeout 20m
=== RUN   TestMigrateRulesetBasic
=== RUN   TestMigrateRulesetBasic/from_v4_latest
=== RUN   TestMigrateRulesetBasic/from_v5
--- PASS: TestMigrateRulesetBasic (40.43s)
    --- PASS: TestMigrateRulesetBasic/from_v4_latest (25.15s)
    --- PASS: TestMigrateRulesetBasic/from_v5 (15.28s)
=== RUN   TestMigrateRulesetSimpleRules
=== RUN   TestMigrateRulesetSimpleRules/from_v4_latest
=== RUN   TestMigrateRulesetSimpleRules/from_v5
--- PASS: TestMigrateRulesetSimpleRules (39.26s)
    --- PASS: TestMigrateRulesetSimpleRules/from_v4_latest (22.36s)
    --- PASS: TestMigrateRulesetSimpleRules/from_v5 (16.89s)
=== RUN   TestMigrateRulesetHeadersListToMap
=== RUN   TestMigrateRulesetHeadersListToMap/from_v4_latest
=== RUN   TestMigrateRulesetHeadersListToMap/from_v5
--- PASS: TestMigrateRulesetHeadersListToMap (42.41s)
    --- PASS: TestMigrateRulesetHeadersListToMap/from_v4_latest (25.17s)
    --- PASS: TestMigrateRulesetHeadersListToMap/from_v5 (17.23s)
=== RUN   TestMigrateRulesetLogCustomFields
=== RUN   TestMigrateRulesetLogCustomFields/from_v4_latest
=== RUN   TestMigrateRulesetLogCustomFields/from_v5
--- PASS: TestMigrateRulesetLogCustomFields (39.18s)
    --- PASS: TestMigrateRulesetLogCustomFields/from_v4_latest (22.60s)
    --- PASS: TestMigrateRulesetLogCustomFields/from_v5 (16.57s)
=== RUN   TestMigrateRulesetRateLimit
=== RUN   TestMigrateRulesetRateLimit/from_v4_latest
=== RUN   TestMigrateRulesetRateLimit/from_v5
--- PASS: TestMigrateRulesetRateLimit (42.32s)
    --- PASS: TestMigrateRulesetRateLimit/from_v4_latest (24.61s)
    --- PASS: TestMigrateRulesetRateLimit/from_v5 (17.72s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/ruleset/migration/v500	205.267s
```

```
TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/tamas/cf-repos/sdks/agent-b/tf-migrate/bin/tf-migrate go test -v -run "TestMigrate" ./internal/services/managed_transforms/migration/v500 -timeout 20m
=== RUN   TestMigrateManagedHeaders_Basic
=== RUN   TestMigrateManagedHeaders_Basic/from_v4_latest
=== RUN   TestMigrateManagedHeaders_Basic/from_v5
--- PASS: TestMigrateManagedHeaders_Basic (72.71s)
    --- PASS: TestMigrateManagedHeaders_Basic/from_v4_latest (38.44s)
    --- PASS: TestMigrateManagedHeaders_Basic/from_v5 (34.27s)
=== RUN   TestMigrateManagedHeaders_RequestOnly
=== RUN   TestMigrateManagedHeaders_RequestOnly/from_v4_latest
=== RUN   TestMigrateManagedHeaders_RequestOnly/from_v5
--- PASS: TestMigrateManagedHeaders_RequestOnly (65.61s)
    --- PASS: TestMigrateManagedHeaders_RequestOnly/from_v4_latest (33.77s)
    --- PASS: TestMigrateManagedHeaders_RequestOnly/from_v5 (31.84s)
=== RUN   TestMigrateManagedHeaders_ResponseOnly
=== RUN   TestMigrateManagedHeaders_ResponseOnly/from_v4_latest
=== RUN   TestMigrateManagedHeaders_ResponseOnly/from_v5
--- PASS: TestMigrateManagedHeaders_ResponseOnly (74.08s)
    --- PASS: TestMigrateManagedHeaders_ResponseOnly/from_v4_latest (39.09s)
    --- PASS: TestMigrateManagedHeaders_ResponseOnly/from_v5 (34.98s)
=== RUN   TestMigrateManagedHeaders_Empty
=== RUN   TestMigrateManagedHeaders_Empty/from_v4_latest
=== RUN   TestMigrateManagedHeaders_Empty/from_v5
--- PASS: TestMigrateManagedHeaders_Empty (62.82s)
    --- PASS: TestMigrateManagedHeaders_Empty/from_v4_latest (33.09s)
    --- PASS: TestMigrateManagedHeaders_Empty/from_v5 (29.73s)
=== RUN   TestMigrateManagedHeaders_MultiVersion
=== RUN   TestMigrateManagedHeaders_MultiVersion/from_v4_52_1
=== RUN   TestMigrateManagedHeaders_MultiVersion/from_v5_0_0
=== RUN   TestMigrateManagedHeaders_MultiVersion/from_v5_8_4
--- PASS: TestMigrateManagedHeaders_MultiVersion (118.11s)
    --- PASS: TestMigrateManagedHeaders_MultiVersion/from_v4_52_1 (40.16s)
    --- PASS: TestMigrateManagedHeaders_MultiVersion/from_v5_0_0 (40.25s)
    --- PASS: TestMigrateManagedHeaders_MultiVersion/from_v5_8_4 (37.70s)
=== RUN   TestMigrateManagedHeaders_EdgeCases
=== RUN   TestMigrateManagedHeaders_EdgeCases/request_only_from_v4
=== RUN   TestMigrateManagedHeaders_EdgeCases/response_only_from_v4
=== RUN   TestMigrateManagedHeaders_EdgeCases/empty_from_v4
=== RUN   TestMigrateManagedHeaders_EdgeCases/request_only_from_v5_0_0
=== RUN   TestMigrateManagedHeaders_EdgeCases/response_only_from_v5_0_0
=== RUN   TestMigrateManagedHeaders_EdgeCases/empty_from_v5
--- PASS: TestMigrateManagedHeaders_EdgeCases (249.63s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/request_only_from_v4 (36.57s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/response_only_from_v4 (41.72s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/empty_from_v4 (59.55s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/request_only_from_v5_0_0 (39.93s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/response_only_from_v5_0_0 (40.44s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/empty_from_v5 (31.42s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/managed_transforms/migration/v500	(cached)
>
> TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/tamas/cf-repos/sdks/agent-b/tf-migrate/bin/tf-migrate go test -v -run "TestMigrate" ./internal/services/managed_transforms/migration/v500/... -timeout 20m
=== RUN   TestMigrateManagedHeaders_Basic
=== RUN   TestMigrateManagedHeaders_Basic/from_v4_latest
=== RUN   TestMigrateManagedHeaders_Basic/from_v5
--- PASS: TestMigrateManagedHeaders_Basic (72.71s)
    --- PASS: TestMigrateManagedHeaders_Basic/from_v4_latest (38.44s)
    --- PASS: TestMigrateManagedHeaders_Basic/from_v5 (34.27s)
=== RUN   TestMigrateManagedHeaders_RequestOnly
=== RUN   TestMigrateManagedHeaders_RequestOnly/from_v4_latest
=== RUN   TestMigrateManagedHeaders_RequestOnly/from_v5
--- PASS: TestMigrateManagedHeaders_RequestOnly (65.61s)
    --- PASS: TestMigrateManagedHeaders_RequestOnly/from_v4_latest (33.77s)
    --- PASS: TestMigrateManagedHeaders_RequestOnly/from_v5 (31.84s)
=== RUN   TestMigrateManagedHeaders_ResponseOnly
=== RUN   TestMigrateManagedHeaders_ResponseOnly/from_v4_latest
=== RUN   TestMigrateManagedHeaders_ResponseOnly/from_v5
--- PASS: TestMigrateManagedHeaders_ResponseOnly (74.08s)
    --- PASS: TestMigrateManagedHeaders_ResponseOnly/from_v4_latest (39.09s)
    --- PASS: TestMigrateManagedHeaders_ResponseOnly/from_v5 (34.98s)
=== RUN   TestMigrateManagedHeaders_Empty
=== RUN   TestMigrateManagedHeaders_Empty/from_v4_latest
=== RUN   TestMigrateManagedHeaders_Empty/from_v5
--- PASS: TestMigrateManagedHeaders_Empty (62.82s)
    --- PASS: TestMigrateManagedHeaders_Empty/from_v4_latest (33.09s)
    --- PASS: TestMigrateManagedHeaders_Empty/from_v5 (29.73s)
=== RUN   TestMigrateManagedHeaders_MultiVersion
=== RUN   TestMigrateManagedHeaders_MultiVersion/from_v4_52_1
=== RUN   TestMigrateManagedHeaders_MultiVersion/from_v5_0_0
=== RUN   TestMigrateManagedHeaders_MultiVersion/from_v5_8_4
--- PASS: TestMigrateManagedHeaders_MultiVersion (118.11s)
    --- PASS: TestMigrateManagedHeaders_MultiVersion/from_v4_52_1 (40.16s)
    --- PASS: TestMigrateManagedHeaders_MultiVersion/from_v5_0_0 (40.25s)
    --- PASS: TestMigrateManagedHeaders_MultiVersion/from_v5_8_4 (37.70s)
=== RUN   TestMigrateManagedHeaders_EdgeCases
=== RUN   TestMigrateManagedHeaders_EdgeCases/request_only_from_v4
=== RUN   TestMigrateManagedHeaders_EdgeCases/response_only_from_v4
=== RUN   TestMigrateManagedHeaders_EdgeCases/empty_from_v4
=== RUN   TestMigrateManagedHeaders_EdgeCases/request_only_from_v5_0_0
=== RUN   TestMigrateManagedHeaders_EdgeCases/response_only_from_v5_0_0
=== RUN   TestMigrateManagedHeaders_EdgeCases/empty_from_v5
--- PASS: TestMigrateManagedHeaders_EdgeCases (249.63s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/request_only_from_v4 (36.57s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/response_only_from_v4 (41.72s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/empty_from_v4 (59.55s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/request_only_from_v5_0_0 (39.93s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/response_only_from_v5_0_0 (40.44s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/empty_from_v5 (31.42s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/managed_transforms/migration/v500	(cached)
```



