### PR TITLE
fix(zero_trust_device_default_profile): idempotent split tunnel include/exclude

### DIFF
--- a/internal/services/zero_trust_device_default_profile/resource.go
+++ b/internal/services/zero_trust_device_default_profile/resource.go
@@ -12,8 +12,10 @@ import (
 	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -55,6 +57,230 @@ func (r *ZeroTrustDeviceDefaultProfileResource) Configure(ctx context.Context, r
 	r.client = client
 }
 
+// syncSplitTunnelInclude writes the include list to PUT /devices/policy/include.
+// The main PATCH /devices/policy endpoint silently ignores the include field;
+// the WARP client only honors entries written via this dedicated endpoint.
+// See: https://github.com/cloudflare/terraform-provider-cloudflare/issues/6608
+func (r *ZeroTrustDeviceDefaultProfileResource) syncSplitTunnelInclude(ctx context.Context, data *ZeroTrustDeviceDefaultProfileModel) error {
+	if data.Include.IsNull() || data.Include.IsUnknown() {
+		return nil
+	}
+
+	elements, diags := data.Include.AsStructSliceT(ctx)
+	if diags.HasError() {
+		return fmt.Errorf("failed to read include list from plan: %s", diagsString(diags))
+	}
+
+	body := make([]zero_trust.SplitTunnelIncludeUnionParam, 0, len(elements))
+	for _, elem := range elements {
+		entry := zero_trust.SplitTunnelIncludeParam{
+			Description: cloudflare.F(elem.Description.ValueString()),
+		}
+		if !elem.Address.IsNull() && elem.Address.ValueString() != "" {
+			entry.Address = cloudflare.F(elem.Address.ValueString())
+		}
+		if !elem.Host.IsNull() && elem.Host.ValueString() != "" {
+			entry.Host = cloudflare.F(elem.Host.ValueString())
+		}
+		body = append(body, entry)
+	}
+
+	if len(body) == 0 {
+		return nil
+	}
+
+	_, err := r.client.ZeroTrust.Devices.Policies.Default.Includes.Update(
+		ctx,
+		zero_trust.DevicePolicyDefaultIncludeUpdateParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+			Body:      body,
+		},
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	return err
+}
+
+// syncSplitTunnelExclude writes the exclude list to PUT /devices/policy/exclude.
+// See syncSplitTunnelInclude for context.
+func (r *ZeroTrustDeviceDefaultProfileResource) syncSplitTunnelExclude(ctx context.Context, data *ZeroTrustDeviceDefaultProfileModel) error {
+	if data.Exclude.IsNull() || data.Exclude.IsUnknown() {
+		return nil
+	}
+
+	elements, diags := data.Exclude.AsStructSliceT(ctx)
+	if diags.HasError() {
+		return fmt.Errorf("failed to read exclude list from plan: %s", diagsString(diags))
+	}
+
+	body := make([]zero_trust.SplitTunnelExcludeUnionParam, 0, len(elements))
+	for _, elem := range elements {
+		entry := zero_trust.SplitTunnelExcludeParam{
+			Description: cloudflare.F(elem.Description.ValueString()),
+		}
+		if !elem.Address.IsNull() && elem.Address.ValueString() != "" {
+			entry.Address = cloudflare.F(elem.Address.ValueString())
+		}
+		if !elem.Host.IsNull() && elem.Host.ValueString() != "" {
+			entry.Host = cloudflare.F(elem.Host.ValueString())
+		}
+		body = append(body, entry)
+	}
+
+	if len(body) == 0 {
+		return nil
+	}
+
+	_, err := r.client.ZeroTrust.Devices.Policies.Default.Excludes.Update(
+		ctx,
+		zero_trust.DevicePolicyDefaultExcludeUpdateParams{
+			AccountID: cloudflare.F(data.AccountID.ValueString()),
+			Body:      body,
+		},
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	return err
+}
+
+// readSplitTunnelInclude fetches the include list from GET /devices/policy/include.
+func (r *ZeroTrustDeviceDefaultProfileResource) readSplitTunnelInclude(ctx context.Context, accountID string) (customfield.NestedObjectList[ZeroTrustDeviceDefaultProfileIncludeModel], error) {
+	null := customfield.NullObjectList[ZeroTrustDeviceDefaultProfileIncludeModel](ctx)
+	iter := r.client.ZeroTrust.Devices.Policies.Default.Includes.GetAutoPaging(
+		ctx,
+		zero_trust.DevicePolicyDefaultIncludeGetParams{
+			AccountID: cloudflare.F(accountID),
+		},
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	var items []ZeroTrustDeviceDefaultProfileIncludeModel
+	for iter.Next() {
+		item := iter.Current()
+		items = append(items, ZeroTrustDeviceDefaultProfileIncludeModel{
+			Address:     types.StringValue(item.Address),
+			Description: types.StringValue(item.Description),
+			Host:        types.StringValue(item.Host),
+		})
+	}
+	if err := iter.Err(); err != nil {
+		return null, err
+	}
+	list, diags := customfield.NewObjectList(ctx, items)
+	if diags.HasError() {
+		return null, fmt.Errorf("failed to build include list: %s", diagsString(diags))
+	}
+	return list, nil
+}
+
+// readSplitTunnelExclude fetches the exclude list from GET /devices/policy/exclude.
+func (r *ZeroTrustDeviceDefaultProfileResource) readSplitTunnelExclude(ctx context.Context, accountID string) (customfield.NestedObjectList[ZeroTrustDeviceDefaultProfileExcludeModel], error) {
+	null := customfield.NullObjectList[ZeroTrustDeviceDefaultProfileExcludeModel](ctx)
+	iter := r.client.ZeroTrust.Devices.Policies.Default.Excludes.GetAutoPaging(
+		ctx,
+		zero_trust.DevicePolicyDefaultExcludeGetParams{
+			AccountID: cloudflare.F(accountID),
+		},
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	var items []ZeroTrustDeviceDefaultProfileExcludeModel
+	for iter.Next() {
+		item := iter.Current()
+		items = append(items, ZeroTrustDeviceDefaultProfileExcludeModel{
+			Address:     types.StringValue(item.Address),
+			Description: types.StringValue(item.Description),
+			Host:        types.StringValue(item.Host),
+		})
+	}
+	if err := iter.Err(); err != nil {
+		return null, err
+	}
+	list, diags := customfield.NewObjectList(ctx, items)
+	if diags.HasError() {
+		return null, fmt.Errorf("failed to build exclude list: %s", diagsString(diags))
+	}
+	return list, nil
+}
+
+// applyPlanSplitTunnel restores plan include/exclude on data after the main
+// PATCH overwrites them with empty values from the API response, then syncs
+// both lists to their dedicated endpoints. Unknown plan values are normalised
+// to null — unknown lists occur during a tainted replace, and unknown nested
+// string fields occur when the user configures only one of address/host (the
+// other two fields are computed_optional and plan as unknown). Leaving
+// unknowns in state triggers "provider returned unknown value after apply".
+func (r *ZeroTrustDeviceDefaultProfileResource) applyPlanSplitTunnel(ctx context.Context, data *ZeroTrustDeviceDefaultProfileModel, planInclude customfield.NestedObjectList[ZeroTrustDeviceDefaultProfileIncludeModel], planExclude customfield.NestedObjectList[ZeroTrustDeviceDefaultProfileExcludeModel]) error {
+	if planInclude.IsUnknown() {
+		planInclude = customfield.NullObjectList[ZeroTrustDeviceDefaultProfileIncludeModel](ctx)
+	} else {
+		resolved, diags := resolveDefaultIncludeUnknowns(ctx, planInclude)
+		if diags.HasError() {
+			return fmt.Errorf("resolve include unknowns: %s", diagsString(diags))
+		}
+		planInclude = resolved
+	}
+	if planExclude.IsUnknown() {
+		planExclude = customfield.NullObjectList[ZeroTrustDeviceDefaultProfileExcludeModel](ctx)
+	} else {
+		resolved, diags := resolveDefaultExcludeUnknowns(ctx, planExclude)
+		if diags.HasError() {
+			return fmt.Errorf("resolve exclude unknowns: %s", diagsString(diags))
+		}
+		planExclude = resolved
+	}
+	data.Include = planInclude
+	data.Exclude = planExclude
+
+	if err := r.syncSplitTunnelInclude(ctx, data); err != nil {
+		return fmt.Errorf("sync include list: %w", err)
+	}
+	if err := r.syncSplitTunnelExclude(ctx, data); err != nil {
+		return fmt.Errorf("sync exclude list: %w", err)
+	}
+	return nil
+}
+
+// resolveString returns the input if known, otherwise types.StringNull().
+// Used to turn computed_optional "known after apply" into concrete null values.
+func resolveString(s types.String) types.String {
+	if s.IsUnknown() {
+		return types.StringNull()
+	}
+	return s
+}
+
+// resolveDefaultIncludeUnknowns walks a non-null/non-unknown NestedObjectList and
+// replaces any Unknown string fields on its elements with Null.
+func resolveDefaultIncludeUnknowns(ctx context.Context, in customfield.NestedObjectList[ZeroTrustDeviceDefaultProfileIncludeModel]) (customfield.NestedObjectList[ZeroTrustDeviceDefaultProfileIncludeModel], diag.Diagnostics) {
+	if in.IsNull() || in.IsUnknown() {
+		return in, nil
+	}
+	elements, diags := in.AsStructSliceT(ctx)
+	if diags.HasError() {
+		return in, diags
+	}
+	for i := range elements {
+		elements[i].Address = resolveString(elements[i].Address)
+		elements[i].Description = resolveString(elements[i].Description)
+		elements[i].Host = resolveString(elements[i].Host)
+	}
+	return customfield.NewObjectList(ctx, elements)
+}
+
+// resolveDefaultExcludeUnknowns mirrors resolveDefaultIncludeUnknowns for the exclude list.
+func resolveDefaultExcludeUnknowns(ctx context.Context, in customfield.NestedObjectList[ZeroTrustDeviceDefaultProfileExcludeModel]) (customfield.NestedObjectList[ZeroTrustDeviceDefaultProfileExcludeModel], diag.Diagnostics) {
+	if in.IsNull() || in.IsUnknown() {
+		return in, nil
+	}
+	elements, diags := in.AsStructSliceT(ctx)
+	if diags.HasError() {
+		return in, diags
+	}
+	for i := range elements {
+		elements[i].Address = resolveString(elements[i].Address)
+		elements[i].Description = resolveString(elements[i].Description)
+		elements[i].Host = resolveString(elements[i].Host)
+	}
+	return customfield.NewObjectList(ctx, elements)
+}
+
 func (r *ZeroTrustDeviceDefaultProfileResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data *ZeroTrustDeviceDefaultProfileModel
 
@@ -63,6 +289,16 @@ func (r *ZeroTrustDeviceDefaultProfileResource) Create(ctx context.Context, req 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	planInclude := data.Include
+	planExclude := data.Exclude
+
+	// Strip include/exclude from the main PATCH body. The endpoint silently
+	// ignores them on success and can return a 500 when a previously populated
+	// exclude (e.g. the account default) is swapped for an include in the same
+	// request — see #6608. Both fields are written via dedicated endpoints below.
+	data.Include = customfield.NullObjectList[ZeroTrustDeviceDefaultProfileIncludeModel](ctx)
+	data.Exclude = customfield.NullObjectList[ZeroTrustDeviceDefaultProfileExcludeModel](ctx)
 
 	dataBytes, err := data.MarshalJSON()
 	if err != nil {
@@ -93,6 +329,11 @@ func (r *ZeroTrustDeviceDefaultProfileResource) Create(ctx context.Context, req 
 	data = &env.Result
 	data.ID = data.AccountID
 
+	if err := r.applyPlanSplitTunnel(ctx, data, planInclude, planExclude); err != nil {
+		resp.Diagnostics.AddError("failed to sync split tunnel", err.Error())
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -112,6 +353,18 @@ func (r *ZeroTrustDeviceDefaultProfileResource) Update(ctx context.Context, req 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	planInclude := data.Include
+	planExclude := data.Exclude
+
+	// Strip include/exclude from both plan and state before diffing — the main
+	// PATCH body must not contain these fields (see Create for rationale and #6608).
+	nullInclude := customfield.NullObjectList[ZeroTrustDeviceDefaultProfileIncludeModel](ctx)
+	nullExclude := customfield.NullObjectList[ZeroTrustDeviceDefaultProfileExcludeModel](ctx)
+	data.Include = nullInclude
+	data.Exclude = nullExclude
+	state.Include = nullInclude
+	state.Exclude = nullExclude
 
 	dataBytes, err := data.MarshalJSONForUpdate(*state)
 	if err != nil {
@@ -147,34 +400,37 @@ func (r *ZeroTrustDeviceDefaultProfileResource) Update(ctx context.Context, req 
 		}
 		data = &env.Result
 		data.ID = data.AccountID
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-		return
+	} else {
+		// No-op update: MarshalForPatch produced nil (no serialisable changes).
+		// Do a GET to populate computed fields into state.
+		res := new(http.Response)
+		env := ZeroTrustDeviceDefaultProfileResultEnvelope{*data}
+		_, err = r.client.ZeroTrust.Devices.Policies.Default.Get(
+			ctx,
+			zero_trust.DevicePolicyDefaultGetParams{
+				AccountID: cloudflare.F(data.AccountID.ValueString()),
+			},
+			option.WithResponseBodyInto(&res),
+			option.WithMiddleware(logging.Middleware(ctx)),
+		)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to make http request", err.Error())
+			return
+		}
+		bytes, _ := io.ReadAll(res.Body)
+		err = apijson.UnmarshalComputed(bytes, &env)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
+			return
+		}
+		data = &env.Result
+		data.ID = data.AccountID
 	}
 
-	// No-op update: MarshalForPatch produced nil (no serialisable changes).
-	// Do a GET to populate computed fields into state.
-	res := new(http.Response)
-	env := ZeroTrustDeviceDefaultProfileResultEnvelope{*data}
-	_, err = r.client.ZeroTrust.Devices.Policies.Default.Get(
-		ctx,
-		zero_trust.DevicePolicyDefaultGetParams{
-			AccountID: cloudflare.F(data.AccountID.ValueString()),
-		},
-		option.WithResponseBodyInto(&res),
-		option.WithMiddleware(logging.Middleware(ctx)),
-	)
-	if err != nil {
-		resp.Diagnostics.AddError("failed to make http request", err.Error())
+	if err := r.applyPlanSplitTunnel(ctx, data, planInclude, planExclude); err != nil {
+		resp.Diagnostics.AddError("failed to sync split tunnel", err.Error())
 		return
 	}
-	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.UnmarshalComputed(bytes, &env)
-	if err != nil {
-		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
-		return
-	}
-	data = &env.Result
-	data.ID = data.AccountID
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -187,6 +443,15 @@ func (r *ZeroTrustDeviceDefaultProfileResource) Read(ctx context.Context, req re
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Capture include/exclude from prior state. The main GET /devices/policy
+	// does not return these fields, so we cannot let the API response overwrite
+	// them. The WARP API preserves the order we wrote, but a re-read in plan
+	// would compare against config order (HCL map iteration sorts by key) and
+	// produce perpetual diffs. Preserving prior state values keeps Terraform
+	// in sync with what it last wrote.
+	priorInclude := data.Include
+	priorExclude := data.Exclude
 
 	res := new(http.Response)
 	env := ZeroTrustDeviceDefaultProfileResultEnvelope{*data}
@@ -215,6 +480,8 @@ func (r *ZeroTrustDeviceDefaultProfileResource) Read(ctx context.Context, req re
 	}
 	data = &env.Result
 	data.ID = data.AccountID
+	data.Include = priorInclude
+	data.Exclude = priorExclude
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -262,6 +529,22 @@ func (r *ZeroTrustDeviceDefaultProfileResource) ImportState(ctx context.Context,
 	data = &env.Result
 	data.ID = data.AccountID
 
+	// On import, the include/exclude lists must be fetched from their
+	// dedicated endpoints since GET /devices/policy doesn't return them.
+	includeList, err := r.readSplitTunnelInclude(ctx, path)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to fetch split tunnel include list", err.Error())
+		return
+	}
+	data.Include = includeList
+
+	excludeList, err := r.readSplitTunnelExclude(ctx, path)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to fetch split tunnel exclude list", err.Error())
+		return
+	}
+	data.Exclude = excludeList
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -281,4 +564,68 @@ func (r *ZeroTrustDeviceDefaultProfileResource) ModifyPlan(ctx context.Context, 
 				"in the API, refer to the documentation for how to do it manually.",
 		)
 	}
+
+	// include and exclude are mutually exclusive at the API level (and validated
+	// via ConflictsWith on config). The schema's listplanmodifier.UseStateForUnknown()
+	// runs after validators and copies the stale prior-state value onto the side
+	// the user just removed from config — so when a user swaps include<->exclude
+	// the plan ends up with BOTH populated, and apply tries to sync both which
+	// race and clobber each other on the API.
+	//
+	// When one side is explicitly in config, force the other to null so apply
+	// clears it from the API. When neither side is in config and the plan is
+	// Unknown (fresh create, or null prior state), copy state to avoid a
+	// permanent "(known after apply)" diff for unconfigured lists.
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+	var state, plan, config ZeroTrustDeviceDefaultProfileModel
+	if diags := req.State.Get(ctx, &state); diags.HasError() {
+		return
+	}
+	if diags := req.Plan.Get(ctx, &plan); diags.HasError() {
+		return
+	}
+	if diags := req.Config.Get(ctx, &config); diags.HasError() {
+		return
+	}
+	includeInConfig := !config.Include.IsNull() && !config.Include.IsUnknown()
+	excludeInConfig := !config.Exclude.IsNull() && !config.Exclude.IsUnknown()
+	changed := false
+	if includeInConfig && !plan.Exclude.IsNull() {
+		plan.Exclude = customfield.NullObjectList[ZeroTrustDeviceDefaultProfileExcludeModel](ctx)
+		changed = true
+	}
+	if excludeInConfig && !plan.Include.IsNull() {
+		plan.Include = customfield.NullObjectList[ZeroTrustDeviceDefaultProfileIncludeModel](ctx)
+		changed = true
+	}
+	if !includeInConfig && plan.Include.IsUnknown() {
+		plan.Include = state.Include
+		changed = true
+	}
+	if !excludeInConfig && plan.Exclude.IsUnknown() {
+		plan.Exclude = state.Exclude
+		changed = true
+	}
+	if changed {
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+	}
+}
+
+// diagsString joins error diagnostics into a single string for error wrapping.
+func diagsString(diags diag.Diagnostics) string {
+	errs := diags.Errors()
+	parts := make([]string, 0, len(errs))
+	for _, d := range errs {
+		parts = append(parts, fmt.Sprintf("%s: %s", d.Summary(), d.Detail()))
+	}
+	if len(parts) == 0 {
+		return "(no error details)"
+	}
+	out := parts[0]
+	for _, p := range parts[1:] {
+		out += "; " + p
+	}
+	return out
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

On `cloudflare_zero_trust_device_default_profile` with the current provider (validated against `v5.18.0` stable and `v5.19.0-beta.5`):

1. After a successful `terraform apply` of a config that uses `include` (but not `exclude`, or vice versa), every subsequent `terraform plan` reports a perpetual change:

```
~ resource "..." {
    + exclude = (known after apply)
    ...
}
Plan: 0 to add, 1 to change, 0 to destroy.
```

2. Applying that plan fails with `400 invalid json request` (Cloudflare API error `2003`). Terraform is effectively stuck — the resource is configured correctly on the API but subsequent applies cannot run cleanly.

This PR writes `include`/`exclude` via the dedicated `PUT /devices/policy/{include,exclude}` endpoints instead of the main profile PATCH:

- Strip `include`/`exclude` from the main PATCH/POST body.
- Preserve prior-state `include`/`exclude` on Read to avoid reordering diffs (the API renders them in a different order than the HCL-map iteration order used by the config).
- Fetch `include`/`exclude` from the dedicated endpoints on ImportState.
- Add a `ModifyPlan` hook that (a) forces the unconfigured side to null when the other is in config, so swapping `include`<->`exclude` doesn't race two writes against the API, and (b) copies state onto the plan when `listplanmodifier.UseStateForUnknown()` falls through (Unknown plan + null state), removing the perpetual `(known after apply)` diff.
- Resolve Unknown nested string fields (`address`/`description`/`host` are `computed_optional`) to null before writing back to state, so partially-specified entries don't trigger "provider returned unknown value after apply".

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

```bash
export TF_ACC=1
export CLOUDFLARE_ACCOUNT_ID=<account_id>
export CLOUDFLARE_API_TOKEN=<api_token>

go test ./internal/services/zero_trust_device_default_profile/... \
        ./internal/services/zero_trust_device_custom_profile/... \
        -v -run TestAcc -count 1 -timeout 30m
```

### Test output

```
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_Basic (8.19s)
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_Update (11.20s)
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_Complete (7.40s)
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_WithExclude (8.02s)
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_WithInclude (7.44s)
--- PASS: TestAccUpgradeZeroTrustDeviceDefaultProfile_FromPublishedV5 (18.86s)
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_ServiceModeProxy (6.99s)
--- PASS: TestAccCloudflareZeroTrustDeviceDefaultProfile_UnsetOptionals (10.25s)
ok    zero_trust_device_default_profile       79.998s

--- PASS: TestAccCloudflareZeroTrustDeviceCustomProfile_Basic (5.37s)
--- PASS: TestAccCloudflareZeroTrustDeviceCustomProfile_Complete (9.17s)
--- PASS: TestAccCloudflareZeroTrustDeviceCustomProfile_WithExclude (9.77s)
--- PASS: TestAccCloudflareZeroTrustDeviceCustomProfile_ServiceMode (5.55s)
ok    zero_trust_device_custom_profile        35.743s
```