### PR TITLE
fix(list): accept /32 and /128 in list item IPs

### DIFF
--- a/internal/services/list/cidr_plan_modifier.go
+++ b/internal/services/list/cidr_plan_modifier.go
@@ -1,0 +1,64 @@
+package list
+
+import (
+	"context"
+	"net"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// normalizeListIP canonicalizes an IP or CIDR to match the form the Cloudflare
+// API stores. Returns (normalized, true) on success, ("", false) if the value
+// is not a parseable IP or CIDR.
+//
+//   - 1.2.3.4/32      → 1.2.3.4
+//   - ::1/128         → ::1
+//   - 192.168.1.5/24  → 192.168.1.0/24  (host bits masked)
+//   - ::0001          → ::1
+func normalizeListIP(value string) (string, bool) {
+	if _, netmask, err := net.ParseCIDR(value); err == nil {
+		ones, bits := netmask.Mask.Size()
+		if (bits == 32 && ones == 32) || (bits == 128 && ones == 128) {
+			return netmask.IP.String(), true
+		}
+		return netmask.String(), true
+	}
+	if ip := net.ParseIP(value); ip != nil {
+		return ip.String(), true
+	}
+	return "", false
+}
+
+var _ planmodifier.String = listIPNormalizer{}
+
+// listIPNormalizer rewrites the plan value for list item IPs to the canonical
+// form stored by the Cloudflare API, so equivalent config (e.g. "1.2.3.4/32"
+// vs "1.2.3.4") does not produce perpetual drift.
+type listIPNormalizer struct{}
+
+func (listIPNormalizer) Description(_ context.Context) string {
+	return "Normalizes IPs and CIDRs (strips /32 and /128 suffixes, masks CIDR host bits, canonicalizes IPv6)."
+}
+
+func (m listIPNormalizer) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (listIPNormalizer) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	value := req.ConfigValue.ValueString()
+	normalized, ok := normalizeListIP(value)
+	if !ok {
+		return
+	}
+	if normalized != value {
+		resp.PlanValue = types.StringValue(normalized)
+	}
+}
+
+func ipNormalizer() planmodifier.String {
+	return listIPNormalizer{}
+}

--- a/internal/services/list/cidr_plan_modifier_test.go
+++ b/internal/services/list/cidr_plan_modifier_test.go
@@ -1,0 +1,81 @@
+package list
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestNormalizeListIP(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		parseOK bool
+	}{
+		{"ipv4 /32 stripped", "54.81.199.220/32", "54.81.199.220", true},
+		{"ipv6 /128 stripped", "2001:db8::1/128", "2001:db8::1", true},
+		{"ipv4 cidr host bits masked", "192.168.1.5/24", "192.168.1.0/24", true},
+		{"ipv4 cidr already normalized", "10.0.0.0/24", "10.0.0.0/24", true},
+		{"ipv4 bare already normalized", "1.2.3.4", "1.2.3.4", true},
+		{"ipv6 canonicalized", "2001:0db8:0000:0000:0000:0000:0000:0001", "2001:db8::1", true},
+		{"ipv6 uppercase lowercased", "2001:DB8::1", "2001:db8::1", true},
+		{"ipv6 cidr host bits masked", "2001:db8::1/32", "2001:db8::/32", true},
+		{"unparseable", "banana", "", false},
+		{"empty string", "", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := normalizeListIP(tc.in)
+			if ok != tc.parseOK {
+				t.Fatalf("parse ok = %v, want %v", ok, tc.parseOK)
+			}
+			if got != tc.want {
+				t.Errorf("normalizeListIP(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestListIPNormalizer_PlanModifyString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		config types.String
+		want   types.String
+	}{
+		{"null passes through", types.StringNull(), types.StringNull()},
+		{"unknown passes through", types.StringUnknown(), types.StringUnknown()},
+		{"/32 rewritten", types.StringValue("1.2.3.4/32"), types.StringValue("1.2.3.4")},
+		{"/128 rewritten", types.StringValue("::1/128"), types.StringValue("::1")},
+		{"already canonical unchanged", types.StringValue("10.0.0.0/24"), types.StringValue("10.0.0.0/24")},
+		{"unparseable left alone", types.StringValue("not-an-ip"), types.StringValue("not-an-ip")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := planmodifier.StringRequest{
+				Path:        path.Root("ip"),
+				ConfigValue: tc.config,
+				PlanValue:   tc.config,
+			}
+			resp := &planmodifier.StringResponse{PlanValue: tc.config}
+			listIPNormalizer{}.PlanModifyString(context.Background(), req, resp)
+			if !resp.PlanValue.Equal(tc.want) {
+				t.Errorf("PlanValue = %v, want %v", resp.PlanValue, tc.want)
+			}
+			if resp.Diagnostics.HasError() {
+				t.Errorf("unexpected diagnostics: %v", resp.Diagnostics)
+			}
+		})
+	}
+}

--- a/internal/services/list/cidr_validator.go
+++ b/internal/services/list/cidr_validator.go
@@ -10,70 +10,36 @@ import (
 
 var _ validator.String = listIPValidator{}
 
-// listIPValidator validates that CIDRs or IPs are normalized.
+// listIPValidator rejects values that cannot be parsed as an IP or CIDR.
+// Canonicalization of parseable values (stripping /32, /128, masking host
+// bits, lowercasing IPv6) is handled by the ipNormalizer plan modifier.
 type listIPValidator struct{}
 
-func (v listIPValidator) Description(ctx context.Context) string {
-	return v.MarkdownDescription(ctx)
+func (listIPValidator) Description(_ context.Context) string {
+	return "value must be a valid IP address or CIDR"
 }
 
-func (v listIPValidator) MarkdownDescription(_ context.Context) string {
-	return fmt.Sprintf("CIDRs or IPs must be normalised")
+func (v listIPValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
 }
 
-func (v listIPValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+func (listIPValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
-
 	value := req.ConfigValue.ValueString()
-
-	ip, netmask, err := net.ParseCIDR(value)
-	if err != nil {
-		ip = net.ParseIP(value)
-		if ip == nil {
-			return
-		}
-	}
-
-	if netmask != nil {
-		ones, bits := netmask.Mask.Size()
-		if bits == 32 && ones == 32 {
-			// ipv4
-			resp.Diagnostics.AddAttributeError(req.Path,
-				"IPv4 /32 CIDRs should have the /32 suffix stripped",
-				fmt.Sprintf("CIDR %q must be represented as %q", value, ip),
-			)
-			return
-		} else if bits == 128 && ones == 128 {
-			// ipv6
-			resp.Diagnostics.AddAttributeError(req.Path,
-				"IPv6 /128 CIDRs should have the /128 suffix stripped",
-				fmt.Sprintf("CIDR %q must be represented as %q", value, ip),
-			)
-			return
-		}
-
-		normalized := netmask.String()
-		if value != normalized {
-			resp.Diagnostics.AddAttributeError(req.Path,
-				"CIDR must be normalized",
-				fmt.Sprintf("CIDR %q must be normalized: %q", value, normalized),
-			)
-		}
+	if _, _, err := net.ParseCIDR(value); err == nil {
 		return
 	}
-
-	normalized := ip.String()
-	if value != normalized {
-		resp.Diagnostics.AddAttributeError(req.Path,
-			"IP address must be normalized",
-			fmt.Sprintf("IP address %q must be normalized: %q", value, normalized),
-		)
+	if net.ParseIP(value) != nil {
+		return
 	}
+	resp.Diagnostics.AddAttributeError(req.Path,
+		"Invalid IP address or CIDR",
+		fmt.Sprintf("%q is not a valid IP address or CIDR.", value),
+	)
 }
 
-// ipValidator returns a validator that ensures IPs and CIDRs are normalized.
 func ipValidator() validator.String {
 	return listIPValidator{}
 }

--- a/internal/services/list/schema.go
+++ b/internal/services/list/schema.go
@@ -122,6 +122,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("redirect")),
 								ipValidator(),
 							},
+							PlanModifiers: []planmodifier.String{ipNormalizer()},
 						},
 						"redirect": schema.SingleNestedAttribute{
 							Description: "The definition of the redirect.",


### PR DESCRIPTION
## Changes being requested

Replace the strict list item ip validator with a plan modifier that normalizes valid input to the canonical form the Cloudflare API stores, instead of erroring on it. Today, the provider rejects several semantically-valid forms outright:

- 1.2.3.4/32
- ::1/128
- 192.168.1.5/24 (un-masked host bits)
- 2001:DB8::1 (uppercased hex)

These are all valid CIDR / IP notation. The Cloudflare API stores them as 1.2.3.4, ::1, 192.168.1.0/24, and 2001:db8::1 respectively. Under the previous behavior, a user writing any of these would get a hard plan error with an actionable message but no automatic fix,  every item had to be hand-edited. Users coming from the Cloudflare dashboard, other tools, or older provider state frequently hit this for /32 entries pointing at NAT gateway IPs.

## What changed

- internal/services/list/cidr_plan_modifier.go (new) - `listIPNormalizer` rewrites the plan value to the canonical form via net.ParseCIDR / net.ParseIP. Silent - `noper-item` warning diagnostic, since large lists would produce excessive noise.
- internal/services/list/cidr_validator.go - the validator now only rejects values that cannot be parsed at all. Normalization responsibility moves to the planmodifier.
- internal/services/list/schema.go - `PlanModifiers: []planmodifier.String{ipNormalizer()} `added to the ip attribute alongside the existing ipValidator().
- internal/services/list/cidr_plan_modifier_test.go (new) - table-driven unit tests for both the pure normalization function and the plan modifier behavior.

## Why a plan modifier, not a stricter validator

The Cloudflare API canonicalizes list item IPs server-side. If the provider accepted `/32` verbatim without normalizing, every plan would show perpetual drift. A plan modifier sidesteps this by rewriting the plan value to match the API's stored form before apply, the standard provider pattern for semantically-equivalent representations (ARN casing, DNS trailing dots, etc.).

## Note on generated code

`internal/services/list/schema.go` is marked as Stainless-generated, but already contained a hand-wired `ipValidator()` call on this same attribute. The one-linePlanModifiers addition is a natural extension of that existing hand-customization, not a novel edit. Happy to move the wiring into a post-generate step if maintainers prefer.

Acceptance test run results

- I have added or updated acceptance tests for my changes
- I have run acceptance tests for my changes and included the results below

Unit tests were added covering the normalization function and the plan modifier across null / unknown / parseable /  un-parseable input. Acceptance tests were not added or run,  the pure-function logic is fully exercised by unit tests, but happy to add an acceptance test that exercises a full plan cycle with a /32 list item if maintainers want live-API coverage before merge.

### Steps to run acceptance tests
```
N/A — not run.
```

### Test output

Unit test run (compiled via go test -c due to local disk pressure, invoked directly):
```
=== RUN   TestNormalizeListIP
--- PASS: TestNormalizeListIP (0.00s)
    --- PASS: TestNormalizeListIP/ipv4_/32_stripped (0.00s)
    --- PASS: TestNormalizeListIP/ipv6_/128_stripped (0.00s)
    --- PASS: TestNormalizeListIP/ipv4_cidr_host_bits_masked (0.00s)
    --- PASS: TestNormalizeListIP/ipv4_cidr_already_normalized (0.00s)
    --- PASS: TestNormalizeListIP/ipv4_bare_already_normalized (0.00s)
    --- PASS: TestNormalizeListIP/ipv6_canonicalized (0.00s)
    --- PASS: TestNormalizeListIP/ipv6_uppercase_lowercased (0.00s)
    --- PASS: TestNormalizeListIP/ipv6_cidr_host_bits_masked (0.00s)
    --- PASS: TestNormalizeListIP/unparseable (0.00s)
    --- PASS: TestNormalizeListIP/empty_string (0.00s)
=== RUN   TestListIPNormalizer_PlanModifyString
--- PASS: TestListIPNormalizer_PlanModifyString (0.00s)
    --- PASS: TestListIPNormalizer_PlanModifyString/null_passes_through (0.00s)
    --- PASS: TestListIPNormalizer_PlanModifyString/unknown_passes_through (0.00s)
    --- PASS: TestListIPNormalizer_PlanModifyString//32_rewritten (0.00s)
    --- PASS: TestListIPNormalizer_PlanModifyString//128_rewritten (0.00s)
    --- PASS: TestListIPNormalizer_PlanModifyString/already_canonical_unchanged (0.00s)
    --- PASS: TestListIPNormalizer_PlanModifyString/unparseable_left_alone (0.00s)
PASS
```

### Additional context & links

Error surface this fixes:

Error: IPv4 `/32` CIDRs should have the `/32` suffix stripped
```
  with cloudflare_list.ai_agent_sandbox_addresses,
  on ai_agent_sandboxes.tf line 7, in resource "cloudflare_list" "ai_agent_sandbox_addresses":
    7:   items = [{
    8:       comment = "Terraform - ai-agent-sandboxes VPC NAT gateway"
    9:       ip      = "54.81.199.220/32"
    10:  }, ...

CIDR "54.81.199.220/32" must be represented as "54.81.199.220"
```
`/32` and `/128` are valid CIDR notation; the provider should accept them and normalize, not reject.