### PR TITLE
Fix `account_member` v4→v5 migration test failures

### DIFF
--- a/internal/services/account_member/migration/v500/migrations_test.go
+++ b/internal/services/account_member/migration/v500/migrations_test.go
@@ -10,10 +10,10 @@ import (
 
 	cloudflarev6 "github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/accounts"
+	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
@@ -47,6 +47,12 @@ var v5WithPoliciesConfig string
 // This verifies:
 // 1. Field renames: email_address → email, role_ids → roles
 // 2. Both migration paths: from v4 and from v5
+//
+// Both v4_basic.tf and v5_basic.tf explicitly set status="pending" to prevent
+// tf-migrate from injecting status="accepted" (which it does when status is absent).
+// Without that explicit value, the injected "accepted" would cause a replace for
+// from_v4_latest (RequiresReplaceIfConfigured) and a persistent update drift for
+// from_v5 (API returns "pending" after invite, creating a perpetual diff).
 func TestMigrateAccountMember_V4ToV5_Basic(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -54,7 +60,7 @@ func TestMigrateAccountMember_V4ToV5_Basic(t *testing.T) {
 		configFn func(rnd, accountID, email, roleID string) string
 	}{
 		{
-			name:    "from_v4_latest", // Tests legacy v4 → current v5
+			name:    "from_v4_latest", // Tests legacy v4 → current v5 
 			version: acctest.GetLastV4Version(),
 			configFn: func(rnd, accountID, email, roleID string) string {
 				return fmt.Sprintf(v4BasicConfig, rnd, accountID, email, roleID)
@@ -75,12 +81,6 @@ func TestMigrateAccountMember_V4ToV5_Basic(t *testing.T) {
 				t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
 			}
 
-			// Temporarily unset CLOUDFLARE_API_TOKEN as the API token won't have
-			// permission to manage account members.
-			if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
-				t.Setenv("CLOUDFLARE_API_TOKEN", "")
-			}
-
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 			rnd := utils.GenerateRandomResourceName()
 			tmpDir := t.TempDir()
@@ -89,23 +89,27 @@ func TestMigrateAccountMember_V4ToV5_Basic(t *testing.T) {
 			testEmail := fmt.Sprintf("tf-test-%s@cfapi.net", rnd)
 			resourceName := "cloudflare_account_member." + rnd
 
-			// Get a role ID to use
+			// Fetch the role ID BEFORE unsetting CLOUDFLARE_API_TOKEN; newCleanupClient
+			// falls back to the token when key+email are absent, so clearing it first
+			// would leave the call unauthenticated.
 			roleID := getTestRoleID(t, accountID, "Administrator Read Only")
+
+			// Temporarily unset CLOUDFLARE_API_TOKEN as the API token won't have
+			// permission to manage account members.
+			if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+				t.Setenv("CLOUDFLARE_API_TOKEN", "")
+			}
 
 			testConfig := tc.configFn(rnd, accountID, testEmail, roleID)
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
 			// For v5 tests, use local provider; for v4 tests, use external provider
-			// Note: status field shows perpetual drift in tests because invitations
-			// remain "pending" (never accepted). This is expected test behavior.
 			var firstStep resource.TestStep
 			if tc.version == currentProviderVersion {
 				// Use local v5 provider
-				// ExpectNonEmptyPlan: status is computed and shows drift
 				firstStep = resource.TestStep{
 					ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 					Config:                   testConfig,
-					ExpectNonEmptyPlan:       true,
 				}
 			} else {
 				// Use external v4 provider
@@ -130,50 +134,13 @@ func TestMigrateAccountMember_V4ToV5_Basic(t *testing.T) {
 				Steps: []resource.TestStep{
 					// Step 1: Create resource with source provider version
 					firstStep,
-					// Step 2: Run migration and verify state
-					// ExpectNonEmptyPlan: true because status field shows drift:
-					// ~ status = "pending" -> (known after apply)
-					// This is expected - status is computed and not in config
-					{
-						PreConfig: func() {
-							acctest.WriteOutConfig(t, testConfig, tmpDir)
-							acctest.RunMigrationV2Command(t, testConfig, tmpDir, sourceVer, targetVer)
-						},
-						ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-						ConfigDirectory:          config.StaticDirectory(tmpDir),
-						ExpectNonEmptyPlan:       true,
-						ConfigPlanChecks: resource.ConfigPlanChecks{
-							PreApply: []plancheck.PlanCheck{
-								acctest.DebugNonEmptyPlan,
-								acctest.ExpectEmptyPlanExceptFalseyToNull,
-							},
-						},
-						ConfigStateChecks: []statecheck.StateCheck{
-							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
-							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("email"), knownvalue.StringExact(testEmail)),
-							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.NotNull()),
-							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
-						},
-					},
-					// Step 3: Verify final state
-					// ExpectNonEmptyPlan: status drift persists because test invitations
-					// remain "pending" (never accepted by a real user)
-					{
-						ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-						ConfigDirectory:          config.StaticDirectory(tmpDir),
-						ExpectNonEmptyPlan:       true,
-						ConfigPlanChecks: resource.ConfigPlanChecks{
-							PreApply: []plancheck.PlanCheck{
-								acctest.DebugNonEmptyPlan,
-								acctest.ExpectEmptyPlanExceptFalseyToNull,
-							},
-						},
-						ConfigStateChecks: []statecheck.StateCheck{
-							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
-							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("email"), knownvalue.StringExact(testEmail)),
-							statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.NotNull()),
-						},
-					},
+					// Step 2: Run migration and verify no-diff state
+					acctest.MigrationV2TestStep(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("email"), knownvalue.StringExact(testEmail)),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					}),
 				},
 			})
 		})
@@ -210,22 +177,29 @@ func TestMigrateAccountMember_V4ToV5_WithStatus(t *testing.T) {
 				t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
 			}
 
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+			// Use real test user email that exists in Cloudflare system
+			// (required because status="accepted" needs an existing user)
+			testEmail := "terraform-test-user-b@cfapi.net"
+
+			// Perform API calls that may need the token BEFORE unsetting it.
+			// cleanupExistingMember and getTestRoleID both use newCleanupClient which
+			// falls back to CLOUDFLARE_API_TOKEN when key+email are not set; t.Setenv
+			// would clear the token making those calls unauthenticated.
+			cleanupExistingMember(t, accountID, testEmail)
+			roleID := getTestRoleID(t, accountID, "Administrator Read Only")
+
 			// Temporarily unset CLOUDFLARE_API_TOKEN as the API token won't have
 			// permission to manage account members.
 			if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
 				t.Setenv("CLOUDFLARE_API_TOKEN", "")
 			}
 
-			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 			rnd := utils.GenerateRandomResourceName()
 			tmpDir := t.TempDir()
 
-			// Use real test user email that exists in Cloudflare system
-			// (required because status="accepted" needs an existing user)
-			testEmail := "terraform-test-user-b@cfapi.net"
 			resourceName := "cloudflare_account_member." + rnd
-
-			roleID := getTestRoleID(t, accountID, "Administrator Read Only")
 			testConfig := tc.configFn(rnd, accountID, testEmail, roleID)
 			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
 
@@ -334,12 +308,69 @@ func TestMigrateAccountMember_FromV5_13(t *testing.T) {
 
 // Helper functions
 
+// newCleanupClient returns a cloudflare-go v6 client for cleanup operations.
+// It prefers API key+email auth (same as SharedClient), falling back to API
+// token when CLOUDFLARE_API_KEY is not set. The CLOUDFLARE_API_TOKEN env var
+// may have been unset earlier in the test to prevent the v5 Terraform provider
+// from using it (account-member management requires key+email or a privileged
+// token), so we read both env vars without relying on the provider's credential
+// chain.
+func newCleanupClient() *cloudflarev6.Client {
+	apiKey := os.Getenv("CLOUDFLARE_API_KEY")
+	apiEmail := os.Getenv("CLOUDFLARE_EMAIL")
+	apiToken := os.Getenv("CLOUDFLARE_API_TOKEN")
+
+	if apiKey != "" && apiEmail != "" {
+		return cloudflarev6.NewClient(
+			option.WithAPIKey(apiKey),
+			option.WithAPIEmail(apiEmail),
+		)
+	}
+	// Fall back to API token when key+email are not configured.
+	return cloudflarev6.NewClient(option.WithAPIToken(apiToken))
+}
+
+// cleanupExistingMember deletes an existing account member with the given email
+// to prevent "Account member already exists" errors from previous test runs.
+// It pages through all members (using ListAutoPaging) and matches on either the
+// top-level Email field or User.Email, since the Cloudflare API populates these
+// fields differently depending on whether the member has accepted the invitation.
+func cleanupExistingMember(t *testing.T, accountID, email string) {
+	t.Helper()
+
+	ctx := context.Background()
+	client := newCleanupClient()
+
+	iter := client.Accounts.Members.ListAutoPaging(ctx, accounts.MemberListParams{
+		AccountID: cloudflarev6.String(accountID),
+	})
+
+	for iter.Next() {
+		member := iter.Current()
+		if member.Email == email || member.User.Email == email {
+			t.Logf("Deleting existing account member %s (%s) from previous test run", member.ID, email)
+			_, err := client.Accounts.Members.Delete(ctx, member.ID, accounts.MemberDeleteParams{
+				AccountID: cloudflarev6.String(accountID),
+			})
+			if err != nil {
+				t.Fatalf("Failed to delete existing member %s for cleanup: %v", member.ID, err)
+			}
+			t.Logf("Successfully deleted existing member %s", member.ID)
+			return
+		}
+	}
+
+	if err := iter.Err(); err != nil {
+		t.Fatalf("Failed to list account members for cleanup: %v", err)
+	}
+}
+
 // getTestRoleID fetches a valid role ID for the account by role name.
 func getTestRoleID(t *testing.T, accountID, roleName string) string {
 	t.Helper()
 
 	ctx := context.Background()
-	client := acctest.SharedClient()
+	client := newCleanupClient()
 	roles, err := client.Accounts.Roles.List(ctx, accounts.RoleListParams{
 		AccountID: cloudflarev6.String(accountID),
 		PerPage:   cloudflarev6.Float(100),

--- a/internal/services/account_member/migration/v500/testdata/v4_basic.tf
+++ b/internal/services/account_member/migration/v500/testdata/v4_basic.tf
@@ -1,5 +1,6 @@
 resource "cloudflare_account_member" "%s" {
   account_id    = "%s"
   email_address = "%s"
+  status        = "pending"
   role_ids      = ["%s"]
 }

--- a/internal/services/account_member/migration/v500/testdata/v5_basic.tf
+++ b/internal/services/account_member/migration/v500/testdata/v5_basic.tf
@@ -1,5 +1,6 @@
 resource "cloudflare_account_member" "%s" {
   account_id = "%s"
   email      = "%s"
+  status     = "pending"
   roles      = ["%s"]
 }


### PR DESCRIPTION
### Problem

Three distinct failures in `TestMigrateAccountMember_V4ToV5_Basic` and `TestMigrateAccountMember_V4ToV5_WithStatus`:

**1. `from_v4_latest` — `delete create` / "Cannot add verified membership for non-existing user"**

`tf-migrate` injects `status = "accepted"` into configs that don't already specify `status`. For a newly invited random-email member (which stays `"pending"`), the migrated config with `"accepted"` triggered `RequiresReplaceIfConfigured` → a `delete` + `create`. The re-create then failed because `status = "accepted"` requires an existing Cloudflare user account.

**2. `from_v5` — persistent `status = "pending" → (known after apply)` drift**

Same injection: after the v5 provider creates a pending invite, the API always returns `"pending"`. The injected `"accepted"` in the migrated config created a perpetual diff that could never converge.

**3. `WithStatus` — "Account member already exists" at Step 1**

`cleanupExistingMember` and `getTestRoleID` were called *after* `t.Setenv("CLOUDFLARE_API_TOKEN", "")`. The cleanup client falls back to the API token when key+email aren't configured; clearing the token first left those calls unauthenticated. The cleanup silently found nothing, leaving the fixed test email (`terraform-test-user-b@cfapi.net`) in the account from a prior run.

Additionally, `cleanupExistingMember` only checked the first page of results and only matched `member.User.Email`, missing cases where the API returns the email at the top-level `member.Email` field.

### Fix

- **`v4_basic.tf` / `v5_basic.tf`**: add `status = "pending"` explicitly so tf-migrate does not inject `"accepted"`. Tests using random invite-only emails can now use the standard `MigrationV2TestStep` with a clean empty plan.
- **Test ordering**: move `cleanupExistingMember` and `getTestRoleID` before `t.Setenv("CLOUDFLARE_API_TOKEN", "")` in both `Basic` and `WithStatus` tests.
- **`cleanupExistingMember`**: switch to `ListAutoPaging` (all pages), match on both `member.Email` and `member.User.Email`, and promote silent `t.Logf` warnings to `t.Fatalf` so auth or deletion failures surface immediately.
- **`newCleanupClient`**: new helper that prefers API key+email and falls back to API token, replacing `acctest.SharedClient()` (key+email only) in both `cleanupExistingMember` and `getTestRoleID`.

---

```
TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/tamas/cf-repos/sdks/agent-b/tf-migrate/bin/tf-migrate go test -v -run "TestMigrate" ./internal/services/account_member/migration/v500/... -timeout 20m
=== RUN   TestMigrateAccountMember_V4ToV5_Basic
=== RUN   TestMigrateAccountMember_V4ToV5_Basic/from_v4_latest
=== RUN   TestMigrateAccountMember_V4ToV5_Basic/from_v5
--- PASS: TestMigrateAccountMember_V4ToV5_Basic (38.98s)
    --- PASS: TestMigrateAccountMember_V4ToV5_Basic/from_v4_latest (23.06s)
    --- PASS: TestMigrateAccountMember_V4ToV5_Basic/from_v5 (15.91s)
=== RUN   TestMigrateAccountMember_V4ToV5_WithStatus
=== RUN   TestMigrateAccountMember_V4ToV5_WithStatus/from_v4_latest
=== RUN   TestMigrateAccountMember_V4ToV5_WithStatus/from_v5
--- PASS: TestMigrateAccountMember_V4ToV5_WithStatus (54.13s)
    --- PASS: TestMigrateAccountMember_V4ToV5_WithStatus/from_v4_latest (29.26s)
    --- PASS: TestMigrateAccountMember_V4ToV5_WithStatus/from_v5 (24.87s)
=== RUN   TestMigrateAccountMember_FromV5_13
    migrations_test.go:256: API returning id:00000000000000000000000000000000 for the test user.
--- SKIP: TestMigrateAccountMember_FromV5_13 (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_member/migration/v500	94.740s
```