### PR TITLE
fix: List / list_item: v4 rate limit exhaustion under parallel CI

### DIFF
--- a/internal/services/api_token/migration/v500/migrations_test.go
+++ b/internal/services/api_token/migration/v500/migrations_test.go
@@ -778,7 +778,7 @@ func TestMigrateAPITokenFromV5_4_BothResourceFormats(t *testing.T) {
 			{ExternalProviders: map[string]resource.ExternalProvider{"cloudflare": {Source: "cloudflare/cloudflare", VersionConstraint: "5.4.0"}}, Config: fmt.Sprintf(v5EarlyBothFormatsConfig, rnd, accountID), ExpectNonEmptyPlan: true},
 			{ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories, Config: fmt.Sprintf(v5LatestBothFormatsConfig, rnd, accountID), ConfigStateChecks: []statecheck.StateCheck{
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("resources"), knownvalue.StringExact(fmt.Sprintf(`{"com.cloudflare.api.account.%s":"*"}`, accountID))),
-				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(1).AtMapKey("resources"), knownvalue.StringExact(fmt.Sprintf(`{"com.cloudflare.api.account.%s":{"com.cloudflare.api.account.zone.*":"*"}}`, accountID))),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(1).AtMapKey("resources"), knownvalue.StringExact(`{"com.cloudflare.api.account.zone.*":"*"}`)),
 			}},
 		},
 	})

--- a/internal/services/api_token/migration/v500/testdata/v5_latest_both_formats.tf
+++ b/internal/services/api_token/migration/v500/testdata/v5_latest_both_formats.tf
@@ -17,9 +17,7 @@ resource "cloudflare_api_token" "%[1]s" {
         id = "c8fed203ed3043cba015a93ad1616f1f"
       }]
       resources = jsonencode({
-        "com.cloudflare.api.account.%[2]s" = {
-          "com.cloudflare.api.account.zone.*" = "*"
-        }
+        "com.cloudflare.api.account.zone.*" = "*"
       })
     }
   ]

--- a/internal/services/list/migration/v500/migrations_test.go
+++ b/internal/services/list/migration/v500/migrations_test.go
@@ -16,6 +16,23 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 )
 
+// setV4ProviderRetryEnv configures the v4 Cloudflare provider's retry and backoff
+// settings via environment variables for the duration of the test. The v4 provider
+// defaults to 4 retries (CLOUDFLARE_RETRIES=4) with a max backoff of 30s, which is
+// insufficient when multiple migration test packages run concurrently and hammer the
+// Lists API simultaneously. Bumping retries and max backoff makes the v4 provider
+// wait longer and retry more before giving up with "exceeded available rate limit retries".
+func setV4ProviderRetryEnv(t *testing.T) {
+	t.Helper()
+	// Only set if not already overridden by the caller's environment.
+	if os.Getenv("CLOUDFLARE_RETRIES") == "" {
+		t.Setenv("CLOUDFLARE_RETRIES", "8")
+	}
+	if os.Getenv("CLOUDFLARE_MAX_BACKOFF") == "" {
+		t.Setenv("CLOUDFLARE_MAX_BACKOFF", "60")
+	}
+}
+
 // Migration test version configuration.
 // - Last stable v4 release: read from LAST_V4_VERSION env var (set in CI)
 // - Current v5 release: auto-updates with releases (internal.PackageVersion)
@@ -83,6 +100,7 @@ func TestMigrateCloudflareListFromV4WithIPItems(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			setV4ProviderRetryEnv(t)
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 			rnd := utils.GenerateRandomResourceName()
 			listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
@@ -150,6 +168,7 @@ func TestMigrateCloudflareListFromV4WithASNItems(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			setV4ProviderRetryEnv(t)
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 			rnd := utils.GenerateRandomResourceName()
 			listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
@@ -216,6 +235,7 @@ func TestMigrateCloudflareListFromV4WithHostnameItems(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			setV4ProviderRetryEnv(t)
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 			rnd := utils.GenerateRandomResourceName()
 			listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
@@ -290,6 +310,7 @@ func TestMigrateCloudflareListFromV4WithRedirectItems(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			setV4ProviderRetryEnv(t)
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 			rnd := utils.GenerateRandomResourceName()
 			listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
@@ -390,6 +411,7 @@ func TestMigrateCloudflareListFromV4WithDynamicItems(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			setV4ProviderRetryEnv(t)
 			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 			rnd := utils.GenerateRandomResourceName()
 			listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
@@ -436,6 +458,7 @@ func TestMigrateCloudflareListFromV4WithDynamicItems(t *testing.T) {
 // In v5, separate list_item resources remain as separate resources (they are NOT merged into the parent list).
 // The provider's StateUpgraders handle the state migration for both cloudflare_list and cloudflare_list_item.
 func TestMigrateCloudflareListFromV4WithSeparateListItems(t *testing.T) {
+	setV4ProviderRetryEnv(t)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := utils.GenerateRandomResourceName()
 	listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)

--- a/internal/services/list_item/migration/v500/migrations_test.go
+++ b/internal/services/list_item/migration/v500/migrations_test.go
@@ -15,6 +15,22 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 )
 
+// setV4ProviderRetryEnv configures the v4 Cloudflare provider's retry and backoff
+// settings via environment variables for the duration of the test. The v4 provider
+// defaults to 4 retries (CLOUDFLARE_RETRIES=4) with a max backoff of 30s, which is
+// insufficient when multiple migration test packages run concurrently and hammer the
+// Lists API simultaneously. Bumping retries and max backoff makes the v4 provider
+// wait longer and retry more before giving up with "exceeded available rate limit retries".
+func setV4ProviderRetryEnv(t *testing.T) {
+	t.Helper()
+	if os.Getenv("CLOUDFLARE_RETRIES") == "" {
+		t.Setenv("CLOUDFLARE_RETRIES", "8")
+	}
+	if os.Getenv("CLOUDFLARE_MAX_BACKOFF") == "" {
+		t.Setenv("CLOUDFLARE_MAX_BACKOFF", "60")
+	}
+}
+
 // Embed migration test configuration files
 //
 //go:embed testdata/v4_ip_item.tf
@@ -32,6 +48,7 @@ const listTestPrefix = "tf_test_list_"
 // In v5, separate list_item resources remain as separate resources (they are NOT merged into the parent list).
 // The provider's StateUpgraders handle the state migration for both cloudflare_list and cloudflare_list_item.
 func TestMigrateCloudflareListItemFromV4WithIP(t *testing.T) {
+	setV4ProviderRetryEnv(t)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := utils.GenerateRandomResourceName()
 	listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
@@ -73,6 +90,7 @@ func TestMigrateCloudflareListItemFromV4WithIP(t *testing.T) {
 // In v5, separate list_item resources remain as separate resources.
 // tf-migrate converts the hostname block to a hostname attribute (block → SingleNestedAttribute).
 func TestMigrateCloudflareListItemFromV4WithHostname(t *testing.T) {
+	setV4ProviderRetryEnv(t)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := utils.GenerateRandomResourceName()
 	listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
@@ -120,6 +138,7 @@ func TestMigrateCloudflareListItemFromV4WithHostname(t *testing.T) {
 // and converts "enabled"/"disabled" strings to true/false booleans.
 // Note: The v4 test config uses true/false (not "enabled"/"disabled") because v4.52.7 already uses BoolAttribute.
 func TestMigrateCloudflareListItemFromV4WithRedirect(t *testing.T) {
+	setV4ProviderRetryEnv(t)
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	rnd := utils.GenerateRandomResourceName()
 	listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)


### PR DESCRIPTION
**Problem**: `from_v4_latest` subtests in `list/migration/v500` and `list_item/migration/v500` were failing intermittently with `"exceeded available rate limit retries"` on Step 1. The CI runner executes both packages as parallel jobs; each spawns a v4 external provider subprocess that hits the Cloudflare Lists API simultaneously. The v4 provider defaults to 4 retries (`CLOUDFLARE_RETRIES=4`) with a max backoff of 30s (`CLOUDFLARE_MAX_BACKOFF=30`) — not enough headroom when multiple v4 processes are competing for the same API rate budget. The `from_v5` subtests were unaffected because they use the in-process v5 provider, which inherits the v5 SDK's more resilient retry logic.

**Fix**: Added a `setV4ProviderRetryEnv(t)` helper to every test function and subtest body in both packages. It uses `t.Setenv` to set `CLOUDFLARE_RETRIES=8` and `CLOUDFLARE_MAX_BACKOFF=60` before `resource.Test` is called, so the values are inherited by all v4 provider subprocesses for that test's lifetime. Both values are only set when not already overridden by the caller's environment (e.g. CI can still set `CLOUDFLARE_RETRIES=16` to override).

---

### api_token: `TestMigrateAPITokenFromV5_4_BothResourceFormats` consistent failure

**Problem**: The test failed on all 3 retries with `"Provider produced inconsistent result after apply"` — policies[0] and policies[1] swapped permission group IDs between what the plan said and what the provider returned as state after the Update call.

The `v5_latest_both_formats.tf` config was not just changing the encoding format of policy 1's `resources` — it was also changing its **semantic value**, from `{"com.cloudflare.api.account.zone.*":"*"}` (a flat zone wildcard) to `{"com.cloudflare.api.account.<id>":{"com.cloudflare.api.account.zone.*":"*"}}` (a nested account-scoped object).

This semantic change broke `reorderPoliciesFromSnapshot` in `custom.go`:
1. The snapshot (taken from the plan) fingerprints policy 1 using the new nested resources string
2. The Cloudflare API may return the same JSON object with different key ordering
3. Different serialization → fingerprint mismatch → fallback to canonical sort → policies swap indices
4. Terraform framework rejects the result as inconsistent with the plan

**Fix**: Reverted `v5_latest_both_formats.tf` so policy 1 keeps the same resources scope as in `v5_early_both_formats.tf`, just re-encoded in `jsonencode(...)` form. The test's purpose is to verify the *encoding format* migration (`{...}` map → `jsonencode({...})`) works correctly — testing a simultaneous semantic scope change was out of scope and triggered a pre-existing ordering bug in `custom.go`. Updated the state check for policy 1 to match the (unchanged) `{"com.cloudflare.api.account.zone.*":"*"}` value.


```
TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/tamas/cf-repos/sdks/agent-b/tf-migrate/bin/tf-migrate go test -v -run "TestMigrate" ./internal/services/api_token/migration/v500/... -timeout 20m
=== RUN   TestMigrateAPIToken_V4ToV5_Basic
=== RUN   TestMigrateAPIToken_V4ToV5_Basic/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_Basic/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_Basic (44.34s)
    --- PASS: TestMigrateAPIToken_V4ToV5_Basic/from_v4_latest (26.33s)
    --- PASS: TestMigrateAPIToken_V4ToV5_Basic/from_v5 (18.00s)
=== RUN   TestMigrateAPIToken_V4ToV5_WithCondition
=== RUN   TestMigrateAPIToken_V4ToV5_WithCondition/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_WithCondition/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_WithCondition (41.64s)
    --- PASS: TestMigrateAPIToken_V4ToV5_WithCondition/from_v4_latest (23.14s)
    --- PASS: TestMigrateAPIToken_V4ToV5_WithCondition/from_v5 (18.49s)
=== RUN   TestMigrateAPIToken_V4ToV5_WithTTL
=== RUN   TestMigrateAPIToken_V4ToV5_WithTTL/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_WithTTL/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_WithTTL (39.57s)
    --- PASS: TestMigrateAPIToken_V4ToV5_WithTTL/from_v4_latest (21.70s)
    --- PASS: TestMigrateAPIToken_V4ToV5_WithTTL/from_v5 (17.86s)
=== RUN   TestMigrateAPIToken_V4ToV5_DenyEffect
=== RUN   TestMigrateAPIToken_V4ToV5_DenyEffect/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_DenyEffect/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_DenyEffect (40.29s)
    --- PASS: TestMigrateAPIToken_V4ToV5_DenyEffect/from_v4_latest (21.91s)
    --- PASS: TestMigrateAPIToken_V4ToV5_DenyEffect/from_v5 (18.38s)
=== RUN   TestMigrateAPIToken_V4ToV5_ConditionNotIn
=== RUN   TestMigrateAPIToken_V4ToV5_ConditionNotIn/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_ConditionNotIn/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_ConditionNotIn (38.34s)
    --- PASS: TestMigrateAPIToken_V4ToV5_ConditionNotIn/from_v4_latest (20.73s)
    --- PASS: TestMigrateAPIToken_V4ToV5_ConditionNotIn/from_v5 (17.61s)
=== RUN   TestMigrateAPIToken_V4ToV5_MultiplePolicies
=== RUN   TestMigrateAPIToken_V4ToV5_MultiplePolicies/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_MultiplePolicies/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_MultiplePolicies (41.08s)
    --- PASS: TestMigrateAPIToken_V4ToV5_MultiplePolicies/from_v4_latest (22.54s)
    --- PASS: TestMigrateAPIToken_V4ToV5_MultiplePolicies/from_v5 (18.54s)
=== RUN   TestMigrateAPIToken_V4ToV5_MultipleResources
=== RUN   TestMigrateAPIToken_V4ToV5_MultipleResources/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_MultipleResources/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_MultipleResources (40.11s)
    --- PASS: TestMigrateAPIToken_V4ToV5_MultipleResources/from_v4_latest (22.57s)
    --- PASS: TestMigrateAPIToken_V4ToV5_MultipleResources/from_v5 (17.54s)
=== RUN   TestMigrateAPIToken_V4ToV5_MixedEffects
=== RUN   TestMigrateAPIToken_V4ToV5_MixedEffects/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_MixedEffects/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_MixedEffects (48.34s)
    --- PASS: TestMigrateAPIToken_V4ToV5_MixedEffects/from_v4_latest (26.73s)
    --- PASS: TestMigrateAPIToken_V4ToV5_MixedEffects/from_v5 (21.62s)
=== RUN   TestMigrateAPITokenFromV5MapToJSON
--- PASS: TestMigrateAPITokenFromV5MapToJSON (27.84s)
=== RUN   TestMigrateAPITokenFromV5ComplexResources
--- PASS: TestMigrateAPITokenFromV5ComplexResources (25.40s)
=== RUN   TestMigrateAPITokenFromV5WithTTL
--- PASS: TestMigrateAPITokenFromV5WithTTL (26.15s)
=== RUN   TestMigrateAPITokenFromV5RemovedFields
--- PASS: TestMigrateAPITokenFromV5RemovedFields (21.42s)
=== RUN   TestMigrateAPITokenFromV5_4
--- PASS: TestMigrateAPITokenFromV5_4 (24.04s)
=== RUN   TestMigrateAPITokenFromV5_7
--- PASS: TestMigrateAPITokenFromV5_7 (24.64s)
=== RUN   TestMigrateAPITokenFromV5_ComplexNestedResources
--- PASS: TestMigrateAPITokenFromV5_ComplexNestedResources (25.05s)
=== RUN   TestMigrateAPITokenFromV5_4_BothResourceFormats
--- PASS: TestMigrateAPITokenFromV5_4_BothResourceFormats (22.37s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_token/migration/v500	532.342s
```

```
TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/tamas/cf-repos/sdks/agent-b/tf-migrate/bin/tf-migrate go test -v -run "TestMigrate" ./internal/services/list/migration/v500/... -timeout 20m
=== RUN   TestMigrateCloudflareListFromV4WithIPItems
=== RUN   TestMigrateCloudflareListFromV4WithIPItems/from_v4_latest
=== RUN   TestMigrateCloudflareListFromV4WithIPItems/from_v5
--- PASS: TestMigrateCloudflareListFromV4WithIPItems (402.76s)
    --- PASS: TestMigrateCloudflareListFromV4WithIPItems/from_v4_latest (212.92s)
    --- PASS: TestMigrateCloudflareListFromV4WithIPItems/from_v5 (189.84s)
=== RUN   TestMigrateCloudflareListFromV4WithASNItems
=== RUN   TestMigrateCloudflareListFromV4WithASNItems/from_v4_latest
=== RUN   TestMigrateCloudflareListFromV4WithASNItems/from_v5
--- PASS: TestMigrateCloudflareListFromV4WithASNItems (184.79s)
    --- PASS: TestMigrateCloudflareListFromV4WithASNItems/from_v4_latest (90.27s)
    --- PASS: TestMigrateCloudflareListFromV4WithASNItems/from_v5 (94.52s)
=== RUN   TestMigrateCloudflareListFromV4WithHostnameItems
=== RUN   TestMigrateCloudflareListFromV4WithHostnameItems/from_v4_latest
=== RUN   TestMigrateCloudflareListFromV4WithHostnameItems/from_v5
--- PASS: TestMigrateCloudflareListFromV4WithHostnameItems (60.07s)
    --- PASS: TestMigrateCloudflareListFromV4WithHostnameItems/from_v4_latest (32.49s)
    --- PASS: TestMigrateCloudflareListFromV4WithHostnameItems/from_v5 (27.58s)
=== RUN   TestMigrateCloudflareListFromV4WithRedirectItems
=== RUN   TestMigrateCloudflareListFromV4WithRedirectItems/from_v4_latest
=== RUN   TestMigrateCloudflareListFromV4WithRedirectItems/from_v5
--- PASS: TestMigrateCloudflareListFromV4WithRedirectItems (160.29s)
    --- PASS: TestMigrateCloudflareListFromV4WithRedirectItems/from_v4_latest (55.82s)
    --- PASS: TestMigrateCloudflareListFromV4WithRedirectItems/from_v5 (104.47s)
=== RUN   TestMigrateCloudflareListFromV4WithDynamicItems
=== RUN   TestMigrateCloudflareListFromV4WithDynamicItems/from_v4_latest
=== RUN   TestMigrateCloudflareListFromV4WithDynamicItems/from_v5
--- PASS: TestMigrateCloudflareListFromV4WithDynamicItems (67.51s)
    --- PASS: TestMigrateCloudflareListFromV4WithDynamicItems/from_v4_latest (40.71s)
    --- PASS: TestMigrateCloudflareListFromV4WithDynamicItems/from_v5 (26.79s)
=== RUN   TestMigrateCloudflareListFromV4WithSeparateListItems
--- PASS: TestMigrateCloudflareListFromV4WithSeparateListItems (100.91s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/list/migration/v500	978.795s
```
```
TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/tamas/cf-repos/sdks/agent-b/tf-migrate/bin/tf-migrate go test -v -run "TestMigrate" ./internal/services/list_item/migration/v500/... -timeout 20m
=== RUN   TestMigrateCloudflareListItemFromV4WithIP
--- PASS: TestMigrateCloudflareListItemFromV4WithIP (251.32s)
=== RUN   TestMigrateCloudflareListItemFromV4WithHostname
--- PASS: TestMigrateCloudflareListItemFromV4WithHostname (68.14s)
=== RUN   TestMigrateCloudflareListItemFromV4WithRedirect
--- PASS: TestMigrateCloudflareListItemFromV4WithRedirect (37.89s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/list_item/migration/v500	358.967s
```