### PR TITLE
fix(ruleset): restore phase-entrypoint fallbacks and fix acceptance tests

### DIFF
--- a/internal/services/ruleset/resource.go
+++ b/internal/services/ruleset/resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/option"
@@ -90,8 +91,48 @@ func (r *RulesetResource) Create(ctx context.Context, req resource.CreateRequest
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("failed to make http request", err.Error())
-		return
+		// Error code 20217: "exceeded maximum number of zone/account rulesets for phase X"
+		// This means a singleton entrypoint ruleset already exists for this phase (e.g. because
+		// WAF enrollment pre-creates it). Adopt the existing ruleset by finding it via the phase
+		// entrypoint GET and updating it in-place instead of creating a new one.
+		if strings.Contains(err.Error(), "20217") || strings.Contains(err.Error(), "WAF enrollment is required") {
+			existingID, findErr := r.findExistingRulesetForPhase(ctx, data)
+			if findErr != nil {
+				resp.Diagnostics.AddError("failed to make http request", err.Error())
+				resp.Diagnostics.AddError("failed to find existing ruleset for phase", findErr.Error())
+				return
+			}
+			data.ID = types.StringValue(existingID)
+			// Use the phase entrypoint PUT endpoint instead of the regular ruleset PUT.
+			// The regular PUT enforces that the name matches the locked entrypoint name
+			// ("default"), whereas the entrypoint endpoint accepts any name and updates
+			// only the rules/description.
+			// The phase entrypoint endpoint does not accept "kind" or "phase" in the request body.
+			phaseUpdateBody, _ := sjson.Delete(string(dataBytes), "kind")
+			phaseUpdateBody, _ = sjson.Delete(phaseUpdateBody, "phase")
+			phaseUpdateParams := rulesets.PhaseUpdateParams{}
+			if !data.AccountID.IsNull() {
+				phaseUpdateParams.AccountID = cloudflare.F(data.AccountID.ValueString())
+			} else {
+				phaseUpdateParams.ZoneID = cloudflare.F(data.ZoneID.ValueString())
+			}
+			res = new(http.Response)
+			_, err = r.client.Rulesets.Phases.Update(
+				ctx,
+				rulesets.Phase(data.Phase.ValueString()),
+				phaseUpdateParams,
+				option.WithRequestBody("application/json", []byte(phaseUpdateBody)),
+				option.WithResponseBodyInto(&res),
+				option.WithMiddleware(logging.Middleware(ctx)),
+			)
+			if err != nil {
+				resp.Diagnostics.AddError("failed to make http request", err.Error())
+				return
+			}
+		} else {
+			resp.Diagnostics.AddError("failed to make http request", err.Error())
+			return
+		}
 	}
 	bytes, _ := io.ReadAll(res.Body)
 	bytes = transformQueryStringJSON(bytes)
@@ -103,6 +144,25 @@ func (r *RulesetResource) Create(ctx context.Context, req resource.CreateRequest
 	data = &env.Result
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// findExistingRulesetForPhase fetches the phase entrypoint ruleset and returns its ID.
+// Used as a fallback when Create returns a singleton-phase conflict (error 20217 or
+// "WAF enrollment is required"), meaning the entrypoint already exists and we should
+// adopt it via Update rather than trying to create a new one.
+func (r *RulesetResource) findExistingRulesetForPhase(ctx context.Context, data *RulesetModel) (string, error) {
+	getParams := rulesets.PhaseGetParams{}
+	if !data.AccountID.IsNull() {
+		getParams.AccountID = cloudflare.F(data.AccountID.ValueString())
+	} else {
+		getParams.ZoneID = cloudflare.F(data.ZoneID.ValueString())
+	}
+	phase := rulesets.Phase(data.Phase.ValueString())
+	existing, err := r.client.Rulesets.Phases.Get(ctx, phase, getParams)
+	if err != nil {
+		return "", fmt.Errorf("no existing ruleset found for phase %q: %w", data.Phase.ValueString(), err)
+	}
+	return existing.ID, nil
 }
 
 func (r *RulesetResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -142,8 +202,36 @@ func (r *RulesetResource) Update(ctx context.Context, req resource.UpdateRequest
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("failed to make http request", err.Error())
-		return
+		// The API rejects name changes on singleton phase entrypoint rulesets
+		// ("the name field cannot be modified: got X, want default"). Fall back to
+		// the phase entrypoint PUT endpoint which accepts any name.
+		// The phase entrypoint endpoint does not accept "kind" or "phase" in the request body.
+		if strings.Contains(err.Error(), "name field cannot be modified") {
+			phaseUpdateBody, _ := sjson.Delete(string(dataBytes), "kind")
+			phaseUpdateBody, _ = sjson.Delete(phaseUpdateBody, "phase")
+			phaseUpdateParams := rulesets.PhaseUpdateParams{}
+			if !data.AccountID.IsNull() {
+				phaseUpdateParams.AccountID = cloudflare.F(data.AccountID.ValueString())
+			} else {
+				phaseUpdateParams.ZoneID = cloudflare.F(data.ZoneID.ValueString())
+			}
+			res = new(http.Response)
+			_, err = r.client.Rulesets.Phases.Update(
+				ctx,
+				rulesets.Phase(data.Phase.ValueString()),
+				phaseUpdateParams,
+				option.WithRequestBody("application/json", []byte(phaseUpdateBody)),
+				option.WithResponseBodyInto(&res),
+				option.WithMiddleware(logging.Middleware(ctx)),
+			)
+			if err != nil {
+				resp.Diagnostics.AddError("failed to make http request", err.Error())
+				return
+			}
+		} else {
+			resp.Diagnostics.AddError("failed to make http request", err.Error())
+			return
+		}
 	}
 	bytes, _ := io.ReadAll(res.Body)
 	bytes = transformQueryStringJSON(bytes)

--- a/internal/services/ruleset/ruleset_test.go
+++ b/internal/services/ruleset/ruleset_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/cloudflare-go/v6/rulesets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/config"
@@ -87,9 +88,79 @@ func init() {
 	})
 }
 
+// deletePhaseEntrypoints deletes existing phase entrypoint rulesets of the given kind (KindZone
+// or KindRoot) for the given phases. This is needed before tests that create phase entrypoints,
+// because the API rejects creation with error 20217 if an entrypoint for that phase already exists.
+func deletePhaseEntrypoints(t *testing.T, kind rulesets.Kind, listParams rulesets.RulesetListParams, deleteParams rulesets.RulesetDeleteParams, phases ...rulesets.Phase) {
+	t.Helper()
+	ctx := context.Background()
+	client := acctest.SharedClient()
+	iter := client.Rulesets.ListAutoPaging(ctx, listParams)
+	wantPhase := make(map[rulesets.Phase]bool, len(phases))
+	for _, p := range phases {
+		wantPhase[p] = true
+	}
+	for iter.Next() {
+		r := iter.Current()
+		if r.Kind == kind && wantPhase[r.Phase] {
+			p := deleteParams
+			if err := client.Rulesets.Delete(ctx, r.ID, p); err != nil {
+				t.Logf("deletePhaseEntrypoints: warning deleting %s/%s (%s): %s", kind, r.Phase, r.ID, err)
+			}
+		}
+	}
+	if err := iter.Err(); err != nil {
+		t.Logf("deletePhaseEntrypoints: warning listing rulesets: %s", err)
+	}
+}
+
+// deleteAllZonePhaseEntrypoints deletes all existing kind=zone phase entrypoint rulesets on the
+// test zone. Called in the PreCheck of every test that creates zone phase entrypoints so that
+// leftover entrypoints from prior tests don't cause error 20217.
+func deleteAllZonePhaseEntrypoints(t *testing.T) {
+	t.Helper()
+	if zoneID == "" {
+		return
+	}
+	deletePhaseEntrypoints(t,
+		rulesets.KindZone,
+		rulesets.RulesetListParams{ZoneID: cloudflare.F(zoneID)},
+		rulesets.RulesetDeleteParams{ZoneID: cloudflare.F(zoneID)},
+		rulesets.PhaseHTTPRequestFirewallCustom,
+		rulesets.PhaseHTTPRequestFirewallManaged,
+		rulesets.PhaseDDoSL7,
+		rulesets.PhaseHTTPConfigSettings,
+		rulesets.PhaseHTTPCustomErrors,
+		rulesets.PhaseHTTPLogCustomFields,
+		rulesets.PhaseHTTPRatelimit,
+		rulesets.PhaseHTTPRequestCacheSettings,
+		rulesets.PhaseHTTPRequestDynamicRedirect,
+		rulesets.PhaseHTTPRequestLateTransform,
+		rulesets.PhaseHTTPRequestOrigin,
+		rulesets.PhaseHTTPRequestRedirect,
+		rulesets.PhaseHTTPRequestSanitize,
+		rulesets.PhaseHTTPRequestSBFM,
+		rulesets.PhaseHTTPRequestTransform,
+		rulesets.PhaseHTTPResponseCompression,
+		rulesets.PhaseHTTPResponseFirewallManaged,
+		rulesets.PhaseHTTPResponseHeadersTransform,
+		rulesets.PhaseHTTPResponseCacheSettings,
+	)
+}
+
 func TestAccCloudflareRulesets(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+			deletePhaseEntrypoints(t,
+				rulesets.KindRoot,
+				rulesets.RulesetListParams{AccountID: cloudflare.F(accountID)},
+				rulesets.RulesetDeleteParams{AccountID: cloudflare.F(accountID)},
+				rulesets.PhaseHTTPRequestFirewallCustom,
+				rulesets.PhaseHTTPRequestFirewallManaged,
+			)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -208,7 +279,10 @@ func TestAccCloudflareRulesets(t *testing.T) {
 
 func TestAccCloudflareRuleset_Kind(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -275,7 +349,10 @@ func TestAccCloudflareRuleset_Kind(t *testing.T) {
 
 func TestAccCloudflareRuleset_Name(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -340,9 +417,40 @@ func TestAccCloudflareRuleset_Name(t *testing.T) {
 	})
 }
 
+// ensureWAFEnrollment attempts to advance the zone's WAF migration state so that the rulesets
+// engine accepts creates/updates for the http_request_firewall_managed phase without returning
+// "WAF enrollment is required". It tries the known migration states in order; errors are logged
+// as warnings because the zone may already be at a later state where earlier transitions are
+// no longer accepted.
+func ensureWAFEnrollment(t *testing.T) {
+	t.Helper()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	if zoneID == "" {
+		return
+	}
+	ctx := context.Background()
+	client := acctest.SharedClient()
+	params := rulesets.PhaseUpdateParams{
+		ZoneID: cloudflare.F(zoneID),
+		Rules:  cloudflare.F([]rulesets.PhaseUpdateParamsRuleUnion{}),
+	}
+	for _, state := range []string{"start", "pending"} {
+		// Errors are expected if the zone is already at or past this migration state.
+		client.Rulesets.Phases.Update( //nolint:errcheck
+			ctx,
+			rulesets.PhaseHTTPRequestFirewallManaged,
+			params,
+			option.WithQuery("waf_migration", state),
+		)
+	}
+}
+
 func TestAccCloudflareRuleset_Phase(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -409,7 +517,10 @@ func TestAccCloudflareRuleset_Phase(t *testing.T) {
 
 func TestAccCloudflareRuleset_Description(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -497,7 +608,10 @@ func TestAccCloudflareRuleset_Description(t *testing.T) {
 
 func TestAccCloudflareRuleset_Rules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -556,7 +670,10 @@ func TestAccCloudflareRuleset_Rules(t *testing.T) {
 
 func TestAccCloudflareRuleset_RulesActionParameters(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -635,7 +752,10 @@ func TestAccCloudflareRuleset_RulesActionParameters(t *testing.T) {
 
 func TestAccCloudflareRuleset_RulesDescription(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -755,7 +875,10 @@ func TestAccCloudflareRuleset_RulesDescription(t *testing.T) {
 
 func TestAccCloudflareRuleset_RulesEnabled(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -875,7 +998,10 @@ func TestAccCloudflareRuleset_RulesEnabled(t *testing.T) {
 
 func TestAccCloudflareRuleset_RulesExposedCredentialCheck(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -984,7 +1110,10 @@ func TestAccCloudflareRuleset_RulesExposedCredentialCheck(t *testing.T) {
 
 func TestAccCloudflareRuleset_RulesLogging(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -1120,7 +1249,10 @@ func TestAccCloudflareRuleset_RulesLogging(t *testing.T) {
 	t.Run("modify", func(t *testing.T) {
 		t.Run("action", func(t *testing.T) {
 			resource.Test(t, resource.TestCase{
-				PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+				PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 				Steps: []resource.TestStep{
 					{
@@ -1242,7 +1374,10 @@ func TestAccCloudflareRuleset_RulesLogging(t *testing.T) {
 
 		t.Run("expression", func(t *testing.T) {
 			resource.Test(t, resource.TestCase{
-				PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+				PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 				Steps: []resource.TestStep{
 					{
@@ -1367,7 +1502,10 @@ func TestAccCloudflareRuleset_RulesLogging(t *testing.T) {
 
 		t.Run("id", func(t *testing.T) {
 			resource.Test(t, resource.TestCase{
-				PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+				PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 				Steps: []resource.TestStep{
 					{
@@ -1498,7 +1636,10 @@ func TestAccCloudflareRuleset_RulesLogging(t *testing.T) {
 
 func TestAccCloudflareRuleset_RulesRatelimit(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -1738,7 +1879,10 @@ func TestAccCloudflareRuleset_RulesRatelimit(t *testing.T) {
 func TestAccCloudflareRuleset_RulesRef(t *testing.T) {
 	t.Run("add", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
-			PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+			PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 			ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
 				{
@@ -1895,7 +2039,10 @@ func TestAccCloudflareRuleset_RulesRef(t *testing.T) {
 
 	t.Run("append", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
-			PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+			PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 			ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
 				{
@@ -2052,7 +2199,10 @@ func TestAccCloudflareRuleset_RulesRef(t *testing.T) {
 
 	t.Run("modify", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
-			PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+			PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 			ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
 				{
@@ -2191,7 +2341,10 @@ func TestAccCloudflareRuleset_RulesRef(t *testing.T) {
 
 	t.Run("remove", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
-			PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+			PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 			ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
 				{
@@ -2315,7 +2468,10 @@ func TestAccCloudflareRuleset_RulesRef(t *testing.T) {
 
 	t.Run("reverse", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
-			PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+			PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 			ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
 				{
@@ -2454,7 +2610,10 @@ func TestAccCloudflareRuleset_RulesRef(t *testing.T) {
 
 	t.Run("truncate", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
-			PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+			PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 			ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
 				{
@@ -2579,7 +2738,10 @@ func TestAccCloudflareRuleset_RulesRef(t *testing.T) {
 
 func TestAccCloudflareRuleset_LastUpdated(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -2644,7 +2806,10 @@ func TestAccCloudflareRuleset_LastUpdated(t *testing.T) {
 
 func TestAccCloudflareRuleset_Version(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -2709,7 +2874,10 @@ func TestAccCloudflareRuleset_Version(t *testing.T) {
 
 func TestAccCloudflareRuleset_BlockRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -2830,7 +2998,10 @@ func TestAccCloudflareRuleset_BlockRules(t *testing.T) {
 
 func TestAccCloudflareRuleset_ChallengeRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -2962,7 +3133,10 @@ func TestAccCloudflareRuleset_ChallengeRules(t *testing.T) {
 
 func TestAccCloudflareRuleset_CompressResponseRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -3103,9 +3277,13 @@ func TestAccCloudflareRuleset_CompressResponseRules(t *testing.T) {
 }
 
 func TestAccCloudflareRuleset_ExecuteRules(t *testing.T) {
-	t.Skip("FIXME: skip test; WAF enrollment is required for http_request_firewall_managed phase but is not available in the test environment")
+	t.Skip("FIXME: skip test; WAF subscription is required for http_request_firewall_managed execute rules but is not available in the test environment")
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+			ensureWAFEnrollment(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -3646,7 +3824,10 @@ func TestAccCloudflareRuleset_ExecuteRules(t *testing.T) {
 
 func TestAccCloudflareRuleset_LogRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -3696,7 +3877,10 @@ func TestAccCloudflareRuleset_LogRules(t *testing.T) {
 
 func TestAccCloudflareRuleset_LogCustomFieldRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -3943,7 +4127,10 @@ func TestAccCloudflareRuleset_LogCustomFieldRules(t *testing.T) {
 
 func TestAccCloudflareRuleset_RedirectRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -4213,7 +4400,10 @@ func TestAccCloudflareRuleset_RedirectRules(t *testing.T) {
 
 func TestAccCloudflareRuleset_RewriteRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -5082,7 +5272,10 @@ func TestAccCloudflareRuleset_RouteRules(t *testing.T) {
 
 func TestAccCloudflareRuleset_ServeErrorRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -5209,7 +5402,10 @@ func TestAccCloudflareRuleset_ServeErrorRules(t *testing.T) {
 
 func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -6604,7 +6800,10 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 func TestAccCloudflareRuleset_SetConfigRules(t *testing.T) {
 	t.Skip(`FIXME: skip test due to feature deprecations; mirage and disable_apps are deprecated, but have suddenly EOL'd`)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -7224,7 +7423,10 @@ func TestAccCloudflareRuleset_SetConfigRules(t *testing.T) {
 
 func TestAccCloudflareRuleset_SkipRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -7458,7 +7660,10 @@ func TestAccCloudflareRuleset_SkipRules(t *testing.T) {
 
 func TestAccCloudflareRuleset_SetCacheControlRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -7911,7 +8116,10 @@ func TestAccCloudflareRuleset_SetCacheControlRules(t *testing.T) {
 
 func TestAccCloudflareRuleset_SetCacheTagsRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			deleteAllZonePhaseEntrypoints(t)
+		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
### Problem

Two categories of failures:

1. **Resource regressions** — the `cloudflare_ruleset` Create and Update handlers were missing fallback paths that handle Cloudflare API constraints on singleton phase entrypoints:
   - Create returned error 20217 (`exceeded maximum number of zone/account rulesets for phase X`) or `"WAF enrollment is required"` when a phase entrypoint already existed (e.g. pre-created by WAF enrollment). Instead of adopting it, the resource just errored.
   - Update returned `"name field cannot be modified"` when trying to rename a locked entrypoint via the regular PUT endpoint.

2. **Acceptance test pollution** — tests that create `kind=zone` phase entrypoints share the same zone and run sequentially. Leftover entrypoints from one test caused error 20217 in the next.

### Changes

**`resource.go`**
- Restored the 20217 / "WAF enrollment is required" fallback in `Create`: looks up the existing entrypoint via `Phases.Get` and adopts it with `Phases.Update`, stripping `kind` and `phase` from the request body as the entrypoint endpoint requires.
- Restored the "name field cannot be modified" fallback in `Update`: falls back to `Phases.Update` when the regular `PUT /rulesets/:id` rejects a name change.
- Added `findExistingRulesetForPhase` helper used by the Create fallback.

**`ruleset_test.go`**
- Added `deletePhaseEntrypoints` — generic helper to delete entrypoints of a given kind/scope for specific phases.
- Added `deleteAllZonePhaseEntrypoints` — clears all `kind=zone` entrypoints from the test zone, covering every phase used across the test suite.
- Added `ensureWAFEnrollment` — advances the zone's WAF migration state via `waf_migration=start/pending` query params; errors are silently ignored since the zone may already be past those states.
- Wired `deleteAllZonePhaseEntrypoints` into every test's `PreCheck` so each test starts with a clean slate regardless of execution order.
- `TestAccCloudflareRulesets` also cleans up account-level `root` entrypoints for the two phases it creates.
- Corrected `TestAccCloudflareRuleset_ExecuteRules` skip message: the blocker is a missing WAF **subscription** (not just enrollment state).

---

```
TF_ACC=1 TF_MIGRATE_BINARY_PATH=/Users/tamas/cf-repos/sdks/agent-b/tf-migrate/bin/tf-migrate go test -v -run "TestAcc" ./internal/services/ruleset -timeout 40m
=== RUN   TestAccCloudflareRulesets
--- PASS: TestAccCloudflareRulesets (8.61s)
=== RUN   TestAccCloudflareRuleset_Kind
--- PASS: TestAccCloudflareRuleset_Kind (13.89s)
=== RUN   TestAccCloudflareRuleset_Name
--- PASS: TestAccCloudflareRuleset_Name (15.45s)
=== RUN   TestAccCloudflareRuleset_Phase
--- PASS: TestAccCloudflareRuleset_Phase (15.11s)
=== RUN   TestAccCloudflareRuleset_Description
--- PASS: TestAccCloudflareRuleset_Description (20.95s)
=== RUN   TestAccCloudflareRuleset_Rules
--- PASS: TestAccCloudflareRuleset_Rules (16.00s)
=== RUN   TestAccCloudflareRuleset_RulesActionParameters
--- PASS: TestAccCloudflareRuleset_RulesActionParameters (15.40s)
=== RUN   TestAccCloudflareRuleset_RulesDescription
--- PASS: TestAccCloudflareRuleset_RulesDescription (24.23s)
=== RUN   TestAccCloudflareRuleset_RulesEnabled
--- PASS: TestAccCloudflareRuleset_RulesEnabled (26.79s)
=== RUN   TestAccCloudflareRuleset_RulesExposedCredentialCheck
--- PASS: TestAccCloudflareRuleset_RulesExposedCredentialCheck (21.73s)
=== RUN   TestAccCloudflareRuleset_RulesLogging
=== RUN   TestAccCloudflareRuleset_RulesLogging/modify
=== RUN   TestAccCloudflareRuleset_RulesLogging/modify/action
=== RUN   TestAccCloudflareRuleset_RulesLogging/modify/expression
=== RUN   TestAccCloudflareRuleset_RulesLogging/modify/id
--- PASS: TestAccCloudflareRuleset_RulesLogging (69.24s)
    --- PASS: TestAccCloudflareRuleset_RulesLogging/modify (48.48s)
        --- PASS: TestAccCloudflareRuleset_RulesLogging/modify/action (16.63s)
        --- PASS: TestAccCloudflareRuleset_RulesLogging/modify/expression (16.31s)
        --- PASS: TestAccCloudflareRuleset_RulesLogging/modify/id (15.54s)
=== RUN   TestAccCloudflareRuleset_RulesRatelimit
--- PASS: TestAccCloudflareRuleset_RulesRatelimit (22.84s)
=== RUN   TestAccCloudflareRuleset_RulesRef
=== RUN   TestAccCloudflareRuleset_RulesRef/add
=== RUN   TestAccCloudflareRuleset_RulesRef/append
=== RUN   TestAccCloudflareRuleset_RulesRef/modify
=== RUN   TestAccCloudflareRuleset_RulesRef/remove
=== RUN   TestAccCloudflareRuleset_RulesRef/reverse
=== RUN   TestAccCloudflareRuleset_RulesRef/truncate
--- PASS: TestAccCloudflareRuleset_RulesRef (96.64s)
    --- PASS: TestAccCloudflareRuleset_RulesRef/add (15.92s)
    --- PASS: TestAccCloudflareRuleset_RulesRef/append (17.25s)
    --- PASS: TestAccCloudflareRuleset_RulesRef/modify (17.06s)
    --- PASS: TestAccCloudflareRuleset_RulesRef/remove (15.85s)
    --- PASS: TestAccCloudflareRuleset_RulesRef/reverse (15.68s)
    --- PASS: TestAccCloudflareRuleset_RulesRef/truncate (14.88s)
=== RUN   TestAccCloudflareRuleset_LastUpdated
--- PASS: TestAccCloudflareRuleset_LastUpdated (18.04s)
=== RUN   TestAccCloudflareRuleset_Version
--- PASS: TestAccCloudflareRuleset_Version (15.51s)
=== RUN   TestAccCloudflareRuleset_BlockRules
--- PASS: TestAccCloudflareRuleset_BlockRules (16.97s)
=== RUN   TestAccCloudflareRuleset_ChallengeRules
--- PASS: TestAccCloudflareRuleset_ChallengeRules (21.88s)
=== RUN   TestAccCloudflareRuleset_CompressResponseRules
--- PASS: TestAccCloudflareRuleset_CompressResponseRules (14.97s)
=== RUN   TestAccCloudflareRuleset_ExecuteRules
    ruleset_test.go:3280: FIXME: skip test; WAF subscription is required for http_request_firewall_managed execute rules but is not available in the test environment
--- SKIP: TestAccCloudflareRuleset_ExecuteRules (0.00s)
=== RUN   TestAccCloudflareRuleset_LogRules
--- PASS: TestAccCloudflareRuleset_LogRules (7.50s)
=== RUN   TestAccCloudflareRuleset_LogCustomFieldRules
--- PASS: TestAccCloudflareRuleset_LogCustomFieldRules (14.41s)
=== RUN   TestAccCloudflareRuleset_RedirectRules
--- PASS: TestAccCloudflareRuleset_RedirectRules (32.65s)
=== RUN   TestAccCloudflareRuleset_RewriteRules
--- PASS: TestAccCloudflareRuleset_RewriteRules (58.04s)
=== RUN   TestAccCloudflareRuleset_RouteRules
--- PASS: TestAccCloudflareRuleset_RouteRules (29.20s)
=== RUN   TestAccCloudflareRuleset_ServeErrorRules
--- PASS: TestAccCloudflareRuleset_ServeErrorRules (14.77s)
=== RUN   TestAccCloudflareRuleset_SetCacheSettingsRules
--- PASS: TestAccCloudflareRuleset_SetCacheSettingsRules (78.85s)
=== RUN   TestAccCloudflareRuleset_SetConfigRules
    ruleset_test.go:6801: FIXME: skip test due to feature deprecations; mirage and disable_apps are deprecated, but have suddenly EOL'd
--- SKIP: TestAccCloudflareRuleset_SetConfigRules (0.00s)
=== RUN   TestAccCloudflareRuleset_SkipRules
--- PASS: TestAccCloudflareRuleset_SkipRules (26.02s)
=== RUN   TestAccCloudflareRuleset_SetCacheControlRules
--- PASS: TestAccCloudflareRuleset_SetCacheControlRules (23.75s)
=== RUN   TestAccCloudflareRuleset_SetCacheTagsRules
--- PASS: TestAccCloudflareRuleset_SetCacheTagsRules (24.20s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/ruleset	765.182s
```

