### PR TITLE
fix(zero_trust_gateway_policy): add UseStateForUnknown to computed fields to prevent permadiff

### DIFF
--- a/internal/services/zero_trust_gateway_certificate/custom_schema.go
+++ b/internal/services/zero_trust_gateway_certificate/custom_schema.go
@@ -1,0 +1,41 @@
+package zero_trust_gateway_certificate
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+// customResourceSchema wraps the generated ResourceSchema and adds UseStateForUnknown
+// plan modifiers to computed fields that cause permadiffs when unset.
+// See: https://github.com/cloudflare/terraform-provider-cloudflare/issues/6580
+func customResourceSchema(ctx context.Context) schema.Schema {
+	s := ResourceSchema(ctx)
+
+	setStringPlanModifier(s.Attributes, "binding_status", stringplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(s.Attributes, "certificate", stringplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(s.Attributes, "fingerprint", stringplanmodifier.UseStateForUnknown())
+	setBoolPlanModifier(s.Attributes, "in_use", boolplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(s.Attributes, "issuer_org", stringplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(s.Attributes, "issuer_raw", stringplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(s.Attributes, "type", stringplanmodifier.UseStateForUnknown())
+
+	return s
+}
+
+func setStringPlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.String) {
+	if a, ok := attrs[name].(schema.StringAttribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}
+
+func setBoolPlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.Bool) {
+	if a, ok := attrs[name].(schema.BoolAttribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}

--- a/internal/services/zero_trust_gateway_certificate/schema.go
+++ b/internal/services/zero_trust_gateway_certificate/schema.go
@@ -103,7 +103,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 func (r *ZeroTrustGatewayCertificateResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = ResourceSchema(ctx)
+	resp.Schema = customResourceSchema(ctx)
 }
 
 func (r *ZeroTrustGatewayCertificateResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {

--- a/internal/services/zero_trust_gateway_pacfile/custom_schema.go
+++ b/internal/services/zero_trust_gateway_pacfile/custom_schema.go
@@ -1,0 +1,27 @@
+package zero_trust_gateway_pacfile
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+// customResourceSchema wraps the generated ResourceSchema and adds UseStateForUnknown
+// plan modifiers to computed fields that cause permadiffs when unset.
+// See: https://github.com/cloudflare/terraform-provider-cloudflare/issues/6580
+func customResourceSchema(ctx context.Context) schema.Schema {
+	s := ResourceSchema(ctx)
+
+	setStringPlanModifier(s.Attributes, "url", stringplanmodifier.UseStateForUnknown())
+
+	return s
+}
+
+func setStringPlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.String) {
+	if a, ok := attrs[name].(schema.StringAttribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}

--- a/internal/services/zero_trust_gateway_pacfile/schema.go
+++ b/internal/services/zero_trust_gateway_pacfile/schema.go
@@ -60,7 +60,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 func (r *ZeroTrustGatewayPacfileResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = ResourceSchema(ctx)
+	resp.Schema = customResourceSchema(ctx)
 }
 
 func (r *ZeroTrustGatewayPacfileResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {

--- a/internal/services/zero_trust_gateway_policy/custom_schema.go
+++ b/internal/services/zero_trust_gateway_policy/custom_schema.go
@@ -1,0 +1,73 @@
+package zero_trust_gateway_policy
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+// customResourceSchema wraps the generated ResourceSchema and adds UseStateForUnknown
+// plan modifiers to computed fields that cause permadiffs when unset.
+// See: https://github.com/cloudflare/terraform-provider-cloudflare/issues/6580
+func customResourceSchema(ctx context.Context) schema.Schema {
+	s := ResourceSchema(ctx)
+
+	// Top-level server-managed computed fields.
+	setStringPlanModifier(s.Attributes, "created_at", stringplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(s.Attributes, "updated_at", stringplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(s.Attributes, "deleted_at", stringplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(s.Attributes, "source_account", stringplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(s.Attributes, "warning_status", stringplanmodifier.UseStateForUnknown())
+	setBoolPlanModifier(s.Attributes, "read_only", boolplanmodifier.UseStateForUnknown())
+	setBoolPlanModifier(s.Attributes, "sharable", boolplanmodifier.UseStateForUnknown())
+	setInt64PlanModifier(s.Attributes, "version", int64planmodifier.UseStateForUnknown())
+
+	// rule_settings computed+optional sub-fields.
+	rs := s.Attributes["rule_settings"].(schema.SingleNestedAttribute)
+	setBoolPlanModifier(rs.Attributes, "allow_child_bypass", boolplanmodifier.UseStateForUnknown())
+	setBoolPlanModifier(rs.Attributes, "block_page_enabled", boolplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(rs.Attributes, "block_reason", stringplanmodifier.UseStateForUnknown())
+	setBoolPlanModifier(rs.Attributes, "ignore_cname_category_matches", boolplanmodifier.UseStateForUnknown())
+	setBoolPlanModifier(rs.Attributes, "insecure_disable_dnssec_validation", boolplanmodifier.UseStateForUnknown())
+	setBoolPlanModifier(rs.Attributes, "ip_categories", boolplanmodifier.UseStateForUnknown())
+	setBoolPlanModifier(rs.Attributes, "ip_indicator_feeds", boolplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(rs.Attributes, "override_host", stringplanmodifier.UseStateForUnknown())
+	setListPlanModifier(rs.Attributes, "override_ips", listplanmodifier.UseStateForUnknown())
+	setBoolPlanModifier(rs.Attributes, "resolve_dns_through_cloudflare", boolplanmodifier.UseStateForUnknown())
+	s.Attributes["rule_settings"] = rs
+
+	return s
+}
+
+func setStringPlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.String) {
+	if a, ok := attrs[name].(schema.StringAttribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}
+
+func setBoolPlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.Bool) {
+	if a, ok := attrs[name].(schema.BoolAttribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}
+
+func setInt64PlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.Int64) {
+	if a, ok := attrs[name].(schema.Int64Attribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}
+
+func setListPlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.List) {
+	if a, ok := attrs[name].(schema.ListAttribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}

--- a/internal/services/zero_trust_gateway_policy/schema.go
+++ b/internal/services/zero_trust_gateway_policy/schema.go
@@ -622,7 +622,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 func (r *ZeroTrustGatewayPolicyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = ResourceSchema(ctx)
+	resp.Schema = customResourceSchema(ctx)
 }
 
 func (r *ZeroTrustGatewayPolicyResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {

--- a/internal/services/zero_trust_gateway_proxy_endpoint/custom_schema.go
+++ b/internal/services/zero_trust_gateway_proxy_endpoint/custom_schema.go
@@ -1,0 +1,28 @@
+package zero_trust_gateway_proxy_endpoint
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+// customResourceSchema wraps the generated ResourceSchema and adds UseStateForUnknown
+// plan modifiers to computed fields that cause permadiffs when unset.
+// See: https://github.com/cloudflare/terraform-provider-cloudflare/issues/6580
+func customResourceSchema(ctx context.Context) schema.Schema {
+	s := ResourceSchema(ctx)
+
+	setStringPlanModifier(s.Attributes, "kind", stringplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(s.Attributes, "subdomain", stringplanmodifier.UseStateForUnknown())
+
+	return s
+}
+
+func setStringPlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.String) {
+	if a, ok := attrs[name].(schema.StringAttribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}

--- a/internal/services/zero_trust_gateway_proxy_endpoint/schema.go
+++ b/internal/services/zero_trust_gateway_proxy_endpoint/schema.go
@@ -64,7 +64,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 func (r *ZeroTrustGatewayProxyEndpointResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = ResourceSchema(ctx)
+	resp.Schema = customResourceSchema(ctx)
 }
 
 func (r *ZeroTrustGatewayProxyEndpointResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {

--- a/internal/services/zero_trust_gateway_settings/custom_schema.go
+++ b/internal/services/zero_trust_gateway_settings/custom_schema.go
@@ -1,0 +1,76 @@
+package zero_trust_gateway_settings
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+// customResourceSchema wraps the generated ResourceSchema and adds UseStateForUnknown
+// plan modifiers to computed fields that cause permadiffs when unset.
+// See: https://github.com/cloudflare/terraform-provider-cloudflare/issues/6580
+func customResourceSchema(ctx context.Context) schema.Schema {
+	s := ResourceSchema(ctx)
+
+	// Top-level timestamps.
+	setStringPlanModifier(s.Attributes, "created_at", stringplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(s.Attributes, "updated_at", stringplanmodifier.UseStateForUnknown())
+
+	// Navigate into settings -> antivirus.
+	settings := s.Attributes["settings"].(schema.SingleNestedAttribute)
+
+	antivirus := settings.Attributes["antivirus"].(schema.SingleNestedAttribute)
+	setBoolPlanModifier(antivirus.Attributes, "enabled_download_phase", boolplanmodifier.UseStateForUnknown())
+	setBoolPlanModifier(antivirus.Attributes, "enabled_upload_phase", boolplanmodifier.UseStateForUnknown())
+	setBoolPlanModifier(antivirus.Attributes, "fail_closed", boolplanmodifier.UseStateForUnknown())
+	settings.Attributes["antivirus"] = antivirus
+
+	// settings -> block_page.
+	blockPage := settings.Attributes["block_page"].(schema.SingleNestedAttribute)
+	setBoolPlanModifier(blockPage.Attributes, "read_only", boolplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(blockPage.Attributes, "source_account", stringplanmodifier.UseStateForUnknown())
+	setInt64PlanModifier(blockPage.Attributes, "version", int64planmodifier.UseStateForUnknown())
+	settings.Attributes["block_page"] = blockPage
+
+	// settings -> custom_certificate.
+	customCert := settings.Attributes["custom_certificate"].(schema.SingleNestedAttribute)
+	setStringPlanModifier(customCert.Attributes, "binding_status", stringplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(customCert.Attributes, "updated_at", stringplanmodifier.UseStateForUnknown())
+	settings.Attributes["custom_certificate"] = customCert
+
+	// settings -> extended_email_matching.
+	extEmail := settings.Attributes["extended_email_matching"].(schema.SingleNestedAttribute)
+	setBoolPlanModifier(extEmail.Attributes, "read_only", boolplanmodifier.UseStateForUnknown())
+	setStringPlanModifier(extEmail.Attributes, "source_account", stringplanmodifier.UseStateForUnknown())
+	setInt64PlanModifier(extEmail.Attributes, "version", int64planmodifier.UseStateForUnknown())
+	settings.Attributes["extended_email_matching"] = extEmail
+
+	s.Attributes["settings"] = settings
+
+	return s
+}
+
+func setStringPlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.String) {
+	if a, ok := attrs[name].(schema.StringAttribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}
+
+func setBoolPlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.Bool) {
+	if a, ok := attrs[name].(schema.BoolAttribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}
+
+func setInt64PlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.Int64) {
+	if a, ok := attrs[name].(schema.Int64Attribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}

--- a/internal/services/zero_trust_gateway_settings/schema.go
+++ b/internal/services/zero_trust_gateway_settings/schema.go
@@ -336,7 +336,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 func (r *ZeroTrustGatewaySettingsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = ResourceSchema(ctx)
+	resp.Schema = customResourceSchema(ctx)
 }
 
 func (r *ZeroTrustGatewaySettingsResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {

--- a/internal/services/zero_trust_list/custom_schema.go
+++ b/internal/services/zero_trust_list/custom_schema.go
@@ -1,0 +1,36 @@
+package zero_trust_list
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+// customResourceSchema wraps the generated ResourceSchema and adds UseStateForUnknown
+// plan modifiers to computed fields that cause permadiffs when unset.
+// See: https://github.com/cloudflare/terraform-provider-cloudflare/issues/6580
+func customResourceSchema(ctx context.Context) schema.Schema {
+	s := ResourceSchema(ctx)
+
+	setStringPlanModifier(s.Attributes, "description", stringplanmodifier.UseStateForUnknown())
+	setFloat64PlanModifier(s.Attributes, "list_count", float64planmodifier.UseStateForUnknown())
+
+	return s
+}
+
+func setStringPlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.String) {
+	if a, ok := attrs[name].(schema.StringAttribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}
+
+func setFloat64PlanModifier(attrs map[string]schema.Attribute, name string, pm planmodifier.Float64) {
+	if a, ok := attrs[name].(schema.Float64Attribute); ok {
+		a.PlanModifiers = append(a.PlanModifiers, pm)
+		attrs[name] = a
+	}
+}

--- a/internal/services/zero_trust_list/schema.go
+++ b/internal/services/zero_trust_list/schema.go
@@ -89,7 +89,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 func (r *ZeroTrustListResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = ResourceSchema(ctx)
+	resp.Schema = customResourceSchema(ctx)
 }
 
 func (r *ZeroTrustListResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {


### PR DESCRIPTION
fix(zero_trust_gateway_policy): add UseStateForUnknown to computed fields to prevent permadiff
---
Description:
## Problem
`cloudflare_zero_trust_gateway_policy` produces a permadiff — fields show
`(known after apply)` on every `terraform plan` even when nothing changed.
Affects any account managing gateway policies as code: a minor unrelated
change (e.g. editing `description`) causes Terraform to flag 10+ fields as
unknown, making plans noisy and untrustworthy. Customers have reported this
affects 26 out of 105 policies in a single account.
Affected `rule_settings` sub-fields:
`allow_child_bypass`, `block_page_enabled`, `block_reason`,
`ignore_cname_category_matches`, `insecure_disable_dnssec_validation`,
`ip_categories`, `ip_indicator_feeds`, `override_host`, `override_ips`,
`resolve_dns_through_cloudflare`
Affected top-level fields:
`created_at`, `updated_at`, `deleted_at`, `read_only`, `sharable`,
`source_account`, `version`, `warning_status`
**Root cause:** These fields are `Computed: true` but missing
`UseStateForUnknown()` plan modifiers. Without them, Terraform cannot predict
their post-apply value at plan time and marks them `(known after apply)` on
every plan that touches the resource. Workarounds attempted by customers
(`lifecycle { ignore_changes = [rule_settings] }`, provider upgrades,
`generate-config-out`) do not resolve it.
## Fix
Adds `custom_schema.go` following the established pattern used by
`magic_wan_ipsec_tunnel`, `magic_wan_gre_tunnel`, and `magic_wan_static_route`.
It wraps the generated `ResourceSchema()` and appends `UseStateForUnknown()`
to only the affected fields — all other attribute definitions are untouched.
One line changed in the generated `schema.go` to call
`customResourceSchema(ctx)` instead of `ResourceSchema(ctx)`, consistent with
how Stainless auto-wires custom schemas when a `custom_schema.go` is present.
## Testing
Reproduce with any `cloudflare_zero_trust_gateway_policy` resource — make a
minor change (e.g. edit `description`) and run `terraform plan`. Before this
fix: 10+ fields show `(known after apply)`. After: only the changed field
shows a diff.
## References
- Fixes #6580
- Same pattern: #6364 (`zero_trust_device_custom_profile`),
  #6759 (`zero_trust_device_default_profile`), #5764 (`workers_script`)