### PR TITLE
fix(r2): Add degraded-response handling to the R2 custom domain resource

### DIFF
--- a/internal/services/r2_custom_domain/custom.go
+++ b/internal/services/r2_custom_domain/custom.go
@@ -1,0 +1,130 @@
+package r2_custom_domain
+
+import (
+	"context"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+)
+
+// preserveStateOnDegradedResponse preserves certain state values when the API
+// returns a degraded response due to a transient backend failure (e.g., the
+// SSL for SaaS API being temporarily unavailable).
+//
+// When the R2 custom domain GET API cannot reach SSL4SaaS, it returns:
+//   - status.ssl = "unknown" and status.ownership = "unknown"
+//   - zone_name, min_tls, and ciphers omitted (null)
+//
+// These degraded values would overwrite real state values (e.g., "active"),
+// causing Terraform to detect false drift and potentially trigger unnecessary
+// resource replacement. This function detects the degraded response pattern
+// and preserves the previous state values instead.
+func preserveStateOnDegradedResponse(ctx context.Context, data *R2CustomDomainModel, previousState *R2CustomDomainModel) {
+	if data == nil || previousState == nil {
+		return
+	}
+
+	// Detect whether this is a degraded response by checking if both status
+	// fields are "unknown" — this is the sentinel value the API returns when
+	// the SSL4SaaS backend is unreachable.
+	isDegraded := isDegradedStatusResponse(ctx, data)
+
+	// Preserve status fields: only restore previous values when the API returned
+	// "unknown" (indicating a transient failure), not a legitimate status change.
+	preserveStatusFields(ctx, data, previousState, isDegraded)
+
+	// When the response is degraded, the API may also omit fields that are
+	// normally present. Preserve these from the previous state.
+	if isDegraded {
+		preserveOmittedFields(data, previousState)
+	}
+}
+
+// isDegradedStatusResponse returns true if the API response has both status
+// fields set to "unknown", which indicates a transient failure rather than
+// a real status value.
+func isDegradedStatusResponse(ctx context.Context, data *R2CustomDomainModel) bool {
+	if data.Status.IsNull() || data.Status.IsUnknown() {
+		return false
+	}
+
+	currentStatus, diags := data.Status.Value(ctx)
+	if diags.HasError() || currentStatus == nil {
+		return false
+	}
+
+	return currentStatus.SSL.ValueString() == "unknown" &&
+		currentStatus.Ownership.ValueString() == "unknown"
+}
+
+// preserveStatusFields restores the previous status.ssl and status.ownership
+// values when the API returned "unknown" and we had real values in state.
+func preserveStatusFields(ctx context.Context, data *R2CustomDomainModel, previousState *R2CustomDomainModel, isDegraded bool) {
+	if !isDegraded {
+		return
+	}
+
+	if previousState.Status.IsNull() || previousState.Status.IsUnknown() {
+		return
+	}
+
+	previousStatus, diags := previousState.Status.Value(ctx)
+	if diags.HasError() || previousStatus == nil {
+		return
+	}
+
+	// Only restore if the previous state had real (non-unknown) values.
+	// If the previous state was also "unknown", there's nothing better to restore.
+	hasPreviousSSL := !previousStatus.SSL.IsNull() && !previousStatus.SSL.IsUnknown() && previousStatus.SSL.ValueString() != "unknown"
+	hasPreviousOwnership := !previousStatus.Ownership.IsNull() && !previousStatus.Ownership.IsUnknown() && previousStatus.Ownership.ValueString() != "unknown"
+
+	if !hasPreviousSSL && !hasPreviousOwnership {
+		return
+	}
+
+	restoredStatus := &R2CustomDomainStatusModel{
+		SSL:       previousStatus.SSL,
+		Ownership: previousStatus.Ownership,
+	}
+
+	newStatus, diags := customfield.NewObject(ctx, restoredStatus)
+	if diags.HasError() {
+		return
+	}
+	data.Status = newStatus
+}
+
+// preserveOmittedFields restores zone_name, min_tls, and ciphers from the previous state
+// when the API omits them in a degraded response. These fields are normally
+// present but get dropped when the SSL4SaaS backend is unreachable.
+func preserveOmittedFields(data *R2CustomDomainModel, previousState *R2CustomDomainModel) {
+	// Preserve zone_name if it went null but was previously set
+	if data.ZoneName.IsNull() && !previousState.ZoneName.IsNull() && !previousState.ZoneName.IsUnknown() {
+		data.ZoneName = previousState.ZoneName
+	}
+
+	// Preserve min_tls if it went null but was previously set
+	if data.MinTLS.IsNull() && !previousState.MinTLS.IsNull() && !previousState.MinTLS.IsUnknown() {
+		data.MinTLS = previousState.MinTLS
+	}
+
+	// Preserve ciphers if it went nil but was previously set
+	if data.Ciphers == nil && previousState.Ciphers != nil {
+		data.Ciphers = previousState.Ciphers
+	}
+}
+
+// snapshotState creates a shallow copy of the model so we can compare
+// against it after the API response overwrites the fields.
+//
+// Note: This performs a shallow copy, which means pointer fields like Ciphers
+// are shared between the original and snapshot. This is safe because:
+// 1. The snapshot is only used for reading values in preserveStateOnDegradedResponse
+// 2. The data pointer is completely replaced after API unmarshaling
+// 3. No code modifies slice contents through pointers
+func snapshotState(data *R2CustomDomainModel) *R2CustomDomainModel {
+	if data == nil {
+		return nil
+	}
+	snapshot := *data
+	return &snapshot
+}

--- a/internal/services/r2_custom_domain/custom_test.go
+++ b/internal/services/r2_custom_domain/custom_test.go
@@ -1,0 +1,464 @@
+/* Unit tests for custom domain false drift when API does not return certain fields due to intermittent errors */
+package r2_custom_domain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// makeStatus creates a NestedObject[R2CustomDomainStatusModel] from the given values.
+func makeStatus(t *testing.T, ssl, ownership string) customfield.NestedObject[R2CustomDomainStatusModel] {
+	t.Helper()
+	ctx := context.Background()
+	status := &R2CustomDomainStatusModel{
+		SSL:       types.StringValue(ssl),
+		Ownership: types.StringValue(ownership),
+	}
+	obj, diags := customfield.NewObject(ctx, status)
+	if diags.HasError() {
+		t.Fatalf("failed to create status object: %v", diags)
+	}
+	return obj
+}
+
+// makeNullStatus creates a null NestedObject[R2CustomDomainStatusModel].
+func makeNullStatus(t *testing.T) customfield.NestedObject[R2CustomDomainStatusModel] {
+	t.Helper()
+	ctx := context.Background()
+	return customfield.NullObject[R2CustomDomainStatusModel](ctx)
+}
+
+// getStatusValues extracts ssl and ownership strings from a status NestedObject.
+func getStatusValues(t *testing.T, status customfield.NestedObject[R2CustomDomainStatusModel]) (ssl, ownership string) {
+	t.Helper()
+	ctx := context.Background()
+	s, diags := status.Value(ctx)
+	if diags.HasError() {
+		t.Fatalf("failed to get status value: %v", diags)
+	}
+	if s == nil {
+		t.Fatal("status value is nil")
+	}
+	return s.SSL.ValueString(), s.Ownership.ValueString()
+}
+
+func TestPreserveStateOnDegradedResponse_StatusPreserved(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	ciphers := []types.String{
+		types.StringValue("ECDHE-RSA-AES128-GCM-SHA256"),
+		types.StringValue("ECDHE-RSA-AES256-GCM-SHA384"),
+	}
+
+	// Simulate: previous state had active/active, API returned unknown/unknown
+	data := &R2CustomDomainModel{
+		Domain:   types.StringValue("cdn.example.com"),
+		ZoneID:   types.StringValue("zone123"),
+		ZoneName: types.StringNull(), // API omitted this
+		MinTLS:   types.StringNull(), // API omitted this
+		Ciphers:  nil,                // API omitted this
+		Status:   makeStatus(t, "unknown", "unknown"),
+	}
+
+	previousState := &R2CustomDomainModel{
+		Domain:   types.StringValue("cdn.example.com"),
+		ZoneID:   types.StringValue("zone123"),
+		ZoneName: types.StringValue("example.com"),
+		MinTLS:   types.StringValue("1.2"),
+		Ciphers:  &ciphers,
+		Status:   makeStatus(t, "active", "active"),
+	}
+
+	preserveStateOnDegradedResponse(ctx, data, previousState)
+
+	// Status should be restored to active/active
+	ssl, ownership := getStatusValues(t, data.Status)
+	if ssl != "active" {
+		t.Errorf("expected status.ssl to be preserved as 'active', got %q", ssl)
+	}
+	if ownership != "active" {
+		t.Errorf("expected status.ownership to be preserved as 'active', got %q", ownership)
+	}
+
+	// zone_name, min_tls, and ciphers should be restored
+	if data.ZoneName.ValueString() != "example.com" {
+		t.Errorf("expected zone_name to be preserved as 'example.com', got %q", data.ZoneName.ValueString())
+	}
+	if data.MinTLS.ValueString() != "1.2" {
+		t.Errorf("expected min_tls to be preserved as '1.2', got %q", data.MinTLS.ValueString())
+	}
+	if data.Ciphers == nil {
+		t.Error("expected ciphers to be preserved, got nil")
+	} else if len(*data.Ciphers) != 2 {
+		t.Errorf("expected 2 ciphers to be preserved, got %d", len(*data.Ciphers))
+	}
+}
+
+func TestPreserveStateOnDegradedResponse_NonDegradedNotChanged(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Simulate: API returned a legitimate status change (active -> pending)
+	data := &R2CustomDomainModel{
+		Domain:   types.StringValue("cdn.example.com"),
+		ZoneID:   types.StringValue("zone123"),
+		ZoneName: types.StringValue("example.com"),
+		MinTLS:   types.StringValue("1.2"),
+		Status:   makeStatus(t, "pending", "active"),
+	}
+
+	previousState := &R2CustomDomainModel{
+		Domain:   types.StringValue("cdn.example.com"),
+		ZoneID:   types.StringValue("zone123"),
+		ZoneName: types.StringValue("example.com"),
+		MinTLS:   types.StringValue("1.2"),
+		Status:   makeStatus(t, "active", "active"),
+	}
+
+	preserveStateOnDegradedResponse(ctx, data, previousState)
+
+	// Status should NOT be overridden — this is a real status change
+	ssl, ownership := getStatusValues(t, data.Status)
+	if ssl != "pending" {
+		t.Errorf("expected status.ssl to remain 'pending' (real change), got %q", ssl)
+	}
+	if ownership != "active" {
+		t.Errorf("expected status.ownership to remain 'active', got %q", ownership)
+	}
+}
+
+func TestPreserveStateOnDegradedResponse_NilPreviousState(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Simulate: no previous state (first read, e.g. after import)
+	data := &R2CustomDomainModel{
+		Domain:   types.StringValue("cdn.example.com"),
+		ZoneID:   types.StringValue("zone123"),
+		ZoneName: types.StringNull(),
+		MinTLS:   types.StringNull(),
+		Status:   makeStatus(t, "unknown", "unknown"),
+	}
+
+	// Should not panic with nil previousState
+	preserveStateOnDegradedResponse(ctx, data, nil)
+
+	// Values should remain unchanged (no previous state to restore from)
+	ssl, ownership := getStatusValues(t, data.Status)
+	if ssl != "unknown" {
+		t.Errorf("expected status.ssl to remain 'unknown' (no prior state), got %q", ssl)
+	}
+	if ownership != "unknown" {
+		t.Errorf("expected status.ownership to remain 'unknown' (no prior state), got %q", ownership)
+	}
+}
+
+func TestPreserveStateOnDegradedResponse_NilData(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	previousState := &R2CustomDomainModel{
+		Status: makeStatus(t, "active", "active"),
+	}
+
+	// Should not panic with nil data
+	preserveStateOnDegradedResponse(ctx, nil, previousState)
+}
+
+func TestPreserveStateOnDegradedResponse_PreviousAlsoUnknown(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Simulate: previous state was already unknown (e.g. consecutive failures)
+	data := &R2CustomDomainModel{
+		Domain:   types.StringValue("cdn.example.com"),
+		ZoneName: types.StringNull(),
+		MinTLS:   types.StringNull(),
+		Status:   makeStatus(t, "unknown", "unknown"),
+	}
+
+	previousState := &R2CustomDomainModel{
+		Domain:   types.StringValue("cdn.example.com"),
+		ZoneName: types.StringNull(),
+		MinTLS:   types.StringNull(),
+		Status:   makeStatus(t, "unknown", "unknown"),
+	}
+
+	preserveStateOnDegradedResponse(ctx, data, previousState)
+
+	// Nothing useful to restore — status stays unknown
+	ssl, ownership := getStatusValues(t, data.Status)
+	if ssl != "unknown" {
+		t.Errorf("expected status.ssl to remain 'unknown' (no better value), got %q", ssl)
+	}
+	if ownership != "unknown" {
+		t.Errorf("expected status.ownership to remain 'unknown' (no better value), got %q", ownership)
+	}
+}
+
+func TestPreserveStateOnDegradedResponse_OnlyZoneNameOmitted(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Simulate: non-degraded response but zone_name omitted for some reason
+	// (e.g. domain in initializing state — status would be error, not unknown)
+	data := &R2CustomDomainModel{
+		Domain:   types.StringValue("cdn.example.com"),
+		ZoneName: types.StringNull(),
+		MinTLS:   types.StringValue("1.2"),
+		Status:   makeStatus(t, "error", "error"),
+	}
+
+	previousState := &R2CustomDomainModel{
+		Domain:   types.StringValue("cdn.example.com"),
+		ZoneName: types.StringValue("example.com"),
+		MinTLS:   types.StringValue("1.2"),
+		Status:   makeStatus(t, "active", "active"),
+	}
+
+	preserveStateOnDegradedResponse(ctx, data, previousState)
+
+	// Status is not "unknown"/"unknown", so this is NOT a degraded response.
+	// zone_name should NOT be restored — the API returned a real (non-degraded) response.
+	ssl, ownership := getStatusValues(t, data.Status)
+	if ssl != "error" {
+		t.Errorf("expected status.ssl to remain 'error', got %q", ssl)
+	}
+	if ownership != "error" {
+		t.Errorf("expected status.ownership to remain 'error', got %q", ownership)
+	}
+	if !data.ZoneName.IsNull() {
+		t.Errorf("expected zone_name to remain null (non-degraded response), got %q", data.ZoneName.ValueString())
+	}
+}
+
+func TestPreserveStateOnDegradedResponse_NullPreviousStatus(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Simulate: previous state had null status (shouldn't happen normally)
+	data := &R2CustomDomainModel{
+		Domain: types.StringValue("cdn.example.com"),
+		Status: makeStatus(t, "unknown", "unknown"),
+	}
+
+	previousState := &R2CustomDomainModel{
+		Domain: types.StringValue("cdn.example.com"),
+		Status: makeNullStatus(t),
+	}
+
+	preserveStateOnDegradedResponse(ctx, data, previousState)
+
+	// Can't restore from null previous status — values stay as-is
+	ssl, ownership := getStatusValues(t, data.Status)
+	if ssl != "unknown" {
+		t.Errorf("expected status.ssl to remain 'unknown' (null previous), got %q", ssl)
+	}
+	if ownership != "unknown" {
+		t.Errorf("expected status.ownership to remain 'unknown' (null previous), got %q", ownership)
+	}
+}
+
+func TestIsDegradedStatusResponse(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		ssl      string
+		own      string
+		expected bool
+	}{
+		{"both unknown", "unknown", "unknown", true},
+		{"ssl unknown only", "unknown", "active", false},
+		{"ownership unknown only", "active", "unknown", false},
+		{"both active", "active", "active", false},
+		{"both error", "error", "error", false},
+		{"ssl pending", "pending", "active", false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			data := &R2CustomDomainModel{
+				Status: makeStatus(t, tt.ssl, tt.own),
+			}
+			got := isDegradedStatusResponse(ctx, data)
+			if got != tt.expected {
+				t.Errorf("isDegradedStatusResponse(ssl=%q, ownership=%q) = %v, want %v",
+					tt.ssl, tt.own, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsDegradedStatusResponse_NullStatus(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	data := &R2CustomDomainModel{
+		Status: makeNullStatus(t),
+	}
+	if isDegradedStatusResponse(ctx, data) {
+		t.Error("expected null status to not be considered degraded")
+	}
+}
+
+func TestSnapshotState(t *testing.T) {
+	t.Parallel()
+
+	original := &R2CustomDomainModel{
+		Domain:   types.StringValue("cdn.example.com"),
+		ZoneID:   types.StringValue("zone123"),
+		ZoneName: types.StringValue("example.com"),
+		MinTLS:   types.StringValue("1.2"),
+	}
+
+	snapshot := snapshotState(original)
+
+	// Modify original — snapshot should be unaffected
+	original.ZoneName = types.StringNull()
+	original.MinTLS = types.StringNull()
+
+	if snapshot.ZoneName.ValueString() != "example.com" {
+		t.Errorf("snapshot zone_name was affected by original mutation, got %q", snapshot.ZoneName.ValueString())
+	}
+	if snapshot.MinTLS.ValueString() != "1.2" {
+		t.Errorf("snapshot min_tls was affected by original mutation, got %q", snapshot.MinTLS.ValueString())
+	}
+}
+
+func TestSnapshotState_Nil(t *testing.T) {
+	t.Parallel()
+
+	snapshot := snapshotState(nil)
+	if snapshot != nil {
+		t.Error("expected nil input to return nil snapshot")
+	}
+}
+
+func TestPreserveOmittedFields(t *testing.T) {
+	t.Parallel()
+
+	ciphers1 := []types.String{
+		types.StringValue("ECDHE-RSA-AES128-GCM-SHA256"),
+		types.StringValue("ECDHE-RSA-AES256-GCM-SHA384"),
+	}
+	ciphers2 := []types.String{
+		types.StringValue("ECDHE-RSA-AES128-SHA256"),
+	}
+
+	tests := []struct {
+		name             string
+		dataZoneName     types.String
+		dataMinTLS       types.String
+		dataCiphers      *[]types.String
+		prevZoneName     types.String
+		prevMinTLS       types.String
+		prevCiphers      *[]types.String
+		expectedZoneName types.String
+		expectedMinTLS   types.String
+		expectedCiphers  *[]types.String
+	}{
+		{
+			name:             "all null, all restored",
+			dataZoneName:     types.StringNull(),
+			dataMinTLS:       types.StringNull(),
+			dataCiphers:      nil,
+			prevZoneName:     types.StringValue("example.com"),
+			prevMinTLS:       types.StringValue("1.2"),
+			prevCiphers:      &ciphers1,
+			expectedZoneName: types.StringValue("example.com"),
+			expectedMinTLS:   types.StringValue("1.2"),
+			expectedCiphers:  &ciphers1,
+		},
+		{
+			name:             "zone_name null, min_tls present, ciphers nil",
+			dataZoneName:     types.StringNull(),
+			dataMinTLS:       types.StringValue("1.3"),
+			dataCiphers:      nil,
+			prevZoneName:     types.StringValue("example.com"),
+			prevMinTLS:       types.StringValue("1.2"),
+			prevCiphers:      &ciphers1,
+			expectedZoneName: types.StringValue("example.com"),
+			expectedMinTLS:   types.StringValue("1.3"), // not overwritten, was present
+			expectedCiphers:  &ciphers1,
+		},
+		{
+			name:             "all present, nothing changes",
+			dataZoneName:     types.StringValue("example.com"),
+			dataMinTLS:       types.StringValue("1.2"),
+			dataCiphers:      &ciphers2,
+			prevZoneName:     types.StringValue("old.com"),
+			prevMinTLS:       types.StringValue("1.0"),
+			prevCiphers:      &ciphers1,
+			expectedZoneName: types.StringValue("example.com"),
+			expectedMinTLS:   types.StringValue("1.2"),
+			expectedCiphers:  &ciphers2, // not overwritten, was present
+		},
+		{
+			name:             "previous also null, nothing to restore",
+			dataZoneName:     types.StringNull(),
+			dataMinTLS:       types.StringNull(),
+			dataCiphers:      nil,
+			prevZoneName:     types.StringNull(),
+			prevMinTLS:       types.StringNull(),
+			prevCiphers:      nil,
+			expectedZoneName: types.StringNull(),
+			expectedMinTLS:   types.StringNull(),
+			expectedCiphers:  nil,
+		},
+		{
+			name:             "ciphers nil, should restore",
+			dataZoneName:     types.StringValue("example.com"),
+			dataMinTLS:       types.StringValue("1.2"),
+			dataCiphers:      nil,
+			prevZoneName:     types.StringValue("example.com"),
+			prevMinTLS:       types.StringValue("1.2"),
+			prevCiphers:      &ciphers1,
+			expectedZoneName: types.StringValue("example.com"),
+			expectedMinTLS:   types.StringValue("1.2"),
+			expectedCiphers:  &ciphers1,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := &R2CustomDomainModel{
+				ZoneName: tt.dataZoneName,
+				MinTLS:   tt.dataMinTLS,
+				Ciphers:  tt.dataCiphers,
+			}
+			prev := &R2CustomDomainModel{
+				ZoneName: tt.prevZoneName,
+				MinTLS:   tt.prevMinTLS,
+				Ciphers:  tt.prevCiphers,
+			}
+
+			preserveOmittedFields(data, prev)
+
+			if !data.ZoneName.Equal(tt.expectedZoneName) {
+				t.Errorf("zone_name: got %v, want %v", data.ZoneName, tt.expectedZoneName)
+			}
+			if !data.MinTLS.Equal(tt.expectedMinTLS) {
+				t.Errorf("min_tls: got %v, want %v", data.MinTLS, tt.expectedMinTLS)
+			}
+			if (data.Ciphers == nil) != (tt.expectedCiphers == nil) {
+				t.Errorf("ciphers nil mismatch: got %v, want %v", data.Ciphers == nil, tt.expectedCiphers == nil)
+			}
+			if data.Ciphers != nil && tt.expectedCiphers != nil {
+				if len(*data.Ciphers) != len(*tt.expectedCiphers) {
+					t.Errorf("ciphers length: got %d, want %d", len(*data.Ciphers), len(*tt.expectedCiphers))
+				}
+			}
+		})
+	}
+}

--- a/internal/services/r2_custom_domain/data_source_test.go
+++ b/internal/services/r2_custom_domain/data_source_test.go
@@ -17,6 +17,7 @@ func TestAccCloudflareR2CustomDomainDataSource_Basic(t *testing.T) {
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	domainName := rnd + "." + os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	dataSourceName := "data.cloudflare_r2_custom_domain." + rnd
 
 	resource.Test(t, resource.TestCase{
@@ -31,7 +32,7 @@ func TestAccCloudflareR2CustomDomainDataSource_Basic(t *testing.T) {
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("domain"), knownvalue.StringExact(domainName)),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("zone_name"), knownvalue.StringExact(domainName)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("zone_name"), knownvalue.StringExact(zoneName)),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("status").AtMapKey("ownership"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("status").AtMapKey("ssl"), knownvalue.NotNull()),

--- a/internal/services/r2_custom_domain/model.go
+++ b/internal/services/r2_custom_domain/model.go
@@ -17,10 +17,10 @@ type R2CustomDomainModel struct {
 	BucketName   types.String                                        `tfsdk:"bucket_name" path:"bucket_name,required"`
 	Jurisdiction types.String                                        `tfsdk:"jurisdiction" json:"-,computed_optional,no_refresh"`
 	Domain       types.String                                        `tfsdk:"domain" json:"domain,required"`
-	ZoneID       types.String                                        `tfsdk:"zone_id" json:"zoneId,required"`
+	ZoneID       types.String                                        `tfsdk:"zone_id" json:"zoneId,required,no_refresh"`
 	Enabled      types.Bool                                          `tfsdk:"enabled" json:"enabled,required"`
 	MinTLS       types.String                                        `tfsdk:"min_tls" json:"minTLS,optional"`
-  Ciphers      *[]types.String                                     `tfsdk:"ciphers" json:"ciphers,optional"`
+	Ciphers      *[]types.String                                     `tfsdk:"ciphers" json:"ciphers,optional"`
 	ZoneName     types.String                                        `tfsdk:"zone_name" json:"zoneName,computed"`
 	Status       customfield.NestedObject[R2CustomDomainStatusModel] `tfsdk:"status" json:"status,computed"`
 }

--- a/internal/services/r2_custom_domain/resource.go
+++ b/internal/services/r2_custom_domain/resource.go
@@ -92,6 +92,31 @@ func (r *R2CustomDomainResource) Create(ctx context.Context, req resource.Create
 	}
 	data = &env.Result
 
+	// If the create response is degraded (zone_name is null), do a follow-up GET
+	// to retrieve the complete data. This can happen if the SSL4SaaS backend is
+	// transiently unavailable during the create operation.
+	if data.ZoneName.IsNull() {
+		res = new(http.Response)
+		env = R2CustomDomainResultEnvelope{*data}
+		_, err = r.client.R2.Buckets.Domains.Custom.Get(
+			ctx,
+			data.BucketName.ValueString(),
+			data.Domain.ValueString(),
+			r2.BucketDomainCustomGetParams{
+				AccountID: cloudflare.F(data.AccountID.ValueString()),
+			},
+			option.WithHeader(consts.R2JurisdictionHTTPHeaderName, data.Jurisdiction.ValueString()),
+			option.WithResponseBodyInto(&res),
+			option.WithMiddleware(logging.Middleware(ctx)),
+		)
+		if err == nil {
+			bytes, _ = io.ReadAll(res.Body)
+			_ = apijson.Unmarshal(bytes, &env)
+			data = &env.Result
+		}
+		// If the GET also fails or returns degraded data, we'll just use what we have
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -143,6 +168,31 @@ func (r *R2CustomDomainResource) Update(ctx context.Context, req resource.Update
 	}
 	data = &env.Result
 
+	// If the update response is degraded (zone_name is null), do a follow-up GET
+	// to retrieve the complete data. This can happen if the SSL4SaaS backend is
+	// transiently unavailable during the update operation.
+	if data.ZoneName.IsNull() {
+		res = new(http.Response)
+		env = R2CustomDomainResultEnvelope{*data}
+		_, err = r.client.R2.Buckets.Domains.Custom.Get(
+			ctx,
+			data.BucketName.ValueString(),
+			data.Domain.ValueString(),
+			r2.BucketDomainCustomGetParams{
+				AccountID: cloudflare.F(data.AccountID.ValueString()),
+			},
+			option.WithHeader(consts.R2JurisdictionHTTPHeaderName, data.Jurisdiction.ValueString()),
+			option.WithResponseBodyInto(&res),
+			option.WithMiddleware(logging.Middleware(ctx)),
+		)
+		if err == nil {
+			bytes, _ = io.ReadAll(res.Body)
+			_ = apijson.Unmarshal(bytes, &env)
+			data = &env.Result
+		}
+		// If the GET also fails or returns degraded data, we'll just use what we have
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -154,6 +204,11 @@ func (r *R2CustomDomainResource) Read(ctx context.Context, req resource.ReadRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Snapshot the current state before the API response overwrites it.
+	// This allows us to detect and recover from degraded API responses
+	// where the SSL4SaaS backend is transiently unavailable.
+	previousState := snapshotState(data)
 
 	res := new(http.Response)
 	env := R2CustomDomainResultEnvelope{*data}
@@ -184,6 +239,11 @@ func (r *R2CustomDomainResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 	data = &env.Result
+
+	// When the API returns a degraded response (status "unknown"/"unknown"),
+	// preserve the previous state values for status, zone_name, and min_tls
+	// to prevent false drift detection and unnecessary resource replacement.
+	preserveStateOnDegradedResponse(ctx, data, previousState)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/r2_custom_domain/resource_test.go
+++ b/internal/services/r2_custom_domain/resource_test.go
@@ -249,6 +249,77 @@ func TestAccCloudflareR2CustomDomain_Minimal(t *testing.T) {
 	})
 }
 
+// TestAccCloudflareR2CustomDomain_NoDrift verifies that zone_id, zone_name,
+// min_tls, and status fields remain stable across multiple plan/apply cycles.
+// This is a regression test for the bug where a transient SSL4SaaS failure
+// caused the API to return degraded data (zone_id=null, status=unknown/unknown),
+// which made Terraform detect false drift and trigger resource replacement.
+func TestAccCloudflareR2CustomDomain_NoDrift(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	domainName := rnd + "." + os.Getenv("CLOUDFLARE_DOMAIN")
+	resourceName := "cloudflare_r2_custom_domain." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create the resource with min_tls set
+			{
+				Config: testAccR2CustomDomainNoDriftConfig(rnd, accountID, zoneID, domainName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("min_tls"), knownvalue.StringExact("1.2")),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("min_tls"), knownvalue.StringExact("1.2")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_name"), knownvalue.NotNull()),
+				},
+			},
+			// Step 2: Re-plan with identical config — must be Noop with zone_id stable
+			{
+				Config: testAccR2CustomDomainNoDriftConfig(rnd, accountID, zoneID, domainName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("min_tls"), knownvalue.StringExact("1.2")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_name"), knownvalue.NotNull()),
+				},
+			},
+			// Step 3: Re-plan again — still Noop, no accumulated drift
+			{
+				Config: testAccR2CustomDomainNoDriftConfig(rnd, accountID, zoneID, domainName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("min_tls"), knownvalue.StringExact("1.2")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_name"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+func testAccR2CustomDomainNoDriftConfig(rnd, accountID, zoneID, domainName string) string {
+	return acctest.LoadTestCase("r2custom_nodrift.tf", rnd, accountID, zoneID, domainName)
+}
+
 func testAccR2CustomDomainConfig(rnd, accountID, zoneID, domainName string) string {
 	return acctest.LoadTestCase("r2custom_basic.tf", rnd, accountID, zoneID, domainName)
 }

--- a/internal/services/r2_custom_domain/testdata/r2custom_nodrift.tf
+++ b/internal/services/r2_custom_domain/testdata/r2custom_nodrift.tf
@@ -1,0 +1,13 @@
+resource "cloudflare_r2_bucket" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+}
+
+resource "cloudflare_r2_custom_domain" "%[1]s" {
+  account_id  = "%[2]s"
+  bucket_name = cloudflare_r2_bucket.%[1]s.name
+  domain      = "%[4]s"
+  zone_id     = "%[3]s"
+  enabled     = true
+  min_tls     = "1.2"
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
TF_ACC=1 go test -v ./internal/services/r2_custom_domain/...

### Test output
<!-- Please paste the output of your acceptance test run below --> 
```
=== RUN   TestPreserveStateOnDegradedResponse_StatusPreserved
=== PAUSE TestPreserveStateOnDegradedResponse_StatusPreserved
=== RUN   TestPreserveStateOnDegradedResponse_NonDegradedNotChanged
=== PAUSE TestPreserveStateOnDegradedResponse_NonDegradedNotChanged
=== RUN   TestPreserveStateOnDegradedResponse_NilPreviousState
=== PAUSE TestPreserveStateOnDegradedResponse_NilPreviousState
=== RUN   TestPreserveStateOnDegradedResponse_NilData
=== PAUSE TestPreserveStateOnDegradedResponse_NilData
=== RUN   TestPreserveStateOnDegradedResponse_PreviousAlsoUnknown
=== PAUSE TestPreserveStateOnDegradedResponse_PreviousAlsoUnknown
=== RUN   TestPreserveStateOnDegradedResponse_OnlyZoneNameOmitted
=== PAUSE TestPreserveStateOnDegradedResponse_OnlyZoneNameOmitted
=== RUN   TestPreserveStateOnDegradedResponse_NullPreviousStatus
=== PAUSE TestPreserveStateOnDegradedResponse_NullPreviousStatus
=== RUN   TestIsDegradedStatusResponse
=== PAUSE TestIsDegradedStatusResponse
=== RUN   TestIsDegradedStatusResponse_NullStatus
=== PAUSE TestIsDegradedStatusResponse_NullStatus
=== RUN   TestSnapshotState
=== PAUSE TestSnapshotState
=== RUN   TestSnapshotState_Nil
=== PAUSE TestSnapshotState_Nil
=== RUN   TestPreserveOmittedFields
=== PAUSE TestPreserveOmittedFields
=== RUN   TestR2CustomDomainDataSourceModelSchemaParity
=== PAUSE TestR2CustomDomainDataSourceModelSchemaParity
=== RUN   TestAccCloudflareR2CustomDomainDataSource_Basic
--- PASS: TestAccCloudflareR2CustomDomainDataSource_Basic (12.15s)
=== RUN   TestR2CustomDomainModelSchemaParity
=== PAUSE TestR2CustomDomainModelSchemaParity
=== RUN   TestAccCloudflareR2CustomDomain_Basic
--- PASS: TestAccCloudflareR2CustomDomain_Basic (8.87s)
=== RUN   TestAccCloudflareR2CustomDomain_Update
--- PASS: TestAccCloudflareR2CustomDomain_Update (13.99s)
=== RUN   TestAccCloudflareR2CustomDomain_JurisdictionEU
--- PASS: TestAccCloudflareR2CustomDomain_JurisdictionEU (16.08s)
=== RUN   TestAccCloudflareR2CustomDomain_JurisdictionFedramp
--- PASS: TestAccCloudflareR2CustomDomain_JurisdictionFedramp (9.07s)
=== RUN   TestAccCloudflareR2CustomDomain_Minimal
--- PASS: TestAccCloudflareR2CustomDomain_Minimal (7.87s)
=== RUN   TestAccCloudflareR2CustomDomain_NoDrift
--- PASS: TestAccCloudflareR2CustomDomain_NoDrift (36.96s)
=== CONT  TestR2CustomDomainDataSourceModelSchemaParity
=== CONT  TestPreserveStateOnDegradedResponse_StatusPreserved
=== CONT  TestPreserveStateOnDegradedResponse_NullPreviousStatus
=== CONT  TestR2CustomDomainModelSchemaParity
=== CONT  TestPreserveStateOnDegradedResponse_NilData
=== CONT  TestSnapshotState
=== CONT  TestPreserveOmittedFields
--- PASS: TestSnapshotState (0.00s)
=== CONT  TestPreserveStateOnDegradedResponse_NilPreviousState
=== CONT  TestSnapshotState_Nil
=== CONT  TestPreserveStateOnDegradedResponse_PreviousAlsoUnknown
=== CONT  TestIsDegradedStatusResponse
=== RUN   TestIsDegradedStatusResponse/both_unknown
=== RUN   TestPreserveOmittedFields/all_null,_all_restored
=== CONT  TestPreserveStateOnDegradedResponse_NonDegradedNotChanged
=== CONT  TestPreserveStateOnDegradedResponse_OnlyZoneNameOmitted
=== CONT  TestIsDegradedStatusResponse_NullStatus
--- PASS: TestPreserveStateOnDegradedResponse_NullPreviousStatus (0.00s)
--- PASS: TestSnapshotState_Nil (0.00s)
=== PAUSE TestIsDegradedStatusResponse/both_unknown
=== PAUSE TestPreserveOmittedFields/all_null,_all_restored
--- PASS: TestR2CustomDomainModelSchemaParity (0.00s)
--- PASS: TestPreserveStateOnDegradedResponse_NilData (0.00s)
=== RUN   TestPreserveOmittedFields/zone_name_null,_min_tls_present,_ciphers_nil
=== RUN   TestIsDegradedStatusResponse/ssl_unknown_only
=== PAUSE TestPreserveOmittedFields/zone_name_null,_min_tls_present,_ciphers_nil
=== PAUSE TestIsDegradedStatusResponse/ssl_unknown_only
=== RUN   TestPreserveOmittedFields/all_present,_nothing_changes
--- PASS: TestPreserveStateOnDegradedResponse_NilPreviousState (0.00s)
--- PASS: TestPreserveStateOnDegradedResponse_StatusPreserved (0.00s)
=== PAUSE TestPreserveOmittedFields/all_present,_nothing_changes
=== RUN   TestIsDegradedStatusResponse/ownership_unknown_only
=== PAUSE TestIsDegradedStatusResponse/ownership_unknown_only
=== RUN   TestIsDegradedStatusResponse/both_active
=== RUN   TestPreserveOmittedFields/previous_also_null,_nothing_to_restore
=== PAUSE TestIsDegradedStatusResponse/both_active
=== PAUSE TestPreserveOmittedFields/previous_also_null,_nothing_to_restore
--- PASS: TestR2CustomDomainDataSourceModelSchemaParity (0.00s)
=== RUN   TestPreserveOmittedFields/ciphers_nil,_should_restore
--- PASS: TestIsDegradedStatusResponse_NullStatus (0.00s)
=== PAUSE TestPreserveOmittedFields/ciphers_nil,_should_restore
=== CONT  TestPreserveOmittedFields/all_null,_all_restored
=== CONT  TestPreserveOmittedFields/previous_also_null,_nothing_to_restore
=== CONT  TestPreserveOmittedFields/ciphers_nil,_should_restore
--- PASS: TestPreserveStateOnDegradedResponse_PreviousAlsoUnknown (0.00s)
--- PASS: TestPreserveStateOnDegradedResponse_NonDegradedNotChanged (0.00s)
=== RUN   TestIsDegradedStatusResponse/both_error
=== PAUSE TestIsDegradedStatusResponse/both_error
=== CONT  TestPreserveOmittedFields/zone_name_null,_min_tls_present,_ciphers_nil
=== CONT  TestPreserveOmittedFields/all_present,_nothing_changes
--- PASS: TestPreserveStateOnDegradedResponse_OnlyZoneNameOmitted (0.00s)
=== RUN   TestIsDegradedStatusResponse/ssl_pending
=== PAUSE TestIsDegradedStatusResponse/ssl_pending
=== CONT  TestIsDegradedStatusResponse/both_unknown
--- PASS: TestPreserveOmittedFields (0.00s)
    --- PASS: TestPreserveOmittedFields/all_null,_all_restored (0.00s)
    --- PASS: TestPreserveOmittedFields/previous_also_null,_nothing_to_restore (0.00s)
    --- PASS: TestPreserveOmittedFields/ciphers_nil,_should_restore (0.00s)
    --- PASS: TestPreserveOmittedFields/zone_name_null,_min_tls_present,_ciphers_nil (0.00s)
    --- PASS: TestPreserveOmittedFields/all_present,_nothing_changes (0.00s)
=== CONT  TestIsDegradedStatusResponse/both_active
=== CONT  TestIsDegradedStatusResponse/ssl_pending
=== CONT  TestIsDegradedStatusResponse/both_error
=== CONT  TestIsDegradedStatusResponse/ownership_unknown_only
=== CONT  TestIsDegradedStatusResponse/ssl_unknown_only
--- PASS: TestIsDegradedStatusResponse (0.00s)
    --- PASS: TestIsDegradedStatusResponse/both_unknown (0.00s)
    --- PASS: TestIsDegradedStatusResponse/both_active (0.00s)
    --- PASS: TestIsDegradedStatusResponse/both_error (0.00s)
    --- PASS: TestIsDegradedStatusResponse/ssl_pending (0.00s)
    --- PASS: TestIsDegradedStatusResponse/ownership_unknown_only (0.00s)
    --- PASS: TestIsDegradedStatusResponse/ssl_unknown_only (0.00s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_custom_domain  106.509s
```

## Additional context & links
