### PR TITLE
ci: add custom_page_asset to CI test suite

### DIFF
--- a/scripts/run-ci-tests
+++ b/scripts/run-ci-tests
@@ -190,6 +190,7 @@ declare -a ALL_SERVICES=(
     "resource=./internal/services/custom_hostname"
     "resource=./internal/services/custom_hostname_fallback_origin"
     "resource=./internal/services/custom_pages"
+    "resource=./internal/services/custom_page_asset"
     "resource=./internal/services/custom_ssl"
     "resource=./internal/services/dns_record"
     "resource=./internal/services/dns_settings_internal_view"


### PR DESCRIPTION
Add the custom_page_asset resource to the run-ci-tests script so that acceptance tests run in CI for this new resource.

Related to FLPROD-1343

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below (in the previous PR within the same fork https://github.com/cloudflare/terraform-provider-cloudflare/pull/7018)

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
