### PR TITLE
fix(tests): fix flaky `mtls_certificate` and `queue_consumer` acceptance tests

### DIFF
--- a/internal/services/mtls_certificate/resource_test.go
+++ b/internal/services/mtls_certificate/resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -178,6 +179,12 @@ func TestAccCloudflareMTLSCertificate_CertificateNewlineNormalization(t *testing
 
 	name := "cloudflare_mtls_certificate." + rnd
 
+	expiry := time.Now().Add(time.Hour * 24 * 365)
+	cert, key, err := utils.GenerateEphemeralCertAndKey([]string{"example.com"}, expiry)
+	if err != nil {
+		t.Fatalf("Failed to generate certificate: %s", err)
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.TestAccPreCheck_Credentials(t)
@@ -187,16 +194,16 @@ func TestAccCloudflareMTLSCertificate_CertificateNewlineNormalization(t *testing
 		CheckDestroy:             testAccCheckCloudflareMTLSCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				// Refresh with config trimmed
-				Config: testAccCheckCloudflareMTLSCertificateConfigNormalized(accountID, rnd),
+				// Create with trimmed cert (no trailing newline) - normalized form
+				Config: testAccMTLSCertificateNewlineNormalizationConfig(accountID, rnd, cert, key, false),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 				},
 			},
 			{
-				// Refresh with config trimmed - should not detect drift
-				Config: testAccCheckCloudflareMTLSCertificateConfigNormalized(accountID, rnd),
+				// Refresh with same normalized config - should not detect drift
+				Config: testAccMTLSCertificateNewlineNormalizationConfig(accountID, rnd, cert, key, false),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
@@ -204,8 +211,8 @@ func TestAccCloudflareMTLSCertificate_CertificateNewlineNormalization(t *testing
 				PlanOnly: true,
 			},
 			{
-				// Create with trailing newlines - should not detect drift
-				Config: testAccCheckCloudflareMTLSCertificateConfigWithNewline(accountID, rnd),
+				// Switch to config with trailing newlines - should not detect drift
+				Config: testAccMTLSCertificateNewlineNormalizationConfig(accountID, rnd, cert, key, true),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
@@ -221,6 +228,16 @@ func TestAccCloudflareMTLSCertificate_CertificateChainNewlineNormalization(t *te
 
 	name := "cloudflare_mtls_certificate." + rnd
 
+	expiry := time.Now().Add(time.Hour * 24 * 365)
+	cert, key, err := utils.GenerateEphemeralCertAndKey([]string{"example.com"}, expiry)
+	if err != nil {
+		t.Fatalf("Failed to generate certificate: %s", err)
+	}
+	// Duplicate the cert to simulate a multi-PEM chain; the API returns a single
+	// normalised PEM so we just need any multi-cert string to exercise newline
+	// normalization without relying on cert ordering by the backend.
+	chain := cert + cert
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.TestAccPreCheck_Credentials(t)
@@ -230,16 +247,16 @@ func TestAccCloudflareMTLSCertificate_CertificateChainNewlineNormalization(t *te
 		CheckDestroy:             testAccCheckCloudflareMTLSCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				// Refresh with config trimmed - should not detect drift
-				Config: testAccCheckCloudflareMTLSCertificateChainConfigNormalized(accountID, rnd),
+				// Create with trimmed chain (no trailing newline) - normalized form
+				Config: testAccMTLSCertificateNewlineNormalizationConfig(accountID, rnd, chain, key, false),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
 				},
 			},
 			{
-				// Refresh with config trimmed - should not detect drift
-				Config: testAccCheckCloudflareMTLSCertificateChainConfigNormalized(accountID, rnd),
+				// Refresh with same normalized config - should not detect drift
+				Config: testAccMTLSCertificateNewlineNormalizationConfig(accountID, rnd, chain, key, false),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
@@ -247,8 +264,8 @@ func TestAccCloudflareMTLSCertificate_CertificateChainNewlineNormalization(t *te
 				PlanOnly: true,
 			},
 			{
-				// Create with certificate chain with trailing newlines
-				Config: testAccCheckCloudflareMTLSCertificateChainConfigWithNewline(accountID, rnd),
+				// Switch to config with trailing newlines - should not detect drift
+				Config: testAccMTLSCertificateNewlineNormalizationConfig(accountID, rnd, chain, key, true),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(name, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
 					statecheck.ExpectKnownValue(name, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
@@ -258,20 +275,25 @@ func TestAccCloudflareMTLSCertificate_CertificateChainNewlineNormalization(t *te
 	})
 }
 
-func testAccCheckCloudflareMTLSCertificateConfigWithNewline(accountID, name string) string {
-	return acctest.LoadTestCase("mtlscertificateconfigwithnewline.tf", accountID, name)
-}
-
-func testAccCheckCloudflareMTLSCertificateConfigNormalized(accountID, name string) string {
-	return acctest.LoadTestCase("mtlscertificateconfignormalized.tf", accountID, name)
-}
-
-func testAccCheckCloudflareMTLSCertificateChainConfigWithNewline(accountID, name string) string {
-	return acctest.LoadTestCase("mtlscertificatechainwithnewline.tf", accountID, name)
-}
-
-func testAccCheckCloudflareMTLSCertificateChainConfigNormalized(accountID, name string) string {
-	return acctest.LoadTestCase("mtlscertificatechainnormalized.tf", accountID, name)
+// testAccMTLSCertificateNewlineNormalizationConfig generates a config with an
+// ephemeral certificate. When withTrailingNewline is true the cert and key values
+// have a trailing newline appended; when false they are trimmed. Both forms
+// represent the same certificate and should produce no plan diff.
+func testAccMTLSCertificateNewlineNormalizationConfig(accountID, rnd, certificates, privateKey string, withTrailingNewline bool) string {
+	certVal := strings.TrimRight(certificates, "\n")
+	keyVal := strings.TrimRight(privateKey, "\n")
+	if withTrailingNewline {
+		certVal += "\n"
+		keyVal += "\n"
+	}
+	return fmt.Sprintf(`
+resource "cloudflare_mtls_certificate" "%[2]s" {
+  account_id   = "%[1]s"
+  name         = "%[2]s"
+  certificates = %[3]q
+  private_key  = %[4]q
+  ca           = false
+}`, accountID, rnd, certVal, keyVal)
 }
 
 func TestAccUpgradeMtlsCertificate_FromPublishedV5(t *testing.T) {

--- a/internal/services/queue_consumer/resource_test.go
+++ b/internal/services/queue_consumer/resource_test.go
@@ -274,7 +274,7 @@ func TestAccCloudflareQueueConsumer_Worker(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("queue_id"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("consumer_id"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("type"), knownvalue.StringExact("worker")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("script_name"), knownvalue.StringExact("test-worker")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("script_name"), knownvalue.StringExact("test-worker-"+rnd)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("created_on"), knownvalue.NotNull()),
 				},
 			},

--- a/internal/services/queue_consumer/testdata/queueconsumer_worker.tf
+++ b/internal/services/queue_consumer/testdata/queueconsumer_worker.tf
@@ -5,7 +5,7 @@ resource "cloudflare_queue" "test_queue" {
 
 resource "cloudflare_workers_script" "worker_script" {
   account_id  = "%[5]s"
-  script_name = "test-worker"
+  script_name = "test-worker-%[3]s"
   bindings = [
     {
       type       = "queue"


### PR DESCRIPTION
### `mtls_certificate`

**Problem:** `TestAccCloudflareMTLSCertificate_CertificateNewlineNormalization` and `TestAccCloudflareMTLSCertificate_CertificateChainNewlineNormalization` used hardcoded static certificate bytes embedded in testdata `.tf` files. Because the same certificate content was uploaded on every run, concurrent or retried CI runs would hit:

- `1471: This certificate already exists for this account` on `POST` (if a prior run's cert was not cleaned up)
- `1472: Certificate not found` on `GET`/`DELETE` (if a prior run already deleted it, leaving stale state)

**Fix:** Replace the static testdata file loading with a single inline config builder (`testAccMTLSCertificateNewlineNormalizationConfig`) that generates a fresh ephemeral certificate per test run via `utils.GenerateEphemeralCertAndKey`. The `withTrailingNewline bool` parameter controls whether the PEM value has a trailing `\n`, preserving the normalization test semantics exactly. For the chain variant, a single cert is concatenated with itself to produce a multi-PEM string — the API's cert reordering behaviour made using two different self-signed certs unreliable as a "chain".

### `queue_consumer`

**Problem:** `TestAccCloudflareQueueConsumer_Worker` and `TestAccCloudflareQueueConsumer_Worker_NoReplacementOnReplan` both run with `t.Parallel()` and both used the hardcoded worker script name `"test-worker"`. During parallel teardown, one test's script was still registered as a queue consumer for another test's queue, causing:

```
403: Cannot delete this Worker as it is a consumer for a Queue.
Remove it from the Queue's consumers first, then retry.
```

**Fix:** Randomise the script name to `"test-worker-<rnd>"` in `queueconsumer_worker.tf` so each parallel test run gets a fully isolated worker. Updated the `script_name` state assertion in the test to match.

---

