### PR TITLE
fix(pages_project): fix acceptance test failures

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -248,11 +248,11 @@ func TestAccPreCheck_CrowdStrike(t *testing.T) {
 // are present.
 func TestAccPreCheck_Pages(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_PAGES_OWNER"); v == "" {
-		t.Fatal("CLOUDFLARE_PAGES_OWNER must be set for this acceptance test.")
+		t.Skip("Skipping acceptance test as CLOUDFLARE_PAGES_OWNER is not set.")
 	}
 
 	if v := os.Getenv("CLOUDFLARE_PAGES_REPO"); v == "" {
-		t.Fatal("CLOUDFLARE_PAGES_REPO must be set for this acceptance test.")
+		t.Skip("Skipping acceptance test as CLOUDFLARE_PAGES_REPO is not set.")
 	}
 }
 

--- a/internal/services/pages_project/resource_test.go
+++ b/internal/services/pages_project/resource_test.go
@@ -746,6 +746,10 @@ func TestAccCloudflarePagesProject_RemoveSpecificEnvVar(t *testing.T) {
 				ImportState:         true,
 				ImportStateVerify:   true,
 				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				ImportStateVerifyIgnore: []string{
+					"deployment_configs.preview.env_vars",
+					"deployment_configs.production.env_vars",
+				},
 			},
 		},
 	})

--- a/internal/services/pages_project/testdata/pagesprojectdeploymentconfig.tf
+++ b/internal/services/pages_project/testdata/pagesprojectdeploymentconfig.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_workers_kv_namespace" "%[1]s_kv_namespace" {
   account_id = "%[2]s"
-  title = "tfacctest-pages-project-kv-namespace"
+  title = "tfacctest-pages-project-kv-namespace-%[1]s"
 }
 
 resource "cloudflare_pages_project" "%[1]s" {

--- a/internal/services/pages_project/testdata/pagesprojectfullconfig.tf
+++ b/internal/services/pages_project/testdata/pagesprojectfullconfig.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_workers_kv_namespace" "%[1]s_kv_namespace" {
   account_id = "%[2]s"
-  title = "tfacctest-pages-project-kv-namespace"
+  title = "tfacctest-pages-project-kv-namespace-%[1]s"
 }
 
 resource "cloudflare_pages_project" "%[1]s" {


### PR DESCRIPTION
Three separate issues were causing `pages_project` acceptance tests to fail:

1. **KV namespace title collisions** — `TestAccCloudflarePagesProject_DeploymentConfig` and `TestAccCloudflarePagesProject_FullConfiguration` both created a `cloudflare_workers_kv_namespace` with the hardcoded title `"tfacctest-pages-project-kv-namespace"`. The Cloudflare API enforces `(account_id, title)` uniqueness, so leftover namespaces from previous runs caused `400: a namespace with this account ID and title already exists` errors.

2. **Missing `ImportStateVerifyIgnore` for env_vars** — `TestAccCloudflarePagesProject_RemoveSpecificEnvVar`'s import step expected plain_text env_vars to round-trip through import, but the Cloudflare Pages API does not return env_var values on `GET project`. The `Read` path works around this by always sourcing env_vars from prior state (via `PreserveSecretEnvVars`), but `ImportState` has no prior state to pull from, so env_vars are absent after import.

3. **Fatal instead of skip for missing GitHub env vars** — Tests that require a GitHub-connected Pages project (`CLOUDFLARE_PAGES_OWNER`, `CLOUDFLARE_PAGES_REPO`) were calling `t.Fatal` when those env vars were unset, causing them to show as `FAIL` rather than `SKIP`.

## Changes

- Append `-%[1]s` (the unique random resource ID) to KV namespace titles in `pagesprojectdeploymentconfig.tf` and `pagesprojectfullconfig.tf` so each test run gets a distinct title
- Add `ImportStateVerifyIgnore` for `deployment_configs.preview.env_vars` and `deployment_configs.production.env_vars` in `TestAccCloudflarePagesProject_RemoveSpecificEnvVar`, consistent with how `TestAccCloudflarePagesProject_EnvVarTypes` already handles this
- Change `TestAccPreCheck_Pages` to use `t.Skip` instead of `t.Fatal` when `CLOUDFLARE_PAGES_OWNER`/`CLOUDFLARE_PAGES_REPO` are not set