### PR TITLE
fix(tests): fix flaky leaked_credential_check_rule acceptance tests

### DIFF
--- a/internal/services/leaked_credential_check_rule/resource_test.go
+++ b/internal/services/leaked_credential_check_rule/resource_test.go
@@ -131,23 +131,23 @@ func TestAccCloudflareLeakedCredentialsCheckRule_Basic(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckCloudflareLeakedCredentialCheckRuleDestroy,
 		Steps: []resource.TestStep{
-			// Step 1: Create + Read
-			{
-				Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"username\")")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"pass\")")),
-				},
+		// Step 1: Create + Read
+		{
+			Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \""+rnd+"_user\")")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \""+rnd+"_pass\")")),
 			},
-			// Step 2: Update + Read
-			{
-				Config: testAccCloudflareLeakedCredentialsCheckModified(zoneID, rnd),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"username_modified\")")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"pass_modified\")")),
-				},
+		},
+		// Step 2: Update + Read
+		{
+			Config: testAccCloudflareLeakedCredentialsCheckModified(zoneID, rnd),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \""+rnd+"_user_modified\")")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \""+rnd+"_pass_modified\")")),
 			},
+		},
 		},
 	})
 }
@@ -165,26 +165,26 @@ func TestAccCloudflareLeakedCredentialsCheckRule_StateConsistency(t *testing.T) 
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckCloudflareLeakedCredentialCheckRuleDestroy,
 		Steps: []resource.TestStep{
-			{
-				Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"username\")")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"pass\")")),
+		{
+			Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \""+rnd+"_user\")")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \""+rnd+"_pass\")")),
+			},
+		},
+		{
+			Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectEmptyPlan(),
 				},
 			},
-			{
-				Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"username\")")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"pass\")")),
-				},
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \""+rnd+"_user\")")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \""+rnd+"_pass\")")),
 			},
+		},
 		},
 	})
 }
@@ -202,15 +202,15 @@ func TestAccCloudflareLeakedCredentialsCheckRule_Import(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckCloudflareLeakedCredentialCheckRuleDestroy,
 		Steps: []resource.TestStep{
-			// Step 1: Create the resource
-			{
-				Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"username\")")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \"pass\")")),
-				},
+		// Step 1: Create the resource
+		{
+			Config: testAccCloudflareLeakedCredentialsCheckEnabled(zoneID, rnd),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.ZoneIDSchemaKey), knownvalue.StringExact(zoneID)),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("username"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \""+rnd+"_user\")")),
+				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("password"), knownvalue.StringExact("lookup_json_string(http.request.body.raw, \""+rnd+"_pass\")")),
 			},
+		},
 			// Step 2: Import the resource using zone_id/detection_id format
 			{
 				ResourceName:      resourceName,

--- a/internal/services/leaked_credential_check_rule/testdata/enabled.tf
+++ b/internal/services/leaked_credential_check_rule/testdata/enabled.tf
@@ -4,7 +4,9 @@ resource "cloudflare_leaked_credential_check" "%[2]s" {
 }
 
 resource "cloudflare_leaked_credential_check_rule" "%[2]s" {
-  password = "lookup_json_string(http.request.body.raw, \"pass\")"
-  username = "lookup_json_string(http.request.body.raw, \"username\")"
+  password = "lookup_json_string(http.request.body.raw, \"%[2]s_pass\")"
+  username = "lookup_json_string(http.request.body.raw, \"%[2]s_user\")"
   zone_id  = "%[1]s"
+
+  depends_on = [cloudflare_leaked_credential_check.%[2]s]
 }

--- a/internal/services/leaked_credential_check_rule/testdata/modified.tf
+++ b/internal/services/leaked_credential_check_rule/testdata/modified.tf
@@ -1,5 +1,12 @@
+resource "cloudflare_leaked_credential_check" "%[2]s" {
+  zone_id = "%[1]s"
+  enabled = true
+}
+
 resource "cloudflare_leaked_credential_check_rule" "%[2]s" {
-  password = "lookup_json_string(http.request.body.raw, \"pass_modified\")"
-  username = "lookup_json_string(http.request.body.raw, \"username_modified\")"
+  password = "lookup_json_string(http.request.body.raw, \"%[2]s_pass_modified\")"
+  username = "lookup_json_string(http.request.body.raw, \"%[2]s_user_modified\")"
   zone_id  = "%[1]s"
+
+  depends_on = [cloudflare_leaked_credential_check.%[2]s]
 }


### PR DESCRIPTION
All three tests (Basic, StateConsistency, Import) used hardcoded username/password expressions in their detection rules. Because the API rejects duplicate username+password combinations with 11003 and the product-not-enabled error (11001) prevented cleanup on the first attempt, every retry hit 'custom detection already exists'.

Fix by embedding rnd in the expression field values so each test run creates a unique detection that cannot collide with prior runs.

Also add depends_on from the rule to the cloudflare_leaked_credential_check resource in both testdata configs so the product is guaranteed enabled before the rule is created, preventing the initial 11001 failure.

Restore the cloudflare_leaked_credential_check resource to modified.tf which was missing it, which would have disabled the product mid-test.

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
