### PR TITLE
Fix managed_transforms test failures: remove unavailable rule and fix state upgrade panic

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1338,6 +1338,12 @@ func MigrationTestStep(t *testing.T, v4Config string, tmpDir string, exactVersio
 			} else {
 				debugLogf(t, "Skipping migration command for version: %s", exactVersion)
 			}
+
+			// Remove provider.tf after migration. See MigrationV2TestStep for details.
+			providerTF := filepath.Join(tmpDir, "provider.tf")
+			if err := os.Remove(providerTF); err != nil && !os.IsNotExist(err) {
+				t.Fatalf("failed to remove provider.tf after migration: %v", err)
+			}
 		},
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		ConfigDirectory:          config.StaticDirectory(tmpDir),
@@ -1379,6 +1385,17 @@ func MigrationV2TestStep(t *testing.T, v4Config string, tmpDir string, exactVers
 			WriteOutConfig(t, v4Config, tmpDir)
 			debugLogf(t, "Running migration command for version: %s (%s -> %s)", exactVersion, sourceVersion, targetVersion)
 			RunMigrationV2Command(t, v4Config, tmpDir, sourceVersion, targetVersion)
+
+			// Remove provider.tf after tf-migrate has finished. WriteOutConfig creates it
+			// with a pinned version constraint (~> 4.52.7) for tf-migrate's benefit, but
+			// if it persists into the plan step, Terraform resolves the provider to the
+			// published registry binary instead of the local dev provider supplied via
+			// ProtoV6ProviderFactories, causing "does not support resource type" errors
+			// for resources that only exist in the dev provider.
+			providerTF := filepath.Join(tmpDir, "provider.tf")
+			if err := os.Remove(providerTF); err != nil && !os.IsNotExist(err) {
+				t.Fatalf("failed to remove provider.tf after migration: %v", err)
+			}
 		},
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		ConfigDirectory:          config.StaticDirectory(tmpDir),

--- a/internal/services/managed_transforms/migration/v500/handler.go
+++ b/internal/services/managed_transforms/migration/v500/handler.go
@@ -2,10 +2,84 @@ package v500
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
+
+func stringValue(s string) types.String {
+	if s == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(s)
+}
+
+func boolValue(b bool) types.Bool {
+	return types.BoolValue(b)
+}
+
+// rawStateJSON is a minimal struct for JSON-unmarshalling the raw state to detect
+// whether it looks like a v5 state (has zone_id) or a v4 state (needs transformation).
+type rawStateJSON struct {
+	ID                     string           `json:"id"`
+	ZoneID                 string           `json:"zone_id"`
+	ManagedRequestHeaders  json.RawMessage  `json:"managed_request_headers"`
+	ManagedResponseHeaders json.RawMessage  `json:"managed_response_headers"`
+}
+
+// rawHeaderEntry is a minimal struct for JSON-unmarshalling header entries from raw state.
+type rawHeaderEntry struct {
+	ID      string `json:"id"`
+	Enabled bool   `json:"enabled"`
+}
+
+// parseRawState converts raw JSON state bytes into a SourceManagedHeadersModel.
+// This is used when PriorSchema is nil and req.State is unavailable.
+func parseRawState(rawJSON []byte) (*SourceManagedHeadersModel, error) {
+	var raw rawStateJSON
+	if err := json.Unmarshal(rawJSON, &raw); err != nil {
+		return nil, err
+	}
+
+	state := &SourceManagedHeadersModel{
+		ID:     stringValue(raw.ID),
+		ZoneID: stringValue(raw.ZoneID),
+	}
+
+	var reqEntries []rawHeaderEntry
+	if len(raw.ManagedRequestHeaders) > 0 {
+		if err := json.Unmarshal(raw.ManagedRequestHeaders, &reqEntries); err != nil {
+			return nil, err
+		}
+	}
+	reqHeaders := make([]*SourceHeaderEntryModel, 0, len(reqEntries))
+	for _, e := range reqEntries {
+		reqHeaders = append(reqHeaders, &SourceHeaderEntryModel{
+			ID:      stringValue(e.ID),
+			Enabled: boolValue(e.Enabled),
+		})
+	}
+	state.ManagedRequestHeaders = &reqHeaders
+
+	var respEntries []rawHeaderEntry
+	if len(raw.ManagedResponseHeaders) > 0 {
+		if err := json.Unmarshal(raw.ManagedResponseHeaders, &respEntries); err != nil {
+			return nil, err
+		}
+	}
+	respHeaders := make([]*SourceHeaderEntryModel, 0, len(respEntries))
+	for _, e := range respEntries {
+		respHeaders = append(respHeaders, &SourceHeaderEntryModel{
+			ID:      stringValue(e.ID),
+			Enabled: boolValue(e.Enabled),
+		})
+	}
+	state.ManagedResponseHeaders = &respHeaders
+
+	return state, nil
+}
 
 // UpgradeFromV0 handles state upgrades from schema_version=0 to v5 (version=500).
 //
@@ -17,37 +91,42 @@ import (
 //  2. State from early v5 cloudflare_managed_transforms (versions 5.0.0–5.x.y before
 //     the version was bumped to 500). These already have the correct v5 structure.
 //
-// We distinguish the two by attempting to unmarshal as the v5 target first. If that
-// succeeds, the state is already correct — just bump the version. If it fails, fall back
-// to the v4 source schema and run the full transformation.
+// Because PriorSchema is nil for this upgrader (to accept both formats), req.State
+// is nil. We must use req.RawState.JSON to parse the prior state ourselves.
 func UpgradeFromV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 	tflog.Info(ctx, "Upgrading managed_transforms state from schema_version=0")
 
-	// Try to unmarshal as the v5 target (early v5 state that already has the right structure).
-	var v5State TargetManagedTransformsModel
-	v5Diags := req.State.Get(ctx, &v5State)
-	if !v5Diags.HasError() && !v5State.ZoneID.IsNull() && !v5State.ZoneID.IsUnknown() {
-		tflog.Info(ctx, "Upgrading managed_transforms state: detected early-v5 structure, bumping version (no-op)")
-		resp.Diagnostics.Append(resp.State.Set(ctx, &v5State)...)
+	if req.RawState == nil || len(req.RawState.JSON) == 0 {
+		resp.Diagnostics.AddError(
+			"unable to upgrade managed_transforms state",
+			"raw state is empty or nil",
+		)
 		return
 	}
 
-	// Fall back: unmarshal as v4 managed_headers source and transform.
-	tflog.Info(ctx, "Upgrading managed_transforms state: detected v4 managed_headers structure, transforming")
-	var v4State SourceManagedHeadersModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &v4State)...)
-	if resp.Diagnostics.HasError() {
+	sourceState, err := parseRawState(req.RawState.JSON)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"unable to upgrade managed_transforms state",
+			"failed to parse raw state JSON: "+err.Error(),
+		)
 		return
 	}
 
-	newV5State, diags := Transform(ctx, v4State)
+	if !sourceState.ZoneID.IsNull() {
+		tflog.Info(ctx, "Upgrading managed_transforms state: detected early-v5 structure, transforming")
+	} else {
+		tflog.Info(ctx, "Upgrading managed_transforms state: detected v4 managed_headers structure, transforming")
+	}
+
+	newV5State, diags := Transform(ctx, *sourceState)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, newV5State)...)
-	tflog.Info(ctx, "State upgrade from v4 managed_headers completed successfully")
+	tflog.Info(ctx, "State upgrade from schema_version=0 completed successfully")
 }
 
 // UpgradeFromV1 handles state upgrades from v5 provider (version=1) to v5 (version=500).

--- a/internal/services/managed_transforms/resource.go
+++ b/internal/services/managed_transforms/resource.go
@@ -257,7 +257,6 @@ func (r *ManagedTransformsResource) clearConflictingTransforms(
 		"add_true_client_ip_headers",
 		"remove_visitor_ip_headers",
 		"add_visitor_location_headers",
-		"remove_x_powered_by_headers",
 	}
 
 	// Start with headers from the plan

--- a/internal/services/managed_transforms/resource_test.go
+++ b/internal/services/managed_transforms/resource_test.go
@@ -146,7 +146,6 @@ func clearAllTransforms(ctx context.Context, client *cloudflare.Client, zoneID s
 		"add_true_client_ip_headers",
 		"remove_visitor_ip_headers",
 		"add_visitor_location_headers",
-		"remove_x_powered_by_headers",
 	}
 
 	// Build PATCH body with all known transforms disabled


### PR DESCRIPTION
### Summary
- Remove `remove_x_powered_by_headers` from hardcoded known headers lists, since this rule is not available on all zone plans and causes 404 errors during the fallback `clearConflictingTransforms` path
- Fix nil pointer dereference (SIGSEGV) in `UpgradeFromV0` state upgrader by using `req.RawState.JSON` instead of `req.State.Get()`, which is nil when `PriorSchema` is not set

### Problem

Three acceptance tests were failing:
- `TestAccCloudflareManagedHeaders_NonConflictingTransforms`
- `TestAccCloudflareManagedHeaders_Enterprise`
- `TestAccUpgradeManagedTransforms_FromPublishedV5`

**404 errors:** When the zone is in a conflicting transforms state (GET returns 403), both the production code (`clearConflictingTransforms`) and the test cleanup helper (`clearAllTransforms`) fall back to a hardcoded list of known request headers. This list included `remove_x_powered_by_headers`, which does not exist in the `http_request_late_transform_managed` phase for the test zone's plan level. The subsequent PATCH with that rule returns a 404 from the API.

**State upgrade panic:** `TestAccUpgradeManagedTransforms_FromPublishedV5` creates state with the published v5.16.0 provider (`schema_version=0`), then upgrades to the dev provider (`schema_version=500`). This triggers `UpgradeFromV0`, which has `PriorSchema: nil` to accept both v4 and early-v5 state formats. With nil `PriorSchema`, the framework does not populate `req.State`, so calling `req.State.Get()` panics with a nil pointer dereference.

### Fix

- Removed `remove_x_powered_by_headers` from the hardcoded lists in `resource.go` and `resource_test.go`
- Rewrote `UpgradeFromV0` to parse `req.RawState.JSON` directly via `encoding/json`, extracted into a reusable `parseRawState()` helper that converts raw JSON into a `SourceManagedHeadersModel` for the existing `Transform()` function

Managed Transform E2E using including this change in provider binary:
```
./scripts/run-e2e-tests.sh --resources managed_transforms --apply-exemptions --target-provider-version 5.19.0-beta.5 --provider /Users/tamas/cf-repos/sdks/agent-a/cloudflare-terraform-next

.... blaaa

========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ No material changes
    Result: 0 material changes
    Terraform: Plan: 0 to add, 0 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```

Acceptance tests:
```
TF_ACC=1 go test -v -run "TestAcc" ./internal/services/managed_transforms -timeout 40m
=== RUN   TestAccCloudflareManagedHeaders
--- PASS: TestAccCloudflareManagedHeaders (54.75s)
=== RUN   TestAccCloudflareManagedHeaders_Basic
--- PASS: TestAccCloudflareManagedHeaders_Basic (14.93s)
=== RUN   TestAccCloudflareManagedHeaders_Disabled
--- PASS: TestAccCloudflareManagedHeaders_Disabled (6.85s)
=== RUN   TestAccCloudflareManagedHeaders_RequestOnly
--- PASS: TestAccCloudflareManagedHeaders_RequestOnly (12.39s)
=== RUN   TestAccCloudflareManagedHeaders_ResponseOnly
--- PASS: TestAccCloudflareManagedHeaders_ResponseOnly (11.12s)
=== RUN   TestAccCloudflareManagedHeaders_VisitorLocationHeaders
--- PASS: TestAccCloudflareManagedHeaders_VisitorLocationHeaders (10.12s)
=== RUN   TestAccCloudflareManagedHeaders_LeakedCredentialsCheck
--- PASS: TestAccCloudflareManagedHeaders_LeakedCredentialsCheck (8.10s)
=== RUN   TestAccCloudflareManagedHeaders_RemoveVisitorIP
--- PASS: TestAccCloudflareManagedHeaders_RemoveVisitorIP (10.88s)
=== RUN   TestAccCloudflareManagedHeaders_ResponseHeaderDisabled
--- PASS: TestAccCloudflareManagedHeaders_ResponseHeaderDisabled (6.88s)
=== RUN   TestAccCloudflareManagedHeaders_MultipleRequestHeaders
--- PASS: TestAccCloudflareManagedHeaders_MultipleRequestHeaders (13.14s)
=== RUN   TestAccCloudflareManagedHeaders_MixedEnabledDisabled
--- PASS: TestAccCloudflareManagedHeaders_MixedEnabledDisabled (8.02s)
=== RUN   TestAccCloudflareManagedHeaders_UpdateTransforms
--- PASS: TestAccCloudflareManagedHeaders_UpdateTransforms (12.38s)
=== RUN   TestAccCloudflareManagedHeaders_ConflictDetection
--- PASS: TestAccCloudflareManagedHeaders_ConflictDetection (3.51s)
=== RUN   TestAccCloudflareManagedHeaders_ConflictingTransforms
--- PASS: TestAccCloudflareManagedHeaders_ConflictingTransforms (4.76s)
=== RUN   TestAccCloudflareManagedHeaders_NonConflictingTransforms
--- PASS: TestAccCloudflareManagedHeaders_NonConflictingTransforms (11.38s)
=== RUN   TestAccCloudflareManagedHeaders_Enterprise
--- PASS: TestAccCloudflareManagedHeaders_Enterprise (10.72s)
=== RUN   TestAccUpgradeManagedTransforms_FromPublishedV5
--- PASS: TestAccUpgradeManagedTransforms_FromPublishedV5 (25.99s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/managed_transforms
```

Migration tests:
```
TF_MIGRATE_BINARY_PATH=/Users/tamas/cf-repos/sdks/agent-b/tf-migrate/bin/tf-migrate TF_ACC=1 go test -v -run "TestMigrate" ./internal/services/managed_transforms/migration/v500/... -timeout 40m
=== RUN   TestMigrateManagedHeaders_Basic
=== RUN   TestMigrateManagedHeaders_Basic/from_v4_latest
=== RUN   TestMigrateManagedHeaders_Basic/from_v5
--- PASS: TestMigrateManagedHeaders_Basic (63.52s)
    --- PASS: TestMigrateManagedHeaders_Basic/from_v4_latest (30.42s)
    --- PASS: TestMigrateManagedHeaders_Basic/from_v5 (33.10s)
=== RUN   TestMigrateManagedHeaders_RequestOnly
=== RUN   TestMigrateManagedHeaders_RequestOnly/from_v4_latest
=== RUN   TestMigrateManagedHeaders_RequestOnly/from_v5
--- PASS: TestMigrateManagedHeaders_RequestOnly (63.18s)
    --- PASS: TestMigrateManagedHeaders_RequestOnly/from_v4_latest (29.46s)
    --- PASS: TestMigrateManagedHeaders_RequestOnly/from_v5 (33.72s)
=== RUN   TestMigrateManagedHeaders_ResponseOnly
=== RUN   TestMigrateManagedHeaders_ResponseOnly/from_v4_latest
=== RUN   TestMigrateManagedHeaders_ResponseOnly/from_v5
--- PASS: TestMigrateManagedHeaders_ResponseOnly (66.41s)
    --- PASS: TestMigrateManagedHeaders_ResponseOnly/from_v4_latest (32.21s)
    --- PASS: TestMigrateManagedHeaders_ResponseOnly/from_v5 (34.20s)
=== RUN   TestMigrateManagedHeaders_Empty
=== RUN   TestMigrateManagedHeaders_Empty/from_v4_latest
=== RUN   TestMigrateManagedHeaders_Empty/from_v5
--- PASS: TestMigrateManagedHeaders_Empty (69.13s)
    --- PASS: TestMigrateManagedHeaders_Empty/from_v4_latest (38.67s)
    --- PASS: TestMigrateManagedHeaders_Empty/from_v5 (30.45s)
=== RUN   TestMigrateManagedHeaders_MultiVersion
=== RUN   TestMigrateManagedHeaders_MultiVersion/from_v4_52_1
=== RUN   TestMigrateManagedHeaders_MultiVersion/from_v5_0_0
=== RUN   TestMigrateManagedHeaders_MultiVersion/from_v5_8_4
--- PASS: TestMigrateManagedHeaders_MultiVersion (94.69s)
    --- PASS: TestMigrateManagedHeaders_MultiVersion/from_v4_52_1 (28.11s)
    --- PASS: TestMigrateManagedHeaders_MultiVersion/from_v5_0_0 (31.26s)
    --- PASS: TestMigrateManagedHeaders_MultiVersion/from_v5_8_4 (35.33s)
=== RUN   TestMigrateManagedHeaders_EdgeCases
=== RUN   TestMigrateManagedHeaders_EdgeCases/request_only_from_v4
=== RUN   TestMigrateManagedHeaders_EdgeCases/response_only_from_v4
=== RUN   TestMigrateManagedHeaders_EdgeCases/empty_from_v4
=== RUN   TestMigrateManagedHeaders_EdgeCases/request_only_from_v5_0_0
=== RUN   TestMigrateManagedHeaders_EdgeCases/response_only_from_v5_0_0
=== RUN   TestMigrateManagedHeaders_EdgeCases/empty_from_v5
--- PASS: TestMigrateManagedHeaders_EdgeCases (181.31s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/request_only_from_v4 (28.88s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/response_only_from_v4 (30.41s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/empty_from_v4 (28.21s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/request_only_from_v5_0_0 (31.37s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/response_only_from_v5_0_0 (33.53s)
    --- PASS: TestMigrateManagedHeaders_EdgeCases/empty_from_v5 (28.91s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/managed_transforms/migration/v500539.876s
```
