### PR TITLE
chore: Add acceptance tests for `zero_trust_dlp_settings` resource

### DIFF
--- a/internal/services/zero_trust_dlp_settings/resource_test.go
+++ b/internal/services/zero_trust_dlp_settings/resource_test.go
@@ -1,0 +1,94 @@
+package zero_trust_dlp_settings_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareZeroTrustDLPSettings_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_dlp_settings.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		// No CheckDestroy: this is a singleton settings resource.
+		// DELETE resets to initial values; GET always returns a response.
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("dlp_settings_init.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ai_context_analysis"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ocr"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("payload_logging").AtMapKey("public_key"), knownvalue.StringExact("EmpOvSXw8BfbrGCi0fhGiD/3yXk2SiV1Nzg2lru3oj0=")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("payload_logging").AtMapKey("masking_level"), knownvalue.StringExact("partial")),
+				},
+			},
+			{
+				Config: acctest.LoadTestCase("dlp_settings_update.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("ai_context_analysis"), knownvalue.Bool(false)),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("ocr"), knownvalue.Bool(false)),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("payload_logging").AtMapKey("masking_level"), knownvalue.StringExact("full")),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ai_context_analysis"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ocr"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("payload_logging").AtMapKey("public_key"), knownvalue.StringExact("EmpOvSXw8BfbrGCi0fhGiD/3yXk2SiV1Nzg2lru3oj0=")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("payload_logging").AtMapKey("masking_level"), knownvalue.StringExact("full")),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccCloudflareZeroTrustDLPSettings_PartialConfig verifies that a user
+// can create DLP settings with only a subset of computed_optional fields
+// (e.g. only ocr=true). The apply succeeds and state reflects the correct
+// values from the API.
+func TestAccCloudflareZeroTrustDLPSettings_PartialConfig(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_dlp_settings.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("dlp_settings_partial_ocr.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ocr"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ai_context_analysis"), knownvalue.Bool(false)),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_settings/testdata/dlp_settings_init.tf
+++ b/internal/services/zero_trust_dlp_settings/testdata/dlp_settings_init.tf
@@ -1,0 +1,9 @@
+resource "cloudflare_zero_trust_dlp_settings" "%[1]s" {
+  account_id          = "%[2]s"
+  ai_context_analysis = true
+  ocr                 = true
+  payload_logging = {
+    public_key    = "EmpOvSXw8BfbrGCi0fhGiD/3yXk2SiV1Nzg2lru3oj0="
+    masking_level = "partial"
+  }
+}

--- a/internal/services/zero_trust_dlp_settings/testdata/dlp_settings_partial_ocr.tf
+++ b/internal/services/zero_trust_dlp_settings/testdata/dlp_settings_partial_ocr.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_zero_trust_dlp_settings" "%[1]s" {
+  account_id = "%[2]s"
+  ocr        = true
+}

--- a/internal/services/zero_trust_dlp_settings/testdata/dlp_settings_update.tf
+++ b/internal/services/zero_trust_dlp_settings/testdata/dlp_settings_update.tf
@@ -1,0 +1,9 @@
+resource "cloudflare_zero_trust_dlp_settings" "%[1]s" {
+  account_id          = "%[2]s"
+  ai_context_analysis = false
+  ocr                 = false
+  payload_logging = {
+    public_key    = "EmpOvSXw8BfbrGCi0fhGiD/3yXk2SiV1Nzg2lru3oj0="
+    masking_level = "full"
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Add acceptance tests for `zero_trust_dlp_settings` resource

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
```
TF_ACC=1 go test -v -run 'TestAccCloudflareZeroTrustDLPSettings_' -count=1 ./internal/services/zero_trust_dlp_settings
```

### Test output
<!-- Please paste the output of your acceptance test run below --> 
```
=== RUN   TestAccCloudflareZeroTrustDLPSettings_Basic
--- PASS: TestAccCloudflareZeroTrustDLPSettings_Basic (4.92s)
=== RUN   TestAccCloudflareZeroTrustDLPSettings_PartialConfig
--- PASS: TestAccCloudflareZeroTrustDLPSettings_PartialConfig (3.13s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_dlp_settings	9.818s
```

## Additional context & links
