### PR TITLE
ci: add Semgrep OSS scanning workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,30 @@
+name: Semgrep OSS scan
+on:
+  pull_request: {}
+  push:
+    branches: [main, master]
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 25 * *'
+concurrency:
+  group: semgrep-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  semgrep:
+    name: semgrep-oss
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - id: cache-semgrep
+        uses: actions/cache@v5
+        with:
+          path: ~/.local
+          key: semgrep-1.160.0-${{ runner.os }}
+      - if: steps.cache-semgrep.outputs.cache-hit != 'true'
+        run: pip install --user semgrep==1.160.0
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - run: semgrep scan --config=auto


### PR DESCRIPTION
## Summary

Adds Semgrep Community Edition (OSS) scanning to this repository as part of the App&ProdSec team's migration from Semgrep Pro to Semgrep CE.

## What it does

- Runs on every PR, on `push` to the main/master branch, and monthly on a staggered schedule.
- Uses `actions/cache@v5` so `pip install semgrep` only runs on cold cache (first run, version bump, or 7-day idle).
- Pinned to `semgrep==1.160.0` with `--config=auto` (default OSS ruleset).
- Runs on `ubuntu-slim` with `contents: read` token scope.

## For reviewers

- Findings are informational; the job does not block on findings.
- First PR after merge installs Semgrep; subsequent PRs skip that step.

See the internal App&ProdSec email for migration context, or ping us internally.
