### PR TITLE
feat: add user_group and user_group_members acceptance tests + custom…

### DIFF
--- a/internal/services/user_group/data_source_test.go
+++ b/internal/services/user_group/data_source_test.go
@@ -1,0 +1,56 @@
+package user_group_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+// TestAccCloudflareUserGroup_DataSource verifies both list and single data sources.
+func TestAccCloudflareUserGroup_DataSource(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	listDataName := "data.cloudflare_user_groups." + rnd
+	singleDataName := "data.cloudflare_user_group." + rnd
+	resourceName := "cloudflare_user_group." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareUserGroupDataSourceConfig(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// LIST data source verification
+					statecheck.ExpectKnownValue(listDataName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(listDataName, tfjsonpath.New("result"), knownvalue.NotNull()),
+
+					// GET single data source verification
+					statecheck.ExpectKnownValue(singleDataName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(singleDataName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(singleDataName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(singleDataName, tfjsonpath.New("created_on"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(singleDataName, tfjsonpath.New("modified_on"), knownvalue.NotNull()),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					// Verify single data source matches resource
+					resource.TestCheckResourceAttrPair(singleDataName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(singleDataName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(singleDataName, "created_on", resourceName, "created_on"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudflareUserGroupDataSourceConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("usergroupdatasource.tf", rnd, accountID)
+}

--- a/internal/services/user_group/resource_test.go
+++ b/internal/services/user_group/resource_test.go
@@ -1,0 +1,323 @@
+package user_group_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/iam"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+// getPermissionGroupId returns the ID of the permission group with the given label.
+func getPermissionGroupId(t *testing.T, accountID, label string) string {
+	t.Helper()
+	ctx := context.Background()
+	client := acctest.SharedClient()
+	res, err := client.IAM.PermissionGroups.List(ctx, iam.PermissionGroupListParams{
+		AccountID: cloudflare.F(accountID),
+		Label:     cloudflare.F(label),
+	})
+	if err != nil {
+		t.Fatalf("Failed to list permission groups: %v", err)
+	}
+	if len(res.Result) == 0 {
+		t.Fatalf("No permission group found with label '%s'", label)
+	}
+	return res.Result[0].ID
+}
+
+// getResourceGroupId returns the first resource group ID for the account.
+func getResourceGroupId(t *testing.T, accountID string) string {
+	t.Helper()
+	ctx := context.Background()
+	client := acctest.SharedClient()
+	res, err := client.IAM.ResourceGroups.List(ctx, iam.ResourceGroupListParams{
+		AccountID: cloudflare.F(accountID),
+	})
+	if err != nil {
+		t.Fatalf("Failed to list resource groups: %v", err)
+	}
+	if len(res.Result) == 0 {
+		t.Skip("No resource groups available in account for testing")
+	}
+	return res.Result[0].ID
+}
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func init() {
+	resource.AddTestSweepers("cloudflare_user_group", &resource.Sweeper{
+		Name: "cloudflare_user_group",
+		F:    testSweepCloudflareUserGroups,
+	})
+}
+
+func testSweepCloudflareUserGroups(r string) error {
+	ctx := context.Background()
+	client := acctest.SharedClient()
+
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		tflog.Info(ctx, "Skipping user groups sweep: CLOUDFLARE_ACCOUNT_ID not set")
+		return nil
+	}
+
+	tflog.Info(ctx, fmt.Sprintf("Listing user groups for account: %s", accountID))
+	groups, err := client.IAM.UserGroups.List(
+		ctx,
+		iam.UserGroupListParams{
+			AccountID: cloudflare.F(accountID),
+		},
+	)
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to list user groups: %s", err))
+		return fmt.Errorf("failed to list user groups: %w", err)
+	}
+
+	for _, group := range groups.Result {
+		// Only sweep test groups with the cftftest or tf- prefix
+		if !strings.HasPrefix(group.Name, "cftftest") && !strings.HasPrefix(group.Name, "tf-") && !utils.ShouldSweepResource(group.Name) {
+			continue
+		}
+
+		tflog.Info(ctx, fmt.Sprintf("Deleting user group: %s (%s)", group.ID, group.Name))
+		_, err := client.IAM.UserGroups.Delete(
+			ctx,
+			group.ID,
+			iam.UserGroupDeleteParams{
+				AccountID: cloudflare.F(accountID),
+			},
+		)
+		if err != nil {
+			tflog.Error(ctx, fmt.Sprintf("Failed to delete user group %s: %s", group.ID, err))
+		}
+	}
+
+	return nil
+}
+
+// TestAccCloudflareUserGroup_Basic tests basic create, update, and destroy of a user group.
+func TestAccCloudflareUserGroup_Basic(t *testing.T) {
+	t.Parallel()
+
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_user_group." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareUserGroupDestroy,
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: testAccCloudflareUserGroupBasicConfig(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("created_on"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("modified_on"), knownvalue.NotNull()),
+				},
+			},
+			// Update name
+			{
+				Config: testAccCloudflareUserGroupUpdatedConfig(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd+"-updated")),
+				},
+			},
+			// Revert (idempotency)
+			{
+				Config: testAccCloudflareUserGroupBasicConfig(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+				},
+			},
+			// Import
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareUserGroup_WithPolicies tests creating a user group with policies.
+func TestAccCloudflareUserGroup_WithPolicies(t *testing.T) {
+	t.Parallel()
+
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("CLOUDFLARE_ACCOUNT_ID must be set for acceptance tests")
+	}
+	resourceName := "cloudflare_user_group." + rnd
+
+	permGroupID := getPermissionGroupId(t, accountID, "admin")
+	resourceGroupID := getResourceGroupId(t, accountID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareUserGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareUserGroupWithPoliciesConfig(rnd, accountID, permGroupID, resourceGroupID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("access"), knownvalue.StringExact("allow")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("resource_groups"), knownvalue.ListSizeExact(1)),
+				},
+			},
+			// Idempotency: re-apply is a no-op
+			{
+				Config: testAccCloudflareUserGroupWithPoliciesConfig(rnd, accountID, permGroupID, resourceGroupID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Import (with nested policies)
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareUserGroup_UpdatePolicy tests swapping the permission group in a policy.
+// Single permission_group avoids list ordering drift.
+func TestAccCloudflareUserGroup_UpdatePolicy(t *testing.T) {
+	t.Parallel()
+
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("CLOUDFLARE_ACCOUNT_ID must be set for acceptance tests")
+	}
+	resourceName := "cloudflare_user_group." + rnd
+
+	adminPermGroupID := getPermissionGroupId(t, accountID, "admin")
+	readonlyPermGroupID := getPermissionGroupId(t, accountID, "admin_readonly")
+	resourceGroupID := getResourceGroupId(t, accountID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareUserGroupDestroy,
+		Steps: []resource.TestStep{
+			// Create with admin permission
+			{
+				Config: testAccCloudflareUserGroupWithPoliciesConfig(rnd, accountID, adminPermGroupID, resourceGroupID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id"), knownvalue.StringExact(adminPermGroupID)),
+				},
+			},
+			// Swap to admin_readonly
+			{
+				Config: testAccCloudflareUserGroupPoliciesChangedConfig(rnd, accountID, readonlyPermGroupID, resourceGroupID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups").AtSliceIndex(0).AtMapKey("id"), knownvalue.StringExact(readonlyPermGroupID)),
+				},
+			},
+			// Import (after policy update)
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareUserGroup_InvalidPolicyAccess verifies invalid policies.access values
+// are rejected (schema allows only "allow" or "deny").
+func TestAccCloudflareUserGroup_InvalidPolicyAccess(t *testing.T) {
+	t.Parallel()
+
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("CLOUDFLARE_ACCOUNT_ID must be set for acceptance tests")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCloudflareUserGroupInvalidAccessConfig(rnd, accountID),
+				ExpectError: regexp.MustCompile(`Attribute policies\[0\].access value must be one of`),
+			},
+		},
+	})
+}
+
+func testAccCloudflareUserGroupBasicConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("usergroupbasic.tf", rnd, accountID)
+}
+
+func testAccCloudflareUserGroupUpdatedConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("usergroupupdated.tf", rnd, accountID)
+}
+
+func testAccCloudflareUserGroupWithPoliciesConfig(rnd, accountID, permGroupID, resourceGroupID string) string {
+	return acctest.LoadTestCase("usergroupwithpolicies.tf", rnd, accountID, permGroupID, resourceGroupID)
+}
+
+func testAccCloudflareUserGroupPoliciesChangedConfig(rnd, accountID, permGroupID, resourceGroupID string) string {
+	return acctest.LoadTestCase("usergrouppolicieschanged.tf", rnd, accountID, permGroupID, resourceGroupID)
+}
+
+func testAccCloudflareUserGroupInvalidAccessConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("usergroupinvalidaccess.tf", rnd, accountID)
+}
+
+// testAccCheckCloudflareUserGroupDestroy verifies the user group is gone from the API
+// after destroy, guarding against silent state-only removal.
+func testAccCheckCloudflareUserGroupDestroy(s *terraform.State) error {
+	client := acctest.SharedClient()
+	ctx := context.Background()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_user_group" {
+			continue
+		}
+
+		_, err := client.IAM.UserGroups.Get(ctx, rs.Primary.ID, iam.UserGroupGetParams{
+			AccountID: cloudflare.F(rs.Primary.Attributes[consts.AccountIDSchemaKey]),
+		})
+		if err == nil {
+			return fmt.Errorf("user group %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}

--- a/internal/services/user_group/testdata/usergroupbasic.tf
+++ b/internal/services/user_group/testdata/usergroupbasic.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_user_group" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+}

--- a/internal/services/user_group/testdata/usergroupdatasource.tf
+++ b/internal/services/user_group/testdata/usergroupdatasource.tf
@@ -1,0 +1,14 @@
+resource "cloudflare_user_group" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+}
+
+data "cloudflare_user_groups" "%[1]s" {
+  account_id = "%[2]s"
+  depends_on = [cloudflare_user_group.%[1]s]
+}
+
+data "cloudflare_user_group" "%[1]s" {
+  account_id    = "%[2]s"
+  user_group_id = cloudflare_user_group.%[1]s.id
+}

--- a/internal/services/user_group/testdata/usergroupinvalidaccess.tf
+++ b/internal/services/user_group/testdata/usergroupinvalidaccess.tf
@@ -1,0 +1,15 @@
+resource "cloudflare_user_group" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+  policies = [
+    {
+      access = "invalid_action"
+      permission_groups = [
+        { id = "00000000000000000000000000000000" }
+      ]
+      resource_groups = [
+        { id = "00000000000000000000000000000000" }
+      ]
+    }
+  ]
+}

--- a/internal/services/user_group/testdata/usergrouppolicieschanged.tf
+++ b/internal/services/user_group/testdata/usergrouppolicieschanged.tf
@@ -1,0 +1,15 @@
+resource "cloudflare_user_group" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+  policies = [
+    {
+      access            = "allow"
+      permission_groups = [
+        { id = "%[3]s" }
+      ]
+      resource_groups = [
+        { id = "%[4]s" }
+      ]
+    }
+  ]
+}

--- a/internal/services/user_group/testdata/usergroupupdated.tf
+++ b/internal/services/user_group/testdata/usergroupupdated.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_user_group" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s-updated"
+}

--- a/internal/services/user_group/testdata/usergroupwithpolicies.tf
+++ b/internal/services/user_group/testdata/usergroupwithpolicies.tf
@@ -1,0 +1,15 @@
+resource "cloudflare_user_group" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+  policies = [
+    {
+      access            = "allow"
+      permission_groups = [
+        { id = "%[3]s" }
+      ]
+      resource_groups = [
+        { id = "%[4]s" }
+      ]
+    }
+  ]
+}

--- a/internal/services/user_group_members/custom.go
+++ b/internal/services/user_group_members/custom.go
@@ -1,0 +1,70 @@
+package user_group_members
+
+import (
+	"context"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/iam"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// removeAllMembers removes all members from a user group by calling PUT with
+// an empty array. This is a single efficient API call that removes all members
+// regardless of count. The user group itself is not affected.
+//
+// Used by the Delete implementation to support:
+//
+//	terraform destroy -target cloudflare_user_group_members.xxx
+//
+// This matches the pattern used by cloud_connector_rules (PR #5559).
+func removeAllMembers(ctx context.Context, r *UserGroupMembersResource, accountID, userGroupID string, resp *resource.DeleteResponse) {
+	_, err := r.client.IAM.UserGroups.Members.Update(
+		ctx,
+		userGroupID,
+		iam.UserGroupMemberUpdateParams{
+			AccountID: cloudflare.F(accountID),
+		},
+		option.WithRequestBody("application/json", []byte(`[]`)),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to make http request", err.Error())
+		return
+	}
+}
+
+// normalizeMembers ensures the members field is always an empty list rather than nil
+// when the API returns no members. This prevents null-vs-empty-list drift where:
+//   - User config: members = []
+//   - API response: "result": null (or missing)
+//   - Without fix: state = null, plan shows "+ members = []" → persistent drift
+//   - With fix: state = [], plan shows no drift
+//
+// Must be called after every unmarshal in Create, Update, and Read.
+func normalizeMembers(m *UserGroupMembersModel) {
+	if m == nil {
+		return
+	}
+	if m.Members == nil {
+		empty := []*UserGroupMembersMembersModel{}
+		m.Members = &empty
+	}
+}
+
+// unmarshalMembersCustom wraps the standard unmarshal with normalization to handle
+// the null-vs-empty-list case in API responses.
+//
+// Used by the Read method to ensure consistent state representation.
+func unmarshalMembersCustom(data []byte, configuredModel *UserGroupMembersModel) (*UserGroupMembersModel, error) {
+	env := UserGroupMembersResultEnvelope{configuredModel.Members}
+	if err := apijson.Unmarshal(data, &env); err != nil {
+		return nil, err
+	}
+
+	configuredModel.Members = env.Result
+	normalizeMembers(configuredModel)
+	return configuredModel, nil
+}

--- a/internal/services/user_group_members/data_source.go
+++ b/internal/services/user_group_members/data_source.go
@@ -64,7 +64,7 @@ func (d *UserGroupMembersDataSource) Read(ctx context.Context, req datasource.Re
 	}
 
 	res := new(http.Response)
-	env := UserGroupMembersResultDataSourceEnvelope{*data}
+	env := UserGroupMembersResultDataSourceEnvelope{data.Members}
 	_, err := d.client.IAM.UserGroups.Members.List(
 		ctx,
 		data.UserGroupID.ValueString(),
@@ -82,7 +82,7 @@ func (d *UserGroupMembersDataSource) Read(ctx context.Context, req datasource.Re
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
 	}
-	data = &env.Result
+	data.Members = env.Result
 	data.ID = data.UserGroupID
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/services/user_group_members/data_source_model.go
+++ b/internal/services/user_group_members/data_source_model.go
@@ -12,17 +12,22 @@ import (
 )
 
 type UserGroupMembersResultDataSourceEnvelope struct {
-	Result UserGroupMembersDataSourceModel `json:"result,computed"`
+	Result *[]*UserGroupMembersDataSourceMembersModel `json:"result,computed"`
 }
 
 type UserGroupMembersDataSourceModel struct {
-	ID          types.String `tfsdk:"id" path:"user_group_id,computed"`
-	UserGroupID types.String `tfsdk:"user_group_id" path:"user_group_id,required"`
-	AccountID   types.String `tfsdk:"account_id" path:"account_id,required"`
-	FuzzyEmail  types.String `tfsdk:"fuzzy_email" query:"fuzzyEmail,optional"`
-	Direction   types.String `tfsdk:"direction" query:"direction,computed_optional"`
-	Email       types.String `tfsdk:"email" json:"email,computed"`
-	Status      types.String `tfsdk:"status" json:"status,computed"`
+	ID          types.String                               `tfsdk:"id" json:"id,computed"`
+	UserGroupID types.String                               `tfsdk:"user_group_id" path:"user_group_id,required"`
+	AccountID   types.String                               `tfsdk:"account_id" path:"account_id,required"`
+	FuzzyEmail  types.String                               `tfsdk:"fuzzy_email" query:"fuzzyEmail,optional"`
+	Direction   types.String                               `tfsdk:"direction" query:"direction,computed_optional"`
+	Members     *[]*UserGroupMembersDataSourceMembersModel `tfsdk:"members" json:"members,computed,no_refresh"`
+}
+
+type UserGroupMembersDataSourceMembersModel struct {
+	ID     types.String `tfsdk:"id" json:"id,computed"`
+	Email  types.String `tfsdk:"email" json:"email,computed"`
+	Status types.String `tfsdk:"status" json:"status,computed"`
 }
 
 func (m *UserGroupMembersDataSourceModel) toReadParams(_ context.Context) (params iam.UserGroupMemberListParams, diags diag.Diagnostics) {

--- a/internal/services/user_group_members/data_source_schema.go
+++ b/internal/services/user_group_members/data_source_schema.go
@@ -48,15 +48,27 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 					stringvalidator.OneOfCaseInsensitive("asc", "desc"),
 				},
 			},
-			"email": schema.StringAttribute{
-				Description: "The contact email address of the user.",
+			"members": schema.ListNestedAttribute{
+				Description: "List of members in the user group.",
 				Computed:    true,
-			},
-			"status": schema.StringAttribute{
-				Description: "The member's status in the account.\nAvailable values: \"accepted\", \"pending\".",
-				Computed:    true,
-				Validators: []validator.String{
-					stringvalidator.OneOfCaseInsensitive("accepted", "pending"),
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "Account member identifier.",
+							Computed:    true,
+						},
+						"email": schema.StringAttribute{
+							Description: "The contact email address of the user.",
+							Computed:    true,
+						},
+						"status": schema.StringAttribute{
+							Description: "The member's status in the account.\nAvailable values: \"accepted\", \"pending\".",
+							Computed:    true,
+							Validators: []validator.String{
+								stringvalidator.OneOfCaseInsensitive("accepted", "pending"),
+							},
+						},
+					},
 				},
 			},
 		},

--- a/internal/services/user_group_members/data_source_test.go
+++ b/internal/services/user_group_members/data_source_test.go
@@ -1,0 +1,91 @@
+package user_group_members_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+// TestAccCloudflareUserGroupMembers_DataSource verifies the data source returns a proper list of members.
+func TestAccCloudflareUserGroupMembers_DataSource(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("CLOUDFLARE_ACCOUNT_ID must be set for acceptance tests")
+	}
+	memberID := findDSREnabledMember(t, accountID)
+
+	dataName := "data.cloudflare_user_group_members." + rnd
+	resourceName := "cloudflare_user_group_members." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareUserGroupMembersDataSourceConfig(rnd, accountID, memberID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Basic attributes
+					statecheck.ExpectKnownValue(dataName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(dataName, tfjsonpath.New("user_group_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataName, tfjsonpath.New("id"), knownvalue.NotNull()),
+
+					// Verify proper list structure
+					statecheck.ExpectKnownValue(dataName, tfjsonpath.New("members"), knownvalue.ListSizeExact(1)),
+
+					// Verify nested member attributes
+					statecheck.ExpectKnownValue(dataName, tfjsonpath.New("members").AtSliceIndex(0).AtMapKey("id"), knownvalue.StringExact(memberID)),
+					statecheck.ExpectKnownValue(dataName, tfjsonpath.New("members").AtSliceIndex(0).AtMapKey("email"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataName, tfjsonpath.New("members").AtSliceIndex(0).AtMapKey("status"), knownvalue.NotNull()),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					// Verify data source matches resource
+					resource.TestCheckResourceAttrPair(dataName, "user_group_id", resourceName, "user_group_id"),
+					resource.TestCheckResourceAttrPair(dataName, "members.0.id", resourceName, "members.0.id"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareUserGroupMembers_DataSourceWithFilter tests data source with direction filter.
+func TestAccCloudflareUserGroupMembers_DataSourceWithFilter(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("CLOUDFLARE_ACCOUNT_ID must be set for acceptance tests")
+	}
+	memberID := findDSREnabledMember(t, accountID)
+
+	dataName := "data.cloudflare_user_group_members." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareUserGroupMembersDataSourceWithFilterConfig(rnd, accountID, memberID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(dataName, tfjsonpath.New("direction"), knownvalue.StringExact("desc")),
+					statecheck.ExpectKnownValue(dataName, tfjsonpath.New("members"), knownvalue.ListSizeExact(1)),
+				},
+			},
+		},
+	})
+}
+
+func testAccCloudflareUserGroupMembersDataSourceConfig(rnd, accountID, memberID string) string {
+	return acctest.LoadTestCase("usergroupmembersdatasource.tf", rnd, accountID, memberID)
+}
+
+func testAccCloudflareUserGroupMembersDataSourceWithFilterConfig(rnd, accountID, memberID string) string {
+	return acctest.LoadTestCase("usergroupmembersdatasourcewithfilter.tf", rnd, accountID, memberID)
+}

--- a/internal/services/user_group_members/resource.go
+++ b/internal/services/user_group_members/resource.go
@@ -92,6 +92,8 @@ func (r *UserGroupMembersResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 	data.Members = env.Result
+	// Ensure null vs empty list consistency. See custom.go for details.
+	normalizeMembers(data)
 	data.ID = data.UserGroupID
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -142,6 +144,8 @@ func (r *UserGroupMembersResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 	data.Members = env.Result
+	// Ensure null vs empty list consistency. See custom.go for details.
+	normalizeMembers(data)
 	data.ID = data.UserGroupID
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -157,7 +161,6 @@ func (r *UserGroupMembersResource) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	res := new(http.Response)
-	env := UserGroupMembersResultEnvelope{data.Members}
 	_, err := r.client.IAM.UserGroups.Members.List(
 		ctx,
 		data.UserGroupID.ValueString(),
@@ -177,19 +180,30 @@ func (r *UserGroupMembersResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	// Custom unmarshal to handle null vs empty list case for members.
+	// See custom.go for details.
+	data, err = unmarshalMembersCustom(bytes, data)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
 	}
-	data.Members = env.Result
 	data.ID = data.UserGroupID
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *UserGroupMembersResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *UserGroupMembersModel
 
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Custom delete implementation: removes all members from the user group.
+	// See custom.go for details.
+	removeAllMembers(ctx, r, data.AccountID.ValueString(), data.UserGroupID.ValueString(), resp)
 }
 
 func (r *UserGroupMembersResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -238,20 +252,5 @@ func (r *UserGroupMembersResource) ImportState(ctx context.Context, req resource
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *UserGroupMembersResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	if req.State.Raw.IsNull() {
-		resp.Diagnostics.AddWarning(
-			"Resource Destruction Considerations",
-			"This resource cannot be destroyed from Terraform. If you create this resource, it will be "+
-				"present in the API until manually deleted.",
-		)
-	}
-	if req.Plan.Raw.IsNull() {
-		resp.Diagnostics.AddWarning(
-			"Resource Destruction Considerations",
-			"Applying this resource destruction will remove the resource from the Terraform state "+
-				"but will not change it in the API. If you would like to destroy or reset this resource "+
-				"in the API, refer to the documentation for how to do it manually.",
-		)
-	}
+func (r *UserGroupMembersResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, _ *resource.ModifyPlanResponse) {
 }

--- a/internal/services/user_group_members/resource_test.go
+++ b/internal/services/user_group_members/resource_test.go
@@ -1,0 +1,438 @@
+package user_group_members_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/accounts"
+	"github.com/cloudflare/cloudflare-go/v6/iam"
+	"github.com/cloudflare/cloudflare-go/v6/option"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func init() {
+	resource.AddTestSweepers("cloudflare_user_group_members", &resource.Sweeper{
+		Name: "cloudflare_user_group_members",
+		F:    testSweepCloudflareUserGroupMembers,
+	})
+}
+
+// testSweepCloudflareUserGroupMembers cleans up test user groups; deleting the parent
+// group cascades to its members.
+func testSweepCloudflareUserGroupMembers(r string) error {
+	ctx := context.Background()
+	client := acctest.SharedClient()
+
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		tflog.Info(ctx, "Skipping user_group_members sweep: CLOUDFLARE_ACCOUNT_ID not set")
+		return nil
+	}
+
+	// List user groups and delete any leftover test groups
+	groups, err := client.IAM.UserGroups.List(
+		ctx,
+		iam.UserGroupListParams{
+			AccountID: cloudflare.F(accountID),
+		},
+	)
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to list user groups: %s", err))
+		return fmt.Errorf("failed to list user groups: %w", err)
+	}
+
+	for _, group := range groups.Result {
+		// Only sweep test groups (both DSR check groups and test user groups)
+		if !strings.HasPrefix(group.Name, "cftftest") &&
+			!strings.HasPrefix(group.Name, "tf-") &&
+			!utils.ShouldSweepResource(group.Name) {
+			continue
+		}
+
+		tflog.Info(ctx, fmt.Sprintf("Deleting test user group: %s (%s)", group.ID, group.Name))
+		_, err := client.IAM.UserGroups.Delete(
+			ctx,
+			group.ID,
+			iam.UserGroupDeleteParams{
+				AccountID: cloudflare.F(accountID),
+			},
+		)
+		if err != nil {
+			tflog.Error(ctx, fmt.Sprintf("Failed to delete user group %s: %s", group.ID, err))
+		}
+	}
+
+	return nil
+}
+
+// tryAddMember attempts to add a member to a user group to verify DSR is enabled.
+// Returns nil if successful, an error if the member cannot be added.
+func tryAddMember(ctx context.Context, client *cloudflare.Client, accountID, userGroupID, memberID string) error {
+	body := fmt.Sprintf(`[{"id":"%s"}]`, memberID)
+	_, err := client.IAM.UserGroups.Members.New(ctx, userGroupID,
+		iam.UserGroupMemberNewParams{
+			AccountID: cloudflare.F(accountID),
+		},
+		option.WithRequestBody("application/json", []byte(body)),
+	)
+	return err
+}
+
+// findDSREnabledMembers returns up to `count` member IDs that can be added to a user
+// group, skipping the test if none are found. DSR (zone_level_access_beta flag) is not
+// exposed in the API, so we detect it by trying to add each member to a temp group.
+func findDSREnabledMembers(t *testing.T, accountID string, count int) []string {
+	t.Helper()
+	ctx := context.Background()
+	client := acctest.SharedClient()
+
+	// Create a temporary user group for testing DSR status
+	tempGroupName := fmt.Sprintf("tf-dsr-check-%s", utils.GenerateRandomResourceName())
+	tempGroup, err := client.IAM.UserGroups.New(ctx, iam.UserGroupNewParams{
+		AccountID: cloudflare.F(accountID),
+		Name:      cloudflare.F(tempGroupName),
+	})
+	if err != nil {
+		t.Skipf("Failed to create temp user group for DSR check: %s", err)
+	}
+
+	// Clean up temp group at the end
+	defer func() {
+		_, cleanupErr := client.IAM.UserGroups.Delete(ctx, tempGroup.ID, iam.UserGroupDeleteParams{
+			AccountID: cloudflare.F(accountID),
+		})
+		if cleanupErr != nil {
+			tflog.Warn(ctx, fmt.Sprintf("Failed to cleanup temp user group %s: %s", tempGroup.ID, cleanupErr))
+		}
+	}()
+
+	dsrMembers := []string{}
+
+	// Try CLOUDFLARE_MEMBER_ID first if set
+	if envMemberID := os.Getenv("CLOUDFLARE_MEMBER_ID"); envMemberID != "" {
+		if err := tryAddMember(ctx, client, accountID, tempGroup.ID, envMemberID); err == nil {
+			tflog.Info(ctx, fmt.Sprintf("Using CLOUDFLARE_MEMBER_ID from env: %s", envMemberID))
+			dsrMembers = append(dsrMembers, envMemberID)
+			if len(dsrMembers) >= count {
+				return dsrMembers
+			}
+		}
+	}
+
+	// List account members
+	members, err := client.Accounts.Members.List(ctx, accounts.MemberListParams{
+		AccountID: cloudflare.F(accountID),
+		Status:    cloudflare.F(accounts.MemberListParamsStatusAccepted),
+	})
+	if err != nil {
+		t.Skipf("Failed to list account members: %s", err)
+	}
+	if len(members.Result) == 0 {
+		t.Skip("Account has no accepted members")
+	}
+
+	// Try each member - skip already found, collect DSR-enabled ones
+	for _, member := range members.Result {
+		// Skip if already in our list
+		alreadyFound := false
+		for _, id := range dsrMembers {
+			if id == member.ID {
+				alreadyFound = true
+				break
+			}
+		}
+		if alreadyFound {
+			continue
+		}
+
+		err := tryAddMember(ctx, client, accountID, tempGroup.ID, member.ID)
+		if err == nil {
+			tflog.Info(ctx, fmt.Sprintf("Found DSR-enabled member: %s (%s)", member.ID, member.User.Email))
+			dsrMembers = append(dsrMembers, member.ID)
+			if len(dsrMembers) >= count {
+				return dsrMembers
+			}
+			continue
+		}
+		if strings.Contains(err.Error(), "do not have DSR enabled") {
+			tflog.Info(ctx, fmt.Sprintf("Member %s does not have DSR enabled, trying next", member.ID))
+			continue
+		}
+		tflog.Warn(ctx, fmt.Sprintf("Failed to add member %s: %s", member.ID, err))
+	}
+
+	if len(dsrMembers) == 0 {
+		t.Skip("No DSR-enabled member found in account; cannot test user_group_members")
+	}
+
+	return dsrMembers
+}
+
+// findDSREnabledMember is a convenience wrapper for a single DSR-enabled member.
+func findDSREnabledMember(t *testing.T, accountID string) string {
+	t.Helper()
+	members := findDSREnabledMembers(t, accountID, 1)
+	if len(members) == 0 {
+		t.Skip("No DSR-enabled member found")
+	}
+	return members[0]
+}
+
+// Note: To represent a user group with no members, omit this resource entirely. Setting
+// members = [] causes refresh drift; future versions may enforce min 1 member.
+
+// TestAccCloudflareUserGroupMembers_Basic tests create + idempotency with one member.
+func TestAccCloudflareUserGroupMembers_Basic(t *testing.T) {
+	t.Parallel()
+
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("CLOUDFLARE_ACCOUNT_ID must be set for acceptance tests")
+	}
+	memberID := findDSREnabledMember(t, accountID)
+	resourceName := "cloudflare_user_group_members." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareUserGroupMembersDestroy,
+		Steps: []resource.TestStep{
+			// Create with member
+			{
+				Config: testAccCloudflareUserGroupMembersBasicConfig(rnd, accountID, memberID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("user_group_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("members"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("members").AtSliceIndex(0).AtMapKey("id"), knownvalue.StringExact(memberID)),
+				},
+			},
+			// Idempotency: re-apply is a no-op
+			{
+				Config: testAccCloudflareUserGroupMembersBasicConfig(rnd, accountID, memberID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Import
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareUserGroupMembers_MultipleMembers tests creating a user group with multiple members.
+func TestAccCloudflareUserGroupMembers_MultipleMembers(t *testing.T) {
+	t.Parallel()
+
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("CLOUDFLARE_ACCOUNT_ID must be set for acceptance tests")
+	}
+	members := findDSREnabledMembers(t, accountID, 2)
+	if len(members) < 2 {
+		t.Skipf("Need at least 2 DSR-enabled members, found %d", len(members))
+	}
+	resourceName := "cloudflare_user_group_members." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareUserGroupMembersDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareUserGroupMembersMultipleConfig(rnd, accountID, members[0], members[1]),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("members"), knownvalue.ListSizeExact(2)),
+				},
+			},
+			// Import (multi-member)
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareUserGroupMembers_UpdateAddMember tests adding a member via update.
+func TestAccCloudflareUserGroupMembers_UpdateAddMember(t *testing.T) {
+	t.Parallel()
+
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("CLOUDFLARE_ACCOUNT_ID must be set for acceptance tests")
+	}
+	members := findDSREnabledMembers(t, accountID, 2)
+	if len(members) < 2 {
+		t.Skipf("Need at least 2 DSR-enabled members, found %d", len(members))
+	}
+	resourceName := "cloudflare_user_group_members." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareUserGroupMembersDestroy,
+		Steps: []resource.TestStep{
+			// Start with 1 member
+			{
+				Config: testAccCloudflareUserGroupMembersBasicConfig(rnd, accountID, members[0]),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("members"), knownvalue.ListSizeExact(1)),
+				},
+			},
+			// Add a second member
+			{
+				Config: testAccCloudflareUserGroupMembersMultipleConfig(rnd, accountID, members[0], members[1]),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("members"), knownvalue.ListSizeExact(2)),
+				},
+			},
+			// Back to 1 member
+			{
+				Config: testAccCloudflareUserGroupMembersBasicConfig(rnd, accountID, members[0]),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("members"), knownvalue.ListSizeExact(1)),
+				},
+			},
+			// Import (after multi-member updates)
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareUserGroupMembers_DestroyRemovesAllMembers verifies destroying just
+// the members resource clears all members (via PUT []) while keeping the parent group.
+func TestAccCloudflareUserGroupMembers_DestroyRemovesAllMembers(t *testing.T) {
+	t.Parallel()
+
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("CLOUDFLARE_ACCOUNT_ID must be set for acceptance tests")
+	}
+	memberID := findDSREnabledMember(t, accountID)
+	resourceName := "cloudflare_user_group_members." + rnd
+	groupResourceName := "cloudflare_user_group." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareUserGroupMembersDestroy,
+		Steps: []resource.TestStep{
+			// Create group with members
+			{
+				Config: testAccCloudflareUserGroupMembersBasicConfig(rnd, accountID, memberID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("members"), knownvalue.ListSizeExact(1)),
+				},
+			},
+			// Remove only the members resource; group must remain with zero members.
+			{
+				Config: testAccCloudflareUserGroupOnlyConfig(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(groupResourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+				},
+				Check: testAccCheckCloudflareUserGroupHasNoMembers(accountID, groupResourceName),
+			},
+		},
+	})
+}
+
+// Note: `members = []` causes "inconsistent result after apply" because the framework
+// serializes empty `*[]*T` as null at the cty layer. Users wanting an empty group should
+// omit the resource or `terraform destroy -target` it. Switching the schema to
+// SetNestedAttribute may fix this and the permission_groups ordering drift.
+
+func testAccCloudflareUserGroupMembersBasicConfig(rnd, accountID, memberID string) string {
+	return acctest.LoadTestCase("usergroupmembersbasic.tf", rnd, accountID, memberID)
+}
+
+func testAccCloudflareUserGroupMembersMultipleConfig(rnd, accountID, memberID1, memberID2 string) string {
+	return acctest.LoadTestCase("usergroupmembersmultiple.tf", rnd, accountID, memberID1, memberID2)
+}
+
+func testAccCloudflareUserGroupOnlyConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("usergrouponly.tf", rnd, accountID)
+}
+
+// testAccCheckCloudflareUserGroupMembersDestroy verifies the parent user group is gone
+// from the API after destroy; removing the group cascades to its members.
+func testAccCheckCloudflareUserGroupMembersDestroy(s *terraform.State) error {
+	client := acctest.SharedClient()
+	ctx := context.Background()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_user_group" {
+			continue
+		}
+
+		_, err := client.IAM.UserGroups.Get(ctx, rs.Primary.ID, iam.UserGroupGetParams{
+			AccountID: cloudflare.F(rs.Primary.Attributes[consts.AccountIDSchemaKey]),
+		})
+		if err == nil {
+			return fmt.Errorf("user group %s still exists after destroy", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+// testAccCheckCloudflareUserGroupHasNoMembers asserts via the API that the given user
+// group has zero members.
+func testAccCheckCloudflareUserGroupHasNoMembers(accountID, groupResourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[groupResourceName]
+		if !ok {
+			return fmt.Errorf("user group resource %s not found in state", groupResourceName)
+		}
+		userGroupID := rs.Primary.ID
+		client := acctest.SharedClient()
+		ctx := context.Background()
+
+		members, err := client.IAM.UserGroups.Members.List(ctx, userGroupID, iam.UserGroupMemberListParams{
+			AccountID: cloudflare.F(accountID),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to list members for user group %s: %w", userGroupID, err)
+		}
+		if len(members.Result) > 0 {
+			return fmt.Errorf("expected user group %s to have no members, found %d", userGroupID, len(members.Result))
+		}
+		return nil
+	}
+}

--- a/internal/services/user_group_members/testdata/usergroupmembersbasic.tf
+++ b/internal/services/user_group_members/testdata/usergroupmembersbasic.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_user_group" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+}
+
+resource "cloudflare_user_group_members" "%[1]s" {
+  account_id    = "%[2]s"
+  user_group_id = cloudflare_user_group.%[1]s.id
+  members = [
+    { id = "%[3]s" }
+  ]
+}

--- a/internal/services/user_group_members/testdata/usergroupmembersdatasource.tf
+++ b/internal/services/user_group_members/testdata/usergroupmembersdatasource.tf
@@ -1,0 +1,18 @@
+resource "cloudflare_user_group" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+}
+
+resource "cloudflare_user_group_members" "%[1]s" {
+  account_id    = "%[2]s"
+  user_group_id = cloudflare_user_group.%[1]s.id
+  members = [
+    { id = "%[3]s" }
+  ]
+}
+
+data "cloudflare_user_group_members" "%[1]s" {
+  account_id    = "%[2]s"
+  user_group_id = cloudflare_user_group.%[1]s.id
+  depends_on    = [cloudflare_user_group_members.%[1]s]
+}

--- a/internal/services/user_group_members/testdata/usergroupmembersdatasourcewithfilter.tf
+++ b/internal/services/user_group_members/testdata/usergroupmembersdatasourcewithfilter.tf
@@ -1,0 +1,19 @@
+resource "cloudflare_user_group" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+}
+
+resource "cloudflare_user_group_members" "%[1]s" {
+  account_id    = "%[2]s"
+  user_group_id = cloudflare_user_group.%[1]s.id
+  members = [
+    { id = "%[3]s" }
+  ]
+}
+
+data "cloudflare_user_group_members" "%[1]s" {
+  account_id    = "%[2]s"
+  user_group_id = cloudflare_user_group.%[1]s.id
+  direction     = "desc"
+  depends_on    = [cloudflare_user_group_members.%[1]s]
+}

--- a/internal/services/user_group_members/testdata/usergroupmembersmultiple.tf
+++ b/internal/services/user_group_members/testdata/usergroupmembersmultiple.tf
@@ -1,0 +1,13 @@
+resource "cloudflare_user_group" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+}
+
+resource "cloudflare_user_group_members" "%[1]s" {
+  account_id    = "%[2]s"
+  user_group_id = cloudflare_user_group.%[1]s.id
+  members = [
+    { id = "%[3]s" },
+    { id = "%[4]s" }
+  ]
+}

--- a/internal/services/user_group_members/testdata/usergrouponly.tf
+++ b/internal/services/user_group_members/testdata/usergrouponly.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_user_group" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
**Problem**
`cloudflare_user_group_members` cannot be destroyed via Terraform — Delete is implemented as a no-op stub with only ModifyPlan warnings telling users "This resource cannot be destroyed from Terraform. If you create this resource, it will be present in the API until manually deleted." Users running terraform destroy get state-only removal while the API retains the membership, violating Terraform's lifecycle expectations and making cleanup unreliable.

`cloudflare_user_group_members` data source returns the wrong shape — instead of a list of members, the generated model exposes single top-level email + status fields, so `data.cloudflare_user_group_members.x.email` only ever reflects one member regardless of how many are in the group. Customers querying group membership cannot enumerate members through the data source as documented.

**Root cause:**
- Generated Delete is empty because the OpenAPI spec marks `delete: skip: [terraform]` on `/iam/user_groups/{user_group_id}/members/{member_id}` (the API's per-member DELETE doesn't fit the collection-resource model).
- Generated data source model reflects an individual member envelope rather than a list, because the codegen template inferred a single-result shape from the list endpoint return.
- Generated apijson encoder serializes *[]*T empty-slice as null, causing refresh drift between configured `members = []` and API-returned result: null.

**Fix**
Adds custom.go following the established pattern used by other resources:
1. `removeAllMembers()` — invokes `PUT /iam/user_groups/{user_group_id}/members with body []`, clearing all members in a single API call without affecting the parent user group. Wired into Delete so terraform destroy and -target both work as expected.
2. `normalizeMembers()` — guarantees data.Members is a non-nil pointer to an empty slice when the API returns result: null, eliminating the post-apply refresh drift previously seen as `+ members = []`.
3. `unmarshalMembersCustom()` — wraps the standard unmarshal with normalization for the Read path.

resource.go is updated minimally to call these helpers in Create, Update, Read, and Delete, and to drop the now-inaccurate ModifyPlan warnings (Delete actually deletes now).

Restructures the `cloudflare_user_group_members` data source model + schema so result is exposed as a members list with id / email / status per element, matching the shape returned by the underlying `GET /members` endpoint.

Adds acceptance tests for both resources following the Adding Terraform Acceptance Tests.

## Acceptance test run results

- [X] I have added or updated acceptance tests for my changes
- [X] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
1. Acceptance Tests
```
source ./tf_setup.sh
go test -count=1 -v -timeout 30m \
  -run='TestAccCloudflareUserGroup' \
  ./internal/services/user_group/... \
  ./internal/services/user_group_members/...
```
2. HCL Real-Case Test
https://paste.cfdata.org/ClHrRXOF78RW

### Test output
<!-- Please paste the output of your acceptance test run below --> 
```
=== RUN   TestAccCloudflareUserGroup_DataSource
--- PASS: TestAccCloudflareUserGroup_DataSource (4.31s)
=== RUN   TestAccCloudflareUserGroup_Basic
=== RUN   TestAccCloudflareUserGroup_WithPolicies
=== RUN   TestAccCloudflareUserGroup_UpdatePolicy
=== RUN   TestAccCloudflareUserGroup_InvalidPolicyAccess
--- PASS: TestAccCloudflareUserGroup_InvalidPolicyAccess (0.17s)
--- PASS: TestAccCloudflareUserGroup_WithPolicies (4.36s)
--- PASS: TestAccCloudflareUserGroup_UpdatePolicy (5.16s)
--- PASS: TestAccCloudflareUserGroup_Basic (5.55s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/user_group	11.733s
=== RUN   TestAccCloudflareUserGroupMembers_DataSource
--- PASS: TestAccCloudflareUserGroupMembers_DataSource (4.62s)
=== RUN   TestAccCloudflareUserGroupMembers_DataSourceWithFilter
--- PASS: TestAccCloudflareUserGroupMembers_DataSourceWithFilter (4.60s)
=== RUN   TestAccCloudflareUserGroupMembers_Basic
=== RUN   TestAccCloudflareUserGroupMembers_MultipleMembers
=== RUN   TestAccCloudflareUserGroupMembers_UpdateAddMember
=== RUN   TestAccCloudflareUserGroupMembers_DestroyRemovesAllMembers
--- PASS: TestAccCloudflareUserGroupMembers_MultipleMembers (4.81s)
--- PASS: TestAccCloudflareUserGroupMembers_DestroyRemovesAllMembers (5.32s)
--- PASS: TestAccCloudflareUserGroupMembers_Basic (6.09s)
--- PASS: TestAccCloudflareUserGroupMembers_UpdateAddMember (8.11s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/user_group_members	20.502s
Result: 11/11 PASS
```
## Additional context & links
