### PR TITLE
fix(list_item): ambigous schema while upgrade

### DIFF
--- a/internal/services/list_item/migration/v500/handler.go
+++ b/internal/services/list_item/migration/v500/handler.go
@@ -2,9 +2,12 @@ package v500
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -38,6 +41,10 @@ func UpgradeFromV0(ctx context.Context, req resource.UpgradeStateRequest, resp *
 // In v4.52.5, hostname and redirect are ListNestedBlocks (lists with max 1 element).
 // This upgrade converts them to SingleNestedAttributes (objects).
 // Redirect boolean fields are already bools in v1 (no string conversion needed).
+//
+// IMPORTANT: This must only be called when req.State was populated with the v4.52.5 PriorSchema.
+// When called from UpgradeFromV1Ambiguous (where PriorSchema is nil), use
+// upgradeFromV1ViaRawState instead.
 func UpgradeFromV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 	tflog.Info(ctx, "Upgrading cloudflare_list_item state from v4.52.5 framework (schema_version=1)")
 
@@ -83,4 +90,122 @@ func UpgradeFromV1(ctx context.Context, req resource.UpgradeStateRequest, resp *
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, target)...)
 	tflog.Info(ctx, "State upgrade for cloudflare_list_item from v1 completed successfully")
+}
+
+// UpgradeFromV1Ambiguous handles schema_version=1 state that is AMBIGUOUS between
+// v4.52.5 Plugin Framework format and v5 production format.
+//
+// Both v4.52.5 and v5 production (v5.0-v5.18 with GetSchemaVersion(1,500)) stored state
+// at schema_version=1, but with incompatible formats:
+//   - v4.52.5: hostname/redirect stored as ARRAY (ListNestedBlock)
+//   - v5: hostname/redirect stored as OBJECT (SingleNestedAttribute)
+//
+// migrations.go registers this with PriorSchema=nil so the framework skips pre-decoding
+// req.State entirely. Both paths operate exclusively on req.RawState.JSON.
+//
+// Detection: inspect hostname/redirect in raw JSON.
+// If array -> v4.52.5 format -> transform via raw state.
+// If object (or absent) -> v5 format -> no-op re-decode with target schema.
+func UpgradeFromV1Ambiguous(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading cloudflare_list_item state from schema_version=1 (detecting v4.52.5 vs v5 format)")
+
+	isV4, err := detectV4ListItemState(req)
+	if err != nil {
+		// Cannot determine format — default to no-op to avoid data loss.
+		tflog.Warn(ctx, "Could not detect list_item state format, defaulting to no-op", map[string]interface{}{
+			"error": err.Error(),
+		})
+		// Fall through to no-op path
+	}
+
+	if isV4 {
+		tflog.Info(ctx, "Detected v4.52.5 list_item format (hostname/redirect is array), performing transformation via raw state")
+		upgradeFromV1ViaRawState(ctx, req, resp)
+		return
+	}
+
+	// v5 production state: re-decode raw JSON with the target schema.
+	// req.State is nil here (PriorSchema=nil), so we must use req.RawState directly.
+	tflog.Info(ctx, "Detected v5 list_item format (hostname/redirect is object), performing no-op version bump via raw state")
+	targetType := resp.State.Schema.Type().TerraformType(ctx)
+	rawValue, unmarshalErr := req.RawState.Unmarshal(targetType)
+	if unmarshalErr != nil {
+		resp.Diagnostics.AddError(
+			"Failed to unmarshal v5 list_item state",
+			"Could not parse raw state as v5 format: "+unmarshalErr.Error(),
+		)
+		return
+	}
+	resp.State.Raw = rawValue
+	tflog.Info(ctx, "State version bump from 1 to 500 completed")
+}
+
+// upgradeFromV1ViaRawState performs the v4.52.5->v5 transformation by parsing req.RawState
+// directly with the v4.52.5 schema. This is necessary when the upgrader was registered with
+// PriorSchema=nil (so req.State is nil and cannot be used to parse v4.52.5 arrays).
+func upgradeFromV1ViaRawState(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	if req.RawState == nil {
+		resp.Diagnostics.AddError("Missing raw state", "RawState was nil during v4.52.5 list_item upgrade")
+		return
+	}
+
+	// Parse raw state using the v4.52.5 schema
+	v1Schema := SourceListItemV1Schema()
+	v1Type := v1Schema.Type().TerraformType(ctx)
+
+	rawValue, err := req.RawState.Unmarshal(v1Type)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to unmarshal v4.52.5 list_item state",
+			fmt.Sprintf("Could not parse raw state as v4.52.5 format: %s", err),
+		)
+		return
+	}
+
+	// Build a synthetic req with the v4.52.5-typed state so UpgradeFromV1 can call req.State.Get
+	v1State := &tfsdk.State{Raw: rawValue, Schema: v1Schema}
+	syntheticReq := resource.UpgradeStateRequest{
+		RawState: req.RawState,
+		State:    v1State,
+	}
+
+	UpgradeFromV1(ctx, syntheticReq, resp)
+}
+
+// detectV4ListItemState returns true if the raw state is in v4.52.5 format.
+// v4.52.5 format: hostname/redirect are JSON arrays [] (ListNestedBlock).
+// v5 format: hostname/redirect are JSON objects {} (SingleNestedAttribute) or null.
+func detectV4ListItemState(req resource.UpgradeStateRequest) (bool, error) {
+	if req.RawState == nil || len(req.RawState.JSON) == 0 {
+		return false, nil
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(req.RawState.JSON, &raw); err != nil {
+		return false, err
+	}
+
+	// Check hostname field: array = v4.52.5, object = v5
+	if hostname, ok := raw["hostname"]; ok && hostname != nil {
+		switch hostname.(type) {
+		case []interface{}:
+			return true, nil // v4.52.5 ListNestedBlock
+		case map[string]interface{}:
+			return false, nil // v5 SingleNestedAttribute
+		}
+	}
+
+	// Check redirect field: array = v4.52.5, object = v5
+	if redirect, ok := raw["redirect"]; ok && redirect != nil {
+		switch redirect.(type) {
+		case []interface{}:
+			return true, nil // v4.52.5 ListNestedBlock
+		case map[string]interface{}:
+			return false, nil // v5 SingleNestedAttribute
+		}
+	}
+
+	// Neither hostname nor redirect present (e.g., IP-only or ASN-only list item).
+	// Cannot determine format, but no transformation needed either — assume v5.
+	return false, nil
 }

--- a/internal/services/list_item/migration/v500/handler_test.go
+++ b/internal/services/list_item/migration/v500/handler_test.go
@@ -1,0 +1,322 @@
+package v500_test
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	v500 "github.com/cloudflare/terraform-provider-cloudflare/internal/services/list_item/migration/v500"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/list_item"
+)
+
+// TestUpgradeFromV1Ambiguous_V5HostnameState simulates the exact scenario from
+// GitHub issue #7073: a cloudflare_list_item with hostname created natively in
+// v5 (schema_version=1) must survive the upgrade to schema_version=500 without error.
+//
+// In v5, hostname is a SingleNestedAttribute stored as a JSON object:
+//
+//	{"url_hostname": "example.com", "exclude_exact_hostname": null}
+//
+// The v4.52.5 format would be an array: [{"url_hostname": "example.com"}]
+//
+// UpgradeFromV1Ambiguous must detect the object format and perform a no-op
+// version bump instead of trying to parse it as a v4.52.5 array.
+func TestUpgradeFromV1Ambiguous_V5HostnameState(t *testing.T) {
+	t.Parallel()
+
+	// This is the exact state shape stored by v5.0-v5.18 for a hostname list item.
+	v5State := map[string]interface{}{
+		"account_id": "abc123",
+		"list_id":    "list456",
+		"id":         "item789",
+		"ip":         nil,
+		"asn":        nil,
+		"comment":    "test hostname",
+		"hostname": map[string]interface{}{
+			"url_hostname":           "example.com",
+			"exclude_exact_hostname": nil,
+		},
+		"redirect":     nil,
+		"operation_id": nil,
+		"modified_on":  nil,
+		"created_on":   nil,
+	}
+
+	result := runAmbiguousUpgradeTest(t, v5State)
+
+	hostname := getNestedObject(t, result, "hostname")
+	assertStringField(t, hostname, "url_hostname", "example.com")
+}
+
+// TestUpgradeFromV1Ambiguous_V5RedirectState tests that a v5 native redirect list item
+// (stored as a JSON object) survives the ambiguous upgrade.
+func TestUpgradeFromV1Ambiguous_V5RedirectState(t *testing.T) {
+	t.Parallel()
+
+	v5State := map[string]interface{}{
+		"account_id": "abc123",
+		"list_id":    "list456",
+		"id":         "item789",
+		"ip":         nil,
+		"asn":        nil,
+		"comment":    "test redirect",
+		"hostname":   nil,
+		"redirect": map[string]interface{}{
+			"source_url":            "https://example.com/old",
+			"target_url":            "https://example.com/new",
+			"status_code":           float64(301),
+			"include_subdomains":    true,
+			"subpath_matching":      false,
+			"preserve_query_string": true,
+			"preserve_path_suffix":  false,
+		},
+		"operation_id": nil,
+		"modified_on":  nil,
+		"created_on":   nil,
+	}
+
+	result := runAmbiguousUpgradeTest(t, v5State)
+
+	redirect := getNestedObject(t, result, "redirect")
+	assertStringField(t, redirect, "source_url", "https://example.com/old")
+	assertStringField(t, redirect, "target_url", "https://example.com/new")
+}
+
+// TestUpgradeFromV1Ambiguous_V5IPOnlyState tests that an IP-only list item (no hostname
+// or redirect) also survives the ambiguous upgrade (no-op path).
+func TestUpgradeFromV1Ambiguous_V5IPOnlyState(t *testing.T) {
+	t.Parallel()
+
+	v5State := map[string]interface{}{
+		"account_id":   "abc123",
+		"list_id":      "list456",
+		"id":           "item789",
+		"ip":           "192.0.2.1",
+		"asn":          nil,
+		"comment":      "test ip",
+		"hostname":     nil,
+		"redirect":     nil,
+		"operation_id": nil,
+		"modified_on":  nil,
+		"created_on":   nil,
+	}
+
+	result := runAmbiguousUpgradeTest(t, v5State)
+
+	assertStringField(t, result, "ip", "192.0.2.1")
+	assertStringField(t, result, "comment", "test ip")
+}
+
+// TestUpgradeFromV1Ambiguous_V4HostnameState tests that a v4.52.5 hostname list item
+// (stored as a JSON array) is correctly detected and transformed to v5 object format.
+func TestUpgradeFromV1Ambiguous_V4HostnameState(t *testing.T) {
+	t.Parallel()
+
+	// v4.52.5 stores hostname as an array (ListNestedBlock)
+	v4State := map[string]interface{}{
+		"account_id": "abc123",
+		"list_id":    "list456",
+		"id":         "item789",
+		"ip":         nil,
+		"asn":        nil,
+		"comment":    "test hostname v4",
+		"hostname": []interface{}{
+			map[string]interface{}{
+				"url_hostname": "example.com",
+			},
+		},
+		"redirect": []interface{}{},
+	}
+
+	result := runAmbiguousUpgradeTest(t, v4State)
+
+	// After upgrade, hostname should be an object (not an array)
+	hostname := getNestedObject(t, result, "hostname")
+	assertStringField(t, hostname, "url_hostname", "example.com")
+}
+
+// TestUpgradeFromV1Ambiguous_V4RedirectState tests that a v4.52.5 redirect list item
+// (stored as a JSON array) is correctly detected and transformed to v5 object format.
+func TestUpgradeFromV1Ambiguous_V4RedirectState(t *testing.T) {
+	t.Parallel()
+
+	v4State := map[string]interface{}{
+		"account_id": "abc123",
+		"list_id":    "list456",
+		"id":         "item789",
+		"ip":         nil,
+		"asn":        nil,
+		"comment":    "test redirect v4",
+		"hostname":   []interface{}{},
+		"redirect": []interface{}{
+			map[string]interface{}{
+				"source_url":            "https://example.com/old",
+				"target_url":            "https://example.com/new",
+				"status_code":           float64(301),
+				"include_subdomains":    true,
+				"subpath_matching":      false,
+				"preserve_query_string": true,
+				"preserve_path_suffix":  false,
+			},
+		},
+	}
+
+	result := runAmbiguousUpgradeTest(t, v4State)
+
+	// After upgrade, redirect should be an object (not an array)
+	redirect := getNestedObject(t, result, "redirect")
+	assertStringField(t, redirect, "source_url", "https://example.com/old")
+	assertStringField(t, redirect, "target_url", "https://example.com/new")
+}
+
+// runAmbiguousUpgradeTest constructs the UpgradeStateRequest/Response with
+// PriorSchema=nil (matching how migrations.go registers version 1), invokes
+// UpgradeFromV1Ambiguous, and returns the resulting state as a JSON map.
+//
+// It verifies no diagnostics errors occurred during the upgrade.
+func runAmbiguousUpgradeTest(t *testing.T, stateJSON map[string]interface{}) map[string]interface{} {
+	t.Helper()
+
+	ctx := context.Background()
+
+	rawJSON, err := json.Marshal(stateJSON)
+	if err != nil {
+		t.Fatalf("failed to marshal test state: %v", err)
+	}
+
+	// Build the target schema (v5/v500) that resp.State will use.
+	targetSchema := list_item.ResourceSchema(ctx)
+
+	resp := &resource.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: targetSchema,
+		},
+	}
+
+	req := resource.UpgradeStateRequest{
+		RawState: &tfprotov6.RawState{
+			JSON: rawJSON,
+		},
+		// State is nil because PriorSchema is nil in the migrations.go registration
+		State: nil,
+	}
+
+	v500.UpgradeFromV1Ambiguous(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		for _, d := range resp.Diagnostics.Errors() {
+			t.Errorf("diagnostic error: %s: %s", d.Summary(), d.Detail())
+		}
+		t.FailNow()
+	}
+
+	// Extract the resulting tftypes.Value into a Go map for field-level assertions.
+	// We cannot use resp.State.Get into a Go struct because the migration
+	// handler writes TargetListItemModel (with NestedObject[TargetHostnameModel])
+	// while the schema's CustomType expects NestedObject[ListItemHostnameModel].
+	// The types are structurally identical so tftypes works fine, but Go generics
+	// prevent direct Get deserialization. Instead, extract via tftypes.Value.As().
+	var rawMap map[string]tftypes.Value
+	if err := resp.State.Raw.As(&rawMap); err != nil {
+		t.Fatalf("failed to extract state as map: %v", err)
+	}
+
+	result := tftypesMapToInterface(t, rawMap)
+	return result
+}
+
+// getNestedObject extracts a nested object field from the result map.
+func getNestedObject(t *testing.T, result map[string]interface{}, key string) map[string]interface{} {
+	t.Helper()
+	val, ok := result[key]
+	if !ok || val == nil {
+		t.Fatalf("expected %q field to be present and non-nil", key)
+	}
+	obj, ok := val.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected %q to be an object, got %T", key, val)
+	}
+	return obj
+}
+
+// assertStringField checks that a string field in a map has the expected value.
+func assertStringField(t *testing.T, obj map[string]interface{}, key, expected string) {
+	t.Helper()
+	val, ok := obj[key]
+	if !ok {
+		t.Errorf("expected field %q to be present", key)
+		return
+	}
+	str, ok := val.(string)
+	if !ok {
+		t.Errorf("expected field %q to be a string, got %T", key, val)
+		return
+	}
+	if str != expected {
+		t.Errorf("expected %s=%q, got %q", key, expected, str)
+	}
+}
+
+// tftypesMapToInterface converts a map[string]tftypes.Value into a
+// map[string]interface{} for easy test assertions. Handles nested objects
+// and primitive types (string, number, bool, nil).
+func tftypesMapToInterface(t *testing.T, m map[string]tftypes.Value) map[string]interface{} {
+	t.Helper()
+	result := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		result[k] = tftypesValueToInterface(t, v)
+	}
+	return result
+}
+
+func tftypesValueToInterface(t *testing.T, v tftypes.Value) interface{} {
+	t.Helper()
+
+	if !v.IsKnown() || v.IsNull() {
+		return nil
+	}
+
+	// Try string
+	var s string
+	if err := v.As(&s); err == nil {
+		return s
+	}
+
+	// Try bool
+	var b bool
+	if err := v.As(&b); err == nil {
+		return b
+	}
+
+	// Try number (via big.Float -> float64)
+	var bf *big.Float
+	if err := v.As(&bf); err == nil {
+		f, _ := bf.Float64()
+		return f
+	}
+
+	// Try object (map)
+	var m map[string]tftypes.Value
+	if err := v.As(&m); err == nil {
+		return tftypesMapToInterface(t, m)
+	}
+
+	// Try list/set/tuple
+	var l []tftypes.Value
+	if err := v.As(&l); err == nil {
+		result := make([]interface{}, len(l))
+		for i, item := range l {
+			result[i] = tftypesValueToInterface(t, item)
+		}
+		return result
+	}
+
+	t.Fatalf("unsupported tftypes.Value type: %s", v.Type())
+	return nil
+}

--- a/internal/services/list_item/migration/v500/migrations_test.go
+++ b/internal/services/list_item/migration/v500/migrations_test.go
@@ -11,8 +11,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+var (
+	currentProviderVersion = internal.PackageVersion // Current v5 release
 )
 
 // setV4ProviderRetryEnv configures the v4 Cloudflare provider's retry and backoff
@@ -42,170 +47,252 @@ var v4HostnameItemConfig string
 //go:embed testdata/v4_redirect_item.tf
 var v4RedirectItemConfig string
 
+//go:embed testdata/v5_ip_item.tf
+var v5IPItemConfig string
+
+//go:embed testdata/v5_hostname_item.tf
+var v5HostnameItemConfig string
+
+//go:embed testdata/v5_redirect_item.tf
+var v5RedirectItemConfig string
+
 const listTestPrefix = "tf_test_list_"
 
-// TestMigrateCloudflareListItemFromV4WithIP tests migration of a standalone list_item with IP.
-// In v5, separate list_item resources remain as separate resources (they are NOT merged into the parent list).
-// The provider's StateUpgraders handle the state migration for both cloudflare_list and cloudflare_list_item.
-func TestMigrateCloudflareListItemFromV4WithIP(t *testing.T) {
-	setV4ProviderRetryEnv(t)
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	rnd := utils.GenerateRandomResourceName()
-	listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
-	listResourceName := "cloudflare_list." + rnd
-	itemResourceName := "cloudflare_list_item." + rnd + "_item"
-	tmpDir := t.TempDir()
-	description := fmt.Sprintf("Test list with IP item %s", rnd)
-
-	v4Config := fmt.Sprintf(v4IPItemConfig, rnd, accountID, listName, description)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
-			acctest.TestAccPreCheck_AccountID(t)
-		},
-		WorkingDir: tmpDir,
-		Steps: append([]resource.TestStep{
-			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"cloudflare": {
-						Source:            "cloudflare/cloudflare",
-						VersionConstraint: os.Getenv("LAST_V4_VERSION"),
-					},
-				},
-				Config: v4Config,
+// TestMigrateCloudflareListItemWithIP tests migration of a standalone list_item with IP.
+// Tests both v4→v5 and v5→v5 (stepping stone) upgrade paths.
+func TestMigrateCloudflareListItemWithIP(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, accountID, listName, description string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, accountID, listName, description string) string {
+				return fmt.Sprintf(v4IPItemConfig, rnd, accountID, listName, description)
 			},
-		}, acctest.MigrationV2TestStepAllowCreate(t, v4Config, tmpDir, os.Getenv("LAST_V4_VERSION"), "v4", "v5", []statecheck.StateCheck{
-			statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
-			statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("name"), knownvalue.StringExact(listName)),
-			statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("kind"), knownvalue.StringExact("ip")),
-			// Verify list_item remains as a separate resource
-			statecheck.ExpectKnownValue(itemResourceName, tfjsonpath.New("ip"), knownvalue.StringExact("192.0.2.1")),
-			statecheck.ExpectKnownValue(itemResourceName, tfjsonpath.New("comment"), knownvalue.StringExact("Test IP item")),
-		})...),
-	})
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, accountID, listName, description string) string {
+				return fmt.Sprintf(v5IPItemConfig, rnd, accountID, listName, description)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setV4ProviderRetryEnv(t)
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
+			listResourceName := "cloudflare_list." + rnd
+			itemResourceName := "cloudflare_list_item." + rnd + "_item"
+			tmpDir := t.TempDir()
+			description := fmt.Sprintf("Test list with IP item %s", rnd)
+			testConfig := tc.configFn(rnd, accountID, listName, description)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: append([]resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+				}, acctest.MigrationV2TestStepAllowCreate(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("name"), knownvalue.StringExact(listName)),
+					statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("kind"), knownvalue.StringExact("ip")),
+					statecheck.ExpectKnownValue(itemResourceName, tfjsonpath.New("ip"), knownvalue.StringExact("192.0.2.1")),
+					statecheck.ExpectKnownValue(itemResourceName, tfjsonpath.New("comment"), knownvalue.StringExact("Test IP item")),
+				})...),
+			})
+		})
+	}
 }
 
-// TestMigrateCloudflareListItemFromV4WithHostname tests migration of a standalone list_item with hostname.
-// In v5, separate list_item resources remain as separate resources.
-// tf-migrate converts the hostname block to a hostname attribute (block → SingleNestedAttribute).
-func TestMigrateCloudflareListItemFromV4WithHostname(t *testing.T) {
-	setV4ProviderRetryEnv(t)
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	rnd := utils.GenerateRandomResourceName()
-	listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
-	listResourceName := "cloudflare_list." + rnd
-	itemResourceName := "cloudflare_list_item." + rnd + "_item"
-	tmpDir := t.TempDir()
-	description := fmt.Sprintf("Test list with hostname item %s", rnd)
-
-	v4Config := fmt.Sprintf(v4HostnameItemConfig, rnd, accountID, listName, description)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
-			acctest.TestAccPreCheck_AccountID(t)
-		},
-		WorkingDir: tmpDir,
-		Steps: append([]resource.TestStep{
-			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"cloudflare": {
-						Source:            "cloudflare/cloudflare",
-						VersionConstraint: os.Getenv("LAST_V4_VERSION"),
-					},
-				},
-				Config: v4Config,
+// TestMigrateCloudflareListItemWithHostname tests migration of a standalone list_item with hostname.
+// Tests both v4→v5 (block → SingleNestedAttribute) and v5→v5 (stepping stone) upgrade paths.
+// The from_v5 case specifically reproduces the regression described in GitHub issue #7073.
+func TestMigrateCloudflareListItemWithHostname(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, accountID, listName, description string) string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, accountID, listName, description string) string {
+				return fmt.Sprintf(v4HostnameItemConfig, rnd, accountID, listName, description)
 			},
-		}, acctest.MigrationV2TestStepAllowCreate(t, v4Config, tmpDir, os.Getenv("LAST_V4_VERSION"), "v4", "v5", []statecheck.StateCheck{
-			statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
-			statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("name"), knownvalue.StringExact(listName)),
-			statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("kind"), knownvalue.StringExact("hostname")),
-			// Verify list_item remains as a separate resource with hostname attribute
-			statecheck.ExpectKnownValue(
-				itemResourceName,
-				tfjsonpath.New("hostname").AtMapKey("url_hostname"),
-				knownvalue.StringExact("example.com"),
-			),
-			statecheck.ExpectKnownValue(itemResourceName, tfjsonpath.New("comment"), knownvalue.StringExact("Test hostname item")),
-		})...),
-	})
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, accountID, listName, description string) string {
+				return fmt.Sprintf(v5HostnameItemConfig, rnd, accountID, listName, description)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setV4ProviderRetryEnv(t)
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
+			listResourceName := "cloudflare_list." + rnd
+			itemResourceName := "cloudflare_list_item." + rnd + "_item"
+			tmpDir := t.TempDir()
+			description := fmt.Sprintf("Test list with hostname item %s", rnd)
+			testConfig := tc.configFn(rnd, accountID, listName, description)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: append([]resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+				}, acctest.MigrationV2TestStepAllowCreate(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("name"), knownvalue.StringExact(listName)),
+					statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("kind"), knownvalue.StringExact("hostname")),
+					statecheck.ExpectKnownValue(
+						itemResourceName,
+						tfjsonpath.New("hostname").AtMapKey("url_hostname"),
+						knownvalue.StringExact("example.com"),
+					),
+					statecheck.ExpectKnownValue(itemResourceName, tfjsonpath.New("comment"), knownvalue.StringExact("Test hostname item")),
+				})...),
+			})
+		})
+	}
 }
 
-// TestMigrateCloudflareListItemFromV4WithRedirect tests migration of a standalone list_item with redirect.
-// In v5, separate list_item resources remain as separate resources.
-// tf-migrate converts the redirect block to a redirect attribute (block → SingleNestedAttribute)
-// and converts "enabled"/"disabled" strings to true/false booleans.
-// Note: The v4 test config uses true/false (not "enabled"/"disabled") because v4.52.7 already uses BoolAttribute.
-func TestMigrateCloudflareListItemFromV4WithRedirect(t *testing.T) {
-	setV4ProviderRetryEnv(t)
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	rnd := utils.GenerateRandomResourceName()
-	listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
-	listResourceName := "cloudflare_list." + rnd
-	itemResourceName := "cloudflare_list_item." + rnd + "_item"
-	tmpDir := t.TempDir()
-	description := fmt.Sprintf("Test list with redirect item %s", rnd)
-
-	v4Config := fmt.Sprintf(v4RedirectItemConfig, rnd, accountID, listName, description)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
-			acctest.TestAccPreCheck_AccountID(t)
-		},
-		WorkingDir: tmpDir,
-		Steps: append([]resource.TestStep{
-			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"cloudflare": {
-						Source:            "cloudflare/cloudflare",
-						VersionConstraint: os.Getenv("LAST_V4_VERSION"),
-					},
-				},
-				Config: v4Config,
+// TestMigrateCloudflareListItemWithRedirect tests migration of a standalone list_item with redirect.
+// Tests both v4→v5 (block → SingleNestedAttribute + string→bool) and v5→v5 (stepping stone) paths.
+func TestMigrateCloudflareListItemWithRedirect(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		configFn func(rnd, accountID, listName, description string) string
+		// v4 redirect source_url has no trailing slash; the state upgrader appends one.
+		// v5 config already has the slash.
+		expectedSourceURL string
+	}{
+		{
+			name:    "from_v4_latest",
+			version: acctest.GetLastV4Version(),
+			configFn: func(rnd, accountID, listName, description string) string {
+				return fmt.Sprintf(v4RedirectItemConfig, rnd, accountID, listName, description)
 			},
-		}, acctest.MigrationV2TestStepAllowCreate(t, v4Config, tmpDir, os.Getenv("LAST_V4_VERSION"), "v4", "v5", []statecheck.StateCheck{
-			statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
-			statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("name"), knownvalue.StringExact(listName)),
-			statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("kind"), knownvalue.StringExact("redirect")),
-			// Verify list_item remains as a separate resource with redirect attribute
-			statecheck.ExpectKnownValue(
-				itemResourceName,
-				tfjsonpath.New("redirect").AtMapKey("source_url"),
-				knownvalue.StringExact("https://example.com/old"),
-			),
-			statecheck.ExpectKnownValue(
-				itemResourceName,
-				tfjsonpath.New("redirect").AtMapKey("target_url"),
-				knownvalue.StringExact("https://example.com/new"),
-			),
-			statecheck.ExpectKnownValue(
-				itemResourceName,
-				tfjsonpath.New("redirect").AtMapKey("status_code"),
-				knownvalue.Int64Exact(301),
-			),
-			statecheck.ExpectKnownValue(
-				itemResourceName,
-				tfjsonpath.New("redirect").AtMapKey("include_subdomains"),
-				knownvalue.Bool(true),
-			),
-			statecheck.ExpectKnownValue(
-				itemResourceName,
-				tfjsonpath.New("redirect").AtMapKey("subpath_matching"),
-				knownvalue.Bool(false),
-			),
-			statecheck.ExpectKnownValue(
-				itemResourceName,
-				tfjsonpath.New("redirect").AtMapKey("preserve_query_string"),
-				knownvalue.Bool(true),
-			),
-			statecheck.ExpectKnownValue(
-				itemResourceName,
-				tfjsonpath.New("redirect").AtMapKey("preserve_path_suffix"),
-				knownvalue.Bool(false),
-			),
-			statecheck.ExpectKnownValue(itemResourceName, tfjsonpath.New("comment"), knownvalue.StringExact("Test redirect item")),
-		})...),
-	})
+			expectedSourceURL: "https://example.com/old",
+		},
+		{
+			name:    "from_v5",
+			version: currentProviderVersion,
+			configFn: func(rnd, accountID, listName, description string) string {
+				return fmt.Sprintf(v5RedirectItemConfig, rnd, accountID, listName, description)
+			},
+			expectedSourceURL: "https://example.com/old/",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setV4ProviderRetryEnv(t)
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			rnd := utils.GenerateRandomResourceName()
+			listName := fmt.Sprintf("%s%s", listTestPrefix, rnd)
+			listResourceName := "cloudflare_list." + rnd
+			itemResourceName := "cloudflare_list_item." + rnd + "_item"
+			tmpDir := t.TempDir()
+			description := fmt.Sprintf("Test list with redirect item %s", rnd)
+			testConfig := tc.configFn(rnd, accountID, listName, description)
+			sourceVer, targetVer := acctest.InferMigrationVersions(tc.version)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: append([]resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: testConfig,
+					},
+				}, acctest.MigrationV2TestStepAllowCreate(t, testConfig, tmpDir, tc.version, sourceVer, targetVer, []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("name"), knownvalue.StringExact(listName)),
+					statecheck.ExpectKnownValue(listResourceName, tfjsonpath.New("kind"), knownvalue.StringExact("redirect")),
+					statecheck.ExpectKnownValue(
+						itemResourceName,
+						tfjsonpath.New("redirect").AtMapKey("source_url"),
+						knownvalue.StringExact(tc.expectedSourceURL),
+					),
+					statecheck.ExpectKnownValue(
+						itemResourceName,
+						tfjsonpath.New("redirect").AtMapKey("target_url"),
+						knownvalue.StringExact("https://example.com/new"),
+					),
+					statecheck.ExpectKnownValue(
+						itemResourceName,
+						tfjsonpath.New("redirect").AtMapKey("status_code"),
+						knownvalue.Int64Exact(301),
+					),
+					statecheck.ExpectKnownValue(
+						itemResourceName,
+						tfjsonpath.New("redirect").AtMapKey("include_subdomains"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						itemResourceName,
+						tfjsonpath.New("redirect").AtMapKey("subpath_matching"),
+						knownvalue.Bool(false),
+					),
+					statecheck.ExpectKnownValue(
+						itemResourceName,
+						tfjsonpath.New("redirect").AtMapKey("preserve_query_string"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						itemResourceName,
+						tfjsonpath.New("redirect").AtMapKey("preserve_path_suffix"),
+						knownvalue.Bool(false),
+					),
+					statecheck.ExpectKnownValue(itemResourceName, tfjsonpath.New("comment"), knownvalue.StringExact("Test redirect item")),
+				})...),
+			})
+		})
+	}
 }

--- a/internal/services/list_item/migration/v500/testdata/v5_hostname_item.tf
+++ b/internal/services/list_item/migration/v500/testdata/v5_hostname_item.tf
@@ -1,0 +1,15 @@
+resource "cloudflare_list" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "%[3]s"
+  kind        = "hostname"
+  description = "%[4]s"
+}
+
+resource "cloudflare_list_item" "%[1]s_item" {
+  account_id = "%[2]s"
+  list_id    = cloudflare_list.%[1]s.id
+  hostname = {
+    url_hostname = "example.com"
+  }
+  comment = "Test hostname item"
+}

--- a/internal/services/list_item/migration/v500/testdata/v5_ip_item.tf
+++ b/internal/services/list_item/migration/v500/testdata/v5_ip_item.tf
@@ -1,0 +1,13 @@
+resource "cloudflare_list" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "%[3]s"
+  kind        = "ip"
+  description = "%[4]s"
+}
+
+resource "cloudflare_list_item" "%[1]s_item" {
+  account_id = "%[2]s"
+  list_id    = cloudflare_list.%[1]s.id
+  ip         = "192.0.2.1"
+  comment    = "Test IP item"
+}

--- a/internal/services/list_item/migration/v500/testdata/v5_redirect_item.tf
+++ b/internal/services/list_item/migration/v500/testdata/v5_redirect_item.tf
@@ -1,0 +1,21 @@
+resource "cloudflare_list" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "%[3]s"
+  kind        = "redirect"
+  description = "%[4]s"
+}
+
+resource "cloudflare_list_item" "%[1]s_item" {
+  account_id = "%[2]s"
+  list_id    = cloudflare_list.%[1]s.id
+  redirect = {
+    source_url            = "https://example.com/old/"
+    target_url            = "https://example.com/new"
+    status_code           = 301
+    include_subdomains    = true
+    subpath_matching      = false
+    preserve_query_string = true
+    preserve_path_suffix  = false
+  }
+  comment = "Test redirect item"
+}

--- a/internal/services/list_item/migrations.go
+++ b/internal/services/list_item/migrations.go
@@ -4,28 +4,49 @@ package list_item
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-framework/resource"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/list_item/migration/v500"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 var _ resource.ResourceWithUpgradeState = (*ListItemResource)(nil)
 
+// UpgradeState registers state upgraders for schema version changes.
+//
+// Schema version history:
+//   - v4 SDKv2: schema_version=0
+//   - v4.52.5 Plugin Framework: schema_version=1 (hostname/redirect as ListNestedBlock)
+//   - v5 production (v5.0-v5.18): schema_version=1 (hostname/redirect as SingleNestedAttribute)
+//   - v5 current: schema_version=500
+//
+// IMPORTANT: Both v4.52.5 and v5 production state are at schema_version=1, but they have
+// incompatible formats:
+//   - v4.52.5: hostname/redirect stored as ARRAY (ListNestedBlock)
+//   - v5: hostname/redirect stored as OBJECT (SingleNestedAttribute)
+//
+// Upgrade paths:
+//
+//	0: v4 SDKv2 -> full transform
+//	1: AMBIGUOUS - v4.52.5 format (array) or v5 production format (object), detected at runtime
 func (r *ListItemResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-
 	sourceSchema := v500.SourceListItemSchema()
-	v1Schema := v500.SourceListItemV1Schema()
+
 	return map[int64]resource.StateUpgrader{
 		// Handle upgrades from v4 SDKv2 (schema_version=0) to v500
 		0: {
 			PriorSchema:   &sourceSchema,
 			StateUpgrader: v500.UpgradeFromV0,
 		},
-		// Handle upgrades from v4.52.5 framework (schema_version=1) to v500
-		// v4.52.5 uses ListNestedBlock for hostname/redirect, v5 uses SingleNestedAttribute
+
+		// Handle schema_version=1 -- ambiguous between v4.52.5 and v5 production.
+		//
+		// PriorSchema is nil so the framework skips pre-decoding req.State entirely.
+		// Both paths are handled via req.RawState.JSON in UpgradeFromV1Ambiguous:
+		// - v4.52.5 format (hostname/redirect is array): full transform via raw state
+		// - v5 format (hostname/redirect is object): no-op re-decode with target schema
 		1: {
-			PriorSchema:   &v1Schema,
-			StateUpgrader: v500.UpgradeFromV1,
+			PriorSchema:   nil,
+			StateUpgrader: v500.UpgradeFromV1Ambiguous,
 		},
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/7073

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
List Item:
```
~/c/g/terraform-provider-cloudflare vaishak/zone-settings *1 !10 ?5 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/list_item/... -run "Test" -timeout 30m
```

List:
```
TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/list/... -run "Test" -timeout 30m
```

### Test output
List Item:
```
~/c/g/terraform-provider-cloudflare vaishak/zone-settings *1 !10 ?5 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/list_item/... -run "Test" -timeout 30m
=== RUN   TestListItemDataSourceModelSchemaParity
=== PAUSE TestListItemDataSourceModelSchemaParity
=== RUN   TestListItemsDataSourceModelSchemaParity
=== PAUSE TestListItemsDataSourceModelSchemaParity
=== RUN   TestListItemModelSchemaParity
=== PAUSE TestListItemModelSchemaParity
=== RUN   TestAccCloudflareListItem_Basic
--- PASS: TestAccCloudflareListItem_Basic (67.11s)
=== RUN   TestAccCloudflareListItem_Import
--- PASS: TestAccCloudflareListItem_Import (126.21s)
=== RUN   TestAccCloudflareListItem_MultipleItems
--- PASS: TestAccCloudflareListItem_MultipleItems (126.48s)
=== RUN   TestAccCloudflareListItem_MultipleItemsHostname
--- PASS: TestAccCloudflareListItem_MultipleItemsHostname (129.09s)
=== RUN   TestAccCloudflareListItem_Update
--- PASS: TestAccCloudflareListItem_Update (78.85s)
=== RUN   TestAccCloudflareListItem_UpdateHostname
--- PASS: TestAccCloudflareListItem_UpdateHostname (8.62s)
=== RUN   TestAccCloudflareListItem_UpdateReplace
--- PASS: TestAccCloudflareListItem_UpdateReplace (68.47s)
=== RUN   TestAccCloudflareListItem_ASN
--- PASS: TestAccCloudflareListItem_ASN (4.43s)
=== RUN   TestAccCloudflareListItem_Hostname
--- PASS: TestAccCloudflareListItem_Hostname (6.16s)
=== RUN   TestAccCloudflareListItem_Redirect
--- PASS: TestAccCloudflareListItem_Redirect (4.42s)
=== RUN   TestAccCloudflareListItem_RedirectWithLocalsMap
--- PASS: TestAccCloudflareListItem_RedirectWithLocalsMap (5.48s)
=== RUN   TestAccCloudflareListItem_RedirectWithOverlappingSourceURL
--- PASS: TestAccCloudflareListItem_RedirectWithOverlappingSourceURL (5.82s)
=== RUN   TestAccUpgradeListItem_FromPublishedV5
--- PASS: TestAccUpgradeListItem_FromPublishedV5 (19.40s)
=== CONT  TestListItemDataSourceModelSchemaParity
=== CONT  TestListItemModelSchemaParity
=== CONT  TestListItemsDataSourceModelSchemaParity
--- PASS: TestListItemDataSourceModelSchemaParity (0.00s)
--- PASS: TestListItemsDataSourceModelSchemaParity (0.00s)
--- PASS: TestListItemModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/list_item	652.465s
=== RUN   TestUpgradeFromV1Ambiguous_V5HostnameState
=== PAUSE TestUpgradeFromV1Ambiguous_V5HostnameState
=== RUN   TestUpgradeFromV1Ambiguous_V5RedirectState
=== PAUSE TestUpgradeFromV1Ambiguous_V5RedirectState
=== RUN   TestUpgradeFromV1Ambiguous_V5IPOnlyState
=== PAUSE TestUpgradeFromV1Ambiguous_V5IPOnlyState
=== RUN   TestUpgradeFromV1Ambiguous_V4HostnameState
=== PAUSE TestUpgradeFromV1Ambiguous_V4HostnameState
=== RUN   TestUpgradeFromV1Ambiguous_V4RedirectState
=== PAUSE TestUpgradeFromV1Ambiguous_V4RedirectState
=== RUN   TestListItemMigrationModelSchemaParity
=== PAUSE TestListItemMigrationModelSchemaParity
=== RUN   TestMigrateCloudflareListItemWithIP
=== RUN   TestMigrateCloudflareListItemWithIP/from_v4_latest
=== RUN   TestMigrateCloudflareListItemWithIP/from_v5
--- PASS: TestMigrateCloudflareListItemWithIP (50.33s)
    --- PASS: TestMigrateCloudflareListItemWithIP/from_v4_latest (26.56s)
    --- PASS: TestMigrateCloudflareListItemWithIP/from_v5 (23.77s)
=== RUN   TestMigrateCloudflareListItemWithHostname
=== RUN   TestMigrateCloudflareListItemWithHostname/from_v4_latest
=== RUN   TestMigrateCloudflareListItemWithHostname/from_v5
--- PASS: TestMigrateCloudflareListItemWithHostname (40.17s)
    --- PASS: TestMigrateCloudflareListItemWithHostname/from_v4_latest (21.19s)
    --- PASS: TestMigrateCloudflareListItemWithHostname/from_v5 (18.98s)
=== RUN   TestMigrateCloudflareListItemWithRedirect
=== RUN   TestMigrateCloudflareListItemWithRedirect/from_v4_latest
=== RUN   TestMigrateCloudflareListItemWithRedirect/from_v5
--- PASS: TestMigrateCloudflareListItemWithRedirect (42.60s)
    --- PASS: TestMigrateCloudflareListItemWithRedirect/from_v4_latest (21.70s)
    --- PASS: TestMigrateCloudflareListItemWithRedirect/from_v5 (20.90s)
=== CONT  TestUpgradeFromV1Ambiguous_V5HostnameState
=== CONT  TestUpgradeFromV1Ambiguous_V4HostnameState
=== CONT  TestListItemMigrationModelSchemaParity
=== CONT  TestUpgradeFromV1Ambiguous_V5IPOnlyState
=== CONT  TestUpgradeFromV1Ambiguous_V4RedirectState
=== CONT  TestUpgradeFromV1Ambiguous_V5RedirectState
--- PASS: TestListItemMigrationModelSchemaParity (0.00s)
--- PASS: TestUpgradeFromV1Ambiguous_V5IPOnlyState (0.00s)
--- PASS: TestUpgradeFromV1Ambiguous_V5HostnameState (0.00s)
--- PASS: TestUpgradeFromV1Ambiguous_V5RedirectState (0.00s)
--- PASS: TestUpgradeFromV1Ambiguous_V4HostnameState (0.00s)
--- PASS: TestUpgradeFromV1Ambiguous_V4RedirectState (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/list_item/migration/v500	134.911s
```

List:
```
~/c/github/terraform-provider-cloudflare vaishak/list-items !3 ?4 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/list/... -run "Test" -timeout 30m    01:35:55 PM
=== RUN   TestListDataSourceModelSchemaParity
=== PAUSE TestListDataSourceModelSchemaParity
=== RUN   TestAccCloudflareListWithItems_IP_Datasource
--- PASS: TestAccCloudflareListWithItems_IP_Datasource (9.59s)
=== RUN   TestListsDataSourceModelSchemaParity
=== PAUSE TestListsDataSourceModelSchemaParity
=== RUN   TestListModelSchemaParity
=== PAUSE TestListModelSchemaParity
=== RUN   TestAccCloudflareList
--- PASS: TestAccCloudflareList (36.65s)
=== RUN   TestAccCloudflareListWithItems_IP
--- PASS: TestAccCloudflareListWithItems_IP (11.97s)
=== RUN   TestAccCloudflareListWithItems_Hostname
--- PASS: TestAccCloudflareListWithItems_Hostname (8.44s)
=== RUN   TestAccCloudflareListWithItems_Redirect
--- PASS: TestAccCloudflareListWithItems_Redirect (8.10s)
=== RUN   TestAccUpgradeList_FromPublishedV5
--- PASS: TestAccUpgradeList_FromPublishedV5 (17.31s)
=== CONT  TestListModelSchemaParity
=== CONT  TestListDataSourceModelSchemaParity
=== CONT  TestListsDataSourceModelSchemaParity
--- PASS: TestListsDataSourceModelSchemaParity (0.00s)
--- PASS: TestListModelSchemaParity (0.00s)
--- PASS: TestListDataSourceModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/list	93.910s
=== RUN   TestNormalizeIPAddress
=== RUN   TestNormalizeIPAddress/preserve_network_CIDR
=== RUN   TestNormalizeIPAddress/strip_ipv4_host_CIDR
=== RUN   TestNormalizeIPAddress/strip_ipv6_host_CIDR
=== RUN   TestNormalizeIPAddress/preserve_plain_ip
=== RUN   TestNormalizeIPAddress/preserve_null
--- PASS: TestNormalizeIPAddress (0.00s)
    --- PASS: TestNormalizeIPAddress/preserve_network_CIDR (0.00s)
    --- PASS: TestNormalizeIPAddress/strip_ipv4_host_CIDR (0.00s)
    --- PASS: TestNormalizeIPAddress/strip_ipv6_host_CIDR (0.00s)
    --- PASS: TestNormalizeIPAddress/preserve_plain_ip (0.00s)
    --- PASS: TestNormalizeIPAddress/preserve_null (0.00s)
=== RUN   TestListMigrationModelSchemaParity
=== PAUSE TestListMigrationModelSchemaParity
=== RUN   TestMigrateCloudflareListFromV4WithIPItems
=== RUN   TestMigrateCloudflareListFromV4WithIPItems/from_v4_latest
=== RUN   TestMigrateCloudflareListFromV4WithIPItems/from_v5
--- PASS: TestMigrateCloudflareListFromV4WithIPItems (35.25s)
    --- PASS: TestMigrateCloudflareListFromV4WithIPItems/from_v4_latest (18.55s)
    --- PASS: TestMigrateCloudflareListFromV4WithIPItems/from_v5 (16.70s)
=== RUN   TestMigrateCloudflareListFromV4WithASNItems
=== RUN   TestMigrateCloudflareListFromV4WithASNItems/from_v4_latest
=== RUN   TestMigrateCloudflareListFromV4WithASNItems/from_v5
--- PASS: TestMigrateCloudflareListFromV4WithASNItems (32.23s)
    --- PASS: TestMigrateCloudflareListFromV4WithASNItems/from_v4_latest (16.71s)
    --- PASS: TestMigrateCloudflareListFromV4WithASNItems/from_v5 (15.52s)
=== RUN   TestMigrateCloudflareListFromV4WithHostnameItems
=== RUN   TestMigrateCloudflareListFromV4WithHostnameItems/from_v4_latest
=== RUN   TestMigrateCloudflareListFromV4WithHostnameItems/from_v5
--- PASS: TestMigrateCloudflareListFromV4WithHostnameItems (31.12s)
    --- PASS: TestMigrateCloudflareListFromV4WithHostnameItems/from_v4_latest (16.42s)
    --- PASS: TestMigrateCloudflareListFromV4WithHostnameItems/from_v5 (14.70s)
=== RUN   TestMigrateCloudflareListFromV4WithRedirectItems
=== RUN   TestMigrateCloudflareListFromV4WithRedirectItems/from_v4_latest
=== RUN   TestMigrateCloudflareListFromV4WithRedirectItems/from_v5
--- PASS: TestMigrateCloudflareListFromV4WithRedirectItems (29.51s)
    --- PASS: TestMigrateCloudflareListFromV4WithRedirectItems/from_v4_latest (16.05s)
    --- PASS: TestMigrateCloudflareListFromV4WithRedirectItems/from_v5 (13.46s)
=== RUN   TestMigrateCloudflareListFromV4WithDynamicItems
=== RUN   TestMigrateCloudflareListFromV4WithDynamicItems/from_v4_latest
=== RUN   TestMigrateCloudflareListFromV4WithDynamicItems/from_v5
--- PASS: TestMigrateCloudflareListFromV4WithDynamicItems (32.05s)
    --- PASS: TestMigrateCloudflareListFromV4WithDynamicItems/from_v4_latest (16.43s)
    --- PASS: TestMigrateCloudflareListFromV4WithDynamicItems/from_v5 (15.62s)
=== RUN   TestMigrateCloudflareListFromV4WithSeparateListItems
--- PASS: TestMigrateCloudflareListFromV4WithSeparateListItems (82.76s)
=== CONT  TestListMigrationModelSchemaParity
--- PASS: TestListMigrationModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/list/migration/v500	244.918s
```

## Additional context & links
