### PR TITLE
fix(iam): tokens migrations

### DIFF
--- a/internal/services/account_token/migration/v501/migrations_test.go
+++ b/internal/services/account_token/migration/v501/migrations_test.go
@@ -22,110 +22,251 @@ var v501MultiPolicyConfig string
 //go:embed testdata/v501_multi_permgroups.tf
 var v501MultiPermgroupsConfig string
 
-// TestMigrateAccountTokenFromV500_MultiPolicy tests migration from v500 (Set-based,
-// schema_version=500 via v5.16.0) to v501 (List-based) with multiple policies.
-// This verifies that the Set→List migration properly converts policy collections
-// and that the provider can plan/apply without drift.
-func TestMigrateAccountTokenFromV500_MultiPolicy(t *testing.T) {
-	rnd := utils.GenerateRandomResourceName()
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	tmpDir := t.TempDir()
+// Migration Test Configuration — v1 → v501 (Set→List)
+//
+// v5.16.0 and v5.18.0 both stored account_token state at schema_version=1
+// with Set-typed policies and permission_groups.
+//
+// The version 1 upgrader must decode Set state and sort canonically for stable
+// List ordering. Before the fix for GitHub issue #7077, slot 1 routed through
+// v500.UpgradeFromV1 which performed a no-op (deserialize/re-serialize without
+// sorting), causing permission_groups to appear in arbitrary order and triggering
+// "inconsistent state" errors during apply.
 
-	config := fmt.Sprintf(v501MultiPolicyConfig, rnd, accountID)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
-			acctest.TestAccPreCheck_AccountID(t)
+// TestMigrateAccountTokenFromV1_Basic tests the simplest case: a single-policy
+// account_token created in v5.18 upgrading to the current version.
+// Before the fix, the version 1 upgrader performed a no-op without sorting,
+// causing List-based state with arbitrary Set ordering.
+func TestMigrateAccountTokenFromV1_Basic(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+	}{
+		{
+			name:    "from_v5.16",
+			version: "5.16.0",
 		},
-		WorkingDir: tmpDir,
-		Steps: []resource.TestStep{
-			{
-				// Create with v5.16.0 which has schema_version=500 (Set-based)
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"cloudflare": {
-						Source:            "cloudflare/cloudflare",
-						VersionConstraint: "5.16.0",
+		{
+			name:    "from_v5.18",
+			version: "5.18.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rnd := utils.GenerateRandomResourceName()
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			tmpDir := t.TempDir()
+
+			config := fmt.Sprintf(`
+resource "cloudflare_account_token" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+
+  policies = [
+    {
+      effect = "allow"
+      permission_groups = [{
+        id = "82e64a83756745bbbb1c9c2701bf816b"
+      }]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = "*"
+      })
+    }
+  ]
+}`, rnd, accountID)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: config,
+					},
+					{
+						ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+						Config:                   config,
+						ConfigPlanChecks: resource.ConfigPlanChecks{
+							PostApplyPostRefresh: []plancheck.PlanCheck{
+								plancheck.ExpectEmptyPlan(),
+							},
+						},
+						ConfigStateChecks: []statecheck.StateCheck{
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_account_token.%s", rnd),
+								tfjsonpath.New("name"),
+								knownvalue.StringExact(rnd),
+							),
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_account_token.%s", rnd),
+								tfjsonpath.New("policies"),
+								knownvalue.ListSizeExact(1),
+							),
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_account_token.%s", rnd),
+								tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("effect"),
+								knownvalue.StringExact("allow"),
+							),
+						},
 					},
 				},
-				Config: config,
-			},
-			{
-				// Migrate to current (v501, List-based) and verify no drift
-				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-				Config:                   config,
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						fmt.Sprintf("cloudflare_account_token.%s", rnd),
-						tfjsonpath.New("name"),
-						knownvalue.StringExact(rnd),
-					),
-					statecheck.ExpectKnownValue(
-						fmt.Sprintf("cloudflare_account_token.%s", rnd),
-						tfjsonpath.New("policies"),
-						knownvalue.ListSizeExact(2),
-					),
-				},
-			},
-		},
-	})
+			})
+		})
+	}
 }
 
-// TestMigrateAccountTokenFromV500_MultiPermGroups tests migration from v500
-// (Set-based) to v501 (List-based) with a policy that has multiple permission
-// groups. This is the scenario that triggers the O(n²) performance issue —
-// verifying that migration works correctly and produces no drift.
-func TestMigrateAccountTokenFromV500_MultiPermGroups(t *testing.T) {
-	rnd := utils.GenerateRandomResourceName()
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	tmpDir := t.TempDir()
-
-	config := fmt.Sprintf(v501MultiPermgroupsConfig, rnd, accountID)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
-			acctest.TestAccPreCheck_AccountID(t)
+// TestMigrateAccountTokenFromV1_MultiPolicy tests migration from schema_version=1
+// (Set-based) to v501 (List-based) with multiple policies.
+func TestMigrateAccountTokenFromV1_MultiPolicy(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+	}{
+		{
+			name:    "from_v5.16",
+			version: "5.16.0",
 		},
-		WorkingDir: tmpDir,
-		Steps: []resource.TestStep{
-			{
-				// Create with v5.16.0 which has schema_version=500 (Set-based)
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"cloudflare": {
-						Source:            "cloudflare/cloudflare",
-						VersionConstraint: "5.16.0",
+		{
+			name:    "from_v5.18",
+			version: "5.18.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rnd := utils.GenerateRandomResourceName()
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			tmpDir := t.TempDir()
+
+			config := fmt.Sprintf(v501MultiPolicyConfig, rnd, accountID)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						// Create with v5.16/v5.18 (stores schema_version=1, Set-based)
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: config,
+					},
+					{
+						// Upgrade to current (v501, List-based)
+						ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+						Config:                   config,
+						ConfigPlanChecks: resource.ConfigPlanChecks{
+							PostApplyPostRefresh: []plancheck.PlanCheck{
+								plancheck.ExpectEmptyPlan(),
+							},
+						},
+						ConfigStateChecks: []statecheck.StateCheck{
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_account_token.%s", rnd),
+								tfjsonpath.New("name"),
+								knownvalue.StringExact(rnd),
+							),
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_account_token.%s", rnd),
+								tfjsonpath.New("policies"),
+								knownvalue.ListSizeExact(2),
+							),
+						},
 					},
 				},
-				Config: config,
-			},
-			{
-				// Migrate to current (v501, List-based) and verify no drift
-				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-				Config:                   config,
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
+			})
+		})
+	}
+}
+
+// TestMigrateAccountTokenFromV1_MultiPermGroups tests migration from schema_version=1
+// (Set-based) to v501 (List-based) with a policy that has multiple permission groups.
+//
+// This is the exact scenario from GitHub issue #7077 where the "inconsistent state"
+// error occurred: permission_groups were returned by the API in a different order
+// than stored in state, and without canonical sorting during the v1→v501 upgrade,
+// the List-based state had arbitrary ordering.
+func TestMigrateAccountTokenFromV1_MultiPermGroups(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+	}{
+		{
+			name:    "from_v5.16",
+			version: "5.16.0",
+		},
+		{
+			name:    "from_v5.18",
+			version: "5.18.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rnd := utils.GenerateRandomResourceName()
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			tmpDir := t.TempDir()
+
+			config := fmt.Sprintf(v501MultiPermgroupsConfig, rnd, accountID)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						// Create with v5.16/v5.18 (stores schema_version=1, Set-based)
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: config,
+					},
+					{
+						// Upgrade to current (v501, List-based) — before the fix,
+						// this could produce unsorted permission_groups causing
+						// "inconsistent state" on the next apply
+						ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+						Config:                   config,
+						ConfigPlanChecks: resource.ConfigPlanChecks{
+							PostApplyPostRefresh: []plancheck.PlanCheck{
+								plancheck.ExpectEmptyPlan(),
+							},
+						},
+						ConfigStateChecks: []statecheck.StateCheck{
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_account_token.%s", rnd),
+								tfjsonpath.New("name"),
+								knownvalue.StringExact(rnd),
+							),
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_account_token.%s", rnd),
+								tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"),
+								knownvalue.ListSizeExact(3),
+							),
+						},
 					},
 				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						fmt.Sprintf("cloudflare_account_token.%s", rnd),
-						tfjsonpath.New("name"),
-						knownvalue.StringExact(rnd),
-					),
-					statecheck.ExpectKnownValue(
-						fmt.Sprintf("cloudflare_account_token.%s", rnd),
-						tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"),
-						knownvalue.ListSizeExact(3),
-					),
-				},
-			},
-		},
-	})
+			})
+		})
+	}
 }

--- a/internal/services/account_token/migrations.go
+++ b/internal/services/account_token/migrations.go
@@ -16,20 +16,28 @@ var _ resource.ResourceWithUpgradeState = (*AccountTokenResource)(nil)
 //
 // This handles three upgrade paths:
 //
-// 1. v0 state (schema_version=0) → v501: Full transformation via v500
+// 1. v0 state (schema_version=0) → v501: Full transformation from early v5
 //   - Converts policies[].resources from map to JSON string
 //   - Removes policies[].id (computed field)
 //   - Removes policies[].permission_groups[].meta and .name (computed fields)
 //
-// 2. v1 state (schema_version=1) → v501: Deserialize/re-serialize via v500
-//   - Converts Set-typed state to List-compatible state
+// 2. v1 state (schema_version=1) → v501: Set→List migration with sorting
+//   - v5.16-v5.18 stored state at schema_version=1 with Set-based policies/permission_groups
+//   - Structurally identical to v500 state — reuse v500 schema for deserialization
+//   - Must sort canonically for stable List ordering (same as v500→v501)
+//   - Note: The framework runs only ONE upgrader (the slot matching the state version),
+//     so we cannot rely on slot 500 running after slot 1. Slot 1 must do sorting itself.
 //
 // 3. v500 state (schema_version=500) → v501: Set→List migration
 //   - Converts Set-typed policies and permission_groups to sorted Lists
 func (r *AccountTokenResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	v0Schema := v500.SourceSchemaV0()
-	v1Schema := v500.SourceSchemaV1()
 	v500Schema := v501.SourceSchemaV500()
+
+	// v5.16-v5.18 stored state at schema_version=1 with the same Set-based schema
+	// as v500. Reuse the v500 schema for deserialization.
+	v1Schema := v501.SourceSchemaV500()
+	v1Schema.Version = 1
 
 	return map[int64]resource.StateUpgrader{
 		// Handle state from early v5 releases (v5.10, v5.11) with map-based resources
@@ -38,10 +46,11 @@ func (r *AccountTokenResource) UpgradeState(ctx context.Context) map[int64]resou
 			StateUpgrader: v500.UpgradeFromV0,
 		},
 
-		// Handle state from dormant v5 (version=1) — deserialize/re-serialize
+		// Handle state from v5.16-v5.18 (schema_version=1, Set-based)
+		// Same format as v500 — deserialize Sets, sort canonically, write as Lists
 		1: {
 			PriorSchema:   &v1Schema,
-			StateUpgrader: v500.UpgradeFromV1,
+			StateUpgrader: v501.UpgradeFromV500,
 		},
 
 		// Handle state from v500 (Set-based) → v501 (List-based with FastSetType)

--- a/internal/services/api_token/migration/v501/migrations_test.go
+++ b/internal/services/api_token/migration/v501/migrations_test.go
@@ -22,102 +22,251 @@ var v501MultiPolicyConfig string
 //go:embed testdata/v501_multi_permgroups.tf
 var v501MultiPermgroupsConfig string
 
-// TestMigrateAPITokenFromV500_MultiPolicy tests migration from v500 (Set-based,
-// schema_version=500 via v5.16.0) to v501 (List-based) with multiple policies.
-func TestMigrateAPITokenFromV500_MultiPolicy(t *testing.T) {
-	rnd := utils.GenerateRandomResourceName()
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	tmpDir := t.TempDir()
+// Migration Test Configuration — v1 → v501 (Set→List)
+//
+// v5.16.0 and v5.18.0 both stored api_token state at schema_version=1
+// (via `Version: 1` or `GetSchemaVersion(1, 500)` in production).
+// The state uses Set-typed policies and permission_groups.
+//
+// The version 1 upgrader must use the Set-based PriorSchema (not the current
+// List-based schema) to decode this state, then sort canonically for List ordering.
+//
+// GitHub issue #7077: upgrading from v5.18→v5.19 caused a nil pointer dereference
+// because the version 1 PriorSchema incorrectly used the current List-based schema
+// to decode Set-encoded state.
 
-	config := fmt.Sprintf(v501MultiPolicyConfig, rnd, accountID)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
-			acctest.TestAccPreCheck_AccountID(t)
+// TestMigrateAPITokenFromV1_MultiPolicy tests migration from schema_version=1
+// (Set-based, v5.16.0) to v501 (List-based) with multiple policies.
+// This verifies the version 1 upgrader correctly decodes Set state and sorts
+// policies canonically for stable List ordering.
+func TestMigrateAPITokenFromV1_MultiPolicy(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+	}{
+		{
+			name:    "from_v5.16",
+			version: "5.16.0",
 		},
-		WorkingDir: tmpDir,
-		Steps: []resource.TestStep{
-			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"cloudflare": {
-						Source:            "cloudflare/cloudflare",
-						VersionConstraint: "5.16.0",
+		{
+			name:    "from_v5.18",
+			version: "5.18.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rnd := utils.GenerateRandomResourceName()
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			tmpDir := t.TempDir()
+
+			config := fmt.Sprintf(v501MultiPolicyConfig, rnd, accountID)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: config,
+					},
+					{
+						ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+						Config:                   config,
+						ConfigPlanChecks: resource.ConfigPlanChecks{
+							PostApplyPostRefresh: []plancheck.PlanCheck{
+								plancheck.ExpectEmptyPlan(),
+							},
+						},
+						ConfigStateChecks: []statecheck.StateCheck{
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_api_token.%s", rnd),
+								tfjsonpath.New("name"),
+								knownvalue.StringExact(rnd),
+							),
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_api_token.%s", rnd),
+								tfjsonpath.New("policies"),
+								knownvalue.ListSizeExact(2),
+							),
+						},
 					},
 				},
-				Config: config,
-			},
-			{
-				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-				Config:                   config,
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						fmt.Sprintf("cloudflare_api_token.%s", rnd),
-						tfjsonpath.New("name"),
-						knownvalue.StringExact(rnd),
-					),
-					statecheck.ExpectKnownValue(
-						fmt.Sprintf("cloudflare_api_token.%s", rnd),
-						tfjsonpath.New("policies"),
-						knownvalue.ListSizeExact(2),
-					),
-				},
-			},
-		},
-	})
+			})
+		})
+	}
 }
 
-// TestMigrateAPITokenFromV500_MultiPermGroups tests migration from v500
+// TestMigrateAPITokenFromV1_MultiPermGroups tests migration from schema_version=1
 // (Set-based) to v501 (List-based) with multiple permission groups.
-func TestMigrateAPITokenFromV500_MultiPermGroups(t *testing.T) {
-	rnd := utils.GenerateRandomResourceName()
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	tmpDir := t.TempDir()
-
-	config := fmt.Sprintf(v501MultiPermgroupsConfig, rnd, accountID)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
-			acctest.TestAccPreCheck_AccountID(t)
+// This verifies permission groups are sorted canonically within each policy.
+func TestMigrateAPITokenFromV1_MultiPermGroups(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+	}{
+		{
+			name:    "from_v5.16",
+			version: "5.16.0",
 		},
-		WorkingDir: tmpDir,
-		Steps: []resource.TestStep{
-			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"cloudflare": {
-						Source:            "cloudflare/cloudflare",
-						VersionConstraint: "5.16.0",
+		{
+			name:    "from_v5.18",
+			version: "5.18.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rnd := utils.GenerateRandomResourceName()
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			tmpDir := t.TempDir()
+
+			config := fmt.Sprintf(v501MultiPermgroupsConfig, rnd, accountID)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: config,
+					},
+					{
+						ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+						Config:                   config,
+						ConfigPlanChecks: resource.ConfigPlanChecks{
+							PostApplyPostRefresh: []plancheck.PlanCheck{
+								plancheck.ExpectEmptyPlan(),
+							},
+						},
+						ConfigStateChecks: []statecheck.StateCheck{
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_api_token.%s", rnd),
+								tfjsonpath.New("name"),
+								knownvalue.StringExact(rnd),
+							),
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_api_token.%s", rnd),
+								tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"),
+								knownvalue.ListSizeExact(3),
+							),
+						},
 					},
 				},
-				Config: config,
-			},
-			{
-				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-				Config:                   config,
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
+			})
+		})
+	}
+}
+
+// TestMigrateAPITokenFromV1_Basic tests the simplest case: a single-policy
+// token created in v5.18 upgrading to the current version.
+// This is the minimal reproducer for GitHub issue #7077 — the nil pointer
+// dereference when the version 1 PriorSchema was List-based but state was
+// Set-encoded.
+func TestMigrateAPITokenFromV1_Basic(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+	}{
+		{
+			name:    "from_v5.16",
+			version: "5.16.0",
+		},
+		{
+			name:    "from_v5.18",
+			version: "5.18.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rnd := utils.GenerateRandomResourceName()
+			accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+			tmpDir := t.TempDir()
+
+			// Single-policy token with one permission group — simplest possible case
+			config := fmt.Sprintf(`
+resource "cloudflare_api_token" "%[1]s" {
+  name = "%[1]s"
+
+  policies = [
+    {
+      effect = "allow"
+      permission_groups = [{
+        id = "82e64a83756745bbbb1c9c2701bf816b"
+      }]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = "*"
+      })
+    }
+  ]
+}`, rnd, accountID)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					acctest.TestAccPreCheck(t)
+					acctest.TestAccPreCheck_AccountID(t)
+				},
+				WorkingDir: tmpDir,
+				Steps: []resource.TestStep{
+					{
+						// Step 1: Create with v5.16/v5.18 (stores schema_version=1, Set-based)
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"cloudflare": {
+								Source:            "cloudflare/cloudflare",
+								VersionConstraint: tc.version,
+							},
+						},
+						Config: config,
+					},
+					{
+						// Step 2: Upgrade to current (v501, List-based)
+						// Before the fix, this step would panic with:
+						//   nil pointer dereference in UpgradeFromV1
+						// because the PriorSchema was List-based but state was Set-encoded.
+						ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+						Config:                   config,
+						ConfigPlanChecks: resource.ConfigPlanChecks{
+							PostApplyPostRefresh: []plancheck.PlanCheck{
+								plancheck.ExpectEmptyPlan(),
+							},
+						},
+						ConfigStateChecks: []statecheck.StateCheck{
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_api_token.%s", rnd),
+								tfjsonpath.New("name"),
+								knownvalue.StringExact(rnd),
+							),
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_api_token.%s", rnd),
+								tfjsonpath.New("policies"),
+								knownvalue.ListSizeExact(1),
+							),
+							statecheck.ExpectKnownValue(
+								fmt.Sprintf("cloudflare_api_token.%s", rnd),
+								tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("effect"),
+								knownvalue.StringExact("allow"),
+							),
+						},
 					},
 				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						fmt.Sprintf("cloudflare_api_token.%s", rnd),
-						tfjsonpath.New("name"),
-						knownvalue.StringExact(rnd),
-					),
-					statecheck.ExpectKnownValue(
-						fmt.Sprintf("cloudflare_api_token.%s", rnd),
-						tfjsonpath.New("policies").AtSliceIndex(0).AtMapKey("permission_groups"),
-						knownvalue.ListSizeExact(3),
-					),
-				},
-			},
-		},
-	})
+			})
+		})
+	}
 }

--- a/internal/services/api_token/migrations.go
+++ b/internal/services/api_token/migrations.go
@@ -23,24 +23,28 @@ var _ resource.ResourceWithUpgradeState = (*APITokenResource)(nil)
 //
 // This handles three upgrade paths:
 //
-// 1. v0 state (schema_version=0) → v501: Full transformation via v500
+// 1. v0 state (schema_version=0) → v501: Full transformation from v4 SDKv2
 //   - Converts policy[] block to policies[] attribute
 //   - Converts permission_groups from strings to objects
 //   - Converts resources from map to JSON string
 //   - Converts condition/request_ip from arrays to single nested
 //
-// 2. v1 state (schema_version=1) → v501: Deserialize/re-serialize via v500
-//   - Converts Set-typed state to List-compatible state
+// 2. v1 state (schema_version=1) → v501: Set→List migration
+//   - v5.16-v5.18 stored state at schema_version=1 with Set-based policies/permission_groups
+//   - This is structurally identical to v500 state (same Set-based schema)
+//   - Reuses the v500 Set-based schema for deserialization and UpgradeFromV500 for sorting
 //
 // 3. v500 state (schema_version=500) → v501: Set→List migration
 //   - Converts Set-typed policies and permission_groups to sorted Lists
 func (r *APITokenResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	v4Schema := v500.SourceCloudflareAPITokenSchema()
-
-	v5SchemaVersion1 := ResourceSchema(ctx)
-	v5SchemaVersion1.Version = 1
-
 	v500Schema := v501.SourceSchemaV500()
+
+	// v5.16-v5.18 stored state at schema_version=1 with the same Set-based schema
+	// as v500. We must NOT use the current ResourceSchema (which is List-based at v501)
+	// because the framework would fail to decode Set-encoded state with a List schema.
+	v1Schema := v501.SourceSchemaV500()
+	v1Schema.Version = 1
 
 	return map[int64]resource.StateUpgrader{
 		// Handle state from v4 SDKv2 provider (schema_version=0)
@@ -48,10 +52,11 @@ func (r *APITokenResource) UpgradeState(ctx context.Context) map[int64]resource.
 			PriorSchema:   &v4Schema,
 			StateUpgrader: v500.UpgradeFromV4,
 		},
-		// Handle state from v5 Plugin Framework provider (version=1)
+		// Handle state from v5.16-v5.18 (schema_version=1, Set-based)
+		// Same format as v500 — deserialize Sets, sort canonically, write as Lists
 		1: {
-			PriorSchema:   &v5SchemaVersion1,
-			StateUpgrader: v500.UpgradeFromV1,
+			PriorSchema:   &v1Schema,
+			StateUpgrader: v501.UpgradeFromV500,
 		},
 		// Handle state from v500 (Set-based) → v501 (List-based with FastSetType)
 		500: {


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/7077

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
```
TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/account_token/... -run "Test" -timeout 30m
TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/api_token/... -run "Test" -timeout 30m
```
### Test output
```
~/cf-repos/github/terraform-provider-cloudflare vaishak/tokens !2 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/api_token/... -run "Test" -timeout 30m
=== RUN   TestMarshalCustom
--- PASS: TestMarshalCustom (0.00s)
=== RUN   TestMarshalCustom_BadJson
--- PASS: TestMarshalCustom_BadJson (0.00s)
=== RUN   TestUnmarshalCustom
--- PASS: TestUnmarshalCustom (0.00s)
=== RUN   TestUnmarshalComputedCustom
--- PASS: TestUnmarshalComputedCustom (0.00s)
=== RUN   TestSortPolicies_SortsPermissionGroupsByID
--- PASS: TestSortPolicies_SortsPermissionGroupsByID (0.00s)
=== RUN   TestSortPolicies_SortsPoliciesByEffectThenResources
--- PASS: TestSortPolicies_SortsPoliciesByEffectThenResources (0.00s)
=== RUN   TestUnmarshalCustom_SortsPermissionGroups
--- PASS: TestUnmarshalCustom_SortsPermissionGroups (0.00s)
=== RUN   TestAPITokenDataSourceModelSchemaParity
=== PAUSE TestAPITokenDataSourceModelSchemaParity
=== RUN   TestAccCloudflareAPITokenData
=== PAUSE TestAccCloudflareAPITokenData
=== RUN   TestAPITokensDataSourceModelSchemaParity
=== PAUSE TestAPITokensDataSourceModelSchemaParity
=== RUN   TestRead_ActiveToken_PreservesState
--- PASS: TestRead_ActiveToken_PreservesState (0.00s)
=== RUN   TestRead_ExpiredToken_RemovesFromState
--- PASS: TestRead_ExpiredToken_RemovesFromState (0.00s)
=== RUN   TestRead_RevokedExposedToken_RemovesFromState
--- PASS: TestRead_RevokedExposedToken_RemovesFromState (0.00s)
=== RUN   TestRead_DisabledToken_PreservesState
--- PASS: TestRead_DisabledToken_PreservesState (0.00s)
=== RUN   TestRead_404_RemovesFromState
--- PASS: TestRead_404_RemovesFromState (0.00s)
=== RUN   TestAPITokenModelSchemaParity
=== PAUSE TestAPITokenModelSchemaParity
=== RUN   TestAccAPIToken_Basic
--- PASS: TestAccAPIToken_Basic (12.82s)
=== RUN   TestAccAPIToken_SetIndividualCondition
--- PASS: TestAccAPIToken_SetIndividualCondition (10.36s)
=== RUN   TestAccAPIToken_SetAllCondition
--- PASS: TestAccAPIToken_SetAllCondition (7.28s)
=== RUN   TestAccAPIToken_TokenTTL
--- PASS: TestAccAPIToken_TokenTTL (11.00s)
=== RUN   TestAccAPIToken_PermissionGroupOrder
--- PASS: TestAccAPIToken_PermissionGroupOrder (44.15s)
=== RUN   TestAccAPIToken_PolicyOrder
--- PASS: TestAccAPIToken_PolicyOrder (39.74s)
=== RUN   TestAccAPIToken_ResourcesFlexible
--- PASS: TestAccAPIToken_ResourcesFlexible (13.23s)
=== RUN   TestAccAPIToken_CRUD
--- PASS: TestAccAPIToken_CRUD (12.05s)
=== RUN   TestAccUpgradeApiToken_FromPublishedV5
--- PASS: TestAccUpgradeApiToken_FromPublishedV5 (21.31s)
=== CONT  TestAPITokenDataSourceModelSchemaParity
=== CONT  TestAPITokensDataSourceModelSchemaParity
=== CONT  TestAccCloudflareAPITokenData
=== CONT  TestAPITokenModelSchemaParity
--- PASS: TestAPITokenModelSchemaParity (0.00s)
--- PASS: TestAPITokenDataSourceModelSchemaParity (0.00s)
--- PASS: TestAPITokensDataSourceModelSchemaParity (0.00s)
--- PASS: TestAccCloudflareAPITokenData (3.92s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_token	177.753s
=== RUN   TestAPITokenMigrationModelSchemaParity
=== PAUSE TestAPITokenMigrationModelSchemaParity
=== RUN   TestMigrateAPIToken_V4ToV5_Basic
=== RUN   TestMigrateAPIToken_V4ToV5_Basic/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_Basic/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_Basic (36.21s)
    --- PASS: TestMigrateAPIToken_V4ToV5_Basic/from_v4_latest (21.87s)
    --- PASS: TestMigrateAPIToken_V4ToV5_Basic/from_v5 (14.33s)
=== RUN   TestMigrateAPIToken_V4ToV5_WithCondition
=== RUN   TestMigrateAPIToken_V4ToV5_WithCondition/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_WithCondition/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_WithCondition (27.29s)
    --- PASS: TestMigrateAPIToken_V4ToV5_WithCondition/from_v4_latest (14.77s)
    --- PASS: TestMigrateAPIToken_V4ToV5_WithCondition/from_v5 (12.52s)
=== RUN   TestMigrateAPIToken_V4ToV5_WithTTL
=== RUN   TestMigrateAPIToken_V4ToV5_WithTTL/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_WithTTL/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_WithTTL (28.82s)
    --- PASS: TestMigrateAPIToken_V4ToV5_WithTTL/from_v4_latest (14.36s)
    --- PASS: TestMigrateAPIToken_V4ToV5_WithTTL/from_v5 (14.46s)
=== RUN   TestMigrateAPIToken_V4ToV5_DenyEffect
=== RUN   TestMigrateAPIToken_V4ToV5_DenyEffect/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_DenyEffect/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_DenyEffect (29.41s)
    --- PASS: TestMigrateAPIToken_V4ToV5_DenyEffect/from_v4_latest (16.42s)
    --- PASS: TestMigrateAPIToken_V4ToV5_DenyEffect/from_v5 (12.99s)
=== RUN   TestMigrateAPIToken_V4ToV5_ConditionNotIn
=== RUN   TestMigrateAPIToken_V4ToV5_ConditionNotIn/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_ConditionNotIn/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_ConditionNotIn (28.65s)
    --- PASS: TestMigrateAPIToken_V4ToV5_ConditionNotIn/from_v4_latest (14.98s)
    --- PASS: TestMigrateAPIToken_V4ToV5_ConditionNotIn/from_v5 (13.67s)
=== RUN   TestMigrateAPIToken_V4ToV5_MultiplePolicies
=== RUN   TestMigrateAPIToken_V4ToV5_MultiplePolicies/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_MultiplePolicies/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_MultiplePolicies (29.31s)
    --- PASS: TestMigrateAPIToken_V4ToV5_MultiplePolicies/from_v4_latest (15.43s)
    --- PASS: TestMigrateAPIToken_V4ToV5_MultiplePolicies/from_v5 (13.89s)
=== RUN   TestMigrateAPIToken_V4ToV5_MultipleResources
=== RUN   TestMigrateAPIToken_V4ToV5_MultipleResources/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_MultipleResources/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_MultipleResources (28.51s)
    --- PASS: TestMigrateAPIToken_V4ToV5_MultipleResources/from_v4_latest (15.38s)
    --- PASS: TestMigrateAPIToken_V4ToV5_MultipleResources/from_v5 (13.13s)
=== RUN   TestMigrateAPIToken_V4ToV5_MixedEffects
=== RUN   TestMigrateAPIToken_V4ToV5_MixedEffects/from_v4_latest
=== RUN   TestMigrateAPIToken_V4ToV5_MixedEffects/from_v5
--- PASS: TestMigrateAPIToken_V4ToV5_MixedEffects (27.77s)
    --- PASS: TestMigrateAPIToken_V4ToV5_MixedEffects/from_v4_latest (14.48s)
    --- PASS: TestMigrateAPIToken_V4ToV5_MixedEffects/from_v5 (13.29s)
=== RUN   TestMigrateAPITokenFromV5MapToJSON
--- PASS: TestMigrateAPITokenFromV5MapToJSON (26.64s)
=== RUN   TestMigrateAPITokenFromV5ComplexResources
--- PASS: TestMigrateAPITokenFromV5ComplexResources (23.04s)
=== RUN   TestMigrateAPITokenFromV5WithTTL
--- PASS: TestMigrateAPITokenFromV5WithTTL (23.75s)
=== RUN   TestMigrateAPITokenFromV5RemovedFields
--- PASS: TestMigrateAPITokenFromV5RemovedFields (14.84s)
=== RUN   TestMigrateAPITokenFromV5_4
--- PASS: TestMigrateAPITokenFromV5_4 (17.51s)
=== RUN   TestMigrateAPITokenFromV5_7
--- PASS: TestMigrateAPITokenFromV5_7 (17.82s)
=== RUN   TestMigrateAPITokenFromV5_ComplexNestedResources
--- PASS: TestMigrateAPITokenFromV5_ComplexNestedResources (18.44s)
=== RUN   TestMigrateAPITokenFromV5_4_BothResourceFormats
--- PASS: TestMigrateAPITokenFromV5_4_BothResourceFormats (16.27s)
=== CONT  TestAPITokenMigrationModelSchemaParity
--- PASS: TestAPITokenMigrationModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_token/migration/v500	396.120s
=== RUN   TestMigrateAPITokenFromV1_MultiPolicy
=== RUN   TestMigrateAPITokenFromV1_MultiPolicy/from_v5.16
=== RUN   TestMigrateAPITokenFromV1_MultiPolicy/from_v5.18
--- PASS: TestMigrateAPITokenFromV1_MultiPolicy (37.79s)
    --- PASS: TestMigrateAPITokenFromV1_MultiPolicy/from_v5.16 (19.53s)
    --- PASS: TestMigrateAPITokenFromV1_MultiPolicy/from_v5.18 (18.25s)
=== RUN   TestMigrateAPITokenFromV1_MultiPermGroups
=== RUN   TestMigrateAPITokenFromV1_MultiPermGroups/from_v5.16
=== RUN   TestMigrateAPITokenFromV1_MultiPermGroups/from_v5.18
--- PASS: TestMigrateAPITokenFromV1_MultiPermGroups (33.64s)
    --- PASS: TestMigrateAPITokenFromV1_MultiPermGroups/from_v5.16 (16.19s)
    --- PASS: TestMigrateAPITokenFromV1_MultiPermGroups/from_v5.18 (17.45s)
=== RUN   TestMigrateAPITokenFromV1_Basic
=== RUN   TestMigrateAPITokenFromV1_Basic/from_v5.16
=== RUN   TestMigrateAPITokenFromV1_Basic/from_v5.18
--- PASS: TestMigrateAPITokenFromV1_Basic (33.93s)
    --- PASS: TestMigrateAPITokenFromV1_Basic/from_v5.16 (16.42s)
    --- PASS: TestMigrateAPITokenFromV1_Basic/from_v5.18 (17.51s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_token/migration/v501	107.259s

~/c/github/terraform-provider-cloudflare vaishak/tokens !4 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/account_token/... -run "Test" -timeout 30m
=== RUN   TestMarshalCustom
--- PASS: TestMarshalCustom (0.00s)
=== RUN   TestMarshalCustom_BadJson
--- PASS: TestMarshalCustom_BadJson (0.00s)
=== RUN   TestUnmarshalCustom
--- PASS: TestUnmarshalCustom (0.00s)
=== RUN   TestUnmarshalComputedCustom
--- PASS: TestUnmarshalComputedCustom (0.00s)
=== RUN   TestSortPolicies_SortsPermissionGroupsByID
--- PASS: TestSortPolicies_SortsPermissionGroupsByID (0.00s)
=== RUN   TestSortPolicies_SortsPoliciesByEffectThenResources
--- PASS: TestSortPolicies_SortsPoliciesByEffectThenResources (0.00s)
=== RUN   TestUnmarshalCustom_SortsPermissionGroups
--- PASS: TestUnmarshalCustom_SortsPermissionGroups (0.00s)
=== RUN   TestAccountTokenDataSourceModelSchemaParity
=== PAUSE TestAccountTokenDataSourceModelSchemaParity
=== RUN   TestAccountTokensDataSourceModelSchemaParity
=== PAUSE TestAccountTokensDataSourceModelSchemaParity
=== RUN   TestRead_ActiveAccountToken_PreservesState
--- PASS: TestRead_ActiveAccountToken_PreservesState (0.00s)
=== RUN   TestRead_ExpiredAccountToken_RemovesFromState
--- PASS: TestRead_ExpiredAccountToken_RemovesFromState (0.00s)
=== RUN   TestRead_RevokedExposedAccountToken_RemovesFromState
--- PASS: TestRead_RevokedExposedAccountToken_RemovesFromState (0.00s)
=== RUN   TestRead_DisabledAccountToken_PreservesState
--- PASS: TestRead_DisabledAccountToken_PreservesState (0.00s)
=== RUN   TestAccountTokenModelSchemaParity
=== PAUSE TestAccountTokenModelSchemaParity
=== RUN   TestAccAccountToken_Basic
--- PASS: TestAccAccountToken_Basic (14.36s)
=== RUN   TestAccAccountToken_SetIndividualCondition
--- PASS: TestAccAccountToken_SetIndividualCondition (8.40s)
=== RUN   TestAccAccountToken_SetAllCondition
--- PASS: TestAccAccountToken_SetAllCondition (8.45s)
=== RUN   TestAccAccountToken_TokenTTL
--- PASS: TestAccAccountToken_TokenTTL (11.96s)
=== RUN   TestAccAccountToken_PermissionGroupOrder
--- PASS: TestAccAccountToken_PermissionGroupOrder (47.44s)
=== RUN   TestAccAccountToken_PolicyOrder
--- PASS: TestAccAccountToken_PolicyOrder (41.49s)
=== RUN   TestAccAccountToken_ResourcesFlexible
--- PASS: TestAccAccountToken_ResourcesFlexible (19.60s)
=== RUN   TestAccAccountToken_CRUD
--- PASS: TestAccAccountToken_CRUD (11.38s)
=== RUN   TestAccUpgradeAccountToken_FromPublishedV5
--- PASS: TestAccUpgradeAccountToken_FromPublishedV5 (21.95s)
=== CONT  TestAccountTokenDataSourceModelSchemaParity
=== CONT  TestAccountTokenModelSchemaParity
=== CONT  TestAccountTokensDataSourceModelSchemaParity
--- PASS: TestAccountTokenModelSchemaParity (0.00s)
--- PASS: TestAccountTokenDataSourceModelSchemaParity (0.00s)
--- PASS: TestAccountTokensDataSourceModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_token	186.784s
=== RUN   TestAccountTokenMigrationModelSchemaParity
=== PAUSE TestAccountTokenMigrationModelSchemaParity
=== RUN   TestMigrateAccountTokenFromV5MapToJSON
--- PASS: TestMigrateAccountTokenFromV5MapToJSON (18.59s)
=== RUN   TestMigrateAccountTokenFromV5ComplexResources
--- PASS: TestMigrateAccountTokenFromV5ComplexResources (8.68s)
=== RUN   TestMigrateAccountTokenFromV5_ComplexNestedResources
--- PASS: TestMigrateAccountTokenFromV5_ComplexNestedResources (8.82s)
=== RUN   TestMigrateAccountTokenFromV5_10_BothResourceFormats
--- PASS: TestMigrateAccountTokenFromV5_10_BothResourceFormats (18.36s)
=== RUN   TestMigrateAccountTokenFromV5WithTTL
--- PASS: TestMigrateAccountTokenFromV5WithTTL (16.69s)
=== RUN   TestMigrateAccountTokenFromV5NestedResources
--- PASS: TestMigrateAccountTokenFromV5NestedResources (18.18s)
=== RUN   TestMigrateAccountTokenFromV5RemovedFields
--- PASS: TestMigrateAccountTokenFromV5RemovedFields (16.46s)
=== RUN   TestMigrateAccountTokenFromV5_10
--- PASS: TestMigrateAccountTokenFromV5_10 (16.09s)
=== RUN   TestMigrateAccountTokenFromV5_11
--- PASS: TestMigrateAccountTokenFromV5_11 (22.49s)
=== RUN   TestMigrateAccountTokenFromV5_12
--- PASS: TestMigrateAccountTokenFromV5_12 (18.72s)
=== CONT  TestAccountTokenMigrationModelSchemaParity
--- PASS: TestAccountTokenMigrationModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_token/migration/v500	164.927s
=== RUN   TestMigrateAccountTokenFromV1_Basic
=== RUN   TestMigrateAccountTokenFromV1_Basic/from_v5.16
=== RUN   TestMigrateAccountTokenFromV1_Basic/from_v5.18
--- PASS: TestMigrateAccountTokenFromV1_Basic (42.15s)
    --- PASS: TestMigrateAccountTokenFromV1_Basic/from_v5.16 (19.73s)
    --- PASS: TestMigrateAccountTokenFromV1_Basic/from_v5.18 (22.42s)
=== RUN   TestMigrateAccountTokenFromV1_MultiPolicy
=== RUN   TestMigrateAccountTokenFromV1_MultiPolicy/from_v5.16
=== RUN   TestMigrateAccountTokenFromV1_MultiPolicy/from_v5.18
--- PASS: TestMigrateAccountTokenFromV1_MultiPolicy (38.08s)
    --- PASS: TestMigrateAccountTokenFromV1_MultiPolicy/from_v5.16 (19.18s)
    --- PASS: TestMigrateAccountTokenFromV1_MultiPolicy/from_v5.18 (18.90s)
=== RUN   TestMigrateAccountTokenFromV1_MultiPermGroups
=== RUN   TestMigrateAccountTokenFromV1_MultiPermGroups/from_v5.16
=== RUN   TestMigrateAccountTokenFromV1_MultiPermGroups/from_v5.18
--- PASS: TestMigrateAccountTokenFromV1_MultiPermGroups (35.10s)
    --- PASS: TestMigrateAccountTokenFromV1_MultiPermGroups/from_v5.16 (17.26s)
    --- PASS: TestMigrateAccountTokenFromV1_MultiPermGroups/from_v5.18 (17.84s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_token/migration/v501	117.387s
```

```
========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ No changes needed

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected

Logs saved to:
  - /Users/vaishak/cf-repos/github/tf-migrate/e2e/tmp

```

## Additional context & links
