### PR TITLE
fix(zero_trust_access_group): fix v4 migration of same name

### DIFF
--- a/internal/services/zero_trust_access_group/migration/v500/handler.go
+++ b/internal/services/zero_trust_access_group/migration/v500/handler.go
@@ -3,16 +3,30 @@ package v500
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // UpgradeFromV0 handles state upgrades from v0 to v500.
 // This is triggered for resources that were created with schema version 0
 // (either from the old cloudflare_access_group or early cloudflare_zero_trust_access_group).
+//
+// NOTE: When called from the parent package dispatcher (PriorSchema=nil), req.State is empty
+// and we must unmarshal from req.RawState using the v4 source schema directly.
 func UpgradeFromV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// Parse source state (v4 SDKv2 format)
+	if req.RawState == nil {
+		resp.Diagnostics.AddError("Missing raw state", "RawState was nil for schema version 0 migration")
+		return
+	}
+
+	tflog.Info(ctx, "Upgrading zero_trust_access_group state from v4 SDKv2 provider (schema_version=0)")
+
+	// Parse source state (v4 SDKv2 format) from RawState using v4 schema
 	var sourceState SourceV4ZeroTrustAccessGroupModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &sourceState)...)
+	resp.Diagnostics.Append(unmarshalV4State(ctx, req.RawState, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -26,4 +40,24 @@ func UpgradeFromV0(ctx context.Context, req resource.UpgradeStateRequest, resp *
 
 	// Set upgraded state
 	resp.Diagnostics.Append(resp.State.Set(ctx, targetState)...)
+	tflog.Info(ctx, "State upgrade from v4 to v5 completed successfully")
+}
+
+// unmarshalV4State decodes RawState bytes into the v4 source model using the v4 source schema.
+// This is necessary when PriorSchema is nil (dispatcher pattern) so req.State isn't pre-populated.
+func unmarshalV4State(ctx context.Context, rawState *tfprotov6.RawState, target *SourceV4ZeroTrustAccessGroupModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	sourceSchema := SourceV4ZeroTrustAccessGroupSchema()
+	sourceType := sourceSchema.Type().TerraformType(ctx)
+
+	rawValue, err := rawState.Unmarshal(sourceType)
+	if err != nil {
+		diags.AddError("Failed to unmarshal v4 state", "Could not parse raw state as v4 format: "+err.Error())
+		return diags
+	}
+
+	state := tfsdk.State{Raw: rawValue, Schema: sourceSchema}
+	diags.Append(state.Get(ctx, target)...)
+	return diags
 }

--- a/internal/services/zero_trust_access_group/migration/v500/migrations_test.go
+++ b/internal/services/zero_trust_access_group/migration/v500/migrations_test.go
@@ -43,6 +43,12 @@ var v4BooleanConfig string
 //go:embed testdata/v5_boolean.tf
 var v5BooleanConfig string
 
+//go:embed testdata/v4_service_token_boolean.tf
+var v4ServiceTokenBooleanConfig string
+
+//go:embed testdata/v5_service_token_boolean.tf
+var v5ServiceTokenBooleanConfig string
+
 //go:embed testdata/v4_multi_list.tf
 var v4MultiListConfig string
 
@@ -300,6 +306,63 @@ func TestMigrateZeroTrustAccessGroup_V4ToV5_Boolean(t *testing.T) {
 
 		// Use MigrationV2TestStepWithStateNormalization because the v5 provider's schema
 		// returns nil selector fields (like common_name) that need to be normalized away
+		migrationSteps := acctest.MigrationV2TestStepWithStateNormalization(t, testConfig, tmpDir, version, sourceVer, targetVer, stateChecks)
+
+		resource.Test(t, resource.TestCase{
+			WorkingDir: tmpDir,
+			Steps: append([]resource.TestStep{
+				{
+					// Step 1: Create with v4 external provider
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"cloudflare": {
+							Source:            "cloudflare/cloudflare",
+							VersionConstraint: version,
+						},
+					},
+					Config: testConfig,
+				},
+			}, migrationSteps...),
+		})
+	})
+}
+
+// TestMigrateZeroTrustAccessGroup_V4ToV5_ServiceTokenBoolean tests the any_valid_service_token
+// boolean-to-object transformation that was reported as broken in APIX-741.
+//
+// This is the exact scenario that fails without the UpgradeState fix:
+//   - v4 state has any_valid_service_token = true (boolean) in include block
+//   - v5 expects any_valid_service_token = {} (SingleNestedAttribute, empty object)
+//   - Without the fix, UpgradeState fails with:
+//     "invalid JSON, expected "{", got false"
+func TestMigrateZeroTrustAccessGroup_V4ToV5_ServiceTokenBoolean(t *testing.T) {
+	t.Run("from_v4_latest", func(t *testing.T) {
+		// Test setup
+		accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+		rnd := utils.GenerateRandomResourceName()
+		name := "tf-test-" + rnd
+		tmpDir := t.TempDir()
+		testConfig := fmt.Sprintf(v4ServiceTokenBooleanConfig, rnd, accountID, name)
+		version := acctest.GetLastV4Version()
+		sourceVer, targetVer := acctest.InferMigrationVersions(version)
+
+		stateChecks := []statecheck.StateCheck{
+			// CRITICAL: Verify any_valid_service_token boolean → empty object transformation
+			// This is the exact field that causes the APIX-741 error
+			statecheck.ExpectKnownValue(
+				"cloudflare_zero_trust_access_group."+rnd,
+				tfjsonpath.New("include").AtSliceIndex(0).AtMapKey("any_valid_service_token"),
+				knownvalue.MapExact(map[string]knownvalue.Check{}),
+			),
+			// Verify exclude block email is preserved
+			statecheck.ExpectKnownValue(
+				"cloudflare_zero_trust_access_group."+rnd,
+				tfjsonpath.New("exclude").AtSliceIndex(0).AtMapKey("email").AtMapKey("email"),
+				knownvalue.StringExact("blocked@example.com"),
+			),
+		}
+
+		// Use MigrationV2TestStepWithStateNormalization because the v5 provider's schema
+		// returns nil selector fields that need to be normalized away
 		migrationSteps := acctest.MigrationV2TestStepWithStateNormalization(t, testConfig, tmpDir, version, sourceVer, targetVer, stateChecks)
 
 		resource.Test(t, resource.TestCase{

--- a/internal/services/zero_trust_access_group/migration/v500/testdata/v4_service_token_boolean.tf
+++ b/internal/services/zero_trust_access_group/migration/v500/testdata/v4_service_token_boolean.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_access_group" "%s" {
+  account_id = "%s"
+  name       = "%s"
+
+  include {
+    any_valid_service_token = true
+  }
+
+  exclude {
+    email = ["blocked@example.com"]
+  }
+}

--- a/internal/services/zero_trust_access_group/migration/v500/testdata/v5_service_token_boolean.tf
+++ b/internal/services/zero_trust_access_group/migration/v500/testdata/v5_service_token_boolean.tf
@@ -1,0 +1,18 @@
+resource "cloudflare_zero_trust_access_group" "%s" {
+  account_id = "%s"
+  name       = "%s"
+
+  include = [
+    {
+      any_valid_service_token = {}
+    },
+  ]
+
+  exclude = [
+    {
+      email = {
+        email = "blocked@example.com"
+      }
+    },
+  ]
+}

--- a/internal/services/zero_trust_access_group/migrations.go
+++ b/internal/services/zero_trust_access_group/migrations.go
@@ -31,21 +31,60 @@ func (r *ZeroTrustAccessGroupResource) MoveState(ctx context.Context) []resource
 }
 
 // UpgradeState handles schema version upgrades for cloudflare_zero_trust_access_group.
-// This is triggered when users manually run `terraform state mv` (Terraform < 1.8).
+//
+// This handles two upgrade paths:
+// 1. v4 state (schema_version=0) → v5 (version=500): Full transformation
+// 2. v5 state (version=1) → v5 (version=500): No-op upgrade
 func (r *ZeroTrustAccessGroupResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	targetSchema := ResourceSchema(ctx)
+	// v5 schema for version=1 upgrader (override version to match production state)
+	v5SchemaVersion1 := ResourceSchema(ctx)
+	v5SchemaVersion1.Version = 1
+
 	return map[int64]resource.StateUpgrader{
+		// Handle BOTH version=0 formats:
+		// - v4 SDKv2 state (boolean selectors like any_valid_service_token) -> full transform
+		// - early v5 published state (object selectors) -> no-op version bump
+		//
+		// PriorSchema is nil to avoid the framework trying to decode v4 state
+		// using the v5 schema, which fails for boolean-to-object type changes
+		// (e.g., any_valid_service_token: bool in v4 → SingleNestedAttribute in v5).
 		0: {
-			PriorSchema: &targetSchema,
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				resp.State.Raw = req.State.Raw
-			},
+			PriorSchema:   nil,
+			StateUpgrader: upgradeFromV0,
 		},
+
+		// Handle state from v5 Plugin Framework provider (version=1)
+		// No-op: schema is compatible, just bumps version to 500
 		1: {
-			PriorSchema: &targetSchema,
+			PriorSchema: &v5SchemaVersion1,
 			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 				resp.State.Raw = req.State.Raw
 			},
 		},
 	}
+}
+
+// upgradeFromV0 dispatches version=0 state to the correct handler based on format.
+// Version=0 state can be either:
+// - v4 SDKv2 format: boolean selectors (any_valid_service_token = false), list fields
+// - early v5 format: object selectors (any_valid_service_token = {}), published before version bump
+func upgradeFromV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	if req.RawState == nil {
+		resp.Diagnostics.AddError("Missing raw state", "RawState was nil for schema version 0 migration")
+		return
+	}
+
+	// Try decoding as early v5 (version=0) first.
+	// If this succeeds, state is already v5-shaped and can be passed through.
+	v5SchemaVersion0 := ResourceSchema(ctx)
+	v5SchemaVersion0.Version = 0
+	v5Type := v5SchemaVersion0.Type().TerraformType(ctx)
+	v5RawValue, err := req.RawState.Unmarshal(v5Type)
+	if err == nil {
+		resp.State.Raw = v5RawValue
+		return
+	}
+
+	// Not decodable as v5 version=0; treat as v4 SDKv2 and transform.
+	v500.UpgradeFromV0(ctx, req, resp)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

fixes a migration issue for zero trust access group when the same name as the v5 resource is used in v4.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
```
TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/zero_trust_access_group/... -run "Test" -timeout 30m
```

### Test output
```
~/cf-repos/github/terraform-provider-cloudflare next !3 ?3 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/zero_trust_access_group/... -run "Test" -timeout 30m
=== RUN   TestZeroTrustAccessGroupDataSourceModelSchemaParity
=== PAUSE TestZeroTrustAccessGroupDataSourceModelSchemaParity
=== RUN   TestZeroTrustAccessGroupsDataSourceModelSchemaParity
=== PAUSE TestZeroTrustAccessGroupsDataSourceModelSchemaParity
=== RUN   TestMigrateZeroTrustAccessGroupMultiVersion_Basic
=== RUN   TestMigrateZeroTrustAccessGroupMultiVersion_Basic/from_v4_52_1
--- PASS: TestMigrateZeroTrustAccessGroupMultiVersion_Basic (24.60s)
    --- PASS: TestMigrateZeroTrustAccessGroupMultiVersion_Basic/from_v4_52_1 (24.60s)
=== RUN   TestMigrateZeroTrustAccessGroupMultiVersion_ComplexRules
=== RUN   TestMigrateZeroTrustAccessGroupMultiVersion_ComplexRules/from_v4_52_1
--- PASS: TestMigrateZeroTrustAccessGroupMultiVersion_ComplexRules (20.54s)
    --- PASS: TestMigrateZeroTrustAccessGroupMultiVersion_ComplexRules/from_v4_52_1 (20.54s)
=== RUN   TestMigrateZeroTrustAccessGroupMultiVersion_ZoneScoped
=== RUN   TestMigrateZeroTrustAccessGroupMultiVersion_ZoneScoped/from_v4_52_1
--- PASS: TestMigrateZeroTrustAccessGroupMultiVersion_ZoneScoped (21.30s)
    --- PASS: TestMigrateZeroTrustAccessGroupMultiVersion_ZoneScoped/from_v4_52_1 (21.30s)
=== RUN   TestMigrateZeroTrustAccessGroup_EdgeCases
=== RUN   TestMigrateZeroTrustAccessGroup_EdgeCases/v4_single_email
=== RUN   TestMigrateZeroTrustAccessGroup_EdgeCases/v4_multiple_emails_and_ips
=== RUN   TestMigrateZeroTrustAccessGroup_EdgeCases/v4_all_rule_types
--- PASS: TestMigrateZeroTrustAccessGroup_EdgeCases (62.33s)
    --- PASS: TestMigrateZeroTrustAccessGroup_EdgeCases/v4_single_email (21.31s)
    --- PASS: TestMigrateZeroTrustAccessGroup_EdgeCases/v4_multiple_emails_and_ips (21.10s)
    --- PASS: TestMigrateZeroTrustAccessGroup_EdgeCases/v4_all_rule_types (19.92s)
=== RUN   TestZeroTrustAccessGroupModelSchemaParity
=== PAUSE TestZeroTrustAccessGroupModelSchemaParity
=== RUN   TestAccCloudflareAccessGroup_ConfigBasicAccount
--- PASS: TestAccCloudflareAccessGroup_ConfigBasicAccount (3.71s)
=== RUN   TestAccCloudflareAccessGroup_ConfigBasicZone
--- PASS: TestAccCloudflareAccessGroup_ConfigBasicZone (3.92s)
=== RUN   TestAccCloudflareAccessGroup_ConfigEmailList
--- PASS: TestAccCloudflareAccessGroup_ConfigEmailList (4.73s)
=== RUN   TestAccCloudflareAccessGroup_Exclude
--- PASS: TestAccCloudflareAccessGroup_Exclude (3.71s)
=== RUN   TestAccCloudflareAccessGroup_Require
--- PASS: TestAccCloudflareAccessGroup_Require (3.93s)
=== RUN   TestAccCloudflareAccessGroup_FullConfig
--- PASS: TestAccCloudflareAccessGroup_FullConfig (3.69s)
=== RUN   TestAccCloudflareAccessGroup_WithIDP
--- PASS: TestAccCloudflareAccessGroup_WithIDP (5.11s)
=== RUN   TestAccCloudflareAccessGroup_WithIDPAuthContext
--- PASS: TestAccCloudflareAccessGroup_WithIDPAuthContext (6.00s)
=== RUN   TestAccCloudflareAccessGroup_Updated
--- PASS: TestAccCloudflareAccessGroup_Updated (5.93s)
=== RUN   TestAccCloudflareAccessGroup_UpdatedFromCommonNameToCommonNames
--- PASS: TestAccCloudflareAccessGroup_UpdatedFromCommonNameToCommonNames (5.67s)
=== RUN   TestAccCloudflareAccessGroup_MinimalConfiguration
--- PASS: TestAccCloudflareAccessGroup_MinimalConfiguration (3.39s)
=== RUN   TestAccCloudflareAccessGroup_MultipleIncludeRuleTypes
--- PASS: TestAccCloudflareAccessGroup_MultipleIncludeRuleTypes (3.94s)
=== RUN   TestAccCloudflareAccessGroup_IsDefaultAttribute
--- PASS: TestAccCloudflareAccessGroup_IsDefaultAttribute (5.28s)
=== RUN   TestAccCloudflareAccessGroup_ComplexRuleCombinations
--- PASS: TestAccCloudflareAccessGroup_ComplexRuleCombinations (3.67s)
=== RUN   TestAccCloudflareAccessGroup_UpdateOptionalAttributes
--- PASS: TestAccCloudflareAccessGroup_UpdateOptionalAttributes (7.55s)
=== RUN   TestAccCloudflareAccessGroup_AllRuleTypes
--- PASS: TestAccCloudflareAccessGroup_AllRuleTypes (3.43s)
=== RUN   TestAccCloudflareAccessGroup_MultipleRuleTypesWithGeo
--- PASS: TestAccCloudflareAccessGroup_MultipleRuleTypesWithGeo (3.97s)
=== RUN   TestAccCloudflareAccessGroup_IPRangeRules
--- PASS: TestAccCloudflareAccessGroup_IPRangeRules (3.35s)
=== RUN   TestAccCloudflareAccessGroup_ImportEmptyArrayToNull
--- PASS: TestAccCloudflareAccessGroup_ImportEmptyArrayToNull (7.41s)
=== RUN   TestAccUpgradeZeroTrustAccessGroup_FromPublishedV5
--- PASS: TestAccUpgradeZeroTrustAccessGroup_FromPublishedV5 (16.66s)
=== CONT  TestZeroTrustAccessGroupModelSchemaParity
=== CONT  TestZeroTrustAccessGroupsDataSourceModelSchemaParity
=== CONT  TestZeroTrustAccessGroupDataSourceModelSchemaParity
--- PASS: TestZeroTrustAccessGroupModelSchemaParity (0.00s)
--- PASS: TestZeroTrustAccessGroupDataSourceModelSchemaParity (0.00s)
--- PASS: TestZeroTrustAccessGroupsDataSourceModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_access_group	235.881s
=== RUN   TestZeroTrustAccessGroupMigrationModelSchemaParity
=== PAUSE TestZeroTrustAccessGroupMigrationModelSchemaParity
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_Basic
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_Basic/from_v4_latest
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_Basic/from_v5
--- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_Basic (34.43s)
    --- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_Basic/from_v4_latest (16.93s)
    --- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_Basic/from_v5 (17.49s)
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_ListExplosion
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_ListExplosion/from_v4_latest
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_ListExplosion/from_v5
--- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_ListExplosion (26.45s)
    --- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_ListExplosion/from_v4_latest (14.16s)
    --- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_ListExplosion/from_v5 (12.29s)
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_GitHub
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_GitHub/from_v4_latest
--- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_GitHub (21.91s)
    --- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_GitHub/from_v4_latest (21.91s)
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_Boolean
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_Boolean/from_v4_latest
--- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_Boolean (20.90s)
    --- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_Boolean/from_v4_latest (20.90s)
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_ServiceTokenBoolean
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_ServiceTokenBoolean/from_v4_latest
--- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_ServiceTokenBoolean (28.23s)
    --- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_ServiceTokenBoolean/from_v4_latest (28.23s)
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_MultiList
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_MultiList/from_v4_latest
=== RUN   TestMigrateZeroTrustAccessGroup_V4ToV5_MultiList/from_v5
--- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_MultiList (59.51s)
    --- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_MultiList/from_v4_latest (40.43s)
    --- PASS: TestMigrateZeroTrustAccessGroup_V4ToV5_MultiList/from_v5 (19.08s)
=== CONT  TestZeroTrustAccessGroupMigrationModelSchemaParity
--- PASS: TestZeroTrustAccessGroupMigrationModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_access_group/migration/v500	193.297s
```

```
========================================
✓ E2E Test Complete!
========================================

Summary:

  Step 1: v4 terraform apply
    Status: ✓ SUCCESS

  Step 2: Migration (v4 → v5)
    Status: ✓ SUCCESS

  Step 3: v5 plan (before apply)
    Status: ✓ No material changes
    Result: 0 material changes
    Terraform: Plan: 0 to add, 0 to change, 0 to destroy.

  Step 4: v5 terraform apply
    Status: ✓ SUCCESS

  Step 5: v5 plan (after apply)
    Status: ✓ SUCCESS - Stable state achieved
    Result: No changes detected
```

## Additional context & links
