### PR TITLE
fix(access_rule): suppress diff for canonical IPv6 values

### DIFF
--- a/internal/services/access_rule/ipv6_plan_modifier.go
+++ b/internal/services/access_rule/ipv6_plan_modifier.go
@@ -1,0 +1,78 @@
+package access_rule
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// ipv6CanonicalPlanModifier suppresses spurious diffs for the
+// `configuration.value` attribute when both the prior state value and the
+// configured value parse to the same IPv6 address or network. The Cloudflare
+// API normalises IPv6 input (for example expanding `2001:db8::/32` to its
+// long form), which would otherwise produce a no-op update on every plan.
+type ipv6CanonicalPlanModifier struct{}
+
+func ipv6CanonicalValue() planmodifier.String {
+	return ipv6CanonicalPlanModifier{}
+}
+
+func (ipv6CanonicalPlanModifier) Description(_ context.Context) string {
+	return "Suppresses diffs when prior state and config refer to the same IPv6 address or CIDR network."
+}
+
+func (ipv6CanonicalPlanModifier) MarkdownDescription(_ context.Context) string {
+	return "Suppresses diffs when prior state and config refer to the same IPv6 address or CIDR network."
+}
+
+func (ipv6CanonicalPlanModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Nothing to compare during create/destroy or when either side is unknown.
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+
+	stateStr := req.StateValue.ValueString()
+	planStr := req.PlanValue.ValueString()
+	if stateStr == planStr {
+		return
+	}
+
+	if equalIPv6Value(stateStr, planStr) {
+		// Keep the prior state value so Terraform reports no change.
+		resp.PlanValue = req.StateValue
+	}
+}
+
+// equalIPv6Value reports whether two strings refer to the same IPv6 address or
+// IPv6 network. Returns false for IPv4 inputs so that the existing diff
+// behaviour is preserved.
+func equalIPv6Value(a, b string) bool {
+	if strings.Contains(a, "/") || strings.Contains(b, "/") {
+		_, netA, errA := net.ParseCIDR(a)
+		_, netB, errB := net.ParseCIDR(b)
+		if errA != nil || errB != nil {
+			return false
+		}
+		if netA.IP.To4() != nil || netB.IP.To4() != nil {
+			return false
+		}
+		sizeA, _ := netA.Mask.Size()
+		sizeB, _ := netB.Mask.Size()
+		return sizeA == sizeB && netA.IP.Equal(netB.IP)
+	}
+
+	ipA := net.ParseIP(a)
+	ipB := net.ParseIP(b)
+	if ipA == nil || ipB == nil {
+		return false
+	}
+	if ipA.To4() != nil || ipB.To4() != nil {
+		return false
+	}
+	return ipA.Equal(ipB)
+}

--- a/internal/services/access_rule/ipv6_plan_modifier_test.go
+++ b/internal/services/access_rule/ipv6_plan_modifier_test.go
@@ -1,0 +1,77 @@
+package access_rule
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestIPv6CanonicalPlanModifier(t *testing.T) {
+	type tc struct {
+		state      string
+		plan       string
+		expectKept bool // true if planmodifier should overwrite plan with state
+	}
+
+	cases := map[string]tc{
+		"compressed_vs_long_cidr": {
+			state:      "2001:0db8:0000:0000:0000:0000:0000:0000/32",
+			plan:       "2001:db8::/32",
+			expectKept: true,
+		},
+		"compressed_vs_long_address": {
+			state:      "2001:0db8:0000:0000:0000:0000:0000:0001",
+			plan:       "2001:db8::1",
+			expectKept: true,
+		},
+		"different_networks": {
+			state:      "2001:db8::/32",
+			plan:       "2001:db9::/32",
+			expectKept: false,
+		},
+		"different_prefix_length": {
+			state:      "2001:db8::/32",
+			plan:       "2001:db8::/48",
+			expectKept: false,
+		},
+		"identical_cidr": {
+			state:      "2001:db8::/32",
+			plan:       "2001:db8::/32",
+			expectKept: false, // short-circuited, plan unchanged
+		},
+		"ipv4_unaffected": {
+			state:      "192.0.2.1/24",
+			plan:       "192.0.2.0/24",
+			expectKept: false,
+		},
+		"non_ip_value_unaffected": {
+			state:      "US",
+			plan:       "DE",
+			expectKept: false,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := planmodifier.StringRequest{
+				Path:       path.Root("test"),
+				StateValue: types.StringValue(c.state),
+				PlanValue:  types.StringValue(c.plan),
+			}
+			resp := &planmodifier.StringResponse{PlanValue: types.StringValue(c.plan)}
+
+			ipv6CanonicalValue().PlanModifyString(context.Background(), req, resp)
+
+			got := resp.PlanValue.ValueString()
+			if c.expectKept && got != c.state {
+				t.Errorf("expected plan to be overwritten with state %q, got %q", c.state, got)
+			}
+			if !c.expectKept && got != c.plan {
+				t.Errorf("expected plan to remain %q, got %q", c.plan, got)
+			}
+		})
+	}
+}

--- a/internal/services/access_rule/schema.go
+++ b/internal/services/access_rule/schema.go
@@ -83,6 +83,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							ipv6Validator(),
 							cidrValidator(),
 						},
+						PlanModifiers: []planmodifier.String{
+							ipv6CanonicalValue(),
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Closes #7037.

`cloudflare_access_rule`'s `configuration.value` is stored verbatim in plan, but the Cloudflare API normalises IPv6 input (e.g. `2001:0db8:0000:0000:0000:0000:0000:0000/32` becomes `2001:db8::/32`) — so any round-trip through the API surfaces a no-op update on every plan.

Adds a small string `PlanModifier` on the IPv6 path of `configuration.value` that compares prior state and config via `net.ParseCIDR`/`net.ParseIP` and keeps the prior state value when both sides refer to the same network or address. Includes a table-driven test covering compressed-vs-long, prefix-length differences, identical inputs, and IPv4 inputs (which fall through to the normal diff).