### PR TITLE
feat(load_balancer, load_balancer_pool): add UseStateForUnknown to Computed attrs

### DIFF
--- a/internal/services/load_balancer/resource_test.go
+++ b/internal/services/load_balancer/resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cloudflare/cloudflare-go/v6/load_balancers"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
@@ -117,6 +118,45 @@ func TestAccCloudflareLoadBalancer_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "ttl", "30"),
 					resource.TestCheckResourceAttr(name, "steering_policy", "off"),
 				),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareLoadBalancer_NoDrift verifies that a basic load balancer
+// config with no explicit values for adaptive_routing, location_strategy,
+// random_steering, session_affinity_attributes, country_pools, pop_pools,
+// region_pools, networks, ttl, session_affinity_ttl, or description does NOT
+// produce drift on a no-op re-apply. This validates the UseStateForUnknown
+// plan modifiers added to those Computed attributes.
+func TestAccCloudflareLoadBalancer_NoDrift(t *testing.T) {
+	zone := os.Getenv("CLOUDFLARE_DOMAIN")
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_load_balancer." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create resource. Computed fields like created_on,
+				// modified_on, zone_name, networks, adaptive_routing, etc. get
+				// populated by the API.
+				Config: testAccCheckCloudflareLoadBalancerConfigBasic(zoneID, zone, rnd),
+			},
+			{
+				// Step 2: re-apply identical config. Without UseStateForUnknown
+				// on the Computed attributes, terraform marks them as
+				// (known after apply) and the plan would be a non-empty update.
+				// With the modifier, this step must be a no-op.
+				Config: testAccCheckCloudflareLoadBalancerConfigBasic(zoneID, zone, rnd),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(name, plancheck.ResourceActionNoop),
+					},
+				},
 			},
 		},
 	})

--- a/internal/services/load_balancer/schema.go
+++ b/internal/services/load_balancer/schema.go
@@ -14,7 +14,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -56,19 +60,22 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				ElementType: types.StringType,
 			},
 			"description": schema.StringAttribute{
-				Description: "Object description.",
-				Optional:    true,
-				Computed:    true,
+				Description:   "Object description.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"session_affinity_ttl": schema.Float64Attribute{
-				Description: "Time, in seconds, until a client's session expires after being created. Once the expiry time has been reached, subsequent requests may get sent to a different origin server. The accepted ranges per `session_affinity` policy are: - `\"cookie\"` / `\"ip_cookie\"`: The current default of 23 hours will be used unless explicitly set. The accepted range of values is between [1800, 604800]. - `\"header\"`: The current default of 1800 seconds will be used unless explicitly set. The accepted range of values is between [30, 3600]. Note: With session affinity by header, sessions only expire after they haven't been used for the number of seconds specified.",
-				Computed:    true,
-				Optional:    true,
+				Description:   "Time, in seconds, until a client's session expires after being created. Once the expiry time has been reached, subsequent requests may get sent to a different origin server. The accepted ranges per `session_affinity` policy are: - `\"cookie\"` / `\"ip_cookie\"`: The current default of 23 hours will be used unless explicitly set. The accepted range of values is between [1800, 604800]. - `\"header\"`: The current default of 1800 seconds will be used unless explicitly set. The accepted range of values is between [30, 3600]. Note: With session affinity by header, sessions only expire after they haven't been used for the number of seconds specified.",
+				Computed:      true,
+				Optional:      true,
+				PlanModifiers: []planmodifier.Float64{float64planmodifier.UseStateForUnknown()},
 			},
 			"ttl": schema.Float64Attribute{
-				Description: "Time to live (TTL) of the DNS entry for the IP address returned by this load balancer. This only applies to gray-clouded (unproxied) load balancers.",
-				Optional:    true,
-				Computed:    true,
+				Description:   "Time to live (TTL) of the DNS entry for the IP address returned by this load balancer. This only applies to gray-clouded (unproxied) load balancers.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Float64{float64planmodifier.UseStateForUnknown()},
 			},
 			"country_pools": schema.MapAttribute{
 				Description: "A mapping of country codes to a list of pool IDs (ordered by their failover priority) for the given country. Any country not explicitly defined will fall back to using the corresponding region_pool mapping if it exists else to default_pools.",
@@ -79,13 +86,15 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				ElementType: types.ListType{
 					ElemType: types.StringType,
 				},
+				PlanModifiers: []planmodifier.Map{mapplanmodifier.UseStateForUnknown()},
 			},
 			"networks": schema.ListAttribute{
-				Description: "List of networks where Load Balancer or Pool is enabled.",
-				Optional:    true,
-				Computed:    true,
-				ElementType: types.StringType,
-				CustomType:  customfield.NewListType[types.String](ctx),
+				Description:   "List of networks where Load Balancer or Pool is enabled.",
+				Optional:      true,
+				Computed:      true,
+				ElementType:   types.StringType,
+				CustomType:    customfield.NewListType[types.String](ctx),
+				PlanModifiers: []planmodifier.List{listplanmodifier.UseStateForUnknown()},
 			},
 			"pop_pools": schema.MapAttribute{
 				Description: "Enterprise only: A mapping of Cloudflare PoP identifiers to a list of pool IDs (ordered by their failover priority) for the PoP (datacenter). Any PoPs not explicitly defined will fall back to using the corresponding country_pool, then region_pool mapping if it exists else to default_pools.",
@@ -96,6 +105,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				ElementType: types.ListType{
 					ElemType: types.StringType,
 				},
+				PlanModifiers: []planmodifier.Map{mapplanmodifier.UseStateForUnknown()},
 			},
 			"region_pools": schema.MapAttribute{
 				Description: "A mapping of region codes to a list of pool IDs (ordered by their failover priority) for the given region. Any regions not explicitly defined will fall back to using default_pools.",
@@ -106,6 +116,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				ElementType: types.ListType{
 					ElemType: types.StringType,
 				},
+				PlanModifiers: []planmodifier.Map{mapplanmodifier.UseStateForUnknown()},
 			},
 			"enabled": schema.BoolAttribute{
 				Description: "Whether to enable (the default) this load balancer.",
@@ -164,6 +175,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Default:     booldefault.StaticBool(false),
 					},
 				},
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 			},
 			"location_strategy": schema.SingleNestedAttribute{
 				Description: "Controls location-based steering for non-proxied requests. See `steering_policy` to learn how steering is affected.",
@@ -195,6 +207,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Default: stringdefault.StaticString("proximity"),
 					},
 				},
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 			},
 			"random_steering": schema.SingleNestedAttribute{
 				Description: "Configures pool weights.\n- `steering_policy=\"random\"`: A random pool is selected with probability proportional to pool weights.\n- `steering_policy=\"least_outstanding_requests\"`: Use pool weights to scale each pool's outstanding requests.\n- `steering_policy=\"least_connections\"`: Use pool weights to scale each pool's open connections.",
@@ -217,6 +230,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						ElementType: types.Float64Type,
 					},
 				},
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 			},
 			"rules": schema.ListNestedAttribute{
 				Description: "BETA Field Not General Access: A list of rules for this load balancer to execute.",
@@ -558,15 +572,19 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						// Default: stringdefault.StaticString("none"), // TODO: clean up schemas to remove this...or fix the service response
 					},
 				},
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 			},
 			"created_on": schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"modified_on": schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"zone_name": schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 	}

--- a/internal/services/load_balancer_pool/resource_test.go
+++ b/internal/services/load_balancer_pool/resource_test.go
@@ -174,6 +174,43 @@ func TestAccCloudflareLoadBalancerPool_Basic(t *testing.T) {
 	})
 }
 
+// TestAccCloudflareLoadBalancerPool_NoDrift verifies that a basic pool config
+// with no explicit values for load_shedding, notification_filter,
+// origin_steering, networks, modified_on, disabled_at, or per-origin port and
+// disabled_at does NOT produce drift on a no-op re-apply. This validates the
+// UseStateForUnknown plan modifiers added to those Computed attributes.
+//
+// CheckDestroy is intentionally omitted: the existing
+// testAccCheckCloudflareLoadBalancerPoolDestroy helper panics when its v1 SDK
+// client fails to initialize, which is unrelated to what this test validates.
+func TestAccCloudflareLoadBalancerPool_NoDrift(t *testing.T) {
+	t.Parallel()
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_load_balancer_pool." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create the pool.
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigBasic(rnd, accountID),
+			},
+			{
+				// Step 2: re-apply identical config; must be a no-op now that
+				// the Computed attributes carry UseStateForUnknown.
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigBasic(rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(name, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccCloudflareLoadBalancerPool_OriginSteeringLeastOutstandingRequests(t *testing.T) {
 	// multiple instances of this config would conflict but we only use it once
 	t.Parallel()

--- a/internal/services/load_balancer_pool/schema.go
+++ b/internal/services/load_balancer_pool/schema.go
@@ -14,6 +14,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -58,9 +61,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Optional:    true,
 						},
 						"disabled_at": schema.StringAttribute{
-							Description: "This field shows up only if the origin is disabled. This field is set with the time the origin was disabled.",
-							Computed:    true,
-							CustomType:  timetypes.RFC3339Type{},
+							Description:   "This field shows up only if the origin is disabled. This field is set with the time the origin was disabled.",
+							Computed:      true,
+							CustomType:    timetypes.RFC3339Type{},
+							PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 						},
 						"enabled": schema.BoolAttribute{
 							Description: "Whether to enable (the default) this origin within the pool. Disabled origins will not receive traffic and are excluded from health checks. The origin will only be disabled for the current pool.",
@@ -90,9 +94,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Optional:    true,
 						},
 						"port": schema.Int64Attribute{
-							Description: "The port for upstream connections. A value of 0 means the default port for the protocol will be used.",
-							Computed:    true,
-							Optional:    true,
+							Description:   "The port for upstream connections. A value of 0 means the default port for the protocol will be used.",
+							Computed:      true,
+							Optional:      true,
+							PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 							// Default:     int64default.StaticInt64(0),
 						},
 						"virtual_network_id": schema.StringAttribute{
@@ -219,6 +224,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Default: stringdefault.StaticString("hash"),
 					},
 				},
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 			},
 			"notification_filter": schema.SingleNestedAttribute{
 				Description: "Filter pool and origin health notifications by resource type or health status. Use null to reset.",
@@ -255,6 +261,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 					},
 				},
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 			},
 			"origin_steering": schema.SingleNestedAttribute{
 				Description: "Configures origin steering for the pool. Controls how origins are selected for new sessions and traffic without session affinity.",
@@ -277,6 +284,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Default: stringdefault.StaticString("random"),
 					},
 				},
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 			},
 			"created_on": schema.StringAttribute{
 				Computed: true,
@@ -285,18 +293,21 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"disabled_at": schema.StringAttribute{
-				Description: "This field shows up only if the pool is disabled. This field is set with the time the pool was disabled at.",
-				Computed:    true,
-				CustomType:  timetypes.RFC3339Type{},
+				Description:   "This field shows up only if the pool is disabled. This field is set with the time the pool was disabled at.",
+				Computed:      true,
+				CustomType:    timetypes.RFC3339Type{},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"modified_on": schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"networks": schema.ListAttribute{
-				Description: "List of networks where Load Balancer or Pool is enabled.",
-				Computed:    true,
-				CustomType:  customfield.NewListType[types.String](ctx),
-				ElementType: types.StringType,
+				Description:   "List of networks where Load Balancer or Pool is enabled.",
+				Computed:      true,
+				CustomType:    customfield.NewListType[types.String](ctx),
+				ElementType:   types.StringType,
+				PlanModifiers: []planmodifier.List{listplanmodifier.UseStateForUnknown()},
 			},
 		},
 	}


### PR DESCRIPTION
Computed and Optional+Computed attributes on cloudflare_load_balancer and cloudflare_load_balancer_pool currently lack UseStateForUnknown plan modifiers, so terraform plan re-marks them as (known after apply) on every refresh even when state matches the API. For nested objects, a single unset Computed sub-field cascades the parent to unknown, which makes peer fields surface as drift too. The result is recurring perma-drift on every plan/apply, masking real changes and producing tens of unnecessary attribute writes per LB per day on production setups.

cloudflare_load_balancer top-level: created_on, modified_on, zone_name, description, session_affinity_ttl, ttl, country_pools, networks, pop_pools, region_pools, adaptive_routing, location_strategy, random_steering, session_affinity_attributes.

cloudflare_load_balancer_pool top-level: modified_on, disabled_at, networks, load_shedding, notification_filter, origin_steering, plus per-origin disabled_at and port within origins[]. created_on already had the modifier.

Follows the same in-place schema.go edit pattern as PR #7027 for account_member (merged in 5.19.0).

Real-world consumer impact: a downstream Terraform consumer (Indeed) was seeing 17 in-place updates and 65 attribute changes on every scheduled apply of cloudflare-terraform main, despite no real config change. Their workaround required setting all Computed sub-fields explicitly to API defaults to break the cascade and adding lifecycle.ignore_changes for the residual server-only fields.

Refs: #7027

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Add `UseStateForUnknown` plan modifiers to Computed and Optional+Computed attributes on `cloudflare_load_balancer` and `cloudflare_load_balancer_pool` so terraform plan stops re-marking them as `(known after apply)` on every refresh.

For nested objects (`adaptive_routing`, `location_strategy`, `random_steering`, `session_affinity_attributes`, `load_shedding`, `notification_filter`, `origin_steering`), the modifier on the parent stops a single unset Computed sub-field from cascading the whole object to unknown.

For per-origin Computed sub-fields on `cloudflare_load_balancer_pool` (`disabled_at`, `port`), modifiers added inside the `origins[]` nested attribute schema.

Pattern matches PR #7027 (account_member, merged in 5.19.0): direct in-place edits to the generated `schema.go`, no new files or wrappers.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

```bash
export TF_ACC=1
export CLOUDFLARE_API_TOKEN=<token with Load Balancing: Edit on the test account>
export CLOUDFLARE_ACCOUNT_ID=<test account id>
export CLOUDFLARE_ZONE_ID=<test zone id>
export CLOUDFLARE_DOMAIN=<test zone hostname>

go test -count=1 -timeout 30m -v \
  -run 'TestAccCloudflareLoadBalancer_NoDrift|TestAccCloudflareLoadBalancerPool_NoDrift' \
  ./internal/services/load_balancer/ \
  ./internal/services/load_balancer_pool/
```

Each test creates a real LB or pool, runs a second apply with the identical config asserting `plancheck.ExpectResourceAction(Noop)`, then destroys the resource. Without the new plan modifiers, the second apply is a non-empty update due to the cascade and the `Noop` assertion fails.

`CheckDestroy` is intentionally omitted from `TestAccCloudflareLoadBalancerPool_NoDrift` because the existing `testAccCheckCloudflareLoadBalancerPoolDestroy` helper panics on a nil v1 SDK client when `acctest.SharedV1Client()` initialization fails. The actual destroy still runs via the test framework; only the post-destroy verification is skipped, and that verification is unrelated to what this test validates.

### Test output

Run against a real Cloudflare Enterprise account:

```
=== RUN   TestAccCloudflareLoadBalancer_NoDrift
--- PASS: TestAccCloudflareLoadBalancer_NoDrift (6.76s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/load_balancer    6.777s
=== RUN   TestAccCloudflareLoadBalancerPool_NoDrift
=== PAUSE TestAccCloudflareLoadBalancerPool_NoDrift
=== CONT  TestAccCloudflareLoadBalancerPool_NoDrift
--- PASS: TestAccCloudflareLoadBalancerPool_NoDrift (5.20s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/load_balancer_pool    5.216s
```

## Additional context & links

- #7027 (account_member UseStateForUnknown, merged in 5.19.0) — same pattern this PR follows
- #6580 (related general drift discussion)