### PR TITLE
feat(ai-gateway): add guardrails property to resource and data sources

### DIFF
--- a/internal/services/ai_gateway/data_source_model.go
+++ b/internal/services/ai_gateway/data_source_model.go
@@ -18,32 +18,33 @@ type AIGatewayResultDataSourceEnvelope struct {
 }
 
 type AIGatewayDataSourceModel struct {
-	ID                      types.String                                               `tfsdk:"id" path:"id,computed_optional"`
-	AccountID               types.String                                               `tfsdk:"account_id" path:"account_id,optional"`
-	Authentication          types.Bool                                                 `tfsdk:"authentication" json:"authentication,computed"`
-	CacheInvalidateOnUpdate types.Bool                                                 `tfsdk:"cache_invalidate_on_update" json:"cache_invalidate_on_update,computed"`
-	CacheTTL                types.Int64                                                `tfsdk:"cache_ttl" json:"cache_ttl,computed"`
-	CollectLogs             types.Bool                                                 `tfsdk:"collect_logs" json:"collect_logs,computed"`
-	CreatedAt               timetypes.RFC3339                                          `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
-	IsDefault               types.Bool                                                 `tfsdk:"is_default" json:"is_default,computed"`
-	LogManagement           types.Int64                                                `tfsdk:"log_management" json:"log_management,computed"`
-	LogManagementStrategy   types.String                                               `tfsdk:"log_management_strategy" json:"log_management_strategy,computed"`
-	Logpush                 types.Bool                                                 `tfsdk:"logpush" json:"logpush,computed"`
-	LogpushPublicKey        types.String                                               `tfsdk:"logpush_public_key" json:"logpush_public_key,computed"`
-	ModifiedAt              timetypes.RFC3339                                          `tfsdk:"modified_at" json:"modified_at,computed" format:"date-time"`
-	RateLimitingInterval    types.Int64                                                `tfsdk:"rate_limiting_interval" json:"rate_limiting_interval,computed"`
-	RateLimitingLimit       types.Int64                                                `tfsdk:"rate_limiting_limit" json:"rate_limiting_limit,computed"`
-	RateLimitingTechnique   types.String                                               `tfsdk:"rate_limiting_technique" json:"rate_limiting_technique,computed"`
-	RetryBackoff            types.String                                               `tfsdk:"retry_backoff" json:"retry_backoff,computed"`
-	RetryDelay              types.Int64                                                `tfsdk:"retry_delay" json:"retry_delay,computed"`
-	RetryMaxAttempts        types.Int64                                                `tfsdk:"retry_max_attempts" json:"retry_max_attempts,computed"`
-	StoreID                 types.String                                               `tfsdk:"store_id" json:"store_id,computed"`
-	WorkersAIBillingMode    types.String                                               `tfsdk:"workers_ai_billing_mode" json:"workers_ai_billing_mode,computed"`
-	Zdr                     types.Bool                                                 `tfsdk:"zdr" json:"zdr,computed"`
-	DLP                     customfield.NestedObject[AIGatewayDLPDataSourceModel]      `tfsdk:"dlp" json:"dlp,computed"`
-	Otel                    customfield.NestedObjectList[AIGatewayOtelDataSourceModel] `tfsdk:"otel" json:"otel,computed"`
-	Stripe                  customfield.NestedObject[AIGatewayStripeDataSourceModel]   `tfsdk:"stripe" json:"stripe,computed"`
-	Filter                  *AIGatewayFindOneByDataSourceModel                         `tfsdk:"filter"`
+	ID                      types.String                                                 `tfsdk:"id" path:"id,computed_optional"`
+	AccountID               types.String                                                 `tfsdk:"account_id" path:"account_id,optional"`
+	Authentication          types.Bool                                                   `tfsdk:"authentication" json:"authentication,computed"`
+	CacheInvalidateOnUpdate types.Bool                                                   `tfsdk:"cache_invalidate_on_update" json:"cache_invalidate_on_update,computed"`
+	CacheTTL                types.Int64                                                  `tfsdk:"cache_ttl" json:"cache_ttl,computed"`
+	CollectLogs             types.Bool                                                   `tfsdk:"collect_logs" json:"collect_logs,computed"`
+	CreatedAt               timetypes.RFC3339                                            `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
+	IsDefault               types.Bool                                                   `tfsdk:"is_default" json:"is_default,computed"`
+	LogManagement           types.Int64                                                  `tfsdk:"log_management" json:"log_management,computed"`
+	LogManagementStrategy   types.String                                                 `tfsdk:"log_management_strategy" json:"log_management_strategy,computed"`
+	Logpush                 types.Bool                                                   `tfsdk:"logpush" json:"logpush,computed"`
+	LogpushPublicKey        types.String                                                 `tfsdk:"logpush_public_key" json:"logpush_public_key,computed"`
+	ModifiedAt              timetypes.RFC3339                                            `tfsdk:"modified_at" json:"modified_at,computed" format:"date-time"`
+	RateLimitingInterval    types.Int64                                                  `tfsdk:"rate_limiting_interval" json:"rate_limiting_interval,computed"`
+	RateLimitingLimit       types.Int64                                                  `tfsdk:"rate_limiting_limit" json:"rate_limiting_limit,computed"`
+	RateLimitingTechnique   types.String                                                 `tfsdk:"rate_limiting_technique" json:"rate_limiting_technique,computed"`
+	RetryBackoff            types.String                                                 `tfsdk:"retry_backoff" json:"retry_backoff,computed"`
+	RetryDelay              types.Int64                                                  `tfsdk:"retry_delay" json:"retry_delay,computed"`
+	RetryMaxAttempts        types.Int64                                                  `tfsdk:"retry_max_attempts" json:"retry_max_attempts,computed"`
+	StoreID                 types.String                                                 `tfsdk:"store_id" json:"store_id,computed"`
+	WorkersAIBillingMode    types.String                                                 `tfsdk:"workers_ai_billing_mode" json:"workers_ai_billing_mode,computed"`
+	Zdr                     types.Bool                                                   `tfsdk:"zdr" json:"zdr,computed"`
+	DLP                     customfield.NestedObject[AIGatewayDLPDataSourceModel]        `tfsdk:"dlp" json:"dlp,computed"`
+	Guardrails              customfield.NestedObject[AIGatewayGuardrailsDataSourceModel] `tfsdk:"guardrails" json:"guardrails,computed"`
+	Otel                    customfield.NestedObjectList[AIGatewayOtelDataSourceModel]   `tfsdk:"otel" json:"otel,computed"`
+	Stripe                  customfield.NestedObject[AIGatewayStripeDataSourceModel]     `tfsdk:"stripe" json:"stripe,computed"`
+	Filter                  *AIGatewayFindOneByDataSourceModel                           `tfsdk:"filter"`
 }
 
 func (m *AIGatewayDataSourceModel) toReadParams(_ context.Context) (params ai_gateway.AIGatewayGetParams, diags diag.Diagnostics) {
@@ -82,6 +83,11 @@ type AIGatewayDLPPoliciesDataSourceModel struct {
 	Check    customfield.List[types.String] `tfsdk:"check" json:"check,computed"`
 	Enabled  types.Bool                     `tfsdk:"enabled" json:"enabled,computed"`
 	Profiles customfield.List[types.String] `tfsdk:"profiles" json:"profiles,computed"`
+}
+
+type AIGatewayGuardrailsDataSourceModel struct {
+	Prompt   customfield.Map[types.String] `tfsdk:"prompt" json:"prompt,computed"`
+	Response customfield.Map[types.String] `tfsdk:"response" json:"response,computed"`
 }
 
 type AIGatewayOtelDataSourceModel struct {

--- a/internal/services/ai_gateway/data_source_schema.go
+++ b/internal/services/ai_gateway/data_source_schema.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -193,6 +194,34 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 									ElementType: types.StringType,
 								},
 							},
+						},
+					},
+				},
+			},
+			"guardrails": schema.SingleNestedAttribute{
+				Computed:   true,
+				CustomType: customfield.NewNestedObjectType[AIGatewayGuardrailsDataSourceModel](ctx),
+				Attributes: map[string]schema.Attribute{
+					"prompt": schema.MapAttribute{
+						Description: `Map of hazard codes (e.g. "S1", "P1") to actions. Available values: "BLOCK", "FLAG".`,
+						Computed:    true,
+						CustomType:  customfield.NewMapType[types.String](ctx),
+						ElementType: types.StringType,
+						Validators: []validator.Map{
+							mapvalidator.ValueStringsAre(
+								stringvalidator.OneOfCaseInsensitive("BLOCK", "FLAG"),
+							),
+						},
+					},
+					"response": schema.MapAttribute{
+						Description: `Map of hazard codes (e.g. "S1", "P1") to actions. Available values: "BLOCK", "FLAG".`,
+						Computed:    true,
+						CustomType:  customfield.NewMapType[types.String](ctx),
+						ElementType: types.StringType,
+						Validators: []validator.Map{
+							mapvalidator.ValueStringsAre(
+								stringvalidator.OneOfCaseInsensitive("BLOCK", "FLAG"),
+							),
 						},
 					},
 				},

--- a/internal/services/ai_gateway/list_data_source_model.go
+++ b/internal/services/ai_gateway/list_data_source_model.go
@@ -38,30 +38,31 @@ func (m *AIGatewaysDataSourceModel) toListParams(_ context.Context) (params ai_g
 }
 
 type AIGatewaysResultDataSourceModel struct {
-	ID                      types.String                                                `tfsdk:"id" json:"id,computed"`
-	CacheInvalidateOnUpdate types.Bool                                                  `tfsdk:"cache_invalidate_on_update" json:"cache_invalidate_on_update,computed"`
-	CacheTTL                types.Int64                                                 `tfsdk:"cache_ttl" json:"cache_ttl,computed"`
-	CollectLogs             types.Bool                                                  `tfsdk:"collect_logs" json:"collect_logs,computed"`
-	CreatedAt               timetypes.RFC3339                                           `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
-	ModifiedAt              timetypes.RFC3339                                           `tfsdk:"modified_at" json:"modified_at,computed" format:"date-time"`
-	RateLimitingInterval    types.Int64                                                 `tfsdk:"rate_limiting_interval" json:"rate_limiting_interval,computed"`
-	RateLimitingLimit       types.Int64                                                 `tfsdk:"rate_limiting_limit" json:"rate_limiting_limit,computed"`
-	Authentication          types.Bool                                                  `tfsdk:"authentication" json:"authentication,computed"`
-	DLP                     customfield.NestedObject[AIGatewaysDLPDataSourceModel]      `tfsdk:"dlp" json:"dlp,computed"`
-	IsDefault               types.Bool                                                  `tfsdk:"is_default" json:"is_default,computed"`
-	LogManagement           types.Int64                                                 `tfsdk:"log_management" json:"log_management,computed"`
-	LogManagementStrategy   types.String                                                `tfsdk:"log_management_strategy" json:"log_management_strategy,computed"`
-	Logpush                 types.Bool                                                  `tfsdk:"logpush" json:"logpush,computed"`
-	LogpushPublicKey        types.String                                                `tfsdk:"logpush_public_key" json:"logpush_public_key,computed"`
-	Otel                    customfield.NestedObjectList[AIGatewaysOtelDataSourceModel] `tfsdk:"otel" json:"otel,computed"`
-	RateLimitingTechnique   types.String                                                `tfsdk:"rate_limiting_technique" json:"rate_limiting_technique,computed"`
-	RetryBackoff            types.String                                                `tfsdk:"retry_backoff" json:"retry_backoff,computed"`
-	RetryDelay              types.Int64                                                 `tfsdk:"retry_delay" json:"retry_delay,computed"`
-	RetryMaxAttempts        types.Int64                                                 `tfsdk:"retry_max_attempts" json:"retry_max_attempts,computed"`
-	StoreID                 types.String                                                `tfsdk:"store_id" json:"store_id,computed"`
-	Stripe                  customfield.NestedObject[AIGatewaysStripeDataSourceModel]   `tfsdk:"stripe" json:"stripe,computed"`
-	WorkersAIBillingMode    types.String                                                `tfsdk:"workers_ai_billing_mode" json:"workers_ai_billing_mode,computed"`
-	Zdr                     types.Bool                                                  `tfsdk:"zdr" json:"zdr,computed"`
+	ID                      types.String                                                  `tfsdk:"id" json:"id,computed"`
+	CacheInvalidateOnUpdate types.Bool                                                    `tfsdk:"cache_invalidate_on_update" json:"cache_invalidate_on_update,computed"`
+	CacheTTL                types.Int64                                                   `tfsdk:"cache_ttl" json:"cache_ttl,computed"`
+	CollectLogs             types.Bool                                                    `tfsdk:"collect_logs" json:"collect_logs,computed"`
+	CreatedAt               timetypes.RFC3339                                             `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
+	ModifiedAt              timetypes.RFC3339                                             `tfsdk:"modified_at" json:"modified_at,computed" format:"date-time"`
+	RateLimitingInterval    types.Int64                                                   `tfsdk:"rate_limiting_interval" json:"rate_limiting_interval,computed"`
+	RateLimitingLimit       types.Int64                                                   `tfsdk:"rate_limiting_limit" json:"rate_limiting_limit,computed"`
+	Authentication          types.Bool                                                    `tfsdk:"authentication" json:"authentication,computed"`
+	DLP                     customfield.NestedObject[AIGatewaysDLPDataSourceModel]        `tfsdk:"dlp" json:"dlp,computed"`
+	Guardrails              customfield.NestedObject[AIGatewaysGuardrailsDataSourceModel] `tfsdk:"guardrails" json:"guardrails,computed"`
+	IsDefault               types.Bool                                                    `tfsdk:"is_default" json:"is_default,computed"`
+	LogManagement           types.Int64                                                   `tfsdk:"log_management" json:"log_management,computed"`
+	LogManagementStrategy   types.String                                                  `tfsdk:"log_management_strategy" json:"log_management_strategy,computed"`
+	Logpush                 types.Bool                                                    `tfsdk:"logpush" json:"logpush,computed"`
+	LogpushPublicKey        types.String                                                  `tfsdk:"logpush_public_key" json:"logpush_public_key,computed"`
+	Otel                    customfield.NestedObjectList[AIGatewaysOtelDataSourceModel]   `tfsdk:"otel" json:"otel,computed"`
+	RateLimitingTechnique   types.String                                                  `tfsdk:"rate_limiting_technique" json:"rate_limiting_technique,computed"`
+	RetryBackoff            types.String                                                  `tfsdk:"retry_backoff" json:"retry_backoff,computed"`
+	RetryDelay              types.Int64                                                   `tfsdk:"retry_delay" json:"retry_delay,computed"`
+	RetryMaxAttempts        types.Int64                                                   `tfsdk:"retry_max_attempts" json:"retry_max_attempts,computed"`
+	StoreID                 types.String                                                  `tfsdk:"store_id" json:"store_id,computed"`
+	Stripe                  customfield.NestedObject[AIGatewaysStripeDataSourceModel]     `tfsdk:"stripe" json:"stripe,computed"`
+	WorkersAIBillingMode    types.String                                                  `tfsdk:"workers_ai_billing_mode" json:"workers_ai_billing_mode,computed"`
+	Zdr                     types.Bool                                                    `tfsdk:"zdr" json:"zdr,computed"`
 }
 
 type AIGatewaysDLPDataSourceModel struct {
@@ -77,6 +78,11 @@ type AIGatewaysDLPPoliciesDataSourceModel struct {
 	Check    customfield.List[types.String] `tfsdk:"check" json:"check,computed"`
 	Enabled  types.Bool                     `tfsdk:"enabled" json:"enabled,computed"`
 	Profiles customfield.List[types.String] `tfsdk:"profiles" json:"profiles,computed"`
+}
+
+type AIGatewaysGuardrailsDataSourceModel struct {
+	Prompt   customfield.Map[types.String] `tfsdk:"prompt" json:"prompt,computed"`
+	Response customfield.Map[types.String] `tfsdk:"response" json:"response,computed"`
 }
 
 type AIGatewaysOtelDataSourceModel struct {

--- a/internal/services/ai_gateway/list_data_source_schema.go
+++ b/internal/services/ai_gateway/list_data_source_schema.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -140,6 +141,34 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 												ElementType: types.StringType,
 											},
 										},
+									},
+								},
+							},
+						},
+						"guardrails": schema.SingleNestedAttribute{
+							Computed:   true,
+							CustomType: customfield.NewNestedObjectType[AIGatewaysGuardrailsDataSourceModel](ctx),
+							Attributes: map[string]schema.Attribute{
+								"prompt": schema.MapAttribute{
+									Description: `Map of hazard codes (e.g. "S1", "P1") to actions. Available values: "BLOCK", "FLAG".`,
+									Computed:    true,
+									CustomType:  customfield.NewMapType[types.String](ctx),
+									ElementType: types.StringType,
+									Validators: []validator.Map{
+										mapvalidator.ValueStringsAre(
+											stringvalidator.OneOfCaseInsensitive("BLOCK", "FLAG"),
+										),
+									},
+								},
+								"response": schema.MapAttribute{
+									Description: `Map of hazard codes (e.g. "S1", "P1") to actions. Available values: "BLOCK", "FLAG".`,
+									Computed:    true,
+									CustomType:  customfield.NewMapType[types.String](ctx),
+									ElementType: types.StringType,
+									Validators: []validator.Map{
+										mapvalidator.ValueStringsAre(
+											stringvalidator.OneOfCaseInsensitive("BLOCK", "FLAG"),
+										),
 									},
 								},
 							},

--- a/internal/services/ai_gateway/model.go
+++ b/internal/services/ai_gateway/model.go
@@ -33,6 +33,7 @@ type AIGatewayModel struct {
 	StoreID                 types.String                                     `tfsdk:"store_id" json:"store_id,optional"`
 	Zdr                     types.Bool                                       `tfsdk:"zdr" json:"zdr,optional"`
 	DLP                     *AIGatewayDLPModel                               `tfsdk:"dlp" json:"dlp,optional"`
+	Guardrails              *AIGatewayGuardrailsModel                        `tfsdk:"guardrails" json:"guardrails,optional"`
 	Stripe                  *AIGatewayStripeModel                            `tfsdk:"stripe" json:"stripe,optional"`
 	WorkersAIBillingMode    types.String                                     `tfsdk:"workers_ai_billing_mode" json:"workers_ai_billing_mode,computed_optional"`
 	Otel                    customfield.NestedObjectList[AIGatewayOtelModel] `tfsdk:"otel" json:"otel,computed_optional"`
@@ -62,6 +63,11 @@ type AIGatewayDLPPoliciesModel struct {
 	Check    *[]types.String `tfsdk:"check" json:"check,required"`
 	Enabled  types.Bool      `tfsdk:"enabled" json:"enabled,required"`
 	Profiles *[]types.String `tfsdk:"profiles" json:"profiles,required"`
+}
+
+type AIGatewayGuardrailsModel struct {
+	Prompt   *map[string]types.String `tfsdk:"prompt" json:"prompt,optional"`
+	Response *map[string]types.String `tfsdk:"response" json:"response,optional"`
 }
 
 type AIGatewayStripeModel struct {

--- a/internal/services/ai_gateway/schema.go
+++ b/internal/services/ai_gateway/schema.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -172,6 +173,31 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									ElementType: types.StringType,
 								},
 							},
+						},
+					},
+				},
+			},
+			"guardrails": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"prompt": schema.MapAttribute{
+						Description: `Map of hazard codes (e.g. "S1", "P1") to actions. Available values: "BLOCK", "FLAG".`,
+						Optional:    true,
+						ElementType: types.StringType,
+						Validators: []validator.Map{
+							mapvalidator.ValueStringsAre(
+								stringvalidator.OneOfCaseInsensitive("BLOCK", "FLAG"),
+							),
+						},
+					},
+					"response": schema.MapAttribute{
+						Description: `Map of hazard codes (e.g. "S1", "P1") to actions. Available values: "BLOCK", "FLAG".`,
+						Optional:    true,
+						ElementType: types.StringType,
+						Validators: []validator.Map{
+							mapvalidator.ValueStringsAre(
+								stringvalidator.OneOfCaseInsensitive("BLOCK", "FLAG"),
+							),
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Add `guardrails` property to the `cloudflare_ai_gateway` resource, single data source (`cloudflare_ai_gateway`), and list data source (`cloudflare_ai_gateways`), mirroring the pattern used by the existing `dlp` field.

### What changed
- `guardrails` is a `SingleNestedAttribute` (optional on the resource, computed on data sources)
- It contains two `MapAttribute` fields - `prompt` and `response` - each mapping hazard codes (e.g. `S1`-`S13`, `P1`) to an action string (`"BLOCK"` or `"FLAG"`)
- The map shape matches the Cloudflare API payload directly; using a map instead of fixed per-code fields means new hazard codes added by Cloudflare are automatically supported without a provider release
- `mapvalidator.ValueStringsAre` enforces the `BLOCK`/`FLAG` enum on all values

### Files changed
| File | Change |
|---|---|
| `internal/services/ai_gateway/schema.go` | Add `guardrails` `SingleNestedAttribute` with `mapvalidator` |
| `internal/services/ai_gateway/model.go` | Add `AIGatewayGuardrailsModel` struct and field on `AIGatewayModel` |
| `internal/services/ai_gateway/data_source_schema.go` | Add computed `guardrails` attribute |
| `internal/services/ai_gateway/data_source_model.go` | Add `AIGatewayGuardrailsDataSourceModel` and field |
| `internal/services/ai_gateway/list_data_source_schema.go` | Add computed `guardrails` attribute |
| `internal/services/ai_gateway/list_data_source_model.go` | Add `AIGatewaysGuardrailsDataSourceModel` and field |

### Example HCL
```hcl
resource "cloudflare_ai_gateway" "example" {
  account_id = var.account_id
  id         = "my-gateway"
  # ... other fields ...
  guardrails = {
    prompt = {
      S1  = "BLOCK"
      S2  = "BLOCK"
      S6  = "FLAG"
      P1  = "FLAG"
    }
    response = {
      S1  = "BLOCK"
      S2  = "BLOCK"
      P1  = "FLAG"
    }
  }
}
```

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
pre-existing test suite

### Test output
All schema parity tests pass locally:
```
=== RUN   TestAIGatewayModelSchemaParity
--- PASS: TestAIGatewayModelSchemaParity (0.00s)
=== RUN   TestAIGatewayDataSourceModelSchemaParity
--- PASS: TestAIGatewayDataSourceModelSchemaParity (0.00s)
=== RUN   TestAIGatewaysDataSourceModelSchemaParity
--- PASS: TestAIGatewaysDataSourceModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/ai_gateway	0.564s
```

## Additional context & links
- Cloudflare AI Gateway API payload reference for `guardrails`:
  ```json
  "guardrails": {
    "prompt":   { "S1": "BLOCK", "S2": "BLOCK", "S6": "FLAG", "P1": "FLAG" },
    "response": { "S1": "BLOCK", "P1": "FLAG" }
  }
  ```
- The write path is not blocked by `cloudflare-go/v6` v6.10.0 lacking `Guardrails` on its typed params — the resource serialises the request body via `apijson.MarshalRoot` on the tfsdk model directly, bypassing the SDK's param structs entirely.