### PR TITLE
fix(zero_trust_gateway_policy): remove Computed from user-configurabl…

### DIFF
--- a/internal/services/zero_trust_gateway_policy/custom_schema.go
+++ b/internal/services/zero_trust_gateway_policy/custom_schema.go
@@ -1,0 +1,58 @@
+package zero_trust_gateway_policy
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// customResourceSchema wraps the generated ResourceSchema and removes the
+// Computed flag from user-configurable rule_settings sub-fields.
+//
+// The generated schema marks these fields as Computed+Optional because they
+// appear in both the API request and response schemas. However, they are not
+// server-computed — the API returns what the user set, or null when unset.
+// The Computed flag causes Terraform to mark them unknown on every update,
+// producing noisy plans with (known after apply) on unrelated changes.
+//
+// Removing Computed makes Terraform treat them as Optional-only: the plan
+// uses the config value (or null) directly, with no unknown marking.
+func customResourceSchema(ctx context.Context) schema.Schema {
+	s := ResourceSchema(ctx)
+
+	rs := s.Attributes["rule_settings"].(schema.SingleNestedAttribute)
+	removeBoolComputed(rs.Attributes, "allow_child_bypass")
+	removeBoolComputed(rs.Attributes, "block_page_enabled")
+	removeStringComputed(rs.Attributes, "block_reason")
+	removeBoolComputed(rs.Attributes, "ignore_cname_category_matches")
+	removeBoolComputed(rs.Attributes, "insecure_disable_dnssec_validation")
+	removeBoolComputed(rs.Attributes, "ip_categories")
+	removeBoolComputed(rs.Attributes, "ip_indicator_feeds")
+	removeStringComputed(rs.Attributes, "override_host")
+	removeListComputed(rs.Attributes, "override_ips")
+	removeBoolComputed(rs.Attributes, "resolve_dns_through_cloudflare")
+	s.Attributes["rule_settings"] = rs
+
+	return s
+}
+
+func removeBoolComputed(attrs map[string]schema.Attribute, name string) {
+	if a, ok := attrs[name].(schema.BoolAttribute); ok {
+		a.Computed = false
+		attrs[name] = a
+	}
+}
+
+func removeStringComputed(attrs map[string]schema.Attribute, name string) {
+	if a, ok := attrs[name].(schema.StringAttribute); ok {
+		a.Computed = false
+		attrs[name] = a
+	}
+}
+
+func removeListComputed(attrs map[string]schema.Attribute, name string) {
+	if a, ok := attrs[name].(schema.ListAttribute); ok {
+		a.Computed = false
+		attrs[name] = a
+	}
+}

--- a/internal/services/zero_trust_gateway_policy/schema.go
+++ b/internal/services/zero_trust_gateway_policy/schema.go
@@ -626,7 +626,7 @@ Version: 500,
 }
 
 func (r *ZeroTrustGatewayPolicyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = ResourceSchema(ctx)
+	resp.Schema = customResourceSchema(ctx)
 }
 
 func (r *ZeroTrustGatewayPolicyResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {


### PR DESCRIPTION

## Changes being requested
Removes the `Computed` flag from user-configurable `rule_settings` sub-fields that cause `(known after apply)` permadiffs on every `terraform plan` when any unrelated field changes.

Changing any field (e.g. `description`) on a `cloudflare_zero_trust_gateway_policy` resource causes 10 `rule_settings` sub-fields to show `(known after apply)`, making plans noisy and blocking effective infrastructure-as-code workflows. Customers report this affects all gateway policies managed via Terraform.

Reproduction:

```hcl
resource "cloudflare_zero_trust_gateway_policy" "example" {
  account_id  = var.account_id
  action      = "allow"
  name        = "terraform policy"
  description = "This policy is managed by Terraform"
  enabled     = false
  filters     = ["http"]
  precedence  = 5000
  rule_settings = {
    add_headers = {
      X-Custom-Header-Name = ["value"]
    }
  }
  traffic = "http.request.uri matches \".*a/partial/uri.*\""
}
```

Make a minor change (e.g. edit `description`) and run `terraform plan`:

```
  ~ resource "cloudflare_zero_trust_gateway_policy" "example" {
      ~ description    = "..." -> "..."
      ~ rule_settings  = {
          + allow_child_bypass                 = (known after apply)
          + block_page_enabled                 = (known after apply)
          + block_reason                       = (known after apply)
          + ignore_cname_category_matches      = (known after apply)
          + insecure_disable_dnssec_validation = (known after apply)
          + ip_categories                      = (known after apply)
          + ip_indicator_feeds                 = (known after apply)
          + override_host                      = (known after apply)
          + override_ips                       = (known after apply)
          + resolve_dns_through_cloudflare     = (known after apply)
            # (1 unchanged attribute hidden)
        }
    }
```

Root cause:

The generated schema marks these fields as `Computed+Optional` because they appear in both the API request and response schemas. However, they are not server-computed, the API returns what the user set, or null when unset. The `Computed` flag causes Terraform to mark them unknown on every update, producing the permadiff.

Adds a `custom_schema.go` wrapper (same pattern as `magic_wan_ipsec_tunnel`, `magic_wan_gre_tunnel`, `magic_wan_static_route`) that removes `Computed` from the 10 user-configurable `rule_settings` sub-fields. This makes Terraform treat them as `Optional`-only: the plan uses the config value (or null) directly, with no unknown marking.

[UseStateForUnknown](https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification) doesn't solve this because it copies the prior state value into the plan. When that value is null (field never set), the permadiff remains.

After fix:

```
  ~ resource "cloudflare_zero_trust_gateway_policy" "example" {
      ~ description    = "..." -> "..."
        # (N unchanged attributes hidden)
    }
```

The `rule_settings` block is completely absent from the diff.

Note: some top-level server-computed fields (`deleted_at`, `version`, etc.) still show `(known after apply)`. These are genuinely server-owned.

Fields changed:

All within `rule_settings`:

| Field | Before | After |
|---|---|---|
| `allow_child_bypass` | `Computed+Optional` | `Optional` | 
| `block_page_enabled` | `Computed+Optional` | `Optional` | 
| `block_reason` | `Computed+Optional` | `Optional` | 
| `ignore_cname_category_matches` | `Computed+Optional` | `Optional` | 
| `insecure_disable_dnssec_validation` | `Computed+Optional` | `Optional` | 
| `ip_categories` | `Computed+Optional` | `Optional` | 
| `ip_indicator_feeds` | `Computed+Optional` | `Optional` | 
| `override_host` | `Computed+Optional` | `Optional` | 
| `override_ips` | `Computed+Optional` | `Optional` | 
| `resolve_dns_through_cloudflare` | `Computed+Optional` | `Optional` |

Tested locally with `dev_overrides` against a live Cloudflare account:
1. Created a gateway policy with `rule_settings`
2. Changed `description` and ran `terraform plan`
3. Before fix: 10 `rule_settings` fields show `(known after apply)`
4. After fix: `rule_settings` absent from diff entirely

- Same `custom_schema.go` pattern: #6364 (`zero_trust_device_custom_profile`), #6759 (`zero_trust_device_default_profile`)
- Related (closed, not merged): #7045

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged