### PR TITLE
Declare permissions on the remaining 6 workflows

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - "release-please**"
 
+permissions:
+  contents: read
+
 env:
   CLOUDFLARE_ACCOUNT_ID: f037e56e89293a057740de681ac9abbe
   CLOUDFLARE_ALT_DOMAIN: terraform-alt.cfapi.net

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -5,6 +5,10 @@ on:
     types:
       - opened
 
+# The project mutation uses secrets.ADD_TO_PROJECT_PAT (a separate PAT),
+# not GITHUB_TOKEN. Deny everything for the default token.
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add issue to project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
 env:
   GOPRIVATE: github.com/cloudflare/cloudflare-go/v6,github.com/stainless-sdks/cloudflare-go/v6
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-terraform' && 'depot-ubuntu-24.04' || 'lx64' }}

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - "release-please**"
 
+# gh release download from cloudflare/tf-migrate uses github.token (contents: read).
+permissions:
+  contents: read
+
 env:
   CLOUDFLARE_ACCOUNT_ID: f037e56e89293a057740de681ac9abbe
   CLOUDFLARE_ALT_DOMAIN: terraform-alt.cfapi.net

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -5,6 +5,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release_doctor:
     name: release doctor

--- a/.github/workflows/trigger-terraform-registry-sync.yml
+++ b/.github/workflows/trigger-terraform-registry-sync.yml
@@ -2,6 +2,9 @@ name: Trigger Terraform Registry sync
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   trigger-terraform-registry-sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` for the six workflows still inheriting defaults. Per-workflow rationale:

| Workflow | Scope | Why |
|----------|-------|-----|
| `ci.yml` | `contents: read` | lint + go test matrix; no API writes |
| `acceptance-tests.yml` | `contents: read` | Terraform acceptance matrix; auth via `CLOUDFLARE_API_KEY` per-test secret |
| `migration-tests.yml` | `contents: read` | Terraform migration matrix; downloads cf/tf-migrate release via `gh release download` (read-only) |
| `release-doctor.yml` | `contents: read` | runs `scripts/check-release-environment` with `GPG_PRIVATE_KEY` |
| `trigger-terraform-registry-sync.yml` | `contents: read` | `./scripts/trigger-terraform-registry-sync` posts to the Terraform registry with `TERRAFORM_REGISTRY_COOKIE` |
| `add-to-project.yml` | `permissions: {}` | `actions/add-to-project` uses `secrets.ADD_TO_PROJECT_PAT` for the GraphQL mutation; the default token is unused |

`publish-release.yml` and `semgrep.yml` were already hardened. YAML validated locally for each file.