### PR TITLE
feat: add acceptance tests for virtual_networks on zero_trust_device_custom_profile

### DIFF
--- a/internal/services/zero_trust_device_custom_profile/resource_test.go
+++ b/internal/services/zero_trust_device_custom_profile/resource_test.go
@@ -244,6 +244,57 @@ func TestAccCloudflareZeroTrustDeviceCustomProfile_ServiceMode(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareZeroTrustDeviceCustomProfile_VirtualNetworks(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_device_custom_profile.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	randomPrecedence := rand.Intn(250)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustDeviceCustomProfileDestroy,
+		Steps: []resource.TestStep{
+			// Create with virtual_networks (2 allowed, default = vnet1)
+			{
+				Config: testAccCloudflareZeroTrustDeviceCustomProfileWithVirtualNetworks(accountID, rnd, randomPrecedence),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("virtual_networks").AtMapKey("allowed"), knownvalue.ListSizeExact(2)),
+				},
+			},
+			// Refresh produces no plan changes
+			{
+				Config: testAccCloudflareZeroTrustDeviceCustomProfileWithVirtualNetworks(accountID, rnd, randomPrecedence),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			// Update virtual_networks (shrink allowed to 1, rotate default to vnet2)
+			{
+				Config: testAccCloudflareZeroTrustDeviceCustomProfileWithVirtualNetworksUpdated(accountID, rnd, randomPrecedence),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("virtual_networks").AtMapKey("allowed"), knownvalue.ListSizeExact(1)),
+				},
+			},
+			// Import
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"exclude", "include"},
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
 func testAccCheckCloudflareZeroTrustDeviceCustomProfileDestroy(s *terraform.State) error {
 	client := acctest.SharedClient()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
@@ -290,4 +341,12 @@ func testAccCloudflareZeroTrustDeviceCustomProfileWithInclude(accountID, rnd str
 
 func testAccCloudflareZeroTrustDeviceCustomProfileWithServiceMode(accountID, rnd string, precedence int) string {
 	return acctest.LoadTestCase("devicecustomprofilewithservicemode.tf", rnd, accountID, precedence)
+}
+
+func testAccCloudflareZeroTrustDeviceCustomProfileWithVirtualNetworks(accountID, rnd string, precedence int) string {
+	return acctest.LoadTestCase("devicecustomprofilewithvirtualnetworks.tf", rnd, accountID, precedence)
+}
+
+func testAccCloudflareZeroTrustDeviceCustomProfileWithVirtualNetworksUpdated(accountID, rnd string, precedence int) string {
+	return acctest.LoadTestCase("devicecustomprofilewithvirtualnetworksupdated.tf", rnd, accountID, precedence)
 }

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithvirtualnetworks.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithvirtualnetworks.tf
@@ -1,0 +1,30 @@
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "%[1]s_vnet1" {
+  account_id         = "%[2]s"
+  name               = "%[1]s-vnet1"
+  comment            = "acctest vnet 1"
+  is_default_network = false
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "%[1]s_vnet2" {
+  account_id         = "%[2]s"
+  name               = "%[1]s-vnet2"
+  comment            = "acctest vnet 2"
+  is_default_network = false
+}
+
+resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "%[1]s"
+  match       = "identity.email == \"test@example.com\""
+  precedence  = %[3]d
+  enabled     = true
+  description = "Custom profile with virtual_networks"
+
+  virtual_networks = {
+    allowed = [
+      cloudflare_zero_trust_tunnel_cloudflared_virtual_network.%[1]s_vnet1.id,
+      cloudflare_zero_trust_tunnel_cloudflared_virtual_network.%[1]s_vnet2.id,
+    ]
+    default = cloudflare_zero_trust_tunnel_cloudflared_virtual_network.%[1]s_vnet1.id
+  }
+}

--- a/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithvirtualnetworksupdated.tf
+++ b/internal/services/zero_trust_device_custom_profile/testdata/devicecustomprofilewithvirtualnetworksupdated.tf
@@ -1,0 +1,29 @@
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "%[1]s_vnet1" {
+  account_id         = "%[2]s"
+  name               = "%[1]s-vnet1"
+  comment            = "acctest vnet 1"
+  is_default_network = false
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_virtual_network" "%[1]s_vnet2" {
+  account_id         = "%[2]s"
+  name               = "%[1]s-vnet2"
+  comment            = "acctest vnet 2"
+  is_default_network = false
+}
+
+resource "cloudflare_zero_trust_device_custom_profile" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "%[1]s"
+  match       = "identity.email == \"test@example.com\""
+  precedence  = %[3]d
+  enabled     = true
+  description = "Custom profile with virtual_networks"
+
+  virtual_networks = {
+    allowed = [
+      cloudflare_zero_trust_tunnel_cloudflared_virtual_network.%[1]s_vnet2.id,
+    ]
+    default = cloudflare_zero_trust_tunnel_cloudflared_virtual_network.%[1]s_vnet2.id
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Adds acceptance tests for `virtual_networks` on `zero_trust_device_custom_profile`

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
TF_ACC=1 go test -v ./internal/services/zero_trust_device_custom_profile/... -run 'TestAccCloudflareZeroTrustDeviceCustomProfile_VirtualNetworks'
=== RUN   TestAccCloudflareZeroTrustDeviceCustomProfile_VirtualNetworks
--- PASS: TestAccCloudflareZeroTrustDeviceCustomProfile_VirtualNetworks (14.84s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_device_custom_profile 14.84s

## Additional context & links

