### PR TITLE
fix: suppress plan drift for enable_binding_cookie, options_preflight_bypass, cors_headers on mcp type

### DIFF
--- a/internal/services/zero_trust_access_application/model.go
+++ b/internal/services/zero_trust_access_application/model.go
@@ -28,7 +28,7 @@ type ZeroTrustAccessApplicationModel struct {
 	HeaderBgColor               types.String                                                               `tfsdk:"header_bg_color" json:"header_bg_color,optional"`
 	LogoURL                     types.String                                                               `tfsdk:"logo_url" json:"logo_url,optional"`
 	Name                        types.String                                                               `tfsdk:"name" json:"name,computed_optional"`
-	OptionsPreflightBypass      types.Bool                                                                 `tfsdk:"options_preflight_bypass" json:"options_preflight_bypass,optional"`
+	OptionsPreflightBypass      types.Bool                                                                 `tfsdk:"options_preflight_bypass" json:"options_preflight_bypass,computed_optional"`
 	ReadServiceTokensFromHeader types.String                                                               `tfsdk:"read_service_tokens_from_header" json:"read_service_tokens_from_header,optional"`
 	SameSiteCookieAttribute     types.String                                                               `tfsdk:"same_site_cookie_attribute" json:"same_site_cookie_attribute,optional"`
 	ServiceAuth401Redirect      types.Bool                                                                 `tfsdk:"service_auth_401_redirect" json:"service_auth_401_redirect,optional"`
@@ -36,14 +36,14 @@ type ZeroTrustAccessApplicationModel struct {
 	Type                        types.String                                                               `tfsdk:"type" json:"type,computed_optional"`
 	AllowedIdPs                 *[]types.String                                                            `tfsdk:"allowed_idps" json:"allowed_idps,optional"`
 	CustomPages                 *[]types.String                                                            `tfsdk:"custom_pages" json:"custom_pages,optional"`
-	CORSHeaders                 *ZeroTrustAccessApplicationCORSHeadersModel                                `tfsdk:"cors_headers" json:"cors_headers,optional"`
+	CORSHeaders                 *ZeroTrustAccessApplicationCORSHeadersModel                                `tfsdk:"cors_headers" json:"cors_headers,computed_optional"`
 	FooterLinks                 *[]*ZeroTrustAccessApplicationFooterLinksModel                             `tfsdk:"footer_links" json:"footer_links,optional"`
 	OAuthConfiguration          *ZeroTrustAccessApplicationOAuthConfigurationModel                         `tfsdk:"oauth_configuration" json:"oauth_configuration,optional"`
 	SCIMConfig                  *ZeroTrustAccessApplicationSCIMConfigModel                                 `tfsdk:"scim_config" json:"scim_config,optional"`
 	TargetCriteria              *[]*ZeroTrustAccessApplicationTargetCriteriaModel                          `tfsdk:"target_criteria" json:"target_criteria,optional"`
 	AppLauncherVisible          types.Bool                                                                 `tfsdk:"app_launcher_visible" json:"app_launcher_visible,computed_optional"`
 	AutoRedirectToIdentity      types.Bool                                                                 `tfsdk:"auto_redirect_to_identity" json:"auto_redirect_to_identity,optional"`
-	EnableBindingCookie         types.Bool                                                                 `tfsdk:"enable_binding_cookie" json:"enable_binding_cookie,optional"`
+	EnableBindingCookie         types.Bool                                                                 `tfsdk:"enable_binding_cookie" json:"enable_binding_cookie,computed_optional"`
 	HTTPOnlyCookieAttribute     types.Bool                                                                 `tfsdk:"http_only_cookie_attribute" json:"http_only_cookie_attribute,computed_optional"`
 	PathCookieAttribute         types.Bool                                                                 `tfsdk:"path_cookie_attribute" json:"path_cookie_attribute,optional"`
 	SessionDuration             types.String                                                               `tfsdk:"session_duration" json:"session_duration,computed_optional"`

--- a/internal/services/zero_trust_access_application/plan_modifiers.go
+++ b/internal/services/zero_trust_access_application/plan_modifiers.go
@@ -130,6 +130,21 @@ func modifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resour
 
 	// Add default values for some app type specific attributes
 	setDefaultAccordingToAppTypes(append(selfHostedAppTypes, "mcp"), appType, &planApp.HTTPOnlyCookieAttribute, types.BoolValue(true), types.BoolNull())
+	// For non-selfHosted types (e.g. mcp), enable_binding_cookie, options_preflight_bypass, and cors_headers
+	// are returned by the API but cannot be set in config. Copy state into plan to suppress false -> null diffs.
+	if !slices.Contains(selfHostedAppTypes, appType) && stateApp != nil {
+		if planApp.EnableBindingCookie.IsNull() {
+			planApp.EnableBindingCookie = stateApp.EnableBindingCookie
+		}
+		if planApp.OptionsPreflightBypass.IsNull() {
+			planApp.OptionsPreflightBypass = stateApp.OptionsPreflightBypass
+		}
+		if planApp.CORSHeaders == nil {
+			planApp.CORSHeaders = stateApp.CORSHeaders
+		}
+	}
+	setDefaultAccordingToAppTypes(selfHostedAppTypes, appType, &planApp.EnableBindingCookie, types.BoolValue(false), types.BoolNull())
+	setDefaultAccordingToAppTypes(selfHostedAppTypes, appType, &planApp.OptionsPreflightBypass, types.BoolValue(false), types.BoolNull())
 	setDefaultAccordingToAppTypes(appLauncherVisibleAppTypes, appType, &planApp.AppLauncherVisible, types.BoolValue(true), types.BoolNull())
 	setDefaultAccordingToAppType("app_launcher", appType, &planApp.SkipAppLauncherLoginPage, types.BoolValue(false), types.BoolNull())
 	setDefaultAccordingToAppTypes(sessionDurationCompatibleAppTypes, appType, &planApp.SessionDuration, types.StringValue("24h"), types.StringNull())

--- a/internal/services/zero_trust_access_application/resource_test.go
+++ b/internal/services/zero_trust_access_application/resource_test.go
@@ -2096,18 +2096,21 @@ func TestAccCloudflareAccessApplication_MCPSetup(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
-				ImportStateVerifyIgnore: []string{"enable_binding_cookie", "options_preflight_bypass", "auto_redirect_to_identity"},
+				ImportStateVerifyIgnore: []string{"auto_redirect_to_identity"},
 			},
 			{
 				ResourceName:            mcpAppName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     fmt.Sprintf("accounts/%s/", accountID),
-				ImportStateVerifyIgnore: []string{"service_auth_401_redirect", "destinations", "enable_binding_cookie", "options_preflight_bypass", "self_hosted_domains", "tags", "auto_redirect_to_identity"},
+				ImportStateVerifyIgnore: []string{"service_auth_401_redirect", "destinations", "self_hosted_domains", "tags", "auto_redirect_to_identity"},
 			},
+			// Verify no plan drift after import — enable_binding_cookie, options_preflight_bypass,
+			// and cors_headers must not show false -> null changes for mcp/mcp_portal types.
 			{
-				Config:   testAccCloudflareAccessApplicationMCPConfig(rnd, domain, accountID),
-				PlanOnly: true,
+				Config:             testAccCloudflareAccessApplicationMCPConfig(rnd, domain, accountID),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/internal/services/zero_trust_access_application/schema.go
+++ b/internal/services/zero_trust_access_application/schema.go
@@ -107,6 +107,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"options_preflight_bypass": schema.BoolAttribute{
 				Description: "Allows options preflight requests to bypass Access authentication and go directly to the origin. Cannot turn on if cors_headers is set.",
+				Computed:    true,
 				Optional:    true,
 				Validators: []validator.Bool{
 					customvalidator.RequiresOtherStringAttributeToBeOneOf(path.MatchRoot("type"), selfHostedAppTypes...),
@@ -174,6 +175,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				ElementType: types.StringType,
 			},
 			"cors_headers": schema.SingleNestedAttribute{
+				Computed: true,
 				Optional: true,
 				Validators: []validator.Object{
 					customvalidator.RequiresOtherStringAttributeToBeOneOf(path.MatchRoot("type"), selfHostedAppTypes...),
@@ -479,6 +481,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"enable_binding_cookie": schema.BoolAttribute{
 				Description: "Enables the binding cookie, which increases security against compromised authorization tokens and CSRF attacks.",
+				Computed:    true,
 				Optional:    true,
 				Validators: []validator.Bool{
 					customvalidator.RequiresOtherStringAttributeToBeOneOf(path.MatchRoot("type"), selfHostedAppTypes...),


### PR DESCRIPTION
Fixes #7120

## Problem

The Cloudflare Access API returns `enable_binding_cookie`, `options_preflight_bypass`, and `cors_headers` for `mcp` type applications. However, the provider's type-based validator (`RequiresOtherStringAttributeToBeOneOf` with `selfHostedAppTypes`) rejects any HCL declaration of these attributes when `type = "mcp"`. This creates irreconcilable plan drift: the provider stores the API values in state on import/refresh but cannot reconcile them via config, producing `false -> null` (and `{...} -> null` for `cors_headers`) on every plan.

## Fix

Mirrors the existing handling of `http_only_cookie_attribute`, which already has `Computed: true` and is handled in `modifyPlan`:

1. **`schema.go`**: add `Computed: true` to `enable_binding_cookie`, `options_preflight_bypass`, and `cors_headers`. Note: the v500 migration schema already had `Computed: true` on `enable_binding_cookie` and `options_preflight_bypass`, confirming this is a regression introduced when `mcp` type support was added in #6326.

2. **`plan_modifiers.go`**: for non-`selfHosted` types (e.g. `mcp`), copy state values into the plan when config is null, suppressing the `false -> null` diff. The existing `setDefaultAccordingToAppTypes` calls handle the `unknown -> null/default` case for new resources.

3. **`resource_test.go`**: remove `enable_binding_cookie` and `options_preflight_bypass` from `ImportStateVerifyIgnore` (they were workarounds for this bug), add `ExpectNonEmptyPlan: false` to the existing `PlanOnly` step to explicitly assert no drift after import.