### PR TITLE
fix(snippet,snippet_rules): implement Read for snippet_rules and ImportState for both resources

### DIFF
--- a/internal/services/snippet/resource.go
+++ b/internal/services/snippet/resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/cloudflare-go/v6/snippets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -20,6 +21,7 @@ import (
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.ResourceWithConfigure = (*SnippetResource)(nil)
 var _ resource.ResourceWithModifyPlan = (*SnippetResource)(nil)
+var _ resource.ResourceWithImportState = (*SnippetResource)(nil)
 
 func NewResource() resource.Resource {
 	return &SnippetResource{}
@@ -229,6 +231,75 @@ func (r *SnippetResource) Delete(ctx context.Context, req resource.DeleteRequest
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *SnippetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	var data = new(SnippetModel)
+
+	path_zone_id := ""
+	path_snippet_name := ""
+	diags := importpath.ParseImportID(
+		req.ID,
+		"<zone_id>/<snippet_name>",
+		&path_zone_id,
+		&path_snippet_name,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.ZoneID = types.StringValue(path_zone_id)
+	data.SnippetName = types.StringValue(path_snippet_name)
+
+	res := new(http.Response)
+	env := SnippetResultEnvelope{*data}
+	_, err := r.client.Snippets.Get(
+		ctx,
+		path_snippet_name,
+		snippets.SnippetGetParams{
+			ZoneID: cloudflare.F(path_zone_id),
+		},
+		option.WithResponseBodyInto(&res),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to make http request", err.Error())
+		return
+	}
+	bytes, _ := io.ReadAll(res.Body)
+	err = apijson.Unmarshal(bytes, &env)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
+		return
+	}
+	data = &env.Result
+
+	res = new(http.Response)
+	_, err = r.client.Snippets.Content.Get(
+		ctx,
+		path_snippet_name,
+		snippets.ContentGetParams{
+			ZoneID: cloudflare.F(path_zone_id),
+		},
+		option.WithResponseBodyInto(&res),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to make http request", err.Error())
+		return
+	}
+	data.Metadata = &SnippetMetadataModel{
+		MainModule: types.StringValue(res.Header.Get("Cf-Entrypoint")),
+	}
+	bytes, _ = io.ReadAll(res.Body)
+	err = data.UnmarshalMultipart(bytes, res.Header.Get("Content-Type"))
+	if err != nil {
+		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
 	}
 

--- a/internal/services/snippet_rules/resource.go
+++ b/internal/services/snippet_rules/resource.go
@@ -12,13 +12,16 @@ import (
 	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/cloudflare-go/v6/snippets"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.ResourceWithConfigure = (*SnippetRulesResource)(nil)
 var _ resource.ResourceWithModifyPlan = (*SnippetRulesResource)(nil)
+var _ resource.ResourceWithImportState = (*SnippetRulesResource)(nil)
 
 func NewResource() resource.Resource {
 	return &SnippetRulesResource{}
@@ -141,7 +144,42 @@ func (r *SnippetRulesResource) Update(ctx context.Context, req resource.UpdateRe
 }
 
 func (r *SnippetRulesResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *SnippetRulesModel
 
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	res := new(http.Response)
+	env := SnippetRulesResultEnvelope{*data}
+	_, err := r.client.Snippets.Rules.List(
+		ctx,
+		snippets.RuleListParams{
+			ZoneID: cloudflare.F(data.ZoneID.ValueString()),
+		},
+		option.WithResponseBodyInto(&res),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if res != nil && res.StatusCode == 404 {
+		resp.Diagnostics.AddWarning("Resource not found", "The resource was not found on the server and will be removed from state.")
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError("failed to make http request", err.Error())
+		return
+	}
+	bytes, _ := io.ReadAll(res.Body)
+	err = apijson.Unmarshal(bytes, &env)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
+		return
+	}
+	data = &env.Result
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *SnippetRulesResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -164,6 +202,47 @@ func (r *SnippetRulesResource) Delete(ctx context.Context, req resource.DeleteRe
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *SnippetRulesResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	var data = new(SnippetRulesModel)
+
+	path_zone_id := ""
+	diags := importpath.ParseImportID(
+		req.ID,
+		"<zone_id>",
+		&path_zone_id,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.ZoneID = types.StringValue(path_zone_id)
+
+	res := new(http.Response)
+	env := SnippetRulesResultEnvelope{*data}
+	_, err := r.client.Snippets.Rules.List(
+		ctx,
+		snippets.RuleListParams{
+			ZoneID: cloudflare.F(path_zone_id),
+		},
+		option.WithResponseBodyInto(&res),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to make http request", err.Error())
+		return
+	}
+	bytes, _ := io.ReadAll(res.Body)
+	err = apijson.Unmarshal(bytes, &env)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
+		return
+	}
+	data = &env.Result
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/7049

This PR addresses two bugs in the `cloudflare_snippet` and `cloudflare_snippet_rules` resources:

### Bug 1: `cloudflare_snippet_rules` Read is a no-op

The `Read` function had an empty body — no API call, no state population. This meant:
- `terraform plan` never detected drift for snippet rules modified outside of Terraform
- The resource was effectively write-only after initial creation

**Fix:** Implement `Read` by calling `Snippets.Rules.List` with the zone ID, unmarshalling the response via `apijson.Unmarshal`, and setting state. Handles 404 by removing the resource from state.

### Bug 2: Neither resource supports `terraform import`

Neither `cloudflare_snippet` nor `cloudflare_snippet_rules` implemented the `ResourceWithImportState` interface, so `terraform import` failed with "Resource does not support import".

**Fix:** Add `ImportState` for both resources following established provider patterns:
- `cloudflare_snippet`: import ID format `<zone_id>/<snippet_name>`
- `cloudflare_snippet_rules`: import ID format `<zone_id>` (rules are zone-scoped singletons)

The `cloudflare_snippet` import makes two API calls (same as Read): `Snippets.Get` for metadata and `Snippets.Content.Get` for the multipart file content.

### Testing

Both changed files pass `go vet`. The changes follow the same patterns used by 193+ other resources in this provider (e.g., `waiting_room_rules`, `zone_lockdown`, `ruleset`).