### PR TITLE
fix: state migration robustness — accept early-v5 schema_version=0 + zone-scoped Access policy account_id

### DIFF
--- a/internal/services/load_balancer_pool/migration/v500/handler.go
+++ b/internal/services/load_balancer_pool/migration/v500/handler.go
@@ -4,12 +4,15 @@ package v500
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// UpgradeFromV0 handles state upgrades from schema_version=0 to schema_version=500.
+// UpgradeFromV0 handles state upgrades from schema_version=1 to schema_version=500.
 // This is a no-op upgrade since the schema is compatible - just copy state through.
 //
 // Why this exists: Terraform requires explicit upgraders to be defined for version tracking,
@@ -19,57 +22,77 @@ func UpgradeFromV0(
 	req resource.UpgradeStateRequest,
 	resp *resource.UpgradeStateResponse,
 ) {
-	tflog.Info(ctx, "Upgrading load_balancer_pool state from schema_version=0 (no-op for v5 same-version states)")
+	tflog.Info(ctx, "Upgrading load_balancer_pool state from schema_version=1 (no-op for v5 same-version states)")
 	// No-op upgrade: schema is compatible, just copy raw state through
 	// We use the raw state value directly to avoid issues with custom field type serialization
 	resp.State.Raw = req.State.Raw
 }
 
-// UpgradeFromLegacyV0 handles state upgrades from schema_version=0.
+// UpgradeFromV0Ambiguous handles schema_version=0 state that is AMBIGUOUS between
+// the v4 SDKv2 provider format and early v5 (v5.0-v5.7) provider format.
 //
-// IMPORTANT: schema_version=0 is used by BOTH:
-// 1. v4 (SDKv2) provider - needs transformation (load_shedding/origin_steering as arrays)
-// 2. Early v5 (5.0.0-5.15.x) releases - already in correct format (as objects)
+// Both stored state at schema_version=0, but with incompatible JSON shapes:
+//   - v4 (SDKv2): load_shedding, origin_steering, origins[].header as JSON arrays
+//     (e.g. "load_shedding": [{"default_percent": 50}], single-element list)
+//   - early v5: load_shedding, origin_steering as JSON objects (e.g. "load_shedding": {...})
 //
-// Detection strategy:
-// We try to unmarshal the raw state using the TARGET (current v5) schema type first.
-// - If it succeeds → state is already v5 format → no-op (copy through)
-// - If it fails (e.g., load_shedding is array not object) → v4 format → transform
+// migrations.go registers this with PriorSchema=nil so the Plugin Framework
+// skips the pre-handler unmarshal that would otherwise fail for one shape or
+// the other. The handler then inspects req.RawState.JSON directly.
 //
-// This approach avoids relying on req.State (decoded with v4 PriorSchema) for v5 state,
-// which would strip fields that only exist in v5 (e.g. disabled_at, networks).
-//
-// Key transformations (v4 only):
-// - load_shedding: Array[0] → NestedObject (SDK v2 TypeList MaxItems:1)
-// - origin_steering: Array[0] → NestedObject (SDK v2 TypeList MaxItems:1)
-// - origins.header: Complex nested structure transformation
-// - check_regions: Set → List
-// - origins: Set → List
-func UpgradeFromLegacyV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	tflog.Info(ctx, "Upgrading load_balancer_pool state from schema_version=0")
+// Detection: try to unmarshal raw state with the TARGET schema. If it succeeds,
+// the state is already v5-shaped → no-op. Otherwise, parse with the v4 source
+// schema and run the full v4→v500 transform.
+func UpgradeFromV0Ambiguous(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading load_balancer_pool state from schema_version=0 (detecting v4 vs early-v5 format)")
 
-	// First, try to unmarshal raw state with the TARGET schema type.
-	// This succeeds for v5 state (load_shedding/origin_steering are objects)
-	// and fails for v4 state (they are arrays).
-	targetType := resp.State.Schema.Type().TerraformType(ctx)
-	val, err := req.RawState.Unmarshal(targetType)
-	if err == nil {
-		// v5 format detected - state is already compatible with current schema.
-		// Fields absent from the JSON (e.g. newly added fields) become null.
-		tflog.Info(ctx, "State is v5 format - performing no-op upgrade via RawState")
-		resp.State.Raw = val
+	if req.RawState == nil || len(req.RawState.JSON) == 0 {
+		resp.Diagnostics.AddError(
+			"Missing raw state",
+			"RawState was nil or empty during load_balancer_pool schema_version=0 upgrade",
+		)
 		return
 	}
 
-	// Target schema unmarshal failed - this is v4 format (arrays for load_shedding etc.)
-	tflog.Info(ctx, "State is v4 format (SDKv2) - performing transformation",
-		map[string]interface{}{"unmarshal_err": err.Error()})
+	// First, try the target (current v5) schema. v5 state at schema_version=0
+	// (early v5.0-v5.7) already has object-shaped nested attrs and will parse cleanly.
+	targetType := resp.State.Schema.Type().TerraformType(ctx)
+	if val, err := req.RawState.Unmarshal(targetType); err == nil {
+		tflog.Info(ctx, "Detected early-v5 load_balancer_pool format - performing no-op upgrade via RawState")
+		resp.State.Raw = val
+		return
+	} else {
+		tflog.Debug(ctx, "Target schema unmarshal failed, falling back to v4 path", map[string]interface{}{
+			"unmarshal_err": err.Error(),
+		})
+	}
 
-	// Parse with v4 PriorSchema (req.State was decoded using v4 source schema)
+	// Otherwise: parse with the v4 source schema and transform.
+	upgradeFromV4ViaRawState(ctx, req, resp)
+}
+
+// upgradeFromV4ViaRawState performs the v4→v500 transformation by unmarshalling
+// req.RawState with the v4 source schema and running Transform. Used when the
+// upgrader was registered with PriorSchema=nil (req.State is empty).
+func upgradeFromV4ViaRawState(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	v4Schema := SourceCloudflareLoadBalancerPoolSchema()
+	v4Type := v4Schema.Type().TerraformType(ctx)
+
+	rawValue, err := req.RawState.Unmarshal(v4Type)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to unmarshal v4 load_balancer_pool state",
+			fmt.Sprintf("Could not parse raw state as v4 (SDKv2) format: %s", err),
+		)
+		return
+	}
+
+	syntheticState := tfsdk.State{Raw: rawValue, Schema: v4Schema}
+
 	var sourceState SourceCloudflareLoadBalancerPoolModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &sourceState)...)
+	resp.Diagnostics.Append(syntheticState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
-		tflog.Error(ctx, "Failed to parse v4 state", map[string]interface{}{
+		tflog.Error(ctx, "Failed to parse v4 state from raw value", map[string]interface{}{
 			"diagnostics": resp.Diagnostics,
 		})
 		return
@@ -81,7 +104,6 @@ func UpgradeFromLegacyV0(ctx context.Context, req resource.UpgradeStateRequest, 
 		"name":       sourceState.Name.ValueString(),
 	})
 
-	// Transform to target
 	targetState, diags := Transform(ctx, sourceState)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -91,7 +113,6 @@ func UpgradeFromLegacyV0(ctx context.Context, req resource.UpgradeStateRequest, 
 		return
 	}
 
-	// Set the upgraded state
 	resp.Diagnostics.Append(resp.State.Set(ctx, targetState)...)
 	if resp.Diagnostics.HasError() {
 		tflog.Error(ctx, "Failed to set upgraded state", map[string]interface{}{
@@ -101,4 +122,41 @@ func UpgradeFromLegacyV0(ctx context.Context, req resource.UpgradeStateRequest, 
 	}
 
 	tflog.Info(ctx, "State upgrade from v4 load_balancer_pool completed successfully")
+}
+
+// UpgradeFromLegacyV0 is kept for backwards compatibility with any external
+// callers; new registrations should use UpgradeFromV0Ambiguous via migrations.go.
+//
+// Deprecated: use UpgradeFromV0Ambiguous, which works with PriorSchema=nil and
+// handles both v4 SDKv2 and early-v5 schema_version=0 state correctly.
+func UpgradeFromLegacyV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	UpgradeFromV0Ambiguous(ctx, req, resp)
+}
+
+// isV4LoadBalancerPoolState returns true when the raw state JSON has the v4
+// (SDKv2) array shape for `load_shedding` or `origin_steering` rather than the
+// v5 object shape. Useful for tests and diagnostics; the production path uses
+// the target-schema unmarshal probe in UpgradeFromV0Ambiguous.
+func isV4LoadBalancerPoolState(req resource.UpgradeStateRequest) (bool, error) {
+	if req.RawState == nil || len(req.RawState.JSON) == 0 {
+		return false, nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(req.RawState.JSON, &raw); err != nil {
+		return false, err
+	}
+	for _, field := range []string{"load_shedding", "origin_steering"} {
+		v, ok := raw[field]
+		if !ok || len(v) == 0 || v[0] == 'n' { // not present or null
+			continue
+		}
+		if v[0] == '[' {
+			return true, nil
+		}
+		if v[0] == '{' {
+			return false, nil
+		}
+	}
+	// Neither field present — be conservative: treat as v5 (no-op).
+	return false, nil
 }

--- a/internal/services/load_balancer_pool/migration/v500/handler_test.go
+++ b/internal/services/load_balancer_pool/migration/v500/handler_test.go
@@ -1,0 +1,93 @@
+package v500_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/load_balancer_pool"
+	v500 "github.com/cloudflare/terraform-provider-cloudflare/internal/services/load_balancer_pool/migration/v500"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpgradeFromV0Ambiguous_V5ObjectShape is a regression test for #7098.
+//
+// Before the fix, the slot-0 upgrader was registered with PriorSchema set to
+// the v4 (SDKv2) source schema, which expects `load_shedding` and
+// `origin_steering` as list blocks. When the user's state was written by
+// v5.0–v5.7 (object shape) at schema_version=0, the Plugin Framework rejected
+// the state pre-handler with:
+//
+//	AttributeName("origin_steering"): invalid JSON, expected "[", got "{"
+//
+// With the fix, PriorSchema is nil and the handler probes the raw JSON itself
+// against the target schema. Object-shaped state should pass through cleanly.
+func TestUpgradeFromV0Ambiguous_V5ObjectShape(t *testing.T) {
+	ctx := context.Background()
+
+	// Minimal v5-shaped state (post v5.0, schema_version=0). `load_shedding`
+	// and `origin_steering` are SINGLE objects — this is the exact shape that
+	// broke for the user in #7098.
+	stateJSON := map[string]interface{}{
+		"id":         "pool-1",
+		"account_id": "acct-123",
+		"name":       "test-pool",
+		"enabled":    true,
+		"origins": []interface{}{
+			map[string]interface{}{
+				"name":    "origin-1",
+				"address": "1.2.3.4",
+			},
+		},
+		"origin_steering": map[string]interface{}{
+			"policy": "random",
+		},
+		"load_shedding": map[string]interface{}{
+			"default_percent": 0,
+			"default_policy":  "random",
+			"session_percent": 0,
+			"session_policy":  "hash",
+		},
+	}
+	raw, err := json.Marshal(stateJSON)
+	require.NoError(t, err)
+
+	req := resource.UpgradeStateRequest{
+		// PriorSchema=nil in production: req.State is empty.
+		RawState: &tfprotov6.RawState{JSON: raw},
+	}
+	resp := &resource.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: load_balancer_pool.ResourceSchema(ctx),
+		},
+	}
+
+	v500.UpgradeFromV0Ambiguous(ctx, req, resp)
+
+	require.False(t, resp.Diagnostics.HasError(),
+		"UpgradeFromV0Ambiguous should not error on v5 object-shape state, got: %v",
+		resp.Diagnostics)
+}
+
+// TestUpgradeFromV0Ambiguous_NilRawState verifies that a nil raw state surfaces
+// a clear diagnostic rather than panicking.
+func TestUpgradeFromV0Ambiguous_NilRawState(t *testing.T) {
+	ctx := context.Background()
+
+	req := resource.UpgradeStateRequest{
+		RawState: nil,
+	}
+	resp := &resource.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: load_balancer_pool.ResourceSchema(ctx),
+		},
+	}
+
+	v500.UpgradeFromV0Ambiguous(ctx, req, resp)
+
+	require.True(t, resp.Diagnostics.HasError(),
+		"Expected error diagnostic for nil RawState")
+}

--- a/internal/services/load_balancer_pool/migration/v500/migrations_test.go
+++ b/internal/services/load_balancer_pool/migration/v500/migrations_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
@@ -33,6 +34,9 @@ var v4FullConfig string
 
 //go:embed testdata/v5_full.tf
 var v5FullConfig string
+
+//go:embed testdata/v5_object_attrs.tf
+var v5ObjectAttrsConfig string
 
 //go:embed testdata/v4_check_regions.tf
 var v4CheckRegionsConfig string
@@ -138,10 +142,12 @@ func TestMigrateLoadBalancerPool_V4ToV5_Basic(t *testing.T) {
 	}
 }
 
-// TestMigrateLoadBalancerPool_V4ToV5_FullConfig tests all optional attributes with complex transformations
-// Note: Only testing from_v4_latest because from_v5 with load_shedding/origin_steering creates a schema
-// conflict (v5 state uses objects, but v4 schema expects arrays). This is not a real-world scenario
-// since v5 users already have correct state format.
+// TestMigrateLoadBalancerPool_V4ToV5_FullConfig tests all optional attributes with complex transformations.
+//
+// Note: Historically this only tested from_v4_latest because from_v5 with load_shedding/origin_steering
+// triggered a schema conflict in the upgrader (v5 state uses objects, but the slot-0 PriorSchema was the
+// v4 list shape). That regression is now fixed (#7098) and explicitly covered by
+// TestMigrateLoadBalancerPool_FromEarlyV5_FullConfig below.
 func TestMigrateLoadBalancerPool_V4ToV5_FullConfig(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -362,4 +368,79 @@ func TestMigrateLoadBalancerPool_V4ToV5_CheckRegions(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestMigrateLoadBalancerPool_FromEarlyV5_ObjectAttrs is a regression test for #7098.
+//
+// Before the fix, state written by a pre-v5.19 provider at schema_version=0 with
+// the v5 object shape for `load_shedding` and `origin_steering` could not be
+// upgraded to the current schema_version=500. The framework rejected the state
+// pre-handler with:
+//
+//	AttributeName("origin_steering"): invalid JSON, expected "[", got "{"
+//
+// because slot 0 was registered with the v4 SDKv2 PriorSchema (list shape).
+//
+// This test exercises the exact failing path:
+//  1. Create the resource with v5.18.0 (state at schema_version=0, object shape).
+//  2. Switch to the local current provider — the state upgrader must transparently
+//     accept the object shape and emit an empty plan.
+//
+// We use v5_object_attrs.tf (no `header` block) instead of v5_full.tf because the
+// LB Pool API validates that any origin `header.host` values resolve via DNS against
+// the origin address, which would fail in CI for synthetic test domains and mask the
+// real regression we care about.
+func TestMigrateLoadBalancerPool_FromEarlyV5_ObjectAttrs(t *testing.T) {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := rnd
+	tmpDir := t.TempDir()
+	testConfig := fmt.Sprintf(v5ObjectAttrsConfig, rnd, accountID, name)
+	resourceName := fmt.Sprintf("cloudflare_load_balancer_pool.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			// Step 1: create with v5.18.0 (last release before schema_version bump to 500).
+			// State written at schema_version=0 with v5 object shape for load_shedding / origin_steering.
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "5.18.0",
+					},
+				},
+				Config: testConfig,
+			},
+			// Step 2: switch to local current provider. State upgrade runs (0 → 500).
+			// The handler must accept object-shaped load_shedding/origin_steering
+			// and produce a no-op plan.
+			{
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				Config:                   testConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acctest.DebugNonEmptyPlan,
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("origin_steering").AtMapKey("policy"),
+						knownvalue.StringExact("random"),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("load_shedding").AtMapKey("default_policy"),
+						knownvalue.StringExact("random"),
+					),
+				},
+			},
+		},
+	})
 }

--- a/internal/services/load_balancer_pool/migration/v500/testdata/v5_object_attrs.tf
+++ b/internal/services/load_balancer_pool/migration/v500/testdata/v5_object_attrs.tf
@@ -1,0 +1,38 @@
+resource "cloudflare_load_balancer_pool" "%s" {
+  account_id = "%s"
+  name       = "my-tf-pool-objattrs-%s"
+
+  origins = [
+    {
+      name    = "example-1"
+      address = "192.0.2.1"
+      enabled = true
+      weight  = 1.0
+    },
+    {
+      name    = "example-2"
+      address = "192.0.2.2"
+      enabled = true
+      weight  = 0.5
+    }
+  ]
+
+  # The two attributes that broke the v5.0–v5.18 → v5.19 upgrade (#7098).
+  # In early v5 these were stored as JSON objects at schema_version=0; the
+  # slot-0 upgrader expected the v4 (SDKv2) array shape and rejected them
+  # pre-handler. The fix detects shape from req.RawState directly.
+  load_shedding = {
+    default_percent = 55
+    default_policy  = "random"
+    session_percent = 12
+    session_policy  = "hash"
+  }
+
+  origin_steering = {
+    policy = "random"
+  }
+
+  description     = "tfacc-object-attrs"
+  enabled         = false
+  minimum_origins = 2
+}

--- a/internal/services/load_balancer_pool/migrations.go
+++ b/internal/services/load_balancer_pool/migrations.go
@@ -14,30 +14,30 @@ var _ resource.ResourceWithUpgradeState = (*LoadBalancerPoolResource)(nil)
 //
 // Schema version history:
 // - v4 (SDKv2): schema_version=0 (implicit, no explicit version set)
-// - v5 production (v5.0–v5.18): schema_version=1 (GetSchemaVersion(1, 500) returned 1)
+// - early v5 (v5.0–v5.7, before GetSchemaVersion was added): schema_version=0 with v5 (object) shape
+// - v5 production (v5.0–v5.18 after stepping stone): schema_version=1
 // - v5 current: schema_version=500
 //
 // Upgrade paths:
-// 1. v4 SDKv2 (schema_version=0) → v5 (500): Full transformation
-//    - load_shedding: Array[0] → NestedObject
-//    - origin_steering: Array[0] → NestedObject
-//    - origins.header: Complex nested structure transformation
-//    - check_regions: Set → List
-//    - origins: Set → List
 //
-// 2. v5 production (schema_version=1) → v5 (500): No-op
-//    - State is already in v5 format; just bumps the version number.
+//  1. schema_version=0 → 500: AMBIGUOUS between
+//     - v4 SDKv2 format (load_shedding/origin_steering as JSON arrays [{...}])
+//     - early v5 format (load_shedding/origin_steering as JSON objects {...})
+//     PriorSchema must be nil because the Plugin Framework rejects the state
+//     pre-handler if the prior-schema shape doesn't match the raw JSON (see #7098).
+//     The handler reads req.RawState.JSON directly and routes to the correct path.
+//
+//  2. schema_version=1 → 500: No-op
+//     State is already in v5 format; just bumps the version number.
 func (r *LoadBalancerPoolResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	targetSchema := ResourceSchema(ctx)
-	sourceSchema := v500.SourceCloudflareLoadBalancerPoolSchema()
 
 	return map[int64]resource.StateUpgrader{
-		// Handle upgrades from legacy v4 SDKv2 provider (schema_version=0).
-		// UpgradeFromLegacyV0 detects v4 vs early-v5 format at runtime and
-		// either transforms (v4) or passes through (early v5 at version 0).
+		// Handle schema_version=0 state. AMBIGUOUS between v4 SDKv2 (list shape)
+		// and early v5 (object shape). PriorSchema=nil so the handler can inspect
+		// req.RawState.JSON itself and pick the right path. See #7098.
 		0: {
-			PriorSchema:   &sourceSchema,
-			StateUpgrader: v500.UpgradeFromLegacyV0,
+			StateUpgrader: v500.UpgradeFromV0Ambiguous,
 		},
 		// Handle upgrades from v5 production state (schema_version=1).
 		// Users on v5.0–v5.18 had GetSchemaVersion(1, 500) which stored state

--- a/internal/services/spectrum_application/migration/v500/handler.go
+++ b/internal/services/spectrum_application/migration/v500/handler.go
@@ -2,21 +2,26 @@ package v500
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // UpgradeFromV0 handles state upgrades from v4 provider (schema_version=0) to v5 (version=500).
 //
-// performs the full v4→v5 transformation. In production (no migration mode), a simple
-// no-op is registered at slot 0 instead (see migrations.go).
+// Performs the full v4→v5 transformation:
+//   - dns, origin_dns, edge_ips: array[0] → object (ListNestedBlock → SingleNestedAttribute)
+//   - origin_port_range: block with start/end → origin_port DynamicAttribute string
+//   - origin_port: integer → DynamicAttribute number wrapper
+//   - timestamps: string → timetypes.RFC3339
 //
-// Transforms:
-// - dns, origin_dns, edge_ips: array[0] → object (ListNestedBlock → SingleNestedAttribute)
-// - origin_port_range: block with start/end → origin_port DynamicAttribute string
-// - origin_port: integer → DynamicAttribute number wrapper
-// - timestamps: string → timetypes.RFC3339
+// IMPORTANT: this function requires req.State to have been populated with the
+// v4 PriorSchema (i.e. it must NOT be called directly from a slot where
+// PriorSchema=nil). Use UpgradeFromV0Ambiguous for the production code path —
+// it builds a synthetic req.State from req.RawState and then defers here.
 func UpgradeFromV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 	tflog.Info(ctx, "Upgrading spectrum_application state from v4 provider (schema_version=0)")
 
@@ -41,7 +46,7 @@ func UpgradeFromV0(ctx context.Context, req resource.UpgradeStateRequest, resp *
 
 // UpgradeFromV1 handles state upgrades from v5 provider (version=1) to v5 (version=500).
 //
-// This is a no-op upgrade. Version 1 is the "dormant" v5 state set in production
+// This is a no-op upgrade. Version 1 is the "dormant" v5 state set in production;
 // this bumps from 1 to 500.
 func UpgradeFromV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 	tflog.Info(ctx, "Upgrading spectrum_application state from version=1 to version=500 (no-op)")
@@ -50,4 +55,91 @@ func UpgradeFromV1(ctx context.Context, req resource.UpgradeStateRequest, resp *
 	resp.State.Raw = req.State.Raw
 
 	tflog.Info(ctx, "State version bump from 1 to 500 completed")
+}
+
+// UpgradeFromV0Ambiguous handles schema_version=0 state that is AMBIGUOUS between
+// the v4 SDKv2 provider format and early v5 (v5.0-v5.7) provider format.
+//
+// Both stored state at schema_version=0, but with incompatible JSON shapes for
+// nested blocks such as `dns`, `origin_dns`, `edge_ips`, and `origin_port_range`:
+//   - v4 (SDKv2):  arrays of one element, e.g. `"dns": [{"name":"...","type":"..."}]`
+//   - early v5:    single objects, e.g.       `"dns": {"name":"...","type":"..."}`
+//
+// migrations.go registers this with PriorSchema=nil so the Plugin Framework
+// skips the pre-handler unmarshal that would otherwise reject one shape or the
+// other. We probe the raw JSON ourselves:
+//
+//  1. Try to unmarshal req.RawState with the TARGET (current v5) schema.
+//     If this succeeds, the state is already v5-shaped → no-op upgrade.
+//  2. Otherwise, parse with the v4 source schema and run the full v4→v500
+//     Transform.
+func UpgradeFromV0Ambiguous(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading spectrum_application state from schema_version=0 (detecting v4 vs early-v5 format)")
+
+	if req.RawState == nil || len(req.RawState.JSON) == 0 {
+		resp.Diagnostics.AddError(
+			"Missing raw state",
+			"RawState was nil or empty during spectrum_application schema_version=0 upgrade",
+		)
+		return
+	}
+
+	// Probe with the target schema first; this is the cheap, accurate test.
+	targetType := resp.State.Schema.Type().TerraformType(ctx)
+	if val, err := req.RawState.Unmarshal(targetType); err == nil {
+		tflog.Info(ctx, "Detected early-v5 spectrum_application format - performing no-op upgrade via RawState")
+		resp.State.Raw = val
+		return
+	} else {
+		tflog.Debug(ctx, "Target schema unmarshal failed, falling back to v4 path", map[string]interface{}{
+			"unmarshal_err": err.Error(),
+		})
+	}
+
+	// Fallback: parse as v4 (SDKv2) state and transform.
+	v4Schema := SourceSpectrumApplicationSchema()
+	v4Type := v4Schema.Type().TerraformType(ctx)
+
+	rawValue, err := req.RawState.Unmarshal(v4Type)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to unmarshal v4 spectrum_application state",
+			fmt.Sprintf("Could not parse raw state as v4 (SDKv2) format: %s", err),
+		)
+		return
+	}
+
+	syntheticState := tfsdk.State{Raw: rawValue, Schema: v4Schema}
+	syntheticReq := resource.UpgradeStateRequest{
+		RawState: req.RawState,
+		State:    &syntheticState,
+	}
+
+	UpgradeFromV0(ctx, syntheticReq, resp)
+}
+
+// isV4SpectrumApplicationState returns true when the raw state JSON has the v4
+// SDKv2 array shape for `dns`, `origin_dns`, `edge_ips`, or `origin_port_range`.
+// Used by tests; production uses the target-schema probe in UpgradeFromV0Ambiguous.
+func isV4SpectrumApplicationState(req resource.UpgradeStateRequest) (bool, error) {
+	if req.RawState == nil || len(req.RawState.JSON) == 0 {
+		return false, nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(req.RawState.JSON, &raw); err != nil {
+		return false, err
+	}
+	for _, field := range []string{"dns", "origin_dns", "edge_ips", "origin_port_range"} {
+		v, ok := raw[field]
+		if !ok || len(v) == 0 || v[0] == 'n' {
+			continue
+		}
+		if v[0] == '[' {
+			return true, nil
+		}
+		if v[0] == '{' {
+			return false, nil
+		}
+	}
+	return false, nil
 }

--- a/internal/services/spectrum_application/migration/v500/handler_test.go
+++ b/internal/services/spectrum_application/migration/v500/handler_test.go
@@ -1,0 +1,82 @@
+package v500_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/spectrum_application"
+	v500 "github.com/cloudflare/terraform-provider-cloudflare/internal/services/spectrum_application/migration/v500"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpgradeFromV0Ambiguous_V5ObjectShape is a regression test for #7098.
+//
+// Before the fix, the slot-0 upgrader was registered with PriorSchema set to
+// the v4 (SDKv2) source schema, which expects `dns` as a list block. When the
+// user's state was written by v5.0–v5.7 (object shape) at schema_version=0,
+// the Plugin Framework rejected the state pre-handler with:
+//
+//	AttributeName("dns"): invalid JSON, expected "[", got "{"
+//
+// With the fix, PriorSchema is nil and the handler probes the raw JSON itself
+// against the target schema. Object-shaped state should pass through cleanly.
+func TestUpgradeFromV0Ambiguous_V5ObjectShape(t *testing.T) {
+	ctx := context.Background()
+
+	// Minimal v5-shaped state (post v5.0, schema_version=0). `dns` and
+	// `origin_dns` are SINGLE objects, not arrays — this is the exact shape
+	// that broke for the user in #7098.
+	stateJSON := map[string]interface{}{
+		"id":            "spectrum-app-1",
+		"zone_id":       "zone-123",
+		"protocol":      "tcp/2222",
+		"origin_direct": []string{"tcp://1.2.3.4:22"},
+		"tls":           "off",
+		"dns": map[string]interface{}{
+			"type": "CNAME",
+			"name": "spectrum.example.com",
+		},
+	}
+	raw, err := json.Marshal(stateJSON)
+	require.NoError(t, err)
+
+	req := resource.UpgradeStateRequest{
+		// PriorSchema=nil in production: req.State is empty.
+		RawState: &tfprotov6.RawState{JSON: raw},
+	}
+	resp := &resource.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: spectrum_application.ResourceSchema(ctx),
+		},
+	}
+
+	v500.UpgradeFromV0Ambiguous(ctx, req, resp)
+
+	require.False(t, resp.Diagnostics.HasError(),
+		"UpgradeFromV0Ambiguous should not error on v5 object-shape state, got: %v",
+		resp.Diagnostics)
+}
+
+// TestUpgradeFromV0Ambiguous_NilRawState verifies a nil/empty raw state surfaces
+// a clear diagnostic rather than panicking.
+func TestUpgradeFromV0Ambiguous_NilRawState(t *testing.T) {
+	ctx := context.Background()
+
+	req := resource.UpgradeStateRequest{
+		RawState: nil,
+	}
+	resp := &resource.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: spectrum_application.ResourceSchema(ctx),
+		},
+	}
+
+	v500.UpgradeFromV0Ambiguous(ctx, req, resp)
+
+	require.True(t, resp.Diagnostics.HasError(),
+		"Expected error diagnostic for nil RawState")
+}

--- a/internal/services/spectrum_application/migration/v500/migrations_test.go
+++ b/internal/services/spectrum_application/migration/v500/migrations_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
@@ -29,6 +30,9 @@ var v4OriginDirectConfig string
 
 //go:embed testdata/v4_complex.tf
 var v4ComplexConfig string
+
+//go:embed testdata/v5_complex.tf
+var v5ComplexConfig string
 
 // TestMigrateSpectrumApplication_Basic tests v4→v5 migration with dns block and origin_direct
 func TestMigrateSpectrumApplication_Basic(t *testing.T) {
@@ -223,5 +227,77 @@ func TestMigrateSpectrumApplication_Complex(t *testing.T) {
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ip_firewall"), knownvalue.Bool(true)),
 				statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("traffic_type"), knownvalue.StringExact("direct")),
 			})...),
+	})
+}
+// TestMigrateSpectrumApplication_FromEarlyV5_Complex is a regression test for #7098.
+//
+// Before the fix, state written by a pre-v5.19 provider at schema_version=0 with
+// v5 object shape for `dns` and `edge_ips` could not be upgraded to the current
+// schema_version=500. The framework rejected the state pre-handler with:
+//
+//	AttributeName("dns"): invalid JSON, expected "[", got "{"
+//
+// because slot 0 was registered with the v4 SDKv2 PriorSchema (list shape).
+//
+// This test exercises the exact failing path:
+//  1. Create the resource with v5.18.0 (state at schema_version=0, object shape).
+//  2. Switch to the local current provider — state upgrade must transparently
+//     accept the object shape and produce an empty plan.
+func TestMigrateSpectrumApplication_FromEarlyV5_Complex(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_spectrum_application." + rnd
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	tmpDir := t.TempDir()
+	testConfig := fmt.Sprintf(v5ComplexConfig, rnd, zoneID, rnd, domain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			// Step 1: create with v5.18.0 (last release before schema_version bump to 500).
+			// State written at schema_version=0 with v5 object shape for dns / edge_ips.
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "5.18.0",
+					},
+				},
+				Config: testConfig,
+			},
+			// Step 2: switch to local current provider. State upgrade runs (0 → 500).
+			// The handler must accept object-shaped dns/edge_ips and produce a no-op plan.
+			{
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				Config:                   testConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acctest.DebugNonEmptyPlan,
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("dns").AtMapKey("type"),
+						knownvalue.StringExact("CNAME"),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("dns").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s.%s", rnd, domain)),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("edge_ips").AtMapKey("type"),
+						knownvalue.StringExact("dynamic"),
+					),
+				},
+			},
+		},
 	})
 }

--- a/internal/services/spectrum_application/migrations.go
+++ b/internal/services/spectrum_application/migrations.go
@@ -11,24 +11,29 @@ var _ resource.ResourceWithUpgradeState = (*SpectrumApplicationResource)(nil)
 
 // UpgradeState registers state upgraders for schema version changes.
 //
-// Both v4 and v5 used schema_version=0 (neither set an explicit Version).
+// Schema version history:
+//   - v4 (SDKv2): schema_version=0, dns/origin_dns/edge_ips/origin_port_range as JSON arrays
+//   - early v5 (v5.0–v5.7): schema_version=0, same fields as JSON objects
+//   - v5 production (v5.0–v5.18, with stepping stone): schema_version=1
+//   - v5 current: schema_version=500
 //
-//   - Slot 0: no-op upgrader (safely bumps existing v5 users from 0→1)
+// Upgrade paths:
 //
-// Testing: schema returns version 500
-//   - Slot 0: v4→v5 full transformation (v4 state has schema_version=0)
-//   - Slot 1: v5 no-op (v5 users already bumped to version=1 in prod)
+//  1. schema_version=0 → 500: AMBIGUOUS between v4 (list shape) and early v5
+//     (object shape). PriorSchema MUST be nil — if we set it to the v4 source
+//     schema, the Plugin Framework rejects early-v5 state pre-handler with
+//     `AttributeName("dns"): invalid JSON, expected "[", got "{"` (see #7098).
+//     The handler reads req.RawState.JSON itself and routes accordingly.
+//
+//  2. schema_version=1 → 500: No-op for v5 production state.
 func (r *SpectrumApplicationResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	targetSchema := ResourceSchema(ctx)
 
-	sourceSchema := v500.SourceSpectrumApplicationSchema()
-
 	return map[int64]resource.StateUpgrader{
-		// Handle state from v4 provider (schema_version=0)
-		// Full transformation: arrays→objects, origin_port_range→origin_port, etc.
+		// schema_version=0 — ambiguous between v4 SDKv2 and early v5; format
+		// detection happens in the handler against req.RawState.JSON.
 		0: {
-			PriorSchema:   &sourceSchema,
-			StateUpgrader: v500.UpgradeFromV0,
+			StateUpgrader: v500.UpgradeFromV0Ambiguous,
 		},
 
 		// Handle state from v5 provider with version=1 (production dormant state)

--- a/internal/services/zero_trust_access_policy/migration/v500/migrations_test.go
+++ b/internal/services/zero_trust_access_policy/migration/v500/migrations_test.go
@@ -942,3 +942,203 @@ func renameResourceTypeInState(t *testing.T, tmpDir string, oldType string, newT
 
 	t.Logf("Renamed %s.%s to %s.%s in state file", oldType, resourceName, newType, resourceName)
 }
+
+// removeResourceFromState removes a resource (matched by type+name) from the
+// terraform state file. Simulates `terraform state rm`.
+//
+// Used in cross-provider migration tests when the v4 → v5 rename removes a
+// resource type entirely (e.g. zone-scoped cloudflare_access_application has
+// no direct v5 equivalent in this provider). Without this, the v5 provider
+// errors out reading the dangling resource with:
+//
+//	no schema available for cloudflare_access_application.<name> while reading state
+func removeResourceFromState(t *testing.T, tmpDir string, resourceType string, resourceName string) {
+	matches, err := filepath.Glob(filepath.Join(tmpDir, "work*"))
+	if err != nil || len(matches) == 0 {
+		t.Fatalf("Could not find work directory in %s: %v", tmpDir, err)
+	}
+	workDir := matches[0]
+	stateFile := filepath.Join(workDir, "terraform.tfstate")
+
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("Could not read state file %s: %v", stateFile, err)
+	}
+
+	var state struct {
+		Version   int `json:"version"`
+		Resources []struct {
+			Module    string          `json:"module,omitempty"`
+			Mode      string          `json:"mode"`
+			Type      string          `json:"type"`
+			Name      string          `json:"name"`
+			Provider  string          `json:"provider"`
+			Instances json.RawMessage `json:"instances"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("Could not parse state file: %v", err)
+	}
+
+	filtered := state.Resources[:0]
+	removed := false
+	for _, r := range state.Resources {
+		if r.Type == resourceType && r.Name == resourceName {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	if !removed {
+		t.Fatalf("Could not find resource %s.%s in state to remove", resourceType, resourceName)
+	}
+	state.Resources = filtered
+
+	newData, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		t.Fatalf("Could not marshal state: %v", err)
+	}
+	if err := os.WriteFile(stateFile, newData, 0644); err != nil {
+		t.Fatalf("Could not write state file: %v", err)
+	}
+
+	t.Logf("Removed %s.%s from state file", resourceType, resourceName)
+}
+
+//go:embed testdata/v4_zone_id.tf
+var v4ZoneIDConfig string
+
+// TestMigrateZeroTrustAccessPolicyFromV4_ZoneIDScoped reproduces APIX-851:
+// When a v4 cloudflare_access_policy used zone_id (no account_id), the migration
+// to v5 cloudflare_zero_trust_access_policy produced a null account_id in state.
+// This caused "missing required account_id parameter" on any subsequent CRUD
+// operation because the Go SDK requires a non-empty account_id to construct the
+// API URL: POST accounts/{account_id}/access/policies.
+//
+// The fix derives account_id from the CLOUDFLARE_ACCOUNT_ID env var (with a Warning)
+// or returns a clear Error naming APIX-851 if the env var is also unset.
+//
+// This test focuses on the APIX-851 contract: given a zone-scoped v4 state with
+// CLOUDFLARE_ACCOUNT_ID set, after migration the v5 state has the correct
+// account_id and Read()/plan succeed.
+//
+// We bypass tf-migrate (which doesn't handle the zone-scoped v4 →
+// v5 rename today) and mirror the proven pattern from
+// TestMigrateZeroTrustAccessPolicyStateMvScenario: create with v4, manually
+// rename the resource type in state, then apply with v5 + manually-set
+// account_id in HCL. The state-upgrade path that runs in step 2 is exactly the
+// production path the APIX-851 fix patches.
+func TestMigrateZeroTrustAccessPolicyFromV4_ZoneIDScoped(t *testing.T) {
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "" {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	}
+
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("CLOUDFLARE_ACCOUNT_ID must be set for this test")
+	}
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	if zoneID == "" {
+		t.Skip("CLOUDFLARE_ZONE_ID must be set for this test")
+	}
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	if domain == "" {
+		t.Skip("CLOUDFLARE_DOMAIN must be set for this test")
+	}
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_zero_trust_access_policy." + rnd
+	tmpDir := t.TempDir()
+
+	v4Config := fmt.Sprintf(v4ZoneIDConfig, rnd, zoneID, domain)
+
+	// v5 config: cloudflare_zero_trust_access_policy is account-scoped only and
+	// is no longer tied to an application — the user creates it once and
+	// references it from access applications by ID. The migrated state retains
+	// the original policy ID, so Read() will fetch it from /accounts/{id}/access/policies/{policy_id}.
+	v5Config := fmt.Sprintf(`resource "cloudflare_zero_trust_access_policy" "%[1]s" {
+  account_id       = "%[2]s"
+  name             = "%[1]s"
+  decision         = "allow"
+  session_duration = "24h"
+
+  include = [{
+    email = {
+      email = "test@example.com"
+    }
+  }]
+}`, rnd, accountID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+			acctest.TestAccPreCheck_ZoneID(t)
+		},
+		WorkingDir: tmpDir,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create with v4 provider using zone_id + application_id.
+				// State written has account_id=null, zone_id=<zone>, application_id=<app>.
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"cloudflare": {
+						Source:            "cloudflare/cloudflare",
+						VersionConstraint: "~> 4.52.7",
+					},
+				},
+				Config: v4Config,
+			},
+			{
+				// Step 2: simulate the resource-type rename that tf-migrate would do
+				// (it currently doesn't handle the zone-scoped variant — separate bug),
+				// then apply with v5. The state-upgrade triggered by the type rename
+				// runs Transform → resolveAccountID, which under APIX-851 must
+				// either fall back to CLOUDFLARE_ACCOUNT_ID or emit a clear error.
+				//
+				// We also drop cloudflare_access_application from state — it has no
+				// direct v5 equivalent in this provider (would be renamed to
+				// cloudflare_zero_trust_access_application under a different schema),
+				// and the v5 config doesn't manage it. Leaving it in state causes
+				// the v5 provider to fail with "no schema available for
+				// cloudflare_access_application.<name> while reading state".
+				PreConfig: func() {
+					renameResourceTypeInState(t, tmpDir, "cloudflare_access_policy", "cloudflare_zero_trust_access_policy", rnd)
+					removeResourceFromState(t, tmpDir, "cloudflare_access_application", rnd)
+				},
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				Config:                   v5Config,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("decision"), knownvalue.StringExact("allow")),
+					// APIX-851 contract: account_id is populated post-migration
+					// (derived from CLOUDFLARE_ACCOUNT_ID, since the v4 state was zone-scoped).
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.AccountIDSchemaKey), knownvalue.StringExact(accountID)),
+				},
+			},
+			{
+				// Step 3: scrub the policy from state before the framework's auto-destroy.
+				//
+				// The policy was created in step 1 as an APPLICATION-OWNED (zone-scoped)
+				// v4 access_policy. The v5 cloudflare_zero_trust_access_policy resource
+				// only knows how to delete via the account-scoped endpoint
+				// (DELETE /accounts/{id}/access/policies/{policy_id}), which the API
+				// rejects with "invalid endpoint for deleting application-owned policies".
+				//
+				// This is itself a known limitation of the migration (separate from
+				// APIX-851's account_id contract): once a zone-scoped v4 policy is
+				// migrated to the v5 account-scoped resource, the v5 resource cannot
+				// actually destroy it. Users must either delete via the parent
+				// access_application or via the v4 API.
+				//
+				// For test cleanup we drop the policy from state so the framework's
+				// auto-destroy is a no-op. The orphaned application+policy in the test
+				// account are left for the resource sweeper to clean up.
+				PreConfig: func() {
+					removeResourceFromState(t, tmpDir, "cloudflare_zero_trust_access_policy", rnd)
+				},
+				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+				Config:                   " ",
+				PlanOnly:                 true,
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_access_policy/migration/v500/testdata/v4_zone_id.tf
+++ b/internal/services/zero_trust_access_policy/migration/v500/testdata/v4_zone_id.tf
@@ -1,0 +1,18 @@
+resource "cloudflare_access_application" "%[1]s" {
+  zone_id          = "%[2]s"
+  name             = "%[1]s"
+  domain           = "%[1]s.%[3]s"
+  session_duration = "24h"
+}
+
+resource "cloudflare_access_policy" "%[1]s" {
+  zone_id          = "%[2]s"
+  application_id   = cloudflare_access_application.%[1]s.id
+  name             = "%[1]s"
+  decision         = "allow"
+  precedence       = 1
+  session_duration = "24h"
+  include {
+    email = ["test@example.com"]
+  }
+}

--- a/internal/services/zero_trust_access_policy/migration/v500/transform.go
+++ b/internal/services/zero_trust_access_policy/migration/v500/transform.go
@@ -2,6 +2,8 @@ package v500
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
@@ -23,13 +25,73 @@ func normalizeBoolFalseToNull(b types.Bool) types.Bool {
 	return b
 }
 
+// resolveAccountID derives the v5 account_id from the v4 state. The v5
+// cloudflare_zero_trust_access_policy is account-scoped only; v4 supported
+// zone-scoped policies (zone_id + application_id, no account_id). When the v4
+// state is zone-scoped we fall back to the CLOUDFLARE_ACCOUNT_ID environment
+// variable (the standard provider env var) and emit a Warning. If neither the
+// state nor the env var supplies an account_id, an actionable Error diagnostic
+// is returned naming the resource and pointing at APIX-851.
+//
+// Returns (accountID, diags). On error, accountID is types.StringNull() and
+// diags contains an Error; the caller must abort the transform.
+func resolveAccountID(v4 SourceAccessPolicyModel) (types.String, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Happy path: v4 was account-scoped or both account_id + zone_id were set.
+	if !v4.AccountID.IsNull() && v4.AccountID.ValueString() != "" {
+		return v4.AccountID, diags
+	}
+
+	// v4 was zone-scoped (or under-populated). Try env var fallback.
+	if envID := strings.TrimSpace(os.Getenv("CLOUDFLARE_ACCOUNT_ID")); envID != "" {
+		diags.AddWarning(
+			"Derived account_id from CLOUDFLARE_ACCOUNT_ID during migration",
+			fmt.Sprintf(
+				"The v4 cloudflare_access_policy state was zone-scoped (zone_id=%q, application_id=%q) "+
+					"and contained no account_id, but the v5 cloudflare_zero_trust_access_policy is "+
+					"account-scoped only. Used CLOUDFLARE_ACCOUNT_ID=%q from the environment.\n\n"+
+					"Verify the value is correct for this resource; if not, run `terraform state rm` "+
+					"and re-import after the migration completes. Tracking: APIX-851.",
+				v4.ZoneID.ValueString(),
+				v4.ApplicationID.ValueString(),
+				envID,
+			),
+		)
+		return types.StringValue(envID), diags
+	}
+
+	// No account_id available anywhere.
+	diags.AddError(
+		"Cannot migrate zone-scoped Access policy without account_id",
+		fmt.Sprintf(
+			"The v4 cloudflare_access_policy was zone-scoped (zone_id=%q, application_id=%q) and "+
+				"contained no account_id in state. The v5 cloudflare_zero_trust_access_policy is "+
+				"account-scoped only and requires a non-empty account_id to read, update, or delete.\n\n"+
+				"To resolve, set the CLOUDFLARE_ACCOUNT_ID environment variable to the parent account "+
+				"of this zone and re-run the migration, then verify the resource was imported under "+
+				"the correct account.\n\n"+
+				"Tracking: APIX-851.",
+			v4.ZoneID.ValueString(),
+			v4.ApplicationID.ValueString(),
+		),
+	)
+	return types.StringNull(), diags
+}
+
 // Transform converts a v4 cloudflare_access_policy state to v5 cloudflare_zero_trust_access_policy state.
 func Transform(ctx context.Context, v4 SourceAccessPolicyModel) (*TargetAccessPolicyModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	accountID, accountIDDiags := resolveAccountID(v4)
+	diags.Append(accountIDDiags...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
 	v5 := &TargetAccessPolicyModel{
 		ID:                           v4.ID,
-		AccountID:                    v4.AccountID,
+		AccountID:                    accountID,
 		Name:                         v4.Name,
 		Decision:                     v4.Decision,
 		SessionDuration:              v4.SessionDuration,

--- a/internal/services/zero_trust_access_policy/migration/v500/transform_test.go
+++ b/internal/services/zero_trust_access_policy/migration/v500/transform_test.go
@@ -2,10 +2,162 @@ package v500
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// TestTransform_ZoneIDOnly_AccountIDIsNull reproduces APIX-851:
+// When a v4 cloudflare_access_policy used zone_id (no account_id), the
+// Transform function used to produce a v5 state with null account_id. This
+// caused "missing required account_id parameter" on any subsequent CRUD
+// operation because the Go SDK requires a non-empty account_id to construct
+// the API URL: POST accounts/{account_id}/access/policies.
+//
+// Customer scenario:
+//  1. v4 config: zone_id + application_id (zone-scoped app policy)
+//  2. Migration to v5: cloudflare_zero_trust_access_policy (reusable policy)
+//  3. v5 state has null account_id → Read() fails even when config has account_id hardcoded
+//     because Read() sources account_id from state, not config.
+//
+// Fix (APIX-851): Transform must either:
+//
+//	(a) emit a diagnostic error explaining zone_id-only policies require manual account_id, or
+//	(b) resolve account_id from another source (CLOUDFLARE_ACCOUNT_ID env var).
+//
+// This test exercises path (a) — no env var set, expect a clear diagnostic error.
+// TestTransform_ZoneIDOnly_AccountIDFromEnvVar covers path (b).
+func TestTransform_ZoneIDOnly_AccountIDIsNull(t *testing.T) {
+	// Defensively clear the env var in case the test runner has it set;
+	// path (a) requires no fallback to be available.
+	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "")
+	ctx := context.Background()
+
+	v4State := SourceAccessPolicyModel{
+		ID:              types.StringValue("test-policy-id"),
+		AccountID:       types.StringNull(),
+		ZoneID:          types.StringValue("zone-abc123"),
+		ApplicationID:   types.StringValue("app-def456"),
+		Name:            types.StringValue("test-policy"),
+		Decision:        types.StringValue("allow"),
+		SessionDuration: types.StringValue("24h"),
+		Precedence:      types.Int64Value(1),
+	}
+
+	v5State, diags := Transform(ctx, v4State)
+
+	// Either path is acceptable per APIX-851 contract:
+	//   (a) clear diagnostic error  → v5State==nil, diags.HasError()
+	//   (b) populated account_id    → v5State!=nil, !diags.HasError()
+	if diags.HasError() {
+		// Path (a): make sure the error names APIX-851 so the user knows where to look.
+		msg := diags.Errors()[0].Summary() + " " + diags.Errors()[0].Detail()
+		if !strings.Contains(msg, "APIX-851") {
+			t.Errorf("expected diagnostic error to reference APIX-851, got: %s", msg)
+		}
+		return
+	}
+
+	if v5State == nil {
+		t.Fatalf("Transform returned nil state and no error diagnostic")
+	}
+	if v5State.AccountID.IsNull() || v5State.AccountID.ValueString() == "" {
+		t.Errorf("APIX-851: expected account_id to be populated (or a diagnostic error) after migration "+
+			"from zone_id-scoped policy, but got null/empty. zone_id was %q, application_id was %q",
+			v4State.ZoneID.ValueString(), v4State.ApplicationID.ValueString())
+	}
+}
+
+// TestTransform_ZoneIDOnly_AccountIDFromEnvVar verifies the CLOUDFLARE_ACCOUNT_ID
+// fallback path of the APIX-851 fix: when the v4 state is zone-scoped and no
+// account_id is in state, the migration uses CLOUDFLARE_ACCOUNT_ID and emits a
+// Warning diagnostic (not an Error).
+func TestTransform_ZoneIDOnly_AccountIDFromEnvVar(t *testing.T) {
+	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "env-acct-789")
+	ctx := context.Background()
+
+	v4State := SourceAccessPolicyModel{
+		ID:              types.StringValue("test-policy-id"),
+		AccountID:       types.StringNull(),
+		ZoneID:          types.StringValue("zone-abc123"),
+		ApplicationID:   types.StringValue("app-def456"),
+		Name:            types.StringValue("test-policy"),
+		Decision:        types.StringValue("allow"),
+		SessionDuration: types.StringValue("24h"),
+		Precedence:      types.Int64Value(1),
+	}
+
+	v5State, diags := Transform(ctx, v4State)
+	if diags.HasError() {
+		t.Fatalf("did not expect an error with CLOUDFLARE_ACCOUNT_ID set, got: %v", diags)
+	}
+	if v5State == nil {
+		t.Fatalf("Transform returned nil state without an error diagnostic")
+	}
+	if got := v5State.AccountID.ValueString(); got != "env-acct-789" {
+		t.Errorf("expected account_id to be derived from CLOUDFLARE_ACCOUNT_ID env var (env-acct-789), got %q", got)
+	}
+	if diags.WarningsCount() == 0 {
+		t.Errorf("expected a Warning diagnostic naming the env-var fallback, got none")
+	}
+}
+
+// TestTransform_AccountIDPreservedWhenSet verifies that when a v4 state has
+// account_id set, it is correctly preserved in the v5 state.
+// This is a control test for APIX-851.
+func TestTransform_AccountIDPreservedWhenSet(t *testing.T) {
+	ctx := context.Background()
+
+	v4State := SourceAccessPolicyModel{
+		ID:              types.StringValue("test-policy-id"),
+		AccountID:       types.StringValue("acct-123456"),
+		ZoneID:          types.StringNull(),
+		ApplicationID:   types.StringNull(),
+		Name:            types.StringValue("test-policy"),
+		Decision:        types.StringValue("allow"),
+		SessionDuration: types.StringValue("24h"),
+		Precedence:      types.Int64Value(1),
+	}
+
+	v5State, diags := Transform(ctx, v4State)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if v5State.AccountID.ValueString() != "acct-123456" {
+		t.Errorf("expected account_id to be preserved as 'acct-123456', got %q (null=%v)",
+			v5State.AccountID.ValueString(), v5State.AccountID.IsNull())
+	}
+}
+
+// TestTransform_BothZoneIDAndAccountID_AccountIDPreserved verifies that when
+// both zone_id and account_id are set in v4 state (some users had both), the
+// account_id is correctly preserved in v5.
+func TestTransform_BothZoneIDAndAccountID_AccountIDPreserved(t *testing.T) {
+	ctx := context.Background()
+
+	v4State := SourceAccessPolicyModel{
+		ID:              types.StringValue("test-policy-id"),
+		AccountID:       types.StringValue("acct-123456"),
+		ZoneID:          types.StringValue("zone-abc123"),
+		ApplicationID:   types.StringValue("app-def456"),
+		Name:            types.StringValue("test-policy"),
+		Decision:        types.StringValue("allow"),
+		SessionDuration: types.StringValue("24h"),
+		Precedence:      types.Int64Value(1),
+	}
+
+	v5State, diags := Transform(ctx, v4State)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if v5State.AccountID.ValueString() != "acct-123456" {
+		t.Errorf("expected account_id to be preserved as 'acct-123456', got %q (null=%v)",
+			v5State.AccountID.ValueString(), v5State.AccountID.IsNull())
+	}
+}
 
 func TestTransformConditions_SkipsEmptyAuthMethodAndCommonName(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Changes being requested

Three independent state-upgrader bug fixes, all surfaced after the `schema_version=500` bump:

### 1. `load_balancer_pool` — accept early-v5 object-shape state (#7098)

State written by **v5.0–v5.18** at `schema_version=0` used **object**-shaped `load_shedding` and `origin_steering` blocks. Slot 0 was registered with the v4 SDKv2 `PriorSchema` (list shape), so the Plugin Framework rejected the state pre-handler with:

```
AttributeName("origin_steering"): invalid JSON, expected "[", got "{"
```

Fix: drop `PriorSchema` on slot 0 and probe `req.RawState.JSON` directly against the target schema. Target-unmarshal success → early-v5, no-op pass-through. Failure → parse with v4 source schema and run the existing `Transform`.

### 2. `spectrum_application` — accept early-v5 object-shape state (#7098)

Same root cause and fix as above, but for `dns`, `origin_dns`, `edge_ips`, `origin_port_range`.

### 3. `zero_trust_access_policy` — populate `account_id` when migrating zone-scoped v4 state (APIX-851)

v4 `cloudflare_access_policy` supported zone-scoped policies (`zone_id` + `application_id`, no `account_id`). v5 `cloudflare_zero_trust_access_policy` is **account-scoped only**. `Transform` copied `v4.AccountID` straight through, leaving it null for zone-scoped state. Subsequent CRUD then failed with `missing required account_id parameter` because the SDK builds the URL as `accounts/{account_id}/access/policies`.

Fix — new `resolveAccountID`:
1. If `v4.AccountID` is set → use it.
2. Else fall back to `CLOUDFLARE_ACCOUNT_ID` env var, emit a **Warning** referencing APIX-851.
3. Else return an **Error** naming the resource (zone_id, application_id) and APIX-851.

#### Known follow-up (not addressed in this PR)

After the migration succeeds, the v5 provider still cannot CRUD policies that were originally **application-owned** in v4 — the API rejects account-scoped `DELETE` for them with:

```
invalid endpoint for deleting application-owned policies
```

This PR's fix gets users past the silent `missing account_id` failure into a clear, traceable state, but a complete migration story for application-owned policies needs a follow-up (either detect and block with a diagnostic, or re-route CRUD via the parent application).

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

```sh
# #7098 — load_balancer_pool early-v5 → v500 upgrade
TF_ACC=1 go test -v -p 1 -count 1 \
  ./internal/services/load_balancer_pool/migration/v500 \
  -run "TestMigrateLoadBalancerPool_FromEarlyV5_ObjectAttrs" -timeout 30m

# #7098 — spectrum_application early-v5 → v500 upgrade
TF_ACC=1 go test -v -p 1 -count 1 \
  ./internal/services/spectrum_application/migration/v500 \
  -run "TestMigrateSpectrumApplication_FromEarlyV5_Complex" -timeout 30m

# APIX-851 — zone-scoped v4 → v5 account_id resolution
TF_ACC=1 go test -v -p 1 -count 1 \
  ./internal/services/zero_trust_access_policy/migration/v500 \
  -run "TestMigrateZeroTrustAccessPolicyFromV4_ZoneIDScoped" -timeout 30m

# Unit tests (no TF_ACC required)
go test -count=1 \
  ./internal/services/zero_trust_access_policy/migration/v500/... \
  ./internal/services/load_balancer_pool/migration/v500/... \
  ./internal/services/spectrum_application/migration/v500/...
```

### Test output

Latest local run of the APIX-851 acceptance test after the step-3 state-scrub fix:

```
~/cf-repos/github/terraform-provider-cloudflare next !9 ?5 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/spectrum_application/migration/v500 -run "Test" -timeout 30m    11:10:40 AM
=== RUN   TestUpgradeFromV0Ambiguous_V5ObjectShape
--- PASS: TestUpgradeFromV0Ambiguous_V5ObjectShape (0.00s)
=== RUN   TestUpgradeFromV0Ambiguous_NilRawState
--- PASS: TestUpgradeFromV0Ambiguous_NilRawState (0.00s)
=== RUN   TestSpectrumApplicationMigrationModelSchemaParity
=== PAUSE TestSpectrumApplicationMigrationModelSchemaParity
=== RUN   TestMigrateSpectrumApplication_Basic
--- PASS: TestMigrateSpectrumApplication_Basic (23.01s)
=== RUN   TestMigrateSpectrumApplication_OriginPortRange
--- PASS: TestMigrateSpectrumApplication_OriginPortRange (18.65s)
=== RUN   TestMigrateSpectrumApplication_EdgeIPs
--- PASS: TestMigrateSpectrumApplication_EdgeIPs (18.56s)
=== RUN   TestMigrateSpectrumApplication_OriginDirect
--- PASS: TestMigrateSpectrumApplication_OriginDirect (17.11s)
=== RUN   TestMigrateSpectrumApplication_Complex
--- PASS: TestMigrateSpectrumApplication_Complex (16.79s)
=== RUN   TestMigrateSpectrumApplication_FromEarlyV5_Complex
--- PASS: TestMigrateSpectrumApplication_FromEarlyV5_Complex (18.02s)
=== CONT  TestSpectrumApplicationMigrationModelSchemaParity
--- PASS: TestSpectrumApplicationMigrationModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/spectrum_application/migration/v500	114.059s

~/cf-repos/github/terraform-provider-cloudflare next !9 ?5 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/load_balancer_pool/migration/v500 -run "Test" -timeout 30m
=== RUN   TestUpgradeFromV0Ambiguous_V5ObjectShape
--- PASS: TestUpgradeFromV0Ambiguous_V5ObjectShape (0.00s)
=== RUN   TestUpgradeFromV0Ambiguous_NilRawState
--- PASS: TestUpgradeFromV0Ambiguous_NilRawState (0.00s)
=== RUN   TestLoadBalancerPoolMigrationModelSchemaParity
=== PAUSE TestLoadBalancerPoolMigrationModelSchemaParity
=== RUN   TestMigrateLoadBalancerPool_V4ToV5_Basic
=== RUN   TestMigrateLoadBalancerPool_V4ToV5_Basic/from_v4_latest
=== RUN   TestMigrateLoadBalancerPool_V4ToV5_Basic/from_v5
--- PASS: TestMigrateLoadBalancerPool_V4ToV5_Basic (20.55s)
    --- PASS: TestMigrateLoadBalancerPool_V4ToV5_Basic/from_v4_latest (16.15s)
    --- PASS: TestMigrateLoadBalancerPool_V4ToV5_Basic/from_v5 (4.40s)
=== RUN   TestMigrateLoadBalancerPool_V4ToV5_FullConfig
=== RUN   TestMigrateLoadBalancerPool_V4ToV5_FullConfig/from_v4_latest
--- PASS: TestMigrateLoadBalancerPool_V4ToV5_FullConfig (16.62s)
    --- PASS: TestMigrateLoadBalancerPool_V4ToV5_FullConfig/from_v4_latest (16.62s)
=== RUN   TestMigrateLoadBalancerPool_V4ToV5_CheckRegions
=== RUN   TestMigrateLoadBalancerPool_V4ToV5_CheckRegions/from_v4_latest
=== RUN   TestMigrateLoadBalancerPool_V4ToV5_CheckRegions/from_v5
--- PASS: TestMigrateLoadBalancerPool_V4ToV5_CheckRegions (18.95s)
    --- PASS: TestMigrateLoadBalancerPool_V4ToV5_CheckRegions/from_v4_latest (15.06s)
    --- PASS: TestMigrateLoadBalancerPool_V4ToV5_CheckRegions/from_v5 (3.90s)
=== RUN   TestMigrateLoadBalancerPool_FromEarlyV5_ObjectAttrs
--- PASS: TestMigrateLoadBalancerPool_FromEarlyV5_ObjectAttrs (17.19s)
=== CONT  TestLoadBalancerPoolMigrationModelSchemaParity
--- PASS: TestLoadBalancerPoolMigrationModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/load_balancer_pool/migration/v500	75.180s

~/cf-repos/github/terraform-provider-cloudflare next !9 ?5 ❯ TF_ACC=1 go test -v -p 1 -count 1 ./internal/services/zero_trust_access_policy/migration/v500 -run "Test" -timeout 30m
=== RUN   TestTransform_ZoneIDOnly_AccountIDIsNull
--- PASS: TestTransform_ZoneIDOnly_AccountIDIsNull (0.00s)
=== RUN   TestTransform_ZoneIDOnly_AccountIDFromEnvVar
--- PASS: TestTransform_ZoneIDOnly_AccountIDFromEnvVar (0.00s)
=== RUN   TestTransform_AccountIDPreservedWhenSet
--- PASS: TestTransform_AccountIDPreservedWhenSet (0.00s)
=== RUN   TestTransform_BothZoneIDAndAccountID_AccountIDPreserved
--- PASS: TestTransform_BothZoneIDAndAccountID_AccountIDPreserved (0.00s)
=== RUN   TestTransformConditions_SkipsEmptyAuthMethodAndCommonName
--- PASS: TestTransformConditions_SkipsEmptyAuthMethodAndCommonName (0.00s)
=== RUN   TestTransformConditions_IncludesNonEmptyAuthMethodAndCommonName
--- PASS: TestTransformConditions_IncludesNonEmptyAuthMethodAndCommonName (0.00s)
=== RUN   TestZeroTrustAccessPolicyMigrationModelSchemaParity
=== PAUSE TestZeroTrustAccessPolicyMigrationModelSchemaParity
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4Basic
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4Basic (15.23s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4Complex
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4Complex (15.89s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4OAuthProviders
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4OAuthProviders (14.74s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_Allow
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_Deny
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_NonIdentity
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_Bypass
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes (56.95s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_Allow (13.89s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_Deny (14.31s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_NonIdentity (14.35s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4DecisionTypes/Decision_Bypass (14.40s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans/Boolean_Everyone
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans/Boolean_Certificate
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans/Boolean_AnyValidServiceToken
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans (43.69s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans/Boolean_Everyone (14.65s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans/Boolean_Certificate (14.69s)
    --- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4OptionalBooleans/Boolean_AnyValidServiceToken (14.36s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4UnsupportedFeatures
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4UnsupportedFeatures (14.40s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4ServiceTokens
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4ServiceTokens (15.47s)
=== RUN   TestMigrateZeroTrustAccessPolicyMigrationFromV4RemovedAttributes
--- PASS: TestMigrateZeroTrustAccessPolicyMigrationFromV4RemovedAttributes (14.11s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_12
--- PASS: TestMigrateZeroTrustAccessPolicyFromV5_12 (17.36s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_14
--- PASS: TestMigrateZeroTrustAccessPolicyFromV5_14 (17.78s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_15
--- PASS: TestMigrateZeroTrustAccessPolicyFromV5_15 (17.64s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_12_Complex
--- PASS: TestMigrateZeroTrustAccessPolicyFromV5_12_Complex (15.98s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_Allow
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_Deny
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_NonIdentity
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_Bypass
--- PASS: TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes (70.16s)
    --- PASS: TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_Allow (15.65s)
    --- PASS: TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_Deny (17.30s)
    --- PASS: TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_NonIdentity (16.26s)
    --- PASS: TestMigrateZeroTrustAccessPolicyFromV5_14_WithDecisionTypes/Decision_Bypass (20.95s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV5_15_WithConditionTypes
--- PASS: TestMigrateZeroTrustAccessPolicyFromV5_15_WithConditionTypes (18.44s)
=== RUN   TestMigrateZeroTrustAccessPolicyEmailDomainTransformation
--- PASS: TestMigrateZeroTrustAccessPolicyEmailDomainTransformation (15.79s)
=== RUN   TestMigrateZeroTrustAccessPolicyConnectionRules
--- PASS: TestMigrateZeroTrustAccessPolicyConnectionRules (14.35s)
=== RUN   TestMigrateZeroTrustAccessPolicyStateMvScenario
    migrations_test.go:943: Renamed cloudflare_access_policy.cftftestsekpendnnz to cloudflare_zero_trust_access_policy.cftftestsekpendnnz in state file
--- PASS: TestMigrateZeroTrustAccessPolicyStateMvScenario (14.03s)
=== RUN   TestMigrateZeroTrustAccessPolicyFromV4_ZoneIDScoped
    migrations_test.go:943: Renamed cloudflare_access_policy.cftftestjytbqynkbp to cloudflare_zero_trust_access_policy.cftftestjytbqynkbp in state file
    migrations_test.go:1005: Removed cloudflare_access_application.cftftestjytbqynkbp from state file
    migrations_test.go:1005: Removed cloudflare_zero_trust_access_policy.cftftestjytbqynkbp from state file
--- PASS: TestMigrateZeroTrustAccessPolicyFromV4_ZoneIDScoped (15.80s)
=== CONT  TestZeroTrustAccessPolicyMigrationModelSchemaParity
--- PASS: TestZeroTrustAccessPolicyMigrationModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_access_policy/migration/v500	409.635s
```



## Additional context & links

- #7098 — `Error: AttributeName("origin_steering"): invalid JSON, expected "[", got "{"`
- APIX-851 — internal tracker for the zone-scoped Access policy migration gap
- Sibling test pattern: `TestMigrateZeroTrustAccessPolicyStateMvScenario` (account-scoped variant) — works today because it skips the application_id path
