### PR TITLE
fix(load_balancer_pool): add UseStateForUnknown for load_shedding attribute

### DIFF
--- a/internal/services/load_balancer_pool/resource_test.go
+++ b/internal/services/load_balancer_pool/resource_test.go
@@ -174,6 +174,42 @@ func TestAccCloudflareLoadBalancerPool_Basic(t *testing.T) {
 	})
 }
 
+// TestAccCloudflareLoadBalancerPool_NoLoadSheddingDrift verifies that a pool
+// config with no explicit load_shedding block does NOT produce drift on a
+// no-op re-apply. Without the UseStateForUnknown plan modifier on
+// load_shedding, Terraform fills in child Default values (default_percent=0,
+// session_percent=0) on every plan, causing a perpetual null -> 0 diff.
+func TestAccCloudflareLoadBalancerPool_NoLoadSheddingDrift(t *testing.T) {
+	t.Parallel()
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_load_balancer_pool." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareLoadBalancerPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create pool without load_shedding declared.
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigBasic(rnd, accountID),
+			},
+			{
+				// Step 2: re-apply identical config. Must be a no-op.
+				// Without UseStateForUnknown on load_shedding, this
+				// would plan an in-place update (null -> 0 on percent
+				// fields).
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigBasic(rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(name, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccCloudflareLoadBalancerPool_OriginSteeringLeastOutstandingRequests(t *testing.T) {
 	// multiple instances of this config would conflict but we only use it once
 	t.Parallel()
@@ -404,10 +440,10 @@ func TestAccCloudflareLoadBalancerPool_CreateAfterManualDestroy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckCloudflareLoadBalancerPoolConfigBasic(rnd, accountID),
-				Check: resource.ComposeTestCheckFunc(
-					// TODO: see if this is still actually needed
-					// testAccCheckCloudflareLoadBalancerPoolExists(name, &loadBalancerPool),
-					// testAccManuallyDeleteLoadBalancerPool(name, &loadBalancerPool, &initialId),
+				Check:  resource.ComposeTestCheckFunc(
+				// TODO: see if this is still actually needed
+				// testAccCheckCloudflareLoadBalancerPoolExists(name, &loadBalancerPool),
+				// testAccManuallyDeleteLoadBalancerPool(name, &loadBalancerPool, &initialId),
 				),
 			},
 			{

--- a/internal/services/load_balancer_pool/schema.go
+++ b/internal/services/load_balancer_pool/schema.go
@@ -4,6 +4,7 @@ package load_balancer_pool
 
 import (
 	"context"
+
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/schemata"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -219,6 +221,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Default: stringdefault.StaticString("hash"),
 					},
 				},
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 			},
 			"notification_filter": schema.SingleNestedAttribute{
 				Description: "Filter pool and origin health notifications by resource type or health status. Use null to reset.",


### PR DESCRIPTION
Resolves issue with `load_balancer_pool` `load_shedding` attribute(s) producing continual Terraform plan drift across applies by adding `UseStateForUnknown` plan modifier. This plan modifier should persists the prior Terraform state for field(s) that are not explicitly configured.

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Add `UseStateForUnknown` plan modifier to `load_balancer_pool` `load_shedding` attribute

Reference commit: https://github.com/cloudflare/terraform-provider-cloudflare/commit/248c746ec

## Acceptance test run results

Noting that the original reference commit does not add/modify acceptance tests. It may not be strictly necessary for this changes since it is relatively minor, but I can proceed with additional testing if needed.

- [x] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links

For additional context, please see Cloudflare internal escalation: https://jira.cfdata.org/browse/ESCALATION-2542
