### PR TITLE
fix: tier-1 small fixes (#6779, #6952, #7031, #6969)

### DIFF
--- a/docs/data-sources/zone_hold.md
+++ b/docs/data-sources/zone_hold.md
@@ -67,6 +67,6 @@ data "cloudflare_zone_hold" "example_zone_hold" {
 - `hold` (Boolean)
 - `hold_after` (String)
 - `id` (String) Identifier.
-- `include_subdomains` (String)
+- `include_subdomains` (Boolean)
 
 

--- a/docs/resources/workers_cron_trigger.md
+++ b/docs/resources/workers_cron_trigger.md
@@ -17,11 +17,16 @@ Accepted Permissions
 
 ```terraform
 resource "cloudflare_workers_cron_trigger" "example_workers_cron_trigger" {
-  account_id = "023e105f4ecef8ad9ca31a8372d0c353"
+  account_id  = "023e105f4ecef8ad9ca31a8372d0c353"
   script_name = "this-is_my_script-01"
-  body = [{
-    cron = "*/30 * * * *"
-  }]
+  schedules = [
+    {
+      cron = "*/30 * * * *"
+    },
+    {
+      cron = "0 0 * * *"
+    },
+  ]
 }
 ```
 

--- a/docs/resources/zero_trust_dex_test.md
+++ b/docs/resources/zero_trust_dex_test.md
@@ -76,7 +76,7 @@ Required:
 
 - `id` (String) The id of the DEX rule
 
-Read-Only:
+Optional:
 
 - `default` (Boolean) Whether the DEX rule is the account default
 - `name` (String) The name of the DEX rule

--- a/examples/resources/cloudflare_workers_cron_trigger/resource.tf
+++ b/examples/resources/cloudflare_workers_cron_trigger/resource.tf
@@ -1,7 +1,12 @@
 resource "cloudflare_workers_cron_trigger" "example_workers_cron_trigger" {
-  account_id = "023e105f4ecef8ad9ca31a8372d0c353"
+  account_id  = "023e105f4ecef8ad9ca31a8372d0c353"
   script_name = "this-is_my_script-01"
-  body = [{
-    cron = "*/30 * * * *"
-  }]
+  schedules = [
+    {
+      cron = "*/30 * * * *"
+    },
+    {
+      cron = "0 0 * * *"
+    },
+  ]
 }

--- a/internal/services/page_rule/schema.go
+++ b/internal/services/page_rule/schema.go
@@ -272,7 +272,7 @@ Version: 500,
 						Optional: true,
 						Validators: []validator.Int64{
 							int64validator.AtLeast(0),
-							int64validator.AtMost(2419200),
+							int64validator.AtMost(31536000),
 						},
 					},
 					"email_obfuscation": schema.StringAttribute{

--- a/internal/services/zero_trust_dex_test/model.go
+++ b/internal/services/zero_trust_dex_test/model.go
@@ -41,6 +41,6 @@ type ZeroTrustDEXTestDataModel struct {
 
 type ZeroTrustDEXTestTargetPoliciesModel struct {
 	ID      types.String `tfsdk:"id" json:"id,required"`
-	Default types.Bool   `tfsdk:"default" json:"default,computed"`
-	Name    types.String `tfsdk:"name" json:"name,computed"`
+	Default types.Bool   `tfsdk:"default" json:"default,computed_optional"`
+	Name    types.String `tfsdk:"name" json:"name,computed_optional"`
 }

--- a/internal/services/zero_trust_dex_test/schema.go
+++ b/internal/services/zero_trust_dex_test/schema.go
@@ -98,11 +98,13 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"default": schema.BoolAttribute{
 							Description:   "Whether the DEX rule is the account default",
 							Computed:      true,
+							Optional:      true,
 							PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 						},
 						"name": schema.StringAttribute{
 							Description:   "The name of the DEX rule",
 							Computed:      true,
+							Optional:      true,
 							PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 						},
 					},

--- a/internal/services/zone_hold/data_source_model.go
+++ b/internal/services/zone_hold/data_source_model.go
@@ -20,7 +20,7 @@ type ZoneHoldDataSourceModel struct {
 	ZoneID            types.String `tfsdk:"zone_id" path:"zone_id,optional"`
 	Hold              types.Bool   `tfsdk:"hold" json:"hold,computed"`
 	HoldAfter         types.String `tfsdk:"hold_after" json:"hold_after,computed"`
-	IncludeSubdomains types.String `tfsdk:"include_subdomains" json:"include_subdomains,computed"`
+	IncludeSubdomains types.Bool   `tfsdk:"include_subdomains" json:"include_subdomains,computed"`
 }
 
 func (m *ZoneHoldDataSourceModel) toReadParams(_ context.Context) (params zones.HoldGetParams, diags diag.Diagnostics) {

--- a/internal/services/zone_hold/data_source_schema.go
+++ b/internal/services/zone_hold/data_source_schema.go
@@ -69,7 +69,7 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 			"hold_after": schema.StringAttribute{
 				Computed: true,
 			},
-			"include_subdomains": schema.StringAttribute{
+			"include_subdomains": schema.BoolAttribute{
 				Computed: true,
 			},
 		},

--- a/internal/services/zone_hold/model.go
+++ b/internal/services/zone_hold/model.go
@@ -15,7 +15,7 @@ type ZoneHoldModel struct {
 	ID                types.String `tfsdk:"id" json:"-,computed"`
 	ZoneID            types.String `tfsdk:"zone_id" path:"zone_id,required"`
 	HoldAfter         types.String `tfsdk:"hold_after" json:"hold_after,computed_optional,"`
-	IncludeSubdomains types.Bool   `tfsdk:"include_subdomains" json:"include_subdomains,computed_optional,no_refresh"`
+	IncludeSubdomains types.Bool   `tfsdk:"include_subdomains" json:"include_subdomains,computed_optional"`
 	Hold              types.Bool   `tfsdk:"hold" json:"hold,computed"`
 }
 


### PR DESCRIPTION
## Summary

Batch of small Tier-1 fixes from the open-issue triage. Each is narrowly scoped, has unit tests passing, and corresponds to a separately tracked issue.


## Fixes

### #6779 — \`page_rule\` \`actions.edge_cache_ttl\` validator
The hand-written validator capped \`edge_cache_ttl\` at 2,419,200 (28 days). The Cloudflare API and OpenAPI spec (\`zones_edge_cache_ttl\`) both allow up to 31,536,000 (1 year).

\`\`\`diff
- int64validator.AtMost(2419200),
+ int64validator.AtMost(31536000),
\`\`\`

(The actions enum is \`x-stainless-skip: terraform\` in the spec, so this validator lives only in the provider.)

### #6952 — \`cloudflare_workers_cron_trigger\` example
The auto-generated example used the raw request-body shape (\`body = [{...}]\`) instead of the provider's attribute name (\`schedules\`). Updated the example and added a second cron entry to make it obvious multiple schedules are supported.

### #7031 — \`cloudflare_zone_hold\` doesn't track \`include_subdomains\`
Two bugs:
1. \`data_source_schema.go\` typed \`include_subdomains\` as \`StringAttribute\`; the API returns a JSON boolean. Switched to \`BoolAttribute\` (and \`types.Bool\` in the data source model).
2. \`model.go\` (resource) had \`no_refresh\` on the field, so the resource Read never pulled the value back. Removed.

Root cause was a mistype in the OpenAPI spec (\`type: string\` on the GET/DELETE/PATCH response shapes); fix raised upstream in api-schemas.

### #6969 — \`cloudflare_zero_trust_dex_test.target_policies[]\` read-only
The Cloudflare DEX tests API accepts \`name\` and \`default\` on create, but the v5 schema marked them Computed-only. Now Optional+Computed with \`UseStateForUnknown()\`. Spec annotations also being updated from \`computed\` to \`computed_optional\` upstream.

## Test plan

- \`go build ./...\` clean
- \`go test ./internal/services/page_rule/... ./internal/services/zero_trust_access_service_token/... ./internal/services/workers_cron_trigger/... ./internal/services/zone_hold/... ./internal/services/zero_trust_dex_test/...\` all pass
- \`./scripts/generate-docs\` regenerated docs included in commit

## Issues addressed

Closes #6779
Closes #6952
Closes #7031
Closes #6969

## Issues already fixed (close-out, no code in this PR)

- #6965 \`cni_maintenance_notification\` enum value — already in main
- #7091 \`pages_project\`/\`pages_domain\` \`account_id\` Required — fixed in #7056