### PR TITLE
perf(zero_trust_access_policy): add retry logic if 409

### DIFF
--- a/internal/services/zero_trust_access_policy/resource.go
+++ b/internal/services/zero_trust_access_policy/resource.go
@@ -245,7 +245,7 @@ func (r *ZeroTrustAccessPolicyResource) Delete(ctx context.Context, req resource
 			option.WithMiddleware(logging.Middleware(ctx)),
 		)
 		if retryErr != nil {
-			// Check if it's a 409 where we're just waiting for the policy to detach
+			// Check if 409 and we're just waiting for the policy to detach
 			if res != nil && res.StatusCode == http.StatusConflict {
 				return retry.RetryableError(retryErr)
 			}

--- a/internal/services/zero_trust_access_policy/resource.go
+++ b/internal/services/zero_trust_access_policy/resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/cloudflare/cloudflare-go/v7"
 	"github.com/cloudflare/cloudflare-go/v7/option"
@@ -17,6 +18,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -231,14 +233,26 @@ func (r *ZeroTrustAccessPolicyResource) Delete(ctx context.Context, req resource
 		return
 	}
 
-	_, err := r.client.ZeroTrust.Access.Policies.Delete(
-		ctx,
-		data.ID.ValueString(),
-		zero_trust.AccessPolicyDeleteParams{
-			AccountID: cloudflare.F(data.AccountID.ValueString()),
-		},
-		option.WithMiddleware(logging.Middleware(ctx)),
-	)
+	res := new(http.Response)
+	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		_, retryErr := r.client.ZeroTrust.Access.Policies.Delete(
+			ctx,
+			data.ID.ValueString(),
+			zero_trust.AccessPolicyDeleteParams{
+				AccountID: cloudflare.F(data.AccountID.ValueString()),
+			},
+			option.WithResponseBodyInto(&res),
+			option.WithMiddleware(logging.Middleware(ctx)),
+		)
+		if retryErr != nil {
+			// Check if it's a 409 where we're just waiting for the policy to detach
+			if res != nil && res.StatusCode == http.StatusConflict {
+				return retry.RetryableError(retryErr)
+			}
+			return retry.NonRetryableError(retryErr)
+		}
+		return nil
+	})
 	if err != nil {
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

This adds retry logic to circumvent a 409 that happens when you try to delete and to remove an access policy from an access application at the same time.

Mimics the retry logic present in [zero_trust_access_mtls_hostname_settings](https://github.com/cloudflare/terraform-provider-cloudflare/blob/main/internal/services/zero_trust_access_mtls_hostname_settings/resource.go#L84)

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
