### PR TITLE
resource/cloudflare_ruleset: add asset_name to action_parameters (v4)

### DIFF
--- a/.changelog/asset-name.txt
+++ b/.changelog/asset-name.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_ruleset: add `asset_name` to `action_parameters` for `http_custom_errors` `serve_error` rules
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.3
 
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/cloudflare/cloudflare-go v0.116.0
+	github.com/cloudflare/cloudflare-go v0.117.0
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZ
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/cloudflare/cloudflare-go v0.116.0 h1:iRPMnTtnswRpELO65NTwMX4+RTdxZl+Xf/zi+HPE95s=
-github.com/cloudflare/cloudflare-go v0.116.0/go.mod h1:Ds6urDwn/TF2uIU24mu7H91xkKP8gSAHxQ44DSZgVmU=
+github.com/cloudflare/cloudflare-go v0.117.0 h1:y00E0XCvxuZGplL+gkoMRIhWpfNqIgyBFS6UUWC4s0c=
+github.com/cloudflare/cloudflare-go v0.117.0/go.mod h1:Ds6urDwn/TF2uIU24mu7H91xkKP8gSAHxQ44DSZgVmU=
 github.com/cloudflare/cloudflare-go/v2 v2.4.0 h1:gys/26GoVDklgfq8NYV39WgvOEwzK/XAqYObmnI6iFg=
 github.com/cloudflare/cloudflare-go/v2 v2.4.0/go.mod h1:AoIzb05z/rvdJLztPct4tSa+3IqXJJ6c+pbUFMOlTr8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/framework/service/rulesets/model.go
+++ b/internal/framework/service/rulesets/model.go
@@ -28,6 +28,7 @@ type RulesModel struct {
 
 type ActionParametersModel struct {
 	AdditionalCacheablePorts types.Set                                    `tfsdk:"additional_cacheable_ports"`
+	AssetName                types.String                                 `tfsdk:"asset_name"`
 	AutomaticHTTPSRewrites   types.Bool                                   `tfsdk:"automatic_https_rewrites"`
 	AutoMinify               []*ActionParameterAutoMinifyModel            `tfsdk:"autominify"`
 	BIC                      types.Bool                                   `tfsdk:"bic"`

--- a/internal/framework/service/rulesets/resource.go
+++ b/internal/framework/service/rulesets/resource.go
@@ -317,6 +317,7 @@ func toRulesetResourceModel(ctx context.Context, zoneID, accountID basetypes.Str
 		// action_parameters
 		if !reflect.ValueOf(ruleResponse.ActionParameters).IsNil() {
 			rule.ActionParameters = append(rule.ActionParameters, &ActionParametersModel{
+				AssetName:               flatteners.String(ruleResponse.ActionParameters.AssetName),
 				AutomaticHTTPSRewrites:  flatteners.Bool(ruleResponse.ActionParameters.AutomaticHTTPSRewrites),
 				BIC:                     flatteners.Bool(ruleResponse.ActionParameters.BrowserIntegrityCheck),
 				Cache:                   flatteners.Bool(ruleResponse.ActionParameters.Cache),
@@ -833,6 +834,10 @@ func (r *RulesModel) toRulesetRule(ctx context.Context) cfv1.RulesetRule {
 
 		if !ap.ContentType.IsNull() {
 			rr.ActionParameters.ContentType = ap.ContentType.ValueString()
+		}
+
+		if !ap.AssetName.IsNull() {
+			rr.ActionParameters.AssetName = ap.AssetName.ValueString()
 		}
 
 		if !ap.HostHeader.IsNull() {

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -150,6 +150,10 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 										Optional:            true,
 										MarkdownDescription: "Specifies uncommon ports to allow cacheable assets to be served from.",
 									},
+									"asset_name": schema.StringAttribute{
+										Optional:            true,
+										MarkdownDescription: "Name of a custom asset to serve as the error response.",
+									},
 									"automatic_https_rewrites": schema.BoolAttribute{
 										Optional:            true,
 										MarkdownDescription: "Turn on or off Cloudflare Automatic HTTPS rewrites.",


### PR DESCRIPTION
Adds the `asset_name` attribute to the framework schema for `cloudflare_ruleset.rules.action_parameters`, enabling `http_custom_errors` phase rules using the `serve_error` action to read and set the built-in asset reference returned by the Cloudflare API.

## Why

When a `serve_error` rule references a built-in error asset, the Cloudflare API returns an `asset_name` field in `action_parameters`. The v4 framework schema does not declare this attribute, so:

- On read, the value is silently dropped and absent from the state.
- On create/update, users cannot set `asset_name` in HCL.

This causes drift for any zone using a custom error asset and prevents the resource from representing the full upstream configuration.

## Changes

- `internal/framework/service/rulesets/schema.go`: declare `asset_name` as an optional string attribute, alphabetically placed alongside the other error-response attributes (`content`, `content_type`, `status_code`).
- `internal/framework/service/rulesets/model.go`: add `AssetName types.String` field to `ActionParametersModel`.
- `internal/framework/service/rulesets/resource.go`: flatten `AssetName` from API response into state, and expand from state into API request when non-null.
- `go.mod`: bump `cloudflare-go` to v0.117.0, which adds `AssetName` to `RulesetRuleActionParameters` (cloudflare/cloudflare-go#4312).
- `.changelog/asset-name.txt`: enhancement entry.

## Related

- cloudflare/cloudflare-go#4312 (SDK companion, released as v0.117.0)
- Internal tracking: APIX-861

## Notes

Targets the `v4` maintenance branch. Single-attribute additive change, no schema migration required (V0 → current state upgrader in `migrate.go` is unaffected because `AssetName` is new and absent from V0 state defaults to null, which matches existing semantics).