### PR TITLE
SHELP-845 fixing token policies

### DIFF
--- a/internal/services/account_token/custom.go
+++ b/internal/services/account_token/custom.go
@@ -52,30 +52,7 @@ func UnmarshalCustom(data []byte, model *AccountTokenResultEnvelope) (err error)
 		return
 	}
 
-	// pull out the raw JSON values for each policy resource and map to the model
-	var base map[string]json.RawMessage
-	if err := json.Unmarshal(data, &base); err != nil {
-		return err
-	}
-	var result map[string]json.RawMessage
-	if err := json.Unmarshal(base["result"], &result); err != nil {
-		return err
-	}
-	var policyJsons []json.RawMessage
-	if err := json.Unmarshal(result["policies"], &policyJsons); err != nil {
-		return err
-	}
-	for i, policyJson := range policyJsons {
-		var policy map[string]json.RawMessage
-		if err := json.Unmarshal(policyJson, &policy); err != nil {
-			return err
-		}
-		(*model.Result.Policies)[i].Resources = types.StringValue(string(policy["resources"]))
-	}
-
-	// Reorder to match prior state (or canonical sort if no prior)
-	reorderPoliciesFromSnapshot(model.Result.Policies, snap)
-	return
+	return unmarshalCustomWithSnapshot(data, model, snap)
 }
 
 func UnmarshalComputedCustom(data []byte, model *AccountTokenResultEnvelope) (err error) {
@@ -91,6 +68,15 @@ func UnmarshalComputedCustom(data []byte, model *AccountTokenResultEnvelope) (er
 // unmarshalCustomWithSnapshot is like UnmarshalCustom but uses a provided
 // snapshot instead of capturing its own. apijson.Unmarshal is NOT called
 // because the caller has already done the initial unmarshal.
+//
+// Note: when this is reached via UnmarshalComputedCustom (update path),
+// apijson.UnmarshalComputed leaves the planned Policies slice in place
+// because the field is tagged "required", not "computed". That means the
+// model still carries the user's planned effect + permission_groups for
+// each policy, and only the Resources string still needs to be populated
+// from the API response. The API may reorder policies relative to what
+// was sent, so we must match by policy identity (effect + permission group
+// set), NOT by positional index.
 func unmarshalCustomWithSnapshot(data []byte, model *AccountTokenResultEnvelope, snap *policyOrderSnapshot) error {
 	// pull out the raw JSON values for each policy resource and map to the model
 	var base map[string]json.RawMessage
@@ -105,12 +91,82 @@ func unmarshalCustomWithSnapshot(data []byte, model *AccountTokenResultEnvelope,
 	if err := json.Unmarshal(result["policies"], &policyJsons); err != nil {
 		return err
 	}
-	for i, policyJson := range policyJsons {
-		var policy map[string]json.RawMessage
-		if err := json.Unmarshal(policyJson, &policy); err != nil {
+
+	// Parse each API policy into an identity (effect + permission group IDs)
+	// and a resources string so we can match by identity instead of by index.
+	type apiPolicy struct {
+		effect    string
+		pgIDs     []string
+		resources string
+	}
+	apiPolicies := make([]apiPolicy, 0, len(policyJsons))
+	for _, pj := range policyJsons {
+		var p struct {
+			Effect           string `json:"effect"`
+			PermissionGroups []struct {
+				ID string `json:"id"`
+			} `json:"permission_groups"`
+			Resources json.RawMessage `json:"resources"`
+		}
+		if err := json.Unmarshal(pj, &p); err != nil {
 			return err
 		}
-		(*model.Result.Policies)[i].Resources = types.StringValue(string(policy["resources"]))
+		ids := make([]string, len(p.PermissionGroups))
+		for i, pg := range p.PermissionGroups {
+			ids[i] = pg.ID
+		}
+		apiPolicies = append(apiPolicies, apiPolicy{
+			effect:    p.Effect,
+			pgIDs:     ids,
+			resources: string(p.Resources),
+		})
+	}
+
+	// identityKey is intentionally narrower than policyFingerprint: it omits
+	// resources because that's the field we're trying to assign. Sorting the
+	// permission group IDs makes the key invariant to PG order changes within
+	// a policy (those are handled later by reorderPoliciesFromSnapshot).
+	identityKey := func(effect string, pgIDs []string) string {
+		sorted := make([]string, len(pgIDs))
+		copy(sorted, pgIDs)
+		sort.Strings(sorted)
+		return effect + "|" + strings.Join(sorted, ",")
+	}
+
+	// Index API policies by identity. Use a slice of indices per key so that
+	// duplicate identities (multiple policies with the same effect + PG set
+	// but different resources) are consumed in encounter order.
+	available := make(map[string][]int, len(apiPolicies))
+	for i, ap := range apiPolicies {
+		k := identityKey(ap.effect, ap.pgIDs)
+		available[k] = append(available[k], i)
+	}
+
+	// For each model policy, find the matching API policy by identity and
+	// copy its resources string into the model. If no match is found (which
+	// shouldn't happen for a healthy round-trip), fall back to positional
+	// assignment to preserve previous behavior.
+	policies := *model.Result.Policies
+	for i, p := range policies {
+		var pgIDs []string
+		if p.PermissionGroups != nil {
+			pgIDs = make([]string, len(*p.PermissionGroups))
+			for j, pg := range *p.PermissionGroups {
+				pgIDs[j] = pg.ID.ValueString()
+			}
+		}
+		k := identityKey(p.Effect.ValueString(), pgIDs)
+		if idxs, ok := available[k]; ok && len(idxs) > 0 {
+			apIdx := idxs[0]
+			available[k] = idxs[1:]
+			policies[i].Resources = types.StringValue(apiPolicies[apIdx].resources)
+			continue
+		}
+		// Fallback: positional. Preserves prior (buggy) behavior only when
+		// identity lookup fails, which is better than dropping the value.
+		if i < len(apiPolicies) {
+			policies[i].Resources = types.StringValue(apiPolicies[i].resources)
+		}
 	}
 
 	// Reorder to match prior state (or canonical sort if no prior)

--- a/internal/services/account_token/custom_test.go
+++ b/internal/services/account_token/custom_test.go
@@ -205,6 +205,156 @@ func TestSortPolicies_SortsPoliciesByEffectThenResources(t *testing.T) {
 	}
 }
 
+// TestUnmarshalComputedCustom_GitHub7125 reproduces the bug from
+// https://github.com/cloudflare/terraform-provider-cloudflare/issues/7125.
+//
+// On update, the planned model contains the user's two policies (each with a
+// distinct set of permission_groups and distinct resources). The user changed
+// one permission_group ID inside policy A. The API stored the new policies and
+// returned them in swapped order: [B, A_new].
+//
+// Because Policies is tagged required (not computed), apijson.UnmarshalComputed
+// leaves the planned policies in place. The custom unmarshal then walks the API
+// response by index and overwrites each model policy's Resources using
+// policyJsons[i]. When the API reorders policies relative to what was sent,
+// this assigns the wrong resources to each policy: policy A ends up with
+// policy B's resources and vice-versa. The subsequent reorder step then sees
+// policies whose fingerprints no longer match the snapshot, so they fall
+// through to the canonical sort and the swap is persisted to state.
+//
+// A correct implementation must match API policies to model policies by
+// identity (effect + permission_group set), not by positional index.
+func TestUnmarshalComputedCustom_GitHub7125(t *testing.T) {
+	const resA = `{"com.cloudflare.api.account.acct123":"*"}`
+	const resB = `{"com.cloudflare.api.account.acct123":{"com.cloudflare.api.account.zone.*":"*"}}`
+
+	// Planned model: policy A (R2-ish PGs, flat resources) then policy B
+	// (DNS/Zone PGs, nested resources). One PG ID in A was just changed by
+	// the user (pgA3-new replaces the previous pgA3).
+	pgsA := []*AccountTokenPoliciesPermissionGroupsModel{
+		{ID: types.StringValue("pgA1")},
+		{ID: types.StringValue("pgA2")},
+		{ID: types.StringValue("pgA3-new")},
+		{ID: types.StringValue("pgA4")},
+		{ID: types.StringValue("pgA5")},
+		{ID: types.StringValue("pgA6")},
+	}
+	pgsB := []*AccountTokenPoliciesPermissionGroupsModel{
+		{ID: types.StringValue("pgB1")},
+		{ID: types.StringValue("pgB2")},
+		{ID: types.StringValue("pgB3")},
+		{ID: types.StringValue("pgB4")},
+	}
+	policies := []*AccountTokenPoliciesModel{
+		{
+			Effect:           types.StringValue("allow"),
+			PermissionGroups: &pgsA,
+			Resources:        types.StringValue(resA),
+		},
+		{
+			Effect:           types.StringValue("allow"),
+			PermissionGroups: &pgsB,
+			Resources:        types.StringValue(resB),
+		},
+	}
+	env := AccountTokenResultEnvelope{
+		Result: AccountTokenModel{
+			Name:     types.StringValue("name"),
+			Policies: &policies,
+		},
+	}
+
+	// API response: same two policies as the plan, but in swapped order
+	// ([B, A_new] instead of [A_new, B]).
+	data := json.RawMessage(`{
+		"result":{
+			"name":"name",
+			"policies":[
+				{
+					"effect":"allow",
+					"permission_groups":[
+						{"id":"pgB1"},
+						{"id":"pgB2"},
+						{"id":"pgB3"},
+						{"id":"pgB4"}
+					],
+					"resources":` + resB + `
+				},
+				{
+					"effect":"allow",
+					"permission_groups":[
+						{"id":"pgA1"},
+						{"id":"pgA2"},
+						{"id":"pgA3-new"},
+						{"id":"pgA4"},
+						{"id":"pgA5"},
+						{"id":"pgA6"}
+					],
+					"resources":` + resA + `
+				}
+			]
+		}
+	}`)
+
+	if err := UnmarshalComputedCustom(data, &env); err != nil {
+		t.Fatal(err)
+	}
+
+	// Each policy in the final model must carry the resources that belong to
+	// its own permission_group set, regardless of the order the API returned
+	// the policies in. Verify by matching on a stable PG ID inside each set.
+	got := *env.Result.Policies
+	if len(got) != 2 {
+		t.Fatalf("expected 2 policies, got %d", len(got))
+	}
+
+	pgsContain := func(p *AccountTokenPoliciesModel, id string) bool {
+		if p.PermissionGroups == nil {
+			return false
+		}
+		for _, pg := range *p.PermissionGroups {
+			if pg.ID.ValueString() == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	for i, p := range got {
+		switch {
+		case pgsContain(p, "pgA1"):
+			// This is policy A — must have policy A's flat resources and
+			// must carry the new (post-edit) PG ID.
+			if p.Resources.ValueString() != resA {
+				t.Fatalf("policies[%d] is policy A but has wrong resources:\n  want: %s\n  got:  %s",
+					i, resA, p.Resources.ValueString())
+			}
+			if !pgsContain(p, "pgA3-new") {
+				t.Fatalf("policies[%d] is policy A but does not contain the updated permission_group pgA3-new", i)
+			}
+		case pgsContain(p, "pgB1"):
+			// This is policy B — must have policy B's nested resources.
+			if p.Resources.ValueString() != resB {
+				t.Fatalf("policies[%d] is policy B but has wrong resources:\n  want: %s\n  got:  %s",
+					i, resB, p.Resources.ValueString())
+			}
+		default:
+			t.Fatalf("policies[%d] has unrecognized permission_groups", i)
+		}
+	}
+
+	// And the order in state should still match the planned order [A, B],
+	// so that the next plan is a no-op.
+	if !pgsContain(got[0], "pgA1") {
+		t.Fatalf("expected policies[0] to be policy A (matching planned order), got policy with pgs %+v",
+			*got[0].PermissionGroups)
+	}
+	if !pgsContain(got[1], "pgB1") {
+		t.Fatalf("expected policies[1] to be policy B (matching planned order), got policy with pgs %+v",
+			*got[1].PermissionGroups)
+	}
+}
+
 func TestUnmarshalCustom_SortsPermissionGroups(t *testing.T) {
 	// API returns permission groups in [zzz, aaa, mmm] order, no prior state
 	data := json.RawMessage(`{

--- a/internal/services/account_token/resource_test.go
+++ b/internal/services/account_token/resource_test.go
@@ -742,6 +742,48 @@ func TestAccAccountToken_ResourcesFlexible(t *testing.T) {
 	})
 }
 
+// Because order is not always preserved by the API, there is a danger of
+// "inconsistent results" after an apply. This test ensures that we can handle
+// complex cases where we have different policies with different perms and
+// different resources and that we can correct identify them when they change.
+func TestAccAccountToken_FullFlexible(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_account_token.test_account_token"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareAccountTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("account_token-full-flexible1.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(2)),
+				},
+			},
+			{
+				Config: acctest.LoadTestCase("account_token-full-flexible2.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			// Import step — ignore policies ordering since import uses canonical
+			// sort (no prior state) which may differ from the last config order
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
+				ImportStateVerifyIgnore: []string{"value", "policies"},
+			},
+		},
+	})
+}
+
 func TestAccAccountToken_CRUD(t *testing.T) {
 	// Comprehensive test covering Create, Read, Update, Delete + Import
 	rnd := utils.GenerateRandomResourceName()

--- a/internal/services/account_token/testdata/account_token-full-flexible1.tf
+++ b/internal/services/account_token/testdata/account_token-full-flexible1.tf
@@ -1,0 +1,60 @@
+data "cloudflare_account_api_token_permission_groups_list" "dns_read" {
+  account_id = "%[2]s"
+  name       = "DNS Read"
+  scope      = "com.cloudflare.api.account.zone"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "dns_write" {
+  account_id = "%[2]s"
+  name       = "DNS Write"
+  scope      = "com.cloudflare.api.account.zone"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "zone_write" {
+  account_id = "%[2]s"
+  name       = "Zone Write"
+  scope      = "com.cloudflare.api.account.zone"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "account_api_tokens_write" {
+  account_id = "%[2]s"
+  name       = "Account API Tokens Write"
+  scope      = "com.cloudflare.api.account"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "account_api_tokens_read" {
+  account_id = "%[2]s"
+  name       = "Account API Tokens Read"
+  scope      = "com.cloudflare.api.account"
+}
+
+resource "cloudflare_account_token" "test_account_token" {
+  name       = "%[1]s"
+  account_id = "%[2]s"
+  policies = [
+    {
+      effect = "allow"
+      permission_groups = [
+        { id = data.cloudflare_account_api_token_permission_groups_list.account_api_tokens_write.result[0].id },
+        { id = data.cloudflare_account_api_token_permission_groups_list.account_api_tokens_read.result[0].id },
+      ]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = "*"
+      })
+    },
+    {
+      effect = "allow"
+      permission_groups = [
+        { id = data.cloudflare_account_api_token_permission_groups_list.dns_write.result[0].id },
+        { id = data.cloudflare_account_api_token_permission_groups_list.dns_read.result[0].id },
+        { id = data.cloudflare_account_api_token_permission_groups_list.zone_write.result[0].id },
+      ]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = {
+          "com.cloudflare.api.account.zone.*" = "*"
+        }
+      })
+    },
+  ]
+  status = "active"
+}

--- a/internal/services/account_token/testdata/account_token-full-flexible2.tf
+++ b/internal/services/account_token/testdata/account_token-full-flexible2.tf
@@ -1,0 +1,61 @@
+data "cloudflare_account_api_token_permission_groups_list" "dns_read" {
+  account_id = "%[2]s"
+  name       = "DNS Read"
+  scope      = "com.cloudflare.api.account.zone"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "dns_write" {
+  account_id = "%[2]s"
+  name       = "DNS Write"
+  scope      = "com.cloudflare.api.account.zone"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "zone_security_center_insights_read" {
+  account_id = "%[2]s"
+  name       = "Zone Security Center Insights Read"
+  scope      = "com.cloudflare.api.account.zone"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "account_api_tokens_write" {
+  account_id = "%[2]s"
+  name       = "Account API Tokens Write"
+  scope      = "com.cloudflare.api.account"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "account_api_tokens_read" {
+  account_id = "%[2]s"
+  name       = "Account API Tokens Read"
+  scope      = "com.cloudflare.api.account"
+}
+
+resource "cloudflare_account_token" "test_account_token" {
+  name       = "%[1]s"
+  account_id = "%[2]s"
+  policies = [
+    {
+      effect = "allow"
+      permission_groups = [
+        { id = data.cloudflare_account_api_token_permission_groups_list.account_api_tokens_write.result[0].id },
+        { id = data.cloudflare_account_api_token_permission_groups_list.account_api_tokens_read.result[0].id },
+      ]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = "*"
+      })
+    },
+    {
+      effect = "allow"
+      permission_groups = [
+        { id = data.cloudflare_account_api_token_permission_groups_list.dns_write.result[0].id },
+        { id = data.cloudflare_account_api_token_permission_groups_list.dns_read.result[0].id },
+        // changed this one permission group
+        { id = data.cloudflare_account_api_token_permission_groups_list.zone_security_center_insights_read.result[0].id },
+      ]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = {
+          "com.cloudflare.api.account.zone.*" = "*"
+        }
+      })
+    },
+  ]
+  status = "active"
+}

--- a/internal/services/api_token/custom.go
+++ b/internal/services/api_token/custom.go
@@ -52,30 +52,7 @@ func UnmarshalCustom(data []byte, model *APITokenResultEnvelope) (err error) {
 		return
 	}
 
-	// pull out the raw JSON values for each policy resource and map to the model
-	var base map[string]json.RawMessage
-	if err := json.Unmarshal(data, &base); err != nil {
-		return err
-	}
-	var result map[string]json.RawMessage
-	if err := json.Unmarshal(base["result"], &result); err != nil {
-		return err
-	}
-	var policyJsons []json.RawMessage
-	if err := json.Unmarshal(result["policies"], &policyJsons); err != nil {
-		return err
-	}
-	for i, policyJson := range policyJsons {
-		var policy map[string]json.RawMessage
-		if err := json.Unmarshal(policyJson, &policy); err != nil {
-			return err
-		}
-		(*model.Result.Policies)[i].Resources = types.StringValue(string(policy["resources"]))
-	}
-
-	// Reorder to match prior state (or canonical sort if no prior)
-	reorderPoliciesFromSnapshot(model.Result.Policies, snap)
-	return
+	return unmarshalCustomWithSnapshot(data, model, snap)
 }
 
 func UnmarshalComputedCustom(data []byte, model *APITokenResultEnvelope) (err error) {
@@ -91,6 +68,15 @@ func UnmarshalComputedCustom(data []byte, model *APITokenResultEnvelope) (err er
 // unmarshalCustomWithSnapshot is like UnmarshalCustom but uses a provided
 // snapshot instead of capturing its own. apijson.Unmarshal is NOT called
 // because the caller has already done the initial unmarshal.
+//
+// Note: when this is reached via UnmarshalComputedCustom (update path),
+// apijson.UnmarshalComputed leaves the planned Policies slice in place
+// because the field is tagged "required", not "computed". That means the
+// model still carries the user's planned effect + permission_groups for
+// each policy, and only the Resources string still needs to be populated
+// from the API response. The API may reorder policies relative to what
+// was sent, so we must match by policy identity (effect + permission group
+// set), NOT by positional index.
 func unmarshalCustomWithSnapshot(data []byte, model *APITokenResultEnvelope, snap *policyOrderSnapshot) error {
 	// pull out the raw JSON values for each policy resource and map to the model
 	var base map[string]json.RawMessage
@@ -105,12 +91,82 @@ func unmarshalCustomWithSnapshot(data []byte, model *APITokenResultEnvelope, sna
 	if err := json.Unmarshal(result["policies"], &policyJsons); err != nil {
 		return err
 	}
-	for i, policyJson := range policyJsons {
-		var policy map[string]json.RawMessage
-		if err := json.Unmarshal(policyJson, &policy); err != nil {
+
+	// Parse each API policy into an identity (effect + permission group IDs)
+	// and a resources string so we can match by identity instead of by index.
+	type apiPolicy struct {
+		effect    string
+		pgIDs     []string
+		resources string
+	}
+	apiPolicies := make([]apiPolicy, 0, len(policyJsons))
+	for _, pj := range policyJsons {
+		var p struct {
+			Effect           string `json:"effect"`
+			PermissionGroups []struct {
+				ID string `json:"id"`
+			} `json:"permission_groups"`
+			Resources json.RawMessage `json:"resources"`
+		}
+		if err := json.Unmarshal(pj, &p); err != nil {
 			return err
 		}
-		(*model.Result.Policies)[i].Resources = types.StringValue(string(policy["resources"]))
+		ids := make([]string, len(p.PermissionGroups))
+		for i, pg := range p.PermissionGroups {
+			ids[i] = pg.ID
+		}
+		apiPolicies = append(apiPolicies, apiPolicy{
+			effect:    p.Effect,
+			pgIDs:     ids,
+			resources: string(p.Resources),
+		})
+	}
+
+	// identityKey is intentionally narrower than policyFingerprint: it omits
+	// resources because that's the field we're trying to assign. Sorting the
+	// permission group IDs makes the key invariant to PG order changes within
+	// a policy (those are handled later by reorderPoliciesFromSnapshot).
+	identityKey := func(effect string, pgIDs []string) string {
+		sorted := make([]string, len(pgIDs))
+		copy(sorted, pgIDs)
+		sort.Strings(sorted)
+		return effect + "|" + strings.Join(sorted, ",")
+	}
+
+	// Index API policies by identity. Use a slice of indices per key so that
+	// duplicate identities (multiple policies with the same effect + PG set
+	// but different resources) are consumed in encounter order.
+	available := make(map[string][]int, len(apiPolicies))
+	for i, ap := range apiPolicies {
+		k := identityKey(ap.effect, ap.pgIDs)
+		available[k] = append(available[k], i)
+	}
+
+	// For each model policy, find the matching API policy by identity and
+	// copy its resources string into the model. If no match is found (which
+	// shouldn't happen for a healthy round-trip), fall back to positional
+	// assignment to preserve previous behavior.
+	policies := *model.Result.Policies
+	for i, p := range policies {
+		var pgIDs []string
+		if p.PermissionGroups != nil {
+			pgIDs = make([]string, len(*p.PermissionGroups))
+			for j, pg := range *p.PermissionGroups {
+				pgIDs[j] = pg.ID.ValueString()
+			}
+		}
+		k := identityKey(p.Effect.ValueString(), pgIDs)
+		if idxs, ok := available[k]; ok && len(idxs) > 0 {
+			apIdx := idxs[0]
+			available[k] = idxs[1:]
+			policies[i].Resources = types.StringValue(apiPolicies[apIdx].resources)
+			continue
+		}
+		// Fallback: positional. Preserves prior (buggy) behavior only when
+		// identity lookup fails, which is better than dropping the value.
+		if i < len(apiPolicies) {
+			policies[i].Resources = types.StringValue(apiPolicies[i].resources)
+		}
 	}
 
 	// Reorder to match prior state (or canonical sort if no prior)

--- a/internal/services/api_token/custom_test.go
+++ b/internal/services/api_token/custom_test.go
@@ -205,6 +205,156 @@ func TestSortPolicies_SortsPoliciesByEffectThenResources(t *testing.T) {
 	}
 }
 
+// TestUnmarshalComputedCustom_GitHub7125 reproduces the bug from
+// https://github.com/cloudflare/terraform-provider-cloudflare/issues/7125.
+//
+// On update, the planned model contains the user's two policies (each with a
+// distinct set of permission_groups and distinct resources). The user changed
+// one permission_group ID inside policy A. The API stored the new policies and
+// returned them in swapped order: [B, A_new].
+//
+// Because Policies is tagged required (not computed), apijson.UnmarshalComputed
+// leaves the planned policies in place. The custom unmarshal then walks the API
+// response by index and overwrites each model policy's Resources using
+// policyJsons[i]. When the API reorders policies relative to what was sent,
+// this assigns the wrong resources to each policy: policy A ends up with
+// policy B's resources and vice-versa. The subsequent reorder step then sees
+// policies whose fingerprints no longer match the snapshot, so they fall
+// through to the canonical sort and the swap is persisted to state.
+//
+// A correct implementation must match API policies to model policies by
+// identity (effect + permission_group set), not by positional index.
+func TestUnmarshalComputedCustom_GitHub7125(t *testing.T) {
+	const resA = `{"com.cloudflare.api.account.acct123":"*"}`
+	const resB = `{"com.cloudflare.api.account.acct123":{"com.cloudflare.api.account.zone.*":"*"}}`
+
+	// Planned model: policy A (R2-ish PGs, flat resources) then policy B
+	// (DNS/Zone PGs, nested resources). One PG ID in A was just changed by
+	// the user (pgA3-new replaces the previous pgA3).
+	pgsA := []*APITokenPoliciesPermissionGroupsModel{
+		{ID: types.StringValue("pgA1")},
+		{ID: types.StringValue("pgA2")},
+		{ID: types.StringValue("pgA3-new")},
+		{ID: types.StringValue("pgA4")},
+		{ID: types.StringValue("pgA5")},
+		{ID: types.StringValue("pgA6")},
+	}
+	pgsB := []*APITokenPoliciesPermissionGroupsModel{
+		{ID: types.StringValue("pgB1")},
+		{ID: types.StringValue("pgB2")},
+		{ID: types.StringValue("pgB3")},
+		{ID: types.StringValue("pgB4")},
+	}
+	policies := []*APITokenPoliciesModel{
+		{
+			Effect:           types.StringValue("allow"),
+			PermissionGroups: &pgsA,
+			Resources:        types.StringValue(resA),
+		},
+		{
+			Effect:           types.StringValue("allow"),
+			PermissionGroups: &pgsB,
+			Resources:        types.StringValue(resB),
+		},
+	}
+	env := APITokenResultEnvelope{
+		Result: APITokenModel{
+			Name:     types.StringValue("name"),
+			Policies: &policies,
+		},
+	}
+
+	// API response: same two policies as the plan, but in swapped order
+	// ([B, A_new] instead of [A_new, B]).
+	data := json.RawMessage(`{
+		"result":{
+			"name":"name",
+			"policies":[
+				{
+					"effect":"allow",
+					"permission_groups":[
+						{"id":"pgB1"},
+						{"id":"pgB2"},
+						{"id":"pgB3"},
+						{"id":"pgB4"}
+					],
+					"resources":` + resB + `
+				},
+				{
+					"effect":"allow",
+					"permission_groups":[
+						{"id":"pgA1"},
+						{"id":"pgA2"},
+						{"id":"pgA3-new"},
+						{"id":"pgA4"},
+						{"id":"pgA5"},
+						{"id":"pgA6"}
+					],
+					"resources":` + resA + `
+				}
+			]
+		}
+	}`)
+
+	if err := UnmarshalComputedCustom(data, &env); err != nil {
+		t.Fatal(err)
+	}
+
+	// Each policy in the final model must carry the resources that belong to
+	// its own permission_group set, regardless of the order the API returned
+	// the policies in. Verify by matching on a stable PG ID inside each set.
+	got := *env.Result.Policies
+	if len(got) != 2 {
+		t.Fatalf("expected 2 policies, got %d", len(got))
+	}
+
+	pgsContain := func(p *APITokenPoliciesModel, id string) bool {
+		if p.PermissionGroups == nil {
+			return false
+		}
+		for _, pg := range *p.PermissionGroups {
+			if pg.ID.ValueString() == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	for i, p := range got {
+		switch {
+		case pgsContain(p, "pgA1"):
+			// This is policy A — must have policy A's flat resources and
+			// must carry the new (post-edit) PG ID.
+			if p.Resources.ValueString() != resA {
+				t.Fatalf("policies[%d] is policy A but has wrong resources:\n  want: %s\n  got:  %s",
+					i, resA, p.Resources.ValueString())
+			}
+			if !pgsContain(p, "pgA3-new") {
+				t.Fatalf("policies[%d] is policy A but does not contain the updated permission_group pgA3-new", i)
+			}
+		case pgsContain(p, "pgB1"):
+			// This is policy B — must have policy B's nested resources.
+			if p.Resources.ValueString() != resB {
+				t.Fatalf("policies[%d] is policy B but has wrong resources:\n  want: %s\n  got:  %s",
+					i, resB, p.Resources.ValueString())
+			}
+		default:
+			t.Fatalf("policies[%d] has unrecognized permission_groups", i)
+		}
+	}
+
+	// And the order in state should still match the planned order [A, B],
+	// so that the next plan is a no-op.
+	if !pgsContain(got[0], "pgA1") {
+		t.Fatalf("expected policies[0] to be policy A (matching planned order), got policy with pgs %+v",
+			*got[0].PermissionGroups)
+	}
+	if !pgsContain(got[1], "pgB1") {
+		t.Fatalf("expected policies[1] to be policy B (matching planned order), got policy with pgs %+v",
+			*got[1].PermissionGroups)
+	}
+}
+
 func TestUnmarshalCustom_SortsPermissionGroups(t *testing.T) {
 	// API returns permission groups in [zzz, aaa, mmm] order, no prior state
 	data := json.RawMessage(`{

--- a/internal/services/api_token/resource_test.go
+++ b/internal/services/api_token/resource_test.go
@@ -676,6 +676,47 @@ func TestAccAPIToken_ResourcesFlexible(t *testing.T) {
 	})
 }
 
+// Because order is not always preserved by the API, there is a danger of
+// "inconsistent results" after an apply. This test ensures that we can handle
+// complex cases where we have different policies with different perms and
+// different resources and that we can correct identify them when they change.
+func TestAccApiToken_FullFlexible(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_api_token.test_account_token"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareAPITokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("api_token-full-flexible1.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policies"), knownvalue.ListSizeExact(2)),
+				},
+			},
+			{
+				Config: acctest.LoadTestCase("api_token-full-flexible2.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			// Import step — ignore policies ordering since import uses canonical
+			// sort (no prior state) which may differ from the last config order
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value", "policies"},
+			},
+		},
+	})
+}
+
 func TestAccAPIToken_CRUD(t *testing.T) {
 	// Comprehensive test covering Create, Read, Update, Delete + Import
 	rnd := utils.GenerateRandomResourceName()

--- a/internal/services/api_token/testdata/api_token-full-flexible1.tf
+++ b/internal/services/api_token/testdata/api_token-full-flexible1.tf
@@ -1,0 +1,54 @@
+data "cloudflare_api_token_permission_groups_list" "dns_read" {
+  name  = "DNS Read"
+  scope = "com.cloudflare.api.account.zone"
+}
+
+data "cloudflare_api_token_permission_groups_list" "dns_write" {
+  name  = "DNS Write"
+  scope = "com.cloudflare.api.account.zone"
+}
+
+data "cloudflare_api_token_permission_groups_list" "zone_write" {
+  name  = "Zone Write"
+  scope = "com.cloudflare.api.account.zone"
+}
+
+data "cloudflare_api_token_permission_groups_list" "account_api_tokens_write" {
+  name  = "Account API Tokens Write"
+  scope = "com.cloudflare.api.account"
+}
+
+data "cloudflare_api_token_permission_groups_list" "account_api_tokens_read" {
+  name  = "Account API Tokens Read"
+  scope = "com.cloudflare.api.account"
+}
+
+resource "cloudflare_api_token" "test_account_token" {
+  name = "%[1]s"
+  policies = [
+    {
+      effect = "allow"
+      permission_groups = [
+        { id = data.cloudflare_api_token_permission_groups_list.account_api_tokens_write.result[0].id },
+        { id = data.cloudflare_api_token_permission_groups_list.account_api_tokens_read.result[0].id },
+      ]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = "*"
+      })
+    },
+    {
+      effect = "allow"
+      permission_groups = [
+        { id = data.cloudflare_api_token_permission_groups_list.dns_write.result[0].id },
+        { id = data.cloudflare_api_token_permission_groups_list.dns_read.result[0].id },
+        { id = data.cloudflare_api_token_permission_groups_list.zone_write.result[0].id },
+      ]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = {
+          "com.cloudflare.api.account.zone.*" = "*"
+        }
+      })
+    },
+  ]
+  status = "active"
+}

--- a/internal/services/api_token/testdata/api_token-full-flexible2.tf
+++ b/internal/services/api_token/testdata/api_token-full-flexible2.tf
@@ -1,0 +1,60 @@
+data "cloudflare_account_api_token_permission_groups_list" "dns_read" {
+  account_id = "%[2]s"
+  name       = "DNS Read"
+  scope      = "com.cloudflare.api.account.zone"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "dns_write" {
+  account_id = "%[2]s"
+  name       = "DNS Write"
+  scope      = "com.cloudflare.api.account.zone"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "zone_security_center_insights_read" {
+  account_id = "%[2]s"
+  name       = "Zone Security Center Insights Read"
+  scope      = "com.cloudflare.api.account.zone"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "account_api_tokens_write" {
+  account_id = "%[2]s"
+  name       = "Account API Tokens Write"
+  scope      = "com.cloudflare.api.account"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "account_api_tokens_read" {
+  account_id = "%[2]s"
+  name       = "Account API Tokens Read"
+  scope      = "com.cloudflare.api.account"
+}
+
+resource "cloudflare_api_token" "test_account_token" {
+  name = "%[1]s"
+  policies = [
+    {
+      effect = "allow"
+      permission_groups = [
+        { id = data.cloudflare_account_api_token_permission_groups_list.account_api_tokens_write.result[0].id },
+        { id = data.cloudflare_account_api_token_permission_groups_list.account_api_tokens_read.result[0].id },
+      ]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = "*"
+      })
+    },
+    {
+      effect = "allow"
+      permission_groups = [
+        { id = data.cloudflare_account_api_token_permission_groups_list.dns_write.result[0].id },
+        { id = data.cloudflare_account_api_token_permission_groups_list.dns_read.result[0].id },
+        // changed this one permission group
+        { id = data.cloudflare_account_api_token_permission_groups_list.zone_security_center_insights_read.result[0].id },
+      ]
+      resources = jsonencode({
+        "com.cloudflare.api.account.%[2]s" = {
+          "com.cloudflare.api.account.zone.*" = "*"
+        }
+      })
+    },
+  ]
+  status = "active"
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Token resources are failing to correct diff policies that are returned by the cloudflare API in an order different from the requested policies.

Several attempts were made to avoid these diff problems. An earlier change switched from lists to sets to avoid order from mattering entirely. But, that turned out to be to slow for certain policies (terraform sets are very slow at large comparisons). So, we went back to using lists but with custom go code to correctly resolve the order problem.

It seems that fix was not robust enough, and users ran into a problem that is not hard to reproduce.

This change makes the policy diff logic harder.

## Acceptance test run results

- [X] I have added or updated acceptance tests for my changes
- [X] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

To run the tests you need only set an API key.

### Test output

The failing test below is failing because I ran this against the staging environment and it uses a hardcoded permission group ID that only exists in prod.

```
 terraform-provider-cloudflare git:(sconrad/SHELP-845_fixing-token-policies) TF_ACC=1 go test ./internal/services/account_token
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/account_token     293.220s
 terraform-provider-cloudflare git:(sconrad/SHELP-845_fixing-token-policies) TF_ACC=1 go test ./internal/services/api_token
--- FAIL: TestAccCloudflareAPITokenData (1.24s)
    data_source_test.go:18: Step 1/1 error: Error running apply: exit status 1
        
        Error: failed to make http request
        
          with cloudflare_api_token.cftftesttftokoafkd,
          on terraform_plugin_test.tf line 11, in resource "cloudflare_api_token" "cftftesttftokoafkd":
          11: resource "cloudflare_api_token" "cftftesttftokoafkd" {
        
        POST "https://api.staging.cloudflare.com/client/v4/user/tokens": 400 Bad
        Request {"success":false,"errors":[{"code":1001,"message":"Permission group
        \"82e64a83756745bbbb1c9c2701bf816b\" not
        found"}],"messages":[],"result":null}
FAIL
FAIL    github.com/cloudflare/terraform-provider-cloudflare/internal/services/api_token 273.036s
FAIL
```

## Additional context & links

Fix for https://github.com/cloudflare/terraform-provider-cloudflare/issues/7125
