### PR TITLE
test(origin_cloud_region): add acceptance tests for v2 OPCR resource

### DIFF
--- a/internal/services/origin_cloud_region/resource_test.go
+++ b/internal/services/origin_cloud_region/resource_test.go
@@ -1,0 +1,173 @@
+package origin_cloud_region_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+// Documentation IPs (RFC 5737 / RFC 3849) — safe to use in tests
+const (
+	testIPv4         = "192.0.2.1"
+	testIPv4Other    = "192.0.2.2"
+	testIPv6         = "2001:db8::1"
+	testVendor       = "aws"
+	testRegion       = "us-east-1"
+	testRegionUpdate = "us-west-2"
+)
+
+// Basic CRUD: create → read → update region → delete
+func TestAccCloudflareOriginCloudRegion_Basic(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_origin_cloud_region.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck_ZoneID(t)
+			acctest.TestAccPreCheck_Credentials(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: testAccCloudflareOriginCloudRegionBasic(rnd, zoneID, testIPv4, testVendor, testRegion),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "zone_id", zoneID),
+					resource.TestCheckResourceAttr(name, "origin_ip", testIPv4),
+					resource.TestCheckResourceAttr(name, "vendor", testVendor),
+					resource.TestCheckResourceAttr(name, "region", testRegion),
+					resource.TestCheckResourceAttrSet(name, "modified_on"),
+				),
+			},
+			// Plan should be empty after apply (round-trip consistency)
+			{
+				Config:             testAccCloudflareOriginCloudRegionBasic(rnd, zoneID, testIPv4, testVendor, testRegion),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Update region (in-place; vendor stays)
+			{
+				Config: testAccCloudflareOriginCloudRegionBasic(rnd, zoneID, testIPv4, testVendor, testRegionUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "origin_ip", testIPv4),
+					resource.TestCheckResourceAttr(name, "vendor", testVendor),
+					resource.TestCheckResourceAttr(name, "region", testRegionUpdate),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(name, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(name, tfjsonpath.New("region"), knownvalue.StringExact(testRegionUpdate)),
+						plancheck.ExpectKnownValue(name, tfjsonpath.New("vendor"), knownvalue.StringExact(testVendor)),
+					},
+				},
+			},
+			// Import test — expects "<zone_id>/<origin_ip>" format
+			{
+				ResourceName:                         name,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "origin_ip",
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					return fmt.Sprintf("%s/%s", zoneID, testIPv4), nil
+				},
+			},
+		},
+	})
+}
+
+// Changing origin_ip should force replace (destroy + recreate)
+func TestAccCloudflareOriginCloudRegion_ChangeOriginIPForcesReplace(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_origin_cloud_region.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck_ZoneID(t)
+			acctest.TestAccPreCheck_Credentials(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareOriginCloudRegionBasic(rnd, zoneID, testIPv4, testVendor, testRegion),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "origin_ip", testIPv4),
+				),
+			},
+			{
+				Config: testAccCloudflareOriginCloudRegionBasic(rnd, zoneID, testIPv4Other, testVendor, testRegion),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(name, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "origin_ip", testIPv4Other),
+				),
+			},
+		},
+	})
+}
+
+// IPv6 origin
+func TestAccCloudflareOriginCloudRegion_IPv6(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+	name := fmt.Sprintf("cloudflare_origin_cloud_region.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck_ZoneID(t)
+			acctest.TestAccPreCheck_Credentials(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareOriginCloudRegionBasic(rnd, zoneID, testIPv6, "gcp", "us-central1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "origin_ip", testIPv6),
+					resource.TestCheckResourceAttr(name, "vendor", "gcp"),
+				),
+			},
+			{
+				Config:             testAccCloudflareOriginCloudRegionBasic(rnd, zoneID, testIPv6, "gcp", "us-central1"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Invalid vendor should fail validation
+func TestAccCloudflareOriginCloudRegion_InvalidVendor(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	rnd := utils.GenerateRandomResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck_ZoneID(t)
+			acctest.TestAccPreCheck_Credentials(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCloudflareOriginCloudRegionBasic(rnd, zoneID, testIPv4, "badvendor", testRegion),
+				ExpectError: regexp.MustCompile("Invalid Attribute Value Match|Attribute vendor"),
+			},
+		},
+	})
+}
+
+func testAccCloudflareOriginCloudRegionBasic(rnd, zoneID, originIP, vendor, region string) string {
+	return acctest.LoadTestCase("basic.tf", rnd, zoneID, originIP, vendor, region)
+}

--- a/internal/services/origin_cloud_region/testdata/basic.tf
+++ b/internal/services/origin_cloud_region/testdata/basic.tf
@@ -1,0 +1,6 @@
+resource "cloudflare_origin_cloud_region" "%[1]s" {
+  zone_id   = "%[2]s"
+  origin_ip = "%[3]s"
+  vendor    = "%[4]s"
+  region    = "%[5]s"
+}

--- a/scripts/run-ci-tests
+++ b/scripts/run-ci-tests
@@ -81,7 +81,7 @@ get_product_group_services() {
             echo "waiting_room_settings"
             ;;
         performance)
-            echo "argo_smart_routing argo_tiered_caching tiered_cache regional_tiered_cache"
+            echo "argo_smart_routing argo_tiered_caching tiered_cache regional_tiered_cache origin_cloud_region"
             ;;
         cdn-advanced)
             echo "regional_hostname spectrum_application"


### PR DESCRIPTION
Adds acceptance tests for the `cloudflare_origin_cloud_region` resource (the v2 Origin Public Cloud Region API), and registers it in the CI acceptance-test runner.

This resource was generated by Stainless and landed on `next` via #7056. These tests complete the standard new-resource onboarding (acceptance tests + CI registration).

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Add `internal/services/origin_cloud_region/resource_test.go` with four acceptance tests
- Add `internal/services/origin_cloud_region/testdata/basic.tf` fixture
- Register `origin_cloud_region` in the `performance` product group in `scripts/run-ci-tests`, alongside the other tiered-cache resources (`argo_tiered_caching`, `tiered_cache`, `regional_tiered_cache`)

Test IPs use RFC 5737 / RFC 3849 documentation ranges.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

```
cd internal/services/origin_cloud_region
TF_ACC=1 \
  CLOUDFLARE_API_TOKEN=*** \
  CLOUDFLARE_ZONE_ID=*** \
  go test -v -timeout 20m -run 'TestAccCloudflareOriginCloudRegion_' .
```

### Test output

```
=== RUN   TestAccCloudflareOriginCloudRegion_Basic
--- PASS: TestAccCloudflareOriginCloudRegion_Basic (8.92s)
=== RUN   TestAccCloudflareOriginCloudRegion_ChangeOriginIPForcesReplace
--- PASS: TestAccCloudflareOriginCloudRegion_ChangeOriginIPForcesReplace (5.87s)
=== RUN   TestAccCloudflareOriginCloudRegion_IPv6
--- PASS: TestAccCloudflareOriginCloudRegion_IPv6 (4.08s)
=== RUN   TestAccCloudflareOriginCloudRegion_InvalidVendor
--- PASS: TestAccCloudflareOriginCloudRegion_InvalidVendor (0.23s)
PASS
```

Coverage:
- **Basic** — create / read / empty-plan round-trip / in-place region update / import (`<zone_id>/<origin_ip>`)
- **ChangeOriginIPForcesReplace** — changing `origin_ip` forces destroy-before-create
- **IPv6** — IPv6 origin (`2001:db8::1`) creation + state round-trip
- **InvalidVendor** — plan-time validator rejects an unknown vendor enum

## Additional context & links

The acceptance-tests workflow only runs on `release-please**` branches / `workflow_dispatch`, so these won't execute automatically on this PR. Results above were produced locally against a live zone.
