### PR TITLE
fix: guard against nil SourceState in MoveState migrations

### DIFF
--- a/docs/guides/version-5-upgrade.md
+++ b/docs/guides/version-5-upgrade.md
@@ -33,6 +33,13 @@ security fixes.
 latest version of 4.x to ensure any transitional updates are applied to your
 existing configuration.
 
+~> If your Terraform state was originally created with Terraform 0.11 or earlier,
+it may use the legacy `attributes_flat` storage format. The v5 provider's state
+migration cannot read this format and will return an error. To check, inspect
+your `.tfstate` file for `"attributes_flat"` keys. If present, run
+`terraform apply -refresh-only` with the v4 provider to normalize the state
+before upgrading to v5.
+
 Once ready, make the following change to use the latest 5.x release:
 
 ```hcl

--- a/internal/migrations/helpers.go
+++ b/internal/migrations/helpers.go
@@ -1,6 +1,39 @@
 package migrations
 
-import "github.com/hashicorp/terraform-plugin-framework/types"
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	// ErrMoveStateNilSourceStateTitle is the diagnostic title used when
+	// req.SourceState is nil during a MoveState operation.
+	ErrMoveStateNilSourceStateTitle = "Unable to Read Source State"
+
+	// ErrMoveStateNilSourceStateDetail is the diagnostic detail format string.
+	// Use with fmt.Sprintf, passing the source type name.
+	ErrMoveStateNilSourceStateDetail = "The source state for %s could not be decoded. " +
+		"This typically occurs when the state file uses the legacy flatmap format " +
+		"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' " +
+		"with the v4 provider to upgrade the state format, then retry the v5 migration."
+)
+
+// DiagnoseMoveStateNilSourceState checks whether req.SourceState is nil and,
+// if so, appends an error diagnostic to resp and returns true. Callers should
+// return early when this returns true.
+func DiagnoseMoveStateNilSourceState(req resource.MoveStateRequest, resp *resource.MoveStateResponse) bool {
+	if req.SourceState != nil {
+		return false
+	}
+	resp.Diagnostics.Append(diag.NewErrorDiagnostic(
+		ErrMoveStateNilSourceStateTitle,
+		fmt.Sprintf(ErrMoveStateNilSourceStateDetail, req.SourceTypeName),
+	))
+	return true
+}
 
 func FalseyStringToNull(v types.String) types.String {
 	if v.IsNull() || v.IsUnknown() {

--- a/internal/services/argo_smart_routing/migration/v500/move.go
+++ b/internal/services/argo_smart_routing/migration/v500/move.go
@@ -3,6 +3,7 @@ package v500
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -10,10 +11,10 @@ import (
 // MoveArgoToSmartRouting handles moving state from legacy cloudflare_argo to cloudflare_argo_smart_routing.
 // This is triggered by Terraform 1.8+ when it encounters a `moved` block:
 //
-//   moved {
-//     from = cloudflare_argo.example
-//     to   = cloudflare_argo_smart_routing.example
-//   }
+//	moved {
+//	  from = cloudflare_argo.example
+//	  to   = cloudflare_argo_smart_routing.example
+//	}
 //
 // This handler is called when:
 // - Scenario 1: Neither smart_routing nor tiered_caching attributes exist
@@ -26,14 +27,7 @@ func MoveArgoToSmartRouting(ctx context.Context, req resource.MoveStateRequest, 
 
 	// Parse the source state (legacy v4 cloudflare_argo format)
 	var sourceState SourceCloudflareArgoModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/argo_smart_routing/migration/v500/move.go
+++ b/internal/services/argo_smart_routing/migration/v500/move.go
@@ -26,6 +26,16 @@ func MoveArgoToSmartRouting(ctx context.Context, req resource.MoveStateRequest, 
 
 	// Parse the source state (legacy v4 cloudflare_argo format)
 	var sourceState SourceCloudflareArgoModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/argo_tiered_caching/migration/v500/move.go
+++ b/internal/services/argo_tiered_caching/migration/v500/move.go
@@ -24,6 +24,16 @@ func MoveArgoToTieredCaching(ctx context.Context, req resource.MoveStateRequest,
 
 	// Parse the source state (legacy v4 cloudflare_argo format)
 	var sourceState SourceCloudflareArgoModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/argo_tiered_caching/migration/v500/move.go
+++ b/internal/services/argo_tiered_caching/migration/v500/move.go
@@ -3,6 +3,7 @@ package v500
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -10,10 +11,10 @@ import (
 // MoveArgoToTieredCaching handles moving state from legacy cloudflare_argo to cloudflare_argo_tiered_caching.
 // This is triggered by Terraform 1.8+ when it encounters a `moved` block:
 //
-//   moved {
-//     from = cloudflare_argo.example
-//     to   = cloudflare_argo_tiered_caching.example
-//   }
+//	moved {
+//	  from = cloudflare_argo.example
+//	  to   = cloudflare_argo_tiered_caching.example
+//	}
 //
 // This handler is called when:
 // - Scenario 4: Only tiered_caching attribute exists (no smart_routing)
@@ -24,14 +25,7 @@ func MoveArgoToTieredCaching(ctx context.Context, req resource.MoveStateRequest,
 
 	// Parse the source state (legacy v4 cloudflare_argo format)
 	var sourceState SourceCloudflareArgoModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/authenticated_origin_pulls_hostname_certificate/migration/v500/move.go
+++ b/internal/services/authenticated_origin_pulls_hostname_certificate/migration/v500/move.go
@@ -16,6 +16,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 
 	// Read v4 state into v4 model
 	var v4Model V4Model
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &v4Model)...)
 	if resp.Diagnostics.HasError() {
 		tflog.Error(ctx, "Failed to get source state during move")

--- a/internal/services/authenticated_origin_pulls_hostname_certificate/migration/v500/move.go
+++ b/internal/services/authenticated_origin_pulls_hostname_certificate/migration/v500/move.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -16,14 +17,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 
 	// Read v4 state into v4 model
 	var v4Model V4Model
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &v4Model)...)

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/move.go
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/move.go
@@ -3,6 +3,7 @@ package v500
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -10,13 +11,14 @@ import (
 // MoveState handles moving state from legacy resource to current resource.
 // This is triggered by Terraform 1.8+ when it encounters a `moved` block:
 //
-//   moved {
-//     from = cloudflare_authenticated_origin_pulls.example
-//     to   = cloudflare_authenticated_origin_pulls_settings.example
-//   }
+//	moved {
+//	  from = cloudflare_authenticated_origin_pulls.example
+//	  to   = cloudflare_authenticated_origin_pulls_settings.example
+//	}
 //
 // For Terraform < 1.8, users must manually run:
-//   terraform state mv cloudflare_authenticated_origin_pulls.example cloudflare_authenticated_origin_pulls_settings.example
+//
+//	terraform state mv cloudflare_authenticated_origin_pulls.example cloudflare_authenticated_origin_pulls_settings.example
 //
 // which will preserve the source schema_version and trigger UpgradeFromLegacyV0 instead.
 func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
@@ -24,14 +26,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 
 	// Parse the source state (legacy v4 format)
 	var sourceState SourceCloudflareAuthenticatedOriginPullsModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/authenticated_origin_pulls_settings/migration/v500/move.go
+++ b/internal/services/authenticated_origin_pulls_settings/migration/v500/move.go
@@ -24,6 +24,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 
 	// Parse the source state (legacy v4 format)
 	var sourceState SourceCloudflareAuthenticatedOriginPullsModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/dns_record/migration/v500/move_state.go
+++ b/internal/services/dns_record/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -38,14 +39,7 @@ func MoveState(
 
 	// Parse the source state
 	var sourceState SourceCloudflareRecordModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/dns_record/migration/v500/move_state.go
+++ b/internal/services/dns_record/migration/v500/move_state.go
@@ -38,6 +38,16 @@ func MoveState(
 
 	// Parse the source state
 	var sourceState SourceCloudflareRecordModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/managed_transforms/migration/v500/move.go
+++ b/internal/services/managed_transforms/migration/v500/move.go
@@ -18,6 +18,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 	tflog.Info(ctx, "Moving state from legacy cloudflare_managed_headers to cloudflare_managed_transforms")
 
 	var sourceState SourceManagedHeadersModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/managed_transforms/migration/v500/move.go
+++ b/internal/services/managed_transforms/migration/v500/move.go
@@ -3,6 +3,7 @@ package v500
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -18,14 +19,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 	tflog.Info(ctx, "Moving state from legacy cloudflare_managed_headers to cloudflare_managed_transforms")
 
 	var sourceState SourceManagedHeadersModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/workers_custom_domain/migration/v500/move_state.go
+++ b/internal/services/workers_custom_domain/migration/v500/move_state.go
@@ -27,6 +27,16 @@ func MoveStateV4toV500(ctx context.Context, req resource.MoveStateRequest, resp 
 		})
 
 	var source SourceV4WorkersCustomDomainModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &source)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/workers_custom_domain/migration/v500/move_state.go
+++ b/internal/services/workers_custom_domain/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -27,14 +28,7 @@ func MoveStateV4toV500(ctx context.Context, req resource.MoveStateRequest, resp 
 		})
 
 	var source SourceV4WorkersCustomDomainModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &source)...)

--- a/internal/services/workers_for_platforms_dispatch_namespace/migration/v500/move_state.go
+++ b/internal/services/workers_for_platforms_dispatch_namespace/migration/v500/move_state.go
@@ -42,6 +42,16 @@ func MoveFromWorkersForPlatformsNamespace(
 
 	// Parse the source state
 	var sourceState SourceWorkersForPlatformsNamespaceModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/workers_for_platforms_dispatch_namespace/migration/v500/move_state.go
+++ b/internal/services/workers_for_platforms_dispatch_namespace/migration/v500/move_state.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -42,14 +43,7 @@ func MoveFromWorkersForPlatformsNamespace(
 
 	// Parse the source state
 	var sourceState SourceWorkersForPlatformsNamespaceModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/workers_route/migration/v500/move_state.go
+++ b/internal/services/workers_route/migration/v500/move_state.go
@@ -26,6 +26,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 		})
 
 	var sourceState SourceWorkerRouteModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/workers_route/migration/v500/move_state.go
+++ b/internal/services/workers_route/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -26,14 +27,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 		})
 
 	var sourceState SourceWorkerRouteModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/workers_script/migration/v500/move_state.go
+++ b/internal/services/workers_script/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -36,14 +37,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 
 	// Parse source state using V4 model
 	var sourceState SourceWorkerScriptModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/workers_script/migration/v500/move_state.go
+++ b/internal/services/workers_script/migration/v500/move_state.go
@@ -36,6 +36,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 
 	// Parse source state using V4 model
 	var sourceState SourceWorkerScriptModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_access_group/migration/v500/move_state.go
+++ b/internal/services/zero_trust_access_group/migration/v500/move_state.go
@@ -38,6 +38,16 @@ func MoveState(
 
 	// Parse the source state (v4 SDKv2 format)
 	var sourceState SourceV4ZeroTrustAccessGroupModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_access_group/migration/v500/move_state.go
+++ b/internal/services/zero_trust_access_group/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -38,14 +39,7 @@ func MoveState(
 
 	// Parse the source state (v4 SDKv2 format)
 	var sourceState SourceV4ZeroTrustAccessGroupModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_access_identity_provider/migration/v500/move_state.go
+++ b/internal/services/zero_trust_access_identity_provider/migration/v500/move_state.go
@@ -21,6 +21,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 	tflog.Info(ctx, "Moving state from cloudflare_access_identity_provider")
 
 	var sourceState SourceAccessIdentityProviderModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_access_identity_provider/migration/v500/move_state.go
+++ b/internal/services/zero_trust_access_identity_provider/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -21,14 +22,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 	tflog.Info(ctx, "Moving state from cloudflare_access_identity_provider")
 
 	var sourceState SourceAccessIdentityProviderModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_access_mtls_certificate/migration/v500/move_state.go
+++ b/internal/services/zero_trust_access_mtls_certificate/migration/v500/move_state.go
@@ -32,6 +32,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 		})
 
 	var sourceState SourceAccessMutualTLSCertificateModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_access_mtls_certificate/migration/v500/move_state.go
+++ b/internal/services/zero_trust_access_mtls_certificate/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -32,14 +33,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 		})
 
 	var sourceState SourceAccessMutualTLSCertificateModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_access_service_token/migration/v500/move.go
+++ b/internal/services/zero_trust_access_service_token/migration/v500/move.go
@@ -24,6 +24,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 
 	// Parse the source state (legacy v4 format)
 	var sourceState SourceAccessServiceTokenModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_access_service_token/migration/v500/move.go
+++ b/internal/services/zero_trust_access_service_token/migration/v500/move.go
@@ -3,6 +3,7 @@ package v500
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -10,13 +11,14 @@ import (
 // MoveState handles moving state from legacy resource to current resource.
 // This is triggered by Terraform 1.8+ when it encounters a `moved` block:
 //
-//   moved {
-//     from = cloudflare_access_service_token.example
-//     to   = cloudflare_zero_trust_access_service_token.example
-//   }
+//	moved {
+//	  from = cloudflare_access_service_token.example
+//	  to   = cloudflare_zero_trust_access_service_token.example
+//	}
 //
 // For Terraform < 1.8, users must manually run:
-//   terraform state mv cloudflare_access_service_token.example cloudflare_zero_trust_access_service_token.example
+//
+//	terraform state mv cloudflare_access_service_token.example cloudflare_zero_trust_access_service_token.example
 //
 // which will preserve the source schema_version and trigger UpgradeFromV4 instead.
 func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
@@ -24,14 +26,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 
 	// Parse the source state (legacy v4 format)
 	var sourceState SourceAccessServiceTokenModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_device_custom_profile/migration/v500/move.go
+++ b/internal/services/zero_trust_device_custom_profile/migration/v500/move.go
@@ -5,6 +5,7 @@ package v500
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -43,14 +44,7 @@ func MoveDeviceProfilesToCustomProfile(ctx context.Context, req resource.MoveSta
 
 	// Read the source state using the v4 schema
 	var source SourceDeviceProfileModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	diags := req.SourceState.Get(ctx, &source)

--- a/internal/services/zero_trust_device_custom_profile/migration/v500/move.go
+++ b/internal/services/zero_trust_device_custom_profile/migration/v500/move.go
@@ -43,6 +43,16 @@ func MoveDeviceProfilesToCustomProfile(ctx context.Context, req resource.MoveSta
 
 	// Read the source state using the v4 schema
 	var source SourceDeviceProfileModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	diags := req.SourceState.Get(ctx, &source)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/services/zero_trust_device_custom_profile_local_domain_fallback/migration/v500/move.go
+++ b/internal/services/zero_trust_device_custom_profile_local_domain_fallback/migration/v500/move.go
@@ -49,6 +49,16 @@ func MoveFallbackDomainToCustomProfile(ctx context.Context, req resource.MoveSta
 
 	// Parse the source state (legacy v4 format)
 	var sourceState SourceCloudflareFallbackDomainModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_device_custom_profile_local_domain_fallback/migration/v500/move.go
+++ b/internal/services/zero_trust_device_custom_profile_local_domain_fallback/migration/v500/move.go
@@ -3,6 +3,7 @@ package v500
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -12,17 +13,17 @@ import (
 //
 // This is triggered by Terraform 1.8+ when it encounters a `moved` block:
 //
-//   moved {
-//     from = cloudflare_zero_trust_local_fallback_domain.example
-//     to   = cloudflare_zero_trust_device_custom_profile_local_domain_fallback.example
-//   }
+//	moved {
+//	  from = cloudflare_zero_trust_local_fallback_domain.example
+//	  to   = cloudflare_zero_trust_device_custom_profile_local_domain_fallback.example
+//	}
 //
 // or for the deprecated alias:
 //
-//   moved {
-//     from = cloudflare_fallback_domain.example
-//     to   = cloudflare_zero_trust_device_custom_profile_local_domain_fallback.example
-//   }
+//	moved {
+//	  from = cloudflare_fallback_domain.example
+//	  to   = cloudflare_zero_trust_device_custom_profile_local_domain_fallback.example
+//	}
 //
 // This handler is called when:
 // - The legacy resource has a policy_id (custom profile path)
@@ -34,9 +35,9 @@ func MoveFallbackDomainToCustomProfile(ctx context.Context, req resource.MoveSta
 	if req.SourceTypeName != "cloudflare_zero_trust_local_fallback_domain" && req.SourceTypeName != "cloudflare_fallback_domain" {
 		tflog.Warn(ctx, "MoveFallbackDomainToCustomProfile called with unexpected source type",
 			map[string]any{
-				"source_type":           req.SourceTypeName,
-				"expected_types":        []string{"cloudflare_zero_trust_local_fallback_domain", "cloudflare_fallback_domain"},
-				"target_resource_type":  "cloudflare_zero_trust_device_custom_profile_local_domain_fallback",
+				"source_type":          req.SourceTypeName,
+				"expected_types":       []string{"cloudflare_zero_trust_local_fallback_domain", "cloudflare_fallback_domain"},
+				"target_resource_type": "cloudflare_zero_trust_device_custom_profile_local_domain_fallback",
 			})
 		// Don't handle this move - let Terraform try other handlers or fail
 		return
@@ -49,14 +50,7 @@ func MoveFallbackDomainToCustomProfile(ctx context.Context, req resource.MoveSta
 
 	// Parse the source state (legacy v4 format)
 	var sourceState SourceCloudflareFallbackDomainModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_device_default_profile/migration/v500/move.go
+++ b/internal/services/zero_trust_device_default_profile/migration/v500/move.go
@@ -25,6 +25,16 @@ import (
 func MoveDeviceProfilesToDefaultProfile(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
 	// Read the source state using the v4 schema
 	var source SourceDeviceProfileModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	diags := req.SourceState.Get(ctx, &source)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/services/zero_trust_device_default_profile/migration/v500/move.go
+++ b/internal/services/zero_trust_device_default_profile/migration/v500/move.go
@@ -5,6 +5,7 @@ package v500
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
@@ -25,14 +26,7 @@ import (
 func MoveDeviceProfilesToDefaultProfile(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
 	// Read the source state using the v4 schema
 	var source SourceDeviceProfileModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	diags := req.SourceState.Get(ctx, &source)

--- a/internal/services/zero_trust_device_default_profile_local_domain_fallback/migration/v500/move.go
+++ b/internal/services/zero_trust_device_default_profile_local_domain_fallback/migration/v500/move.go
@@ -41,6 +41,16 @@ func MoveFallbackDomainToDefaultProfile(ctx context.Context, req resource.MoveSt
 
 	// Parse the source state (legacy v4 format)
 	var sourceState SourceCloudflareFallbackDomainModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		tflog.Error(ctx, "Failed to parse source state", map[string]any{

--- a/internal/services/zero_trust_device_default_profile_local_domain_fallback/migration/v500/move.go
+++ b/internal/services/zero_trust_device_default_profile_local_domain_fallback/migration/v500/move.go
@@ -3,6 +3,7 @@ package v500
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -41,14 +42,7 @@ func MoveFallbackDomainToDefaultProfile(ctx context.Context, req resource.MoveSt
 
 	// Parse the source state (legacy v4 format)
 	var sourceState SourceCloudflareFallbackDomainModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_device_managed_networks/migration/v500/move_state.go
+++ b/internal/services/zero_trust_device_managed_networks/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -38,14 +39,7 @@ func MoveState(
 
 	// Parse the source state
 	var sourceState SourceCloudflareDeviceManagedNetworksModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_device_managed_networks/migration/v500/move_state.go
+++ b/internal/services/zero_trust_device_managed_networks/migration/v500/move_state.go
@@ -38,6 +38,16 @@ func MoveState(
 
 	// Parse the source state
 	var sourceState SourceCloudflareDeviceManagedNetworksModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_device_posture_integration/migration/v500/move.go
+++ b/internal/services/zero_trust_device_posture_integration/migration/v500/move.go
@@ -3,6 +3,7 @@ package v500
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -10,13 +11,14 @@ import (
 // MoveState handles moving state from legacy resource to current resource.
 // This is triggered by Terraform 1.8+ when it encounters a `moved` block:
 //
-//   moved {
-//     from = cloudflare_device_posture_integration.example
-//     to   = cloudflare_zero_trust_device_posture_integration.example
-//   }
+//	moved {
+//	  from = cloudflare_device_posture_integration.example
+//	  to   = cloudflare_zero_trust_device_posture_integration.example
+//	}
 //
 // For Terraform < 1.8, users must manually run:
-//   terraform state mv cloudflare_device_posture_integration.example cloudflare_zero_trust_device_posture_integration.example
+//
+//	terraform state mv cloudflare_device_posture_integration.example cloudflare_zero_trust_device_posture_integration.example
 //
 // which will preserve the source schema_version and trigger UpgradeFromV4 instead.
 func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
@@ -24,14 +26,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 
 	// Parse the source state (legacy v4 format)
 	var sourceState SourceCloudflareDevicePostureIntegrationModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_device_posture_integration/migration/v500/move.go
+++ b/internal/services/zero_trust_device_posture_integration/migration/v500/move.go
@@ -24,6 +24,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 
 	// Parse the source state (legacy v4 format)
 	var sourceState SourceCloudflareDevicePostureIntegrationModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_device_posture_rule/migration/v500/move_state.go
+++ b/internal/services/zero_trust_device_posture_rule/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -38,14 +39,7 @@ func MoveState(
 
 	// Parse the source state
 	var sourceState SourceDevicePostureRuleModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_device_posture_rule/migration/v500/move_state.go
+++ b/internal/services/zero_trust_device_posture_rule/migration/v500/move_state.go
@@ -38,6 +38,16 @@ func MoveState(
 
 	// Parse the source state
 	var sourceState SourceDevicePostureRuleModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_dex_test/migration/v500/move_state.go
+++ b/internal/services/zero_trust_dex_test/migration/v500/move_state.go
@@ -44,6 +44,16 @@ func MoveState(
 
 	// Parse the source state
 	var sourceState SourceCloudflareDeviceDexTestModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_dex_test/migration/v500/move_state.go
+++ b/internal/services/zero_trust_dex_test/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -44,14 +45,7 @@ func MoveState(
 
 	// Parse the source state
 	var sourceState SourceCloudflareDeviceDexTestModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_dlp_custom_profile/migration/v500/move_state.go
+++ b/internal/services/zero_trust_dlp_custom_profile/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -38,14 +39,7 @@ func MoveState(
 		})
 
 	var sourceState SourceCloudflareDLPProfileModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_dlp_custom_profile/migration/v500/move_state.go
+++ b/internal/services/zero_trust_dlp_custom_profile/migration/v500/move_state.go
@@ -38,6 +38,16 @@ func MoveState(
 		})
 
 	var sourceState SourceCloudflareDLPProfileModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_dlp_predefined_profile/migration/v500/move_state.go
+++ b/internal/services/zero_trust_dlp_predefined_profile/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -38,14 +39,7 @@ func MoveState(
 		})
 
 	var sourceState SourceCloudflareDLPProfileModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_dlp_predefined_profile/migration/v500/move_state.go
+++ b/internal/services/zero_trust_dlp_predefined_profile/migration/v500/move_state.go
@@ -38,6 +38,16 @@ func MoveState(
 		})
 
 	var sourceState SourceCloudflareDLPProfileModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_gateway_policy/migration/v500/move.go
+++ b/internal/services/zero_trust_gateway_policy/migration/v500/move.go
@@ -24,6 +24,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 
 	// Parse the source state (legacy v4 format)
 	var sourceState SourceCloudflareTeamsRuleModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_gateway_policy/migration/v500/move.go
+++ b/internal/services/zero_trust_gateway_policy/migration/v500/move.go
@@ -3,6 +3,7 @@ package v500
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -10,13 +11,14 @@ import (
 // MoveState handles moving state from legacy resource to current resource.
 // This is triggered by Terraform 1.8+ when it encounters a `moved` block:
 //
-//   moved {
-//     from = cloudflare_teams_rule.example
-//     to   = cloudflare_zero_trust_gateway_policy.example
-//   }
+//	moved {
+//	  from = cloudflare_teams_rule.example
+//	  to   = cloudflare_zero_trust_gateway_policy.example
+//	}
 //
 // For Terraform < 1.8, users must manually run:
-//   terraform state mv cloudflare_teams_rule.example cloudflare_zero_trust_gateway_policy.example
+//
+//	terraform state mv cloudflare_teams_rule.example cloudflare_zero_trust_gateway_policy.example
 //
 // which will preserve the source schema_version and trigger UpgradeFromV4 instead.
 func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
@@ -24,14 +26,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 
 	// Parse the source state (legacy v4 format)
 	var sourceState SourceCloudflareTeamsRuleModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_gateway_settings/migration/v500/move_state.go
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/move_state.go
@@ -3,6 +3,7 @@ package v500
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -24,14 +25,7 @@ func MoveFromCloudflareTeamsAccount(ctx context.Context, req resource.MoveStateR
 
 	// Parse the source state using the v4 source schema
 	var sourceState SourceV4ZeroTrustGatewaySettingsModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_gateway_settings/migration/v500/move_state.go
+++ b/internal/services/zero_trust_gateway_settings/migration/v500/move_state.go
@@ -24,6 +24,16 @@ func MoveFromCloudflareTeamsAccount(ctx context.Context, req resource.MoveStateR
 
 	// Parse the source state using the v4 source schema
 	var sourceState SourceV4ZeroTrustGatewaySettingsModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_list/migration/v500/move_state.go
+++ b/internal/services/zero_trust_list/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -26,14 +27,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 		})
 
 	var sourceState SourceTeamsListModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_list/migration/v500/move_state.go
+++ b/internal/services/zero_trust_list/migration/v500/move_state.go
@@ -26,6 +26,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 		})
 
 	var sourceState SourceTeamsListModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_organization/migration/v500/move_state.go
+++ b/internal/services/zero_trust_organization/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -44,14 +45,7 @@ func MoveState(
 
 	// Parse the source state using the v4 source model
 	var sourceState SourceCloudflareAccessOrganizationModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_organization/migration/v500/move_state.go
+++ b/internal/services/zero_trust_organization/migration/v500/move_state.go
@@ -44,6 +44,16 @@ func MoveState(
 
 	// Parse the source state using the v4 source model
 	var sourceState SourceCloudflareAccessOrganizationModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_tunnel_cloudflared/migration/v500/move_state.go
+++ b/internal/services/zero_trust_tunnel_cloudflared/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
@@ -20,14 +21,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 	}
 
 	var source SourceTunnelCloudflaredModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &source)...)

--- a/internal/services/zero_trust_tunnel_cloudflared/migration/v500/move_state.go
+++ b/internal/services/zero_trust_tunnel_cloudflared/migration/v500/move_state.go
@@ -20,6 +20,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 	}
 
 	var source SourceTunnelCloudflaredModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &source)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_tunnel_cloudflared_config/migration/v500/move_state.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_config/migration/v500/move_state.go
@@ -42,6 +42,16 @@ func MoveStateFromTunnelConfig(
 
 	// Parse the source state using v4 model
 	var sourceState SourceV4TunnelConfigModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_tunnel_cloudflared_config/migration/v500/move_state.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_config/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -42,14 +43,7 @@ func MoveStateFromTunnelConfig(
 
 	// Parse the source state using v4 model
 	var sourceState SourceV4TunnelConfigModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_tunnel_cloudflared_route/migration/v500/move_state.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_route/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -48,14 +49,7 @@ func MoveState(
 
 	// Parse the source state
 	var sourceState SourceTunnelRouteModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)

--- a/internal/services/zero_trust_tunnel_cloudflared_route/migration/v500/move_state.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_route/migration/v500/move_state.go
@@ -48,6 +48,16 @@ func MoveState(
 
 	// Parse the source state
 	var sourceState SourceTunnelRouteModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceState)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_tunnel_cloudflared_virtual_network/migration/v500/move_state.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_virtual_network/migration/v500/move_state.go
@@ -20,6 +20,16 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 	}
 
 	var source SourceVirtualNetworkModel
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Source State",
+			"The source state for "+req.SourceTypeName+" could not be decoded. "+
+				"This typically occurs when the state file uses the legacy flatmap format "+
+				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
+				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
+		)
+		return
+	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &source)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zero_trust_tunnel_cloudflared_virtual_network/migration/v500/move_state.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_virtual_network/migration/v500/move_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/migrations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
@@ -20,14 +21,7 @@ func MoveState(ctx context.Context, req resource.MoveStateRequest, resp *resourc
 	}
 
 	var source SourceVirtualNetworkModel
-	if req.SourceState == nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read Source State",
-			"The source state for "+req.SourceTypeName+" could not be decoded. "+
-				"This typically occurs when the state file uses the legacy flatmap format "+
-				"from Terraform versions prior to 0.12. Run 'terraform apply -refresh-only' "+
-				"with the v4 provider to upgrade the state format, then retry the v5 migration.",
-		)
+	if migrations.DiagnoseMoveStateNilSourceState(req, resp) {
 		return
 	}
 	resp.Diagnostics.Append(req.SourceState.Get(ctx, &source)...)

--- a/templates/guides/version-5-upgrade.md
+++ b/templates/guides/version-5-upgrade.md
@@ -33,6 +33,13 @@ security fixes.
 latest version of 4.x to ensure any transitional updates are applied to your
 existing configuration.
 
+~> If your Terraform state was originally created with Terraform 0.11 or earlier,
+it may use the legacy `attributes_flat` storage format. The v5 provider's state
+migration cannot read this format and will return an error. To check, inspect
+your `.tfstate` file for `"attributes_flat"` keys. If present, run
+`terraform apply -refresh-only` with the v4 provider to normalize the state
+before upgrading to v5.
+
 Once ready, make the following change to use the latest 5.x release:
 
 ```hcl


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
The v5 provider's MoveState implementations panic with a nil pointer dereference when the source Terraform state uses the legacy attributes_flat (flatmap) format from pre-Terraform 0.12. The framework intentionally leaves req.SourceState nil when it cannot unmarshal the source state, but our code calls req.SourceState.Get() without checking.

This adds a nil guard to all 32 MoveState implementations. Instead of crashing, the provider now returns a clear diagnostic telling the user to run terraform apply -refresh-only with the v4 provider to normalize their state before retrying the migration.

Also adds a prerequisite callout to the v5 upgrade guide.
Fixes https://github.com/cloudflare/terraform-provider-cloudflare/issues/7152

## Acceptance Test Results
- [ ] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
`TF_ACC=1 ./scripts/test`
