### PR TITLE
fix(list): prevent inconsistent result after apply

### DIFF
--- a/internal/customfield/normalize.go
+++ b/internal/customfield/normalize.go
@@ -1,0 +1,44 @@
+package customfield
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+)
+
+// NullifyEmptyObject checks whether a NestedObject has all-null attributes and,
+// if so, returns a null NestedObject instead. This is useful when an API returns
+// empty objects (e.g. {"hostname": {}}) for fields the user did not set, which
+// would otherwise cause Terraform set-correlation failures because a known object
+// with all-null attributes is not structurally equal to a null object.
+//
+// IMPORTANT: Do not use this on empty marker structs (zero fields) where the
+// mere presence of the object is the semantic value (e.g. everyone = {},
+// certificate = {}, any_valid_service_token = {}). For those types, {} and null
+// are semantically different. This function is safe for such types because it
+// returns the original object unchanged when there are zero attributes.
+func NullifyEmptyObject[T any](ctx context.Context, obj NestedObject[T]) NestedObject[T] {
+	if obj.IsNull() || obj.IsUnknown() {
+		return obj
+	}
+
+	attrs := obj.ObjectValue.Attributes()
+	if len(attrs) == 0 {
+		// Empty struct (zero fields) -- presence IS the value, do not nullify.
+		return obj
+	}
+
+	for _, v := range attrs {
+		if !attrIsNullOrUnknown(v) {
+			return obj
+		}
+	}
+
+	return NullObject[T](ctx)
+}
+
+// attrIsNullOrUnknown returns true if the given attr.Value is null or unknown.
+// It handles both the attr.Value interface methods and nested null objects.
+func attrIsNullOrUnknown(v attr.Value) bool {
+	return v.IsNull() || v.IsUnknown()
+}

--- a/internal/customfield/normalize_test.go
+++ b/internal/customfield/normalize_test.go
@@ -1,0 +1,139 @@
+package customfield
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type testHostnameModel struct {
+	URLHostname          types.String `tfsdk:"url_hostname"`
+	ExcludeExactHostname types.Bool   `tfsdk:"exclude_exact_hostname"`
+}
+
+type testEmptyMarkerModel struct{}
+
+type testSingleFieldModel struct {
+	Name types.String `tfsdk:"name"`
+}
+
+func TestNullifyEmptyObject_AllNullFields(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a known object where all fields are null (simulates API returning {})
+	obj := NewObjectMust(ctx, &testHostnameModel{
+		URLHostname:          types.StringNull(),
+		ExcludeExactHostname: types.BoolNull(),
+	})
+
+	if obj.IsNull() {
+		t.Fatal("precondition: object should be known (not null) before normalization")
+	}
+
+	result := NullifyEmptyObject(ctx, obj)
+
+	if !result.IsNull() {
+		t.Error("expected NullifyEmptyObject to return null when all attributes are null")
+	}
+}
+
+func TestNullifyEmptyObject_SomeFieldsSet(t *testing.T) {
+	ctx := context.Background()
+
+	obj := NewObjectMust(ctx, &testHostnameModel{
+		URLHostname:          types.StringValue("example.com"),
+		ExcludeExactHostname: types.BoolNull(),
+	})
+
+	result := NullifyEmptyObject(ctx, obj)
+
+	if result.IsNull() {
+		t.Error("expected NullifyEmptyObject to preserve object when some attributes are set")
+	}
+}
+
+func TestNullifyEmptyObject_AllFieldsSet(t *testing.T) {
+	ctx := context.Background()
+
+	obj := NewObjectMust(ctx, &testHostnameModel{
+		URLHostname:          types.StringValue("example.com"),
+		ExcludeExactHostname: types.BoolValue(true),
+	})
+
+	result := NullifyEmptyObject(ctx, obj)
+
+	if result.IsNull() {
+		t.Error("expected NullifyEmptyObject to preserve object when all attributes are set")
+	}
+}
+
+func TestNullifyEmptyObject_AlreadyNull(t *testing.T) {
+	ctx := context.Background()
+
+	obj := NullObject[testHostnameModel](ctx)
+
+	result := NullifyEmptyObject(ctx, obj)
+
+	if !result.IsNull() {
+		t.Error("expected NullifyEmptyObject to return null for already-null input")
+	}
+}
+
+func TestNullifyEmptyObject_AlreadyUnknown(t *testing.T) {
+	ctx := context.Background()
+
+	obj := UnknownObject[testHostnameModel](ctx)
+
+	result := NullifyEmptyObject(ctx, obj)
+
+	if !result.IsUnknown() {
+		t.Error("expected NullifyEmptyObject to return unknown for already-unknown input")
+	}
+}
+
+func TestNullifyEmptyObject_EmptyMarkerStruct(t *testing.T) {
+	ctx := context.Background()
+
+	// Empty marker struct (zero fields) -- presence IS the value.
+	// NullifyEmptyObject must NOT convert this to null.
+	obj := NewObjectMust(ctx, &testEmptyMarkerModel{})
+
+	if obj.IsNull() {
+		t.Fatal("precondition: empty marker object should be known (not null)")
+	}
+
+	result := NullifyEmptyObject(ctx, obj)
+
+	if result.IsNull() {
+		t.Error("expected NullifyEmptyObject to preserve empty marker struct (zero fields)")
+	}
+}
+
+func TestNullifyEmptyObject_SingleFieldNull(t *testing.T) {
+	ctx := context.Background()
+
+	obj := NewObjectMust(ctx, &testSingleFieldModel{
+		Name: types.StringNull(),
+	})
+
+	result := NullifyEmptyObject(ctx, obj)
+
+	if !result.IsNull() {
+		t.Error("expected NullifyEmptyObject to return null when single field is null")
+	}
+}
+
+func TestNullifyEmptyObject_SingleFieldSet(t *testing.T) {
+	ctx := context.Background()
+
+	obj := NewObjectMust(ctx, &testSingleFieldModel{
+		Name: types.StringValue("test"),
+	})
+
+	result := NullifyEmptyObject(ctx, obj)
+
+	if result.IsNull() {
+		t.Error("expected NullifyEmptyObject to preserve object when single field is set")
+	}
+}

--- a/internal/services/list/normalizations.go
+++ b/internal/services/list/normalizations.go
@@ -1,0 +1,25 @@
+package list
+
+import (
+	"context"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+)
+
+// normalizeListItems nullifies empty nested objects on list items returned by the
+// API. When a list is of kind "ip", the API returns each item with hostname and
+// redirect as empty objects ({}) rather than null. Terraform's Set type uses
+// structural equality for element identity, so a known object with all-null
+// attributes is not equal to a null object. This causes "Provider produced
+// inconsistent result after apply" errors because the planned set element (with
+// null hostname/redirect) cannot be correlated with the actual set element (with
+// known-but-empty hostname/redirect).
+//
+// This function normalizes the API response so that empty nested objects are
+// stored as null in state, matching what the user wrote in their configuration.
+func normalizeListItems(ctx context.Context, items []ListItemModel) {
+	for i := range items {
+		items[i].Hostname = customfield.NullifyEmptyObject(ctx, items[i].Hostname)
+		items[i].Redirect = customfield.NullifyEmptyObject(ctx, items[i].Redirect)
+	}
+}

--- a/internal/services/list/resource.go
+++ b/internal/services/list/resource.go
@@ -107,6 +107,8 @@ func (r *ListResource) Create(ctx context.Context, req resource.CreateRequest, r
 			return
 		}
 
+		normalizeListItems(ctx, itemsSet)
+
 		var items customfield.NestedObjectSet[ListItemModel]
 
 		items, diags = customfield.NewObjectSet[ListItemModel](ctx, itemsSet)
@@ -167,6 +169,8 @@ func (r *ListResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		if resp.Diagnostics.HasError() {
 			return
 		}
+
+		normalizeListItems(ctx, itemsSet)
 
 		var items customfield.NestedObjectSet[ListItemModel]
 
@@ -230,6 +234,8 @@ func (r *ListResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		if resp.Diagnostics.HasError() {
 			return
 		}
+
+		normalizeListItems(ctx, itemsSet)
 
 		var items customfield.NestedObjectSet[ListItemModel]
 
@@ -314,6 +320,8 @@ func (r *ListResource) ImportState(ctx context.Context, req resource.ImportState
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	normalizeListItems(ctx, itemsSet)
 
 	var items customfield.NestedObjectSet[ListItemModel]
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
When a list is of kind "ip", the API returns hostname and redirect as
empty objects ({}) rather than null. Terraform's Set type uses structural
equality for element identity, so a known object with all-null attributes
does not correlate with a null object from the plan. This causes
"Provider produced inconsistent result after apply" errors.

Add a generic NullifyEmptyObject helper in customfield that converts a
NestedObject with all-null attributes back to a null NestedObject. Apply
it in Create, Read, Update, and ImportState for list items so the state
always matches the planned representation.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
`TF_ACC=1 ./scripts/test`
