### PR TITLE
SECENG-12655: feat: add secrets_store resources with acceptance tests

### DIFF
--- a/internal/services/secrets_store/resource_test.go
+++ b/internal/services/secrets_store/resource_test.go
@@ -1,0 +1,135 @@
+package secrets_store_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v7"
+	"github.com/cloudflare/cloudflare-go/v7/secrets_store"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+// getExistingStore returns the ID and name of the first store in the account.
+// Secrets Store currently has a one-store-per-account limit.
+func getExistingStore(t *testing.T) (storeID, storeName string) {
+	t.Helper()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	client := acctest.SharedClient()
+	stores, err := client.SecretsStore.Stores.List(context.Background(), secrets_store.StoreListParams{
+		AccountID: cloudflare.F(accountID),
+	})
+	if err != nil {
+		t.Fatalf("listing stores: %s", err)
+	}
+	if len(stores.Result) == 0 {
+		t.Fatal("no secrets store found in account — create one first")
+	}
+	return stores.Result[0].ID, stores.Result[0].Name
+}
+
+// TestAccCloudflareSecretsStore_Import tests importing an existing secrets
+// store into Terraform state and verifying all fields are populated correctly.
+// Due to the one-store-per-account limit, this test uses the pre-existing store.
+func TestAccCloudflareSecretsStore_Import(t *testing.T) {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	storeID, storeName := getExistingStore(t)
+	resourceName := "cloudflare_secrets_store.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:            testAccSecretsStoreConfig(accountID, storeName),
+				ResourceName:     resourceName,
+				ImportStateId:    fmt.Sprintf("%s/%s", accountID, storeID),
+				ImportState:      true,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 state, got %d", len(states))
+					}
+					s := states[0]
+					if s.Attributes["id"] != storeID {
+						return fmt.Errorf("expected id %q, got %q", storeID, s.Attributes["id"])
+					}
+					if s.Attributes["name"] != storeName {
+						return fmt.Errorf("expected name %q, got %q", storeName, s.Attributes["name"])
+					}
+					if s.Attributes["account_id"] != accountID {
+						return fmt.Errorf("expected account_id %q, got %q", accountID, s.Attributes["account_id"])
+					}
+					if s.Attributes["created"] == "" {
+						return fmt.Errorf("expected created to be set")
+					}
+					if s.Attributes["modified"] == "" {
+						return fmt.Errorf("expected modified to be set")
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
+// TestAccCloudflareSecretsStore_Workflow tests the full lifecycle by creating
+// a store with a config, verifying computed fields, and importing. This test
+// requires an account with no existing store (due to the one-store-per-account
+// limit) and is skipped when a store already exists.
+func TestAccCloudflareSecretsStore_Workflow(t *testing.T) {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_secrets_store.test"
+	storeName := "cftftest-store"
+
+	// Skip if account already has a store.
+	client := acctest.SharedClient()
+	stores, err := client.SecretsStore.Stores.List(context.Background(), secrets_store.StoreListParams{
+		AccountID: cloudflare.F(accountID),
+	})
+	if err == nil && len(stores.Result) > 0 {
+		t.Skip("skipping store create/delete test — account already has a store (1-store limit)")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretsStoreConfig(accountID, storeName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(storeName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("created"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("modified"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+func testAccSecretsStoreConfig(accountID, storeName string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_secrets_store" "test" {
+  account_id = "%s"
+  name       = "%s"
+}
+`, accountID, storeName)
+}

--- a/internal/services/secrets_store/testdata/secretsstoreworkflow.tf
+++ b/internal/services/secrets_store/testdata/secretsstoreworkflow.tf
@@ -1,0 +1,5 @@
+
+resource "cloudflare_secrets_store" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+}

--- a/internal/services/secrets_store_secret/model.go
+++ b/internal/services/secrets_store_secret/model.go
@@ -9,6 +9,10 @@ import (
 )
 
 type SecretsStoreSecretResultEnvelope struct {
+	Result *[]*SecretsStoreSecretModel `json:"result"`
+}
+
+type SecretsStoreSecretSingleResultEnvelope struct {
 	Result SecretsStoreSecretModel `json:"result"`
 }
 
@@ -18,10 +22,10 @@ type SecretsStoreSecretModel struct {
 	StoreID   types.String      `tfsdk:"store_id" path:"store_id,required"`
 	Comment   types.String      `tfsdk:"comment" json:"comment,optional"`
 	Value     types.String      `tfsdk:"value" json:"value,optional,no_refresh"`
-	Scopes    *[]types.String   `tfsdk:"scopes" json:"scopes,optional"`
+	Scopes    *[]types.String   `tfsdk:"scopes" json:"scopes,required"`
 	Created   timetypes.RFC3339 `tfsdk:"created" json:"created,computed" format:"date-time"`
 	Modified  timetypes.RFC3339 `tfsdk:"modified" json:"modified,computed" format:"date-time"`
-	Name      types.String      `tfsdk:"name" json:"name,computed"`
+	Name      types.String      `tfsdk:"name" json:"name,required"`
 	Status    types.String      `tfsdk:"status" json:"status,computed"`
 }
 

--- a/internal/services/secrets_store_secret/resource.go
+++ b/internal/services/secrets_store_secret/resource.go
@@ -4,6 +4,7 @@ package secrets_store_secret
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -64,13 +65,13 @@ func (r *SecretsStoreSecretResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	dataBytes, err := data.MarshalJSON()
+	dataBytes, err := json.Marshal([]SecretsStoreSecretModel{*data})
 	if err != nil {
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
 		return
 	}
 	res := new(http.Response)
-	env := SecretsStoreSecretResultEnvelope{*data}
+	env := SecretsStoreSecretResultEnvelope{Result: &[]*SecretsStoreSecretModel{data}}
 	_, err = r.client.SecretsStore.Stores.Secrets.New(
 		ctx,
 		data.StoreID.ValueString(),
@@ -91,7 +92,11 @@ func (r *SecretsStoreSecretResource) Create(ctx context.Context, req resource.Cr
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
 	}
-	data = &env.Result
+	if env.Result == nil || len(*env.Result) == 0 {
+		resp.Diagnostics.AddError("bad state", "expected to have created 1 item")
+		return
+	}
+	data = (*env.Result)[0]
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -119,7 +124,7 @@ func (r *SecretsStoreSecretResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 	res := new(http.Response)
-	env := SecretsStoreSecretResultEnvelope{*data}
+	env := SecretsStoreSecretSingleResultEnvelope{*data}
 	_, err = r.client.SecretsStore.Stores.Secrets.Edit(
 		ctx,
 		data.StoreID.ValueString(),
@@ -156,7 +161,7 @@ func (r *SecretsStoreSecretResource) Read(ctx context.Context, req resource.Read
 	}
 
 	res := new(http.Response)
-	env := SecretsStoreSecretResultEnvelope{*data}
+	env := SecretsStoreSecretSingleResultEnvelope{*data}
 	_, err := r.client.SecretsStore.Stores.Secrets.Get(
 		ctx,
 		data.StoreID.ValueString(),
@@ -236,7 +241,7 @@ func (r *SecretsStoreSecretResource) ImportState(ctx context.Context, req resour
 	data.ID = types.StringValue(path_secret_id)
 
 	res := new(http.Response)
-	env := SecretsStoreSecretResultEnvelope{*data}
+	env := SecretsStoreSecretSingleResultEnvelope{*data}
 	_, err := r.client.SecretsStore.Stores.Secrets.Get(
 		ctx,
 		path_store_id,
@@ -265,3 +270,5 @@ func (r *SecretsStoreSecretResource) ImportState(ctx context.Context, req resour
 func (r *SecretsStoreSecretResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, _ *resource.ModifyPlanResponse) {
 
 }
+
+

--- a/internal/services/secrets_store_secret/resource_test.go
+++ b/internal/services/secrets_store_secret/resource_test.go
@@ -1,0 +1,226 @@
+package secrets_store_secret_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v7"
+	"github.com/cloudflare/cloudflare-go/v7/secrets_store"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func init() {
+	resource.AddTestSweepers("cloudflare_secrets_store_secret", &resource.Sweeper{
+		Name: "cloudflare_secrets_store_secret",
+		F:    testSweepSecretsStoreSecrets,
+	})
+}
+
+// testSweepSecretsStoreSecrets removes test-created secrets (names starting with
+// "cftftest") from all stores in the account. It does not delete the stores
+// themselves or any non-test secrets.
+func testSweepSecretsStoreSecrets(_ string) error {
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		return fmt.Errorf("CLOUDFLARE_ACCOUNT_ID must be set")
+	}
+
+	client := acctest.SharedClient()
+	ctx := context.Background()
+
+	stores, err := client.SecretsStore.Stores.List(ctx, secrets_store.StoreListParams{
+		AccountID: cloudflare.F(accountID),
+	})
+	if err != nil {
+		return fmt.Errorf("listing secrets stores: %w", err)
+	}
+
+	for _, store := range stores.Result {
+		secrets, err := client.SecretsStore.Stores.Secrets.List(ctx, store.ID, secrets_store.StoreSecretListParams{
+			AccountID: cloudflare.F(accountID),
+		})
+		if err != nil {
+			return fmt.Errorf("listing secrets in store %s: %w", store.ID, err)
+		}
+		for _, secret := range secrets.Result {
+			// Only delete secrets created by acceptance tests.
+			if len(secret.Name) >= 8 && secret.Name[:8] == "cftftest" {
+				_, err := client.SecretsStore.Stores.Secrets.Delete(ctx, store.ID, secret.ID, secrets_store.StoreSecretDeleteParams{
+					AccountID: cloudflare.F(accountID),
+				})
+				if err != nil {
+					return fmt.Errorf("deleting secret %s: %w", secret.ID, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// getExistingStoreID returns the ID of the first store in the account.
+// Secrets Store currently has a one-store-per-account limit.
+func getExistingStoreID(t *testing.T) string {
+	t.Helper()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	client := acctest.SharedClient()
+	stores, err := client.SecretsStore.Stores.List(context.Background(), secrets_store.StoreListParams{
+		AccountID: cloudflare.F(accountID),
+	})
+	if err != nil {
+		t.Fatalf("listing stores: %s", err)
+	}
+	if len(stores.Result) == 0 {
+		t.Fatal("no secrets store found in account — create one first")
+	}
+	return stores.Result[0].ID
+}
+
+func TestAccCloudflareSecretsStoreSecret_Workflow(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	storeID := getExistingStoreID(t)
+	secretResourceName := "cloudflare_secrets_store_secret." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckSecretsStoreSecretDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create secret in existing store
+				Config: testAccSecretsStoreSecretCreate(rnd, accountID, storeID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(secretResourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(secretResourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(secretResourceName, tfjsonpath.New("store_id"), knownvalue.StringExact(storeID)),
+					statecheck.ExpectKnownValue(secretResourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(secretResourceName, tfjsonpath.New("comment"), knownvalue.StringExact("initial comment")),
+					statecheck.ExpectKnownValue(secretResourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(secretResourceName, tfjsonpath.New("created"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(secretResourceName, tfjsonpath.New("modified"), knownvalue.NotNull()),
+				},
+			},
+			{
+				// Step 2: Update value via PATCH
+				Config: testAccSecretsStoreSecretUpdateValue(rnd, accountID, storeID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(secretResourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(secretResourceName, tfjsonpath.New("value"), knownvalue.StringExact("updated-secret-value")),
+				},
+			},
+			{
+				// Step 3: Update comment via PATCH
+				Config: testAccSecretsStoreSecretUpdateComment(rnd, accountID, storeID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(secretResourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(secretResourceName, tfjsonpath.New("comment"), knownvalue.StringExact("updated comment")),
+				},
+			},
+			{
+				// Step 4: Update scopes via PATCH
+				// NOTE: scopes must be listed in alphabetical order in the config.
+				// The API returns scopes sorted alphabetically regardless of input
+				// order. Since scopes is a ListAttribute (ordered), any mismatch
+				// between config order and API order causes perpetual drift.
+				// A future improvement would be to use SetAttribute for scopes.
+				Config: testAccSecretsStoreSecretUpdateScopes(rnd, accountID, storeID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(secretResourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(secretResourceName, tfjsonpath.New("scopes"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("ai_gateway"),
+							knownvalue.StringExact("workers"),
+						}),
+					),
+				},
+			},
+			{
+				// Step 5: Import
+				ResourceName: secretResourceName,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					secretRS, ok := s.RootModule().Resources[secretResourceName]
+					if !ok {
+						return "", fmt.Errorf("resource %s not found", secretResourceName)
+					}
+					return fmt.Sprintf("%s/%s/%s", accountID, storeID, secretRS.Primary.ID), nil
+				},
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value", "modified", "status"},
+			},
+		},
+	})
+}
+
+func testAccSecretsStoreSecretCreate(rnd, accountID, storeID string) string {
+	return acctest.LoadTestCase("secretsstoresecretcreate.tf", rnd, accountID, storeID)
+}
+
+func testAccSecretsStoreSecretUpdateValue(rnd, accountID, storeID string) string {
+	return acctest.LoadTestCase("secretsstoresecretupdatevalue.tf", rnd, accountID, storeID)
+}
+
+func testAccSecretsStoreSecretUpdateComment(rnd, accountID, storeID string) string {
+	return acctest.LoadTestCase("secretsstoresecretupdatecomment.tf", rnd, accountID, storeID)
+}
+
+func testAccSecretsStoreSecretUpdateScopes(rnd, accountID, storeID string) string {
+	return acctest.LoadTestCase("secretsstoresecretupdatescopes.tf", rnd, accountID, storeID)
+}
+
+func testAccCheckSecretsStoreSecretDestroy(s *terraform.State) error {
+	client := acctest.SharedClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_secrets_store_secret" {
+			continue
+		}
+
+		accountID := rs.Primary.Attributes[consts.AccountIDSchemaKey]
+		storeID := rs.Primary.Attributes["store_id"]
+		_, err := client.SecretsStore.Stores.Secrets.Get(
+			context.Background(),
+			storeID,
+			rs.Primary.ID,
+			secrets_store.StoreSecretGetParams{
+				AccountID: cloudflare.F(accountID),
+			},
+		)
+		if err == nil {
+			return fmt.Errorf("secrets store secret %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}

--- a/internal/services/secrets_store_secret/schema.go
+++ b/internal/services/secrets_store_secret/schema.go
@@ -49,12 +49,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"value": schema.StringAttribute{
 				Description: "The value of the secret. Maximum 64 KiB (65,536 bytes). Note that this is 'write only' - no API response will provide this value, it is only used to create/modify secrets.",
-				Optional:    true,
+				Required:    true,
 				Sensitive:   true,
 			},
 			"scopes": schema.ListAttribute{
-				Description: "The list of services that can use this secret.",
-				Optional:    true,
+				Description: "The list of services that can use this secret. Valid values are `workers`, `ai_gateway`, `dex`, and `access`. Must be listed in alphabetical order.",
+				Required:    true,
 				ElementType: types.StringType,
 			},
 			"created": schema.StringAttribute{
@@ -68,8 +68,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				CustomType:  timetypes.RFC3339Type{},
 			},
 			"name": schema.StringAttribute{
-				Description: "The name of the secret",
-				Computed:    true,
+				Description:   "The name of the secret",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"status": schema.StringAttribute{
 				Description: `Available values: "pending", "active", "deleted".`,

--- a/internal/services/secrets_store_secret/testdata/secretsstoresecretcreate.tf
+++ b/internal/services/secrets_store_secret/testdata/secretsstoresecretcreate.tf
@@ -1,0 +1,9 @@
+
+resource "cloudflare_secrets_store_secret" "%[1]s" {
+  account_id = "%[2]s"
+  store_id   = "%[3]s"
+  name       = "%[1]s"
+  value      = "test-secret-value"
+  scopes     = ["workers"]
+  comment    = "initial comment"
+}

--- a/internal/services/secrets_store_secret/testdata/secretsstoresecretupdatecomment.tf
+++ b/internal/services/secrets_store_secret/testdata/secretsstoresecretupdatecomment.tf
@@ -1,0 +1,9 @@
+
+resource "cloudflare_secrets_store_secret" "%[1]s" {
+  account_id = "%[2]s"
+  store_id   = "%[3]s"
+  name       = "%[1]s"
+  value      = "updated-secret-value"
+  scopes     = ["workers"]
+  comment    = "updated comment"
+}

--- a/internal/services/secrets_store_secret/testdata/secretsstoresecretupdatescopes.tf
+++ b/internal/services/secrets_store_secret/testdata/secretsstoresecretupdatescopes.tf
@@ -1,0 +1,9 @@
+
+resource "cloudflare_secrets_store_secret" "%[1]s" {
+  account_id = "%[2]s"
+  store_id   = "%[3]s"
+  name       = "%[1]s"
+  value      = "updated-secret-value"
+  scopes     = ["ai_gateway", "workers"]
+  comment    = "updated comment"
+}

--- a/internal/services/secrets_store_secret/testdata/secretsstoresecretupdatevalue.tf
+++ b/internal/services/secrets_store_secret/testdata/secretsstoresecretupdatevalue.tf
@@ -1,0 +1,9 @@
+
+resource "cloudflare_secrets_store_secret" "%[1]s" {
+  account_id = "%[2]s"
+  store_id   = "%[3]s"
+  name       = "%[1]s"
+  value      = "updated-secret-value"
+  scopes     = ["workers"]
+  comment    = "initial comment"
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fix codegen regressions in `secrets_store_secret` resource and add acceptance tests for both `cloudflare_secrets_store` and `cloudflare_secrets_store_secret`.

### Resource fixes (`secrets_store_secret`)

The Stainless codegen on `next` produced incorrect field modifiers and response handling after the `x-stainless-skip: [terraform]` annotation was added to the OpenAPI spec. These custom code fixes bring the resource in line with the correct behavior validated on `staging_`:

- **schema.go**: `name` is `Required` + `RequiresReplace` (was `Computed`), `value` and `scopes` are `Required` (were `Optional`). Added valid scope values and alphabetical ordering note to `scopes` description.
- **model.go**: `ResultEnvelope` uses array type for POST create response. Added `SingleResultEnvelope` for GET/PATCH responses. `Name` tag is `required`, `Scopes` tag is `required`.
- **resource.go**: Create wraps single model into `[{...}]` array for POST body (API expects array). Read/Update/Import use single-object envelope for GET/PATCH responses.

### Acceptance tests

**`cloudflare_secrets_store`**:
- `TestAccCloudflareSecretsStore_Import`: Imports existing store, verifies id/name/account_id/created/modified
- `TestAccCloudflareSecretsStore_Workflow`: Full create/import lifecycle (auto-skips when 1-store limit is hit)

**`cloudflare_secrets_store_secret`**:
- `TestAccCloudflareSecretsStoreSecret_Workflow`: 5-step workflow — create, update value (PATCH), update comment (PATCH), update scopes (PATCH), import. All update steps assert `ResourceActionUpdate` (not replace). Sweeper only deletes test secrets (prefix `cftftest`).

### Note: 1-store-per-account limit and test safety

Secrets Store currently allows only one store per account. The acceptance tests are designed to **never delete existing stores or non-test secrets**. The store import test uses the pre-existing store. The store workflow test auto-skips when a store already exists. The secret sweeper only cleans up secrets with the `cftftest` name prefix. When the multi-store limit is lifted, `TestAccCloudflareSecretsStore_Workflow` will automatically start running (create/delete lifecycle).

### Known limitation: scope ordering

The API returns `scopes` sorted alphabetically regardless of input order. Since `scopes` is a `ListAttribute` (ordered), customers must list scopes in alphabetical order to avoid perpetual drift. This is noted in the schema description and test comments. A future improvement would be to use `SetAttribute` for order-independent comparison.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

```bash
export CLOUDFLARE_API_KEY="<api-key>"
export CLOUDFLARE_EMAIL="<email>"
export CLOUDFLARE_ACCOUNT_ID="<account-id-with-existing-store>"

# Run secrets_store tests
cd internal/services/secrets_store
TF_ACC=1 go test -v -vet=off -run TestAccCloudflareSecretsStore -timeout 120s

# Run secrets_store_secret tests
cd internal/services/secrets_store_secret
TF_ACC=1 go test -v -vet=off -run TestAccCloudflareSecretsStoreSecret_Workflow -timeout 300s
```

### Test output

```
=== RUN   TestAccCloudflareSecretsStore_Import
--- PASS: TestAccCloudflareSecretsStore_Import (2.67s)
=== RUN   TestAccCloudflareSecretsStore_Workflow
    resource_test.go:104: skipping store create/delete test — account already has a store (1-store limit)
--- SKIP: TestAccCloudflareSecretsStore_Workflow (0.40s)
PASS

=== RUN   TestAccCloudflareSecretsStoreSecret_Workflow
--- PASS: TestAccCloudflareSecretsStoreSecret_Workflow (29.11s)
PASS
```

## Additional context & links

- OpenAPI spec: https://gitlab.cfdata.org/cloudflare/https/secrets-store/-/blob/main/schemas/public-api.yaml
- Stainless config (staging): https://gitlab.cfdata.org/cloudflare/sdks/cloudflare-config/-/merge_requests/512
- Stainless config (main): https://gitlab.cfdata.org/cloudflare/sdks/cloudflare-config/-/merge_requests/873
- Jira: SECENG-12655
