### PR TITLE
fix(secrets_store): fix model/schema parity and guard acceptance tests

### DIFF
--- a/internal/services/secrets_store/resource_test.go
+++ b/internal/services/secrets_store/resource_test.go
@@ -26,6 +26,9 @@ func TestMain(m *testing.M) {
 func getExistingStore(t *testing.T) (storeID, storeName string) {
 	t.Helper()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("skipping: CLOUDFLARE_ACCOUNT_ID must be set")
+	}
 	client := acctest.SharedClient()
 	stores, err := client.SecretsStore.Stores.List(context.Background(), secrets_store.StoreListParams{
 		AccountID: cloudflare.F(accountID),
@@ -92,6 +95,9 @@ func TestAccCloudflareSecretsStore_Import(t *testing.T) {
 // limit) and is skipped when a store already exists.
 func TestAccCloudflareSecretsStore_Workflow(t *testing.T) {
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("skipping: CLOUDFLARE_ACCOUNT_ID must be set")
+	}
 	resourceName := "cloudflare_secrets_store.test"
 	storeName := "cftftest-store"
 

--- a/internal/services/secrets_store_secret/model.go
+++ b/internal/services/secrets_store_secret/model.go
@@ -21,7 +21,7 @@ type SecretsStoreSecretModel struct {
 	AccountID types.String      `tfsdk:"account_id" path:"account_id,required"`
 	StoreID   types.String      `tfsdk:"store_id" path:"store_id,required"`
 	Comment   types.String      `tfsdk:"comment" json:"comment,optional"`
-	Value     types.String      `tfsdk:"value" json:"value,optional,no_refresh"`
+	Value     types.String      `tfsdk:"value" json:"value,required,no_refresh"`
 	Scopes    *[]types.String   `tfsdk:"scopes" json:"scopes,required"`
 	Created   timetypes.RFC3339 `tfsdk:"created" json:"created,computed" format:"date-time"`
 	Modified  timetypes.RFC3339 `tfsdk:"modified" json:"modified,computed" format:"date-time"`

--- a/internal/services/secrets_store_secret/resource_test.go
+++ b/internal/services/secrets_store_secret/resource_test.go
@@ -78,6 +78,9 @@ func testSweepSecretsStoreSecrets(_ string) error {
 func getExistingStoreID(t *testing.T) string {
 	t.Helper()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip("skipping: CLOUDFLARE_ACCOUNT_ID must be set")
+	}
 	client := acctest.SharedClient()
 	stores, err := client.SecretsStore.Stores.List(context.Background(), secrets_store.StoreListParams{
 		AccountID: cloudflare.F(accountID),


### PR DESCRIPTION
## Summary

Fixes two CI failures introduced by #7167 on the release branch.

### 1. Model/schema parity mismatch

`SecretsStoreSecretModel.Value` was tagged `json:"value,optional,no_refresh"` but the schema declares `value` as `Required: true`. The `TestSecretsStoreSecretModelSchemaParity` test caught this drift. Fixed by changing the model tag to `required,no_refresh`.

### 2. Acceptance tests fail without credentials

`getExistingStore()`, `getExistingStoreID()`, and `TestAccCloudflareSecretsStore_Workflow` make live API calls before the `PreCheck` hook runs. When `CLOUDFLARE_ACCOUNT_ID` is unset (as in unit test CI shards), the SDK returns `missing required account_id parameter` and `t.Fatalf` fails the test.

Fixed by adding a `t.Skip()` guard at the top of each function when `CLOUDFLARE_ACCOUNT_ID` is empty.

### Verification

```
go test -v -timeout 180s ./internal/services/secrets_store/... ./internal/services/secrets_store_secret/...
```

- `TestSecretsStoreSecretModelSchemaParity` -- PASS
- `TestSecretsStoreModelSchemaParity` -- PASS
- `TestAccCloudflareSecretsStore_Import` -- SKIP
- `TestAccCloudflareSecretsStore_Workflow` -- SKIP
- `TestAccCloudflareSecretsStoreSecret_Workflow` -- SKIP
