### PR TITLE
chore: Add acceptance tests for DLP data classification resources

### DIFF
--- a/internal/services/zero_trust_dlp_data_class/data_source_test.go
+++ b/internal/services/zero_trust_dlp_data_class/data_source_test.go
@@ -1,0 +1,52 @@
+package zero_trust_dlp_data_class_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestAccCloudflareZeroTrustDLPDataClassDataSource_Basic verifies the data
+// source reads the same attributes as the underlying resource.
+func TestAccCloudflareZeroTrustDLPDataClassDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_dlp_data_class.%s", rnd)
+	dataSourceName := fmt.Sprintf("data.cloudflare_zero_trust_dlp_data_class.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("datasource_basic.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("id"),
+						dataSourceName, tfjsonpath.New("id"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("name"),
+						dataSourceName, tfjsonpath.New("name"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("description"),
+						dataSourceName, tfjsonpath.New("description"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("expression"),
+						dataSourceName, tfjsonpath.New("expression"),
+						compare.ValuesSame()),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_data_class/resource_test.go
+++ b/internal/services/zero_trust_dlp_data_class/resource_test.go
@@ -1,0 +1,107 @@
+package zero_trust_dlp_data_class_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestAccCloudflareZeroTrustDLPDataClass_Basic verifies basic CRUD for a data
+// class, including its references to a data_tag and a sensitivity_level.
+func TestAccCloudflareZeroTrustDLPDataClass_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	name := fmt.Sprintf("cloudflare_zero_trust_dlp_data_class.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("account_id"),
+						knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("tf-acc-%s", rnd))),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Acceptance test data class")),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("expression"),
+						knownvalue.StringExact("dlp_match(dlp.entries[\"906fcb91-2eb5-4534-8f86-f95214b651eb\"])")),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("data_tags"),
+						knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("sensitivity_levels"),
+						knownvalue.ListSizeExact(1)),
+				},
+			},
+			// Re-apply: no drift.
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Import: `<account_id>/<data_class_id>`.
+			{
+				ResourceName:        name,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareZeroTrustDLPDataClass_Update verifies in-place update of
+// name, description, and expression on a data class.
+func TestAccCloudflareZeroTrustDLPDataClass_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	name := fmt.Sprintf("cloudflare_zero_trust_dlp_data_class.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+			},
+			{
+				Config: acctest.LoadTestCase("updated.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(name, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("tf-acc-%s-renamed", rnd))),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Updated description")),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("expression"),
+						knownvalue.StringExact("dlp_match(dlp.entries[\"5bce03be-0b03-434c-9f56-7b42512e0ff6\"])")),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_data_class/testdata/basic.tf
+++ b/internal/services/zero_trust_dlp_data_class/testdata/basic.tf
@@ -1,0 +1,42 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-group"
+  description = "Parent group for data_class acceptance test"
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "tf-acc-%[1]s-level"
+  description          = "Sensitivity level for data_class acceptance test"
+}
+
+resource "cloudflare_zero_trust_dlp_data_tag_category" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-category"
+  description = "Parent category for data_class acceptance test"
+}
+
+resource "cloudflare_zero_trust_dlp_data_tag" "%[1]s" {
+  account_id  = "%[2]s"
+  category_id = cloudflare_zero_trust_dlp_data_tag_category.%[1]s.id
+  name        = "tf-acc-%[1]s-tag"
+  description = "Data tag for data_class acceptance test"
+}
+
+resource "cloudflare_zero_trust_dlp_data_class" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s"
+  description = "Acceptance test data class"
+  # Expression references a predefined DLP entry by UUID. Predefined
+  # entries have stable UUIDs across accounts. This one is "AI Prompt
+  # Content: Credentials and Secrets".
+  expression  = "dlp_match(dlp.entries[\"906fcb91-2eb5-4534-8f86-f95214b651eb\"])"
+  data_tags   = [cloudflare_zero_trust_dlp_data_tag.%[1]s.id]
+  sensitivity_levels = [
+    {
+      group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+      level_id = cloudflare_zero_trust_dlp_sensitivity_level.%[1]s.id
+    },
+  ]
+}

--- a/internal/services/zero_trust_dlp_data_class/testdata/datasource_basic.tf
+++ b/internal/services/zero_trust_dlp_data_class/testdata/datasource_basic.tf
@@ -1,0 +1,47 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-group"
+  description = "Parent group for data_class data source test"
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "tf-acc-%[1]s-level"
+  description          = "Sensitivity level for data_class data source test"
+}
+
+resource "cloudflare_zero_trust_dlp_data_tag_category" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-category"
+  description = "Parent category for data_class data source test"
+}
+
+resource "cloudflare_zero_trust_dlp_data_tag" "%[1]s" {
+  account_id  = "%[2]s"
+  category_id = cloudflare_zero_trust_dlp_data_tag_category.%[1]s.id
+  name        = "tf-acc-%[1]s-tag"
+  description = "Data tag for data_class data source test"
+}
+
+resource "cloudflare_zero_trust_dlp_data_class" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s"
+  description = "Acceptance test data class"
+  # Expression references a predefined DLP entry by UUID. Predefined
+  # entries have stable UUIDs across accounts. This one is "AI Prompt
+  # Content: Credentials and Secrets".
+  expression  = "dlp_match(dlp.entries[\"906fcb91-2eb5-4534-8f86-f95214b651eb\"])"
+  data_tags   = [cloudflare_zero_trust_dlp_data_tag.%[1]s.id]
+  sensitivity_levels = [
+    {
+      group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+      level_id = cloudflare_zero_trust_dlp_sensitivity_level.%[1]s.id
+    },
+  ]
+}
+
+data "cloudflare_zero_trust_dlp_data_class" "%[1]s" {
+  account_id    = "%[2]s"
+  data_class_id = cloudflare_zero_trust_dlp_data_class.%[1]s.id
+}

--- a/internal/services/zero_trust_dlp_data_class/testdata/updated.tf
+++ b/internal/services/zero_trust_dlp_data_class/testdata/updated.tf
@@ -1,0 +1,43 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-group"
+  description = "Parent group for data_class acceptance test"
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "tf-acc-%[1]s-level"
+  description          = "Sensitivity level for data_class acceptance test"
+}
+
+resource "cloudflare_zero_trust_dlp_data_tag_category" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-category"
+  description = "Parent category for data_class acceptance test"
+}
+
+resource "cloudflare_zero_trust_dlp_data_tag" "%[1]s" {
+  account_id  = "%[2]s"
+  category_id = cloudflare_zero_trust_dlp_data_tag_category.%[1]s.id
+  name        = "tf-acc-%[1]s-tag"
+  description = "Data tag for data_class acceptance test"
+}
+
+resource "cloudflare_zero_trust_dlp_data_class" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-renamed"
+  description = "Updated description"
+  # Expression references a predefined DLP entry by UUID. Predefined
+  # entries have stable UUIDs across accounts. This one is "AI Prompt
+  # Content: Customer data" — different from basic.tf to exercise the
+  # update path.
+  expression  = "dlp_match(dlp.entries[\"5bce03be-0b03-434c-9f56-7b42512e0ff6\"])"
+  data_tags   = [cloudflare_zero_trust_dlp_data_tag.%[1]s.id]
+  sensitivity_levels = [
+    {
+      group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+      level_id = cloudflare_zero_trust_dlp_sensitivity_level.%[1]s.id
+    },
+  ]
+}

--- a/internal/services/zero_trust_dlp_data_tag/data_source_test.go
+++ b/internal/services/zero_trust_dlp_data_tag/data_source_test.go
@@ -1,0 +1,48 @@
+package zero_trust_dlp_data_tag_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestAccCloudflareZeroTrustDLPDataTagDataSource_Basic verifies the
+// data source reads the same attributes as the underlying resource.
+func TestAccCloudflareZeroTrustDLPDataTagDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_dlp_data_tag.%s", rnd)
+	dataSourceName := fmt.Sprintf("data.cloudflare_zero_trust_dlp_data_tag.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("datasource_basic.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("id"),
+						dataSourceName, tfjsonpath.New("id"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("name"),
+						dataSourceName, tfjsonpath.New("name"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("description"),
+						dataSourceName, tfjsonpath.New("description"),
+						compare.ValuesSame()),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_data_tag/resource_test.go
+++ b/internal/services/zero_trust_dlp_data_tag/resource_test.go
@@ -1,0 +1,114 @@
+package zero_trust_dlp_data_tag_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestAccCloudflareZeroTrustDLPDataTag_Basic verifies basic CRUD for
+// a data tag nested under a data tag category.
+func TestAccCloudflareZeroTrustDLPDataTag_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	name := fmt.Sprintf("cloudflare_zero_trust_dlp_data_tag.%s", rnd)
+	categoryName := fmt.Sprintf("cloudflare_zero_trust_dlp_data_tag_category.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("account_id"),
+						knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("tf-acc-%s", rnd))),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Acceptance test data tag")),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("category_id"),
+						knownvalue.NotNull()),
+				},
+			},
+			// Re-apply: no drift.
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Import: `<account_id>/<category_id>/<tag_id>`.
+			// The import requires both path segments since the tag is nested.
+			{
+				ResourceName: name,
+				ImportState:  true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					category, ok := state.RootModule().Resources[categoryName]
+					if !ok {
+						return "", fmt.Errorf("category resource %s not found in state", categoryName)
+					}
+					tag, ok := state.RootModule().Resources[name]
+					if !ok {
+						return "", fmt.Errorf("tag resource %s not found in state", name)
+					}
+					return fmt.Sprintf("%s/%s/%s",
+						accountID,
+						category.Primary.ID,
+						tag.Primary.ID), nil
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccCloudflareZeroTrustDLPDataTag_Update verifies in-place update
+// of name and description on a data tag.
+func TestAccCloudflareZeroTrustDLPDataTag_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	name := fmt.Sprintf("cloudflare_zero_trust_dlp_data_tag.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+			},
+			{
+				Config: acctest.LoadTestCase("updated.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(name, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("tf-acc-%s-renamed", rnd))),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Updated description")),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_data_tag/testdata/basic.tf
+++ b/internal/services/zero_trust_dlp_data_tag/testdata/basic.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_zero_trust_dlp_data_tag_category" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-category"
+  description = "Parent category for data_tag acceptance test"
+}
+
+resource "cloudflare_zero_trust_dlp_data_tag" "%[1]s" {
+  account_id  = "%[2]s"
+  category_id = cloudflare_zero_trust_dlp_data_tag_category.%[1]s.id
+  name        = "tf-acc-%[1]s"
+  description = "Acceptance test data tag"
+}

--- a/internal/services/zero_trust_dlp_data_tag/testdata/datasource_basic.tf
+++ b/internal/services/zero_trust_dlp_data_tag/testdata/datasource_basic.tf
@@ -1,0 +1,18 @@
+resource "cloudflare_zero_trust_dlp_data_tag_category" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-category"
+  description = "Parent category for data_tag data source test"
+}
+
+resource "cloudflare_zero_trust_dlp_data_tag" "%[1]s" {
+  account_id  = "%[2]s"
+  category_id = cloudflare_zero_trust_dlp_data_tag_category.%[1]s.id
+  name        = "tf-acc-%[1]s"
+  description = "Acceptance test data tag"
+}
+
+data "cloudflare_zero_trust_dlp_data_tag" "%[1]s" {
+  account_id  = "%[2]s"
+  category_id = cloudflare_zero_trust_dlp_data_tag_category.%[1]s.id
+  tag_id      = cloudflare_zero_trust_dlp_data_tag.%[1]s.id
+}

--- a/internal/services/zero_trust_dlp_data_tag/testdata/updated.tf
+++ b/internal/services/zero_trust_dlp_data_tag/testdata/updated.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_zero_trust_dlp_data_tag_category" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-category"
+  description = "Parent category for data_tag acceptance test"
+}
+
+resource "cloudflare_zero_trust_dlp_data_tag" "%[1]s" {
+  account_id  = "%[2]s"
+  category_id = cloudflare_zero_trust_dlp_data_tag_category.%[1]s.id
+  name        = "tf-acc-%[1]s-renamed"
+  description = "Updated description"
+}

--- a/internal/services/zero_trust_dlp_data_tag_category/data_source_test.go
+++ b/internal/services/zero_trust_dlp_data_tag_category/data_source_test.go
@@ -1,0 +1,48 @@
+package zero_trust_dlp_data_tag_category_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestAccCloudflareZeroTrustDLPDataTagCategoryDataSource_Basic verifies the
+// data source reads the same attributes as the underlying resource.
+func TestAccCloudflareZeroTrustDLPDataTagCategoryDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_dlp_data_tag_category.%s", rnd)
+	dataSourceName := fmt.Sprintf("data.cloudflare_zero_trust_dlp_data_tag_category.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("datasource_basic.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("id"),
+						dataSourceName, tfjsonpath.New("id"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("name"),
+						dataSourceName, tfjsonpath.New("name"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("description"),
+						dataSourceName, tfjsonpath.New("description"),
+						compare.ValuesSame()),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_data_tag_category/resource_test.go
+++ b/internal/services/zero_trust_dlp_data_tag_category/resource_test.go
@@ -1,0 +1,94 @@
+package zero_trust_dlp_data_tag_category_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestAccCloudflareZeroTrustDLPDataTagCategory_Basic verifies basic CRUD for
+// a data tag category: apply, read, import, destroy.
+func TestAccCloudflareZeroTrustDLPDataTagCategory_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	name := fmt.Sprintf("cloudflare_zero_trust_dlp_data_tag_category.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("account_id"),
+						knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("tf-acc-%s", rnd))),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Acceptance test data tag category")),
+				},
+			},
+			// Re-apply: no drift.
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Import: `<account_id>/<category_id>`.
+			{
+				ResourceName:        name,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareZeroTrustDLPDataTagCategory_Update verifies in-place update.
+func TestAccCloudflareZeroTrustDLPDataTagCategory_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	name := fmt.Sprintf("cloudflare_zero_trust_dlp_data_tag_category.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+			},
+			{
+				Config: acctest.LoadTestCase("updated.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(name, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("tf-acc-%s-renamed", rnd))),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Updated description")),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_data_tag_category/testdata/basic.tf
+++ b/internal/services/zero_trust_dlp_data_tag_category/testdata/basic.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_zero_trust_dlp_data_tag_category" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s"
+  description = "Acceptance test data tag category"
+}

--- a/internal/services/zero_trust_dlp_data_tag_category/testdata/datasource_basic.tf
+++ b/internal/services/zero_trust_dlp_data_tag_category/testdata/datasource_basic.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_zero_trust_dlp_data_tag_category" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s"
+  description = "Acceptance test data tag category"
+}
+
+data "cloudflare_zero_trust_dlp_data_tag_category" "%[1]s" {
+  account_id  = "%[2]s"
+  category_id = cloudflare_zero_trust_dlp_data_tag_category.%[1]s.id
+}

--- a/internal/services/zero_trust_dlp_data_tag_category/testdata/updated.tf
+++ b/internal/services/zero_trust_dlp_data_tag_category/testdata/updated.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_zero_trust_dlp_data_tag_category" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-renamed"
+  description = "Updated description"
+}

--- a/internal/services/zero_trust_dlp_sensitivity_group/data_source_test.go
+++ b/internal/services/zero_trust_dlp_sensitivity_group/data_source_test.go
@@ -1,0 +1,48 @@
+package zero_trust_dlp_sensitivity_group_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestAccCloudflareZeroTrustDLPSensitivityGroupDataSource_Basic verifies that
+// the data source reads the same attributes as the underlying resource.
+func TestAccCloudflareZeroTrustDLPSensitivityGroupDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_group.%s", rnd)
+	dataSourceName := fmt.Sprintf("data.cloudflare_zero_trust_dlp_sensitivity_group.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("datasource_basic.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("id"),
+						dataSourceName, tfjsonpath.New("id"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("name"),
+						dataSourceName, tfjsonpath.New("name"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("description"),
+						dataSourceName, tfjsonpath.New("description"),
+						compare.ValuesSame()),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_sensitivity_group/resource_test.go
+++ b/internal/services/zero_trust_dlp_sensitivity_group/resource_test.go
@@ -1,0 +1,95 @@
+package zero_trust_dlp_sensitivity_group_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestAccCloudflareZeroTrustDLPSensitivityGroup_Basic verifies basic CRUD
+// for a sensitivity group: apply, read, import, destroy.
+func TestAccCloudflareZeroTrustDLPSensitivityGroup_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	name := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_group.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("account_id"),
+						knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("tf-acc-%s", rnd))),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Acceptance test sensitivity group")),
+				},
+			},
+			// Re-apply: no drift.
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Import: `<account_id>/<sensitivity_group_id>`.
+			{
+				ResourceName:        name,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareZeroTrustDLPSensitivityGroup_Update verifies that updating
+// name and description produces an in-place update (no recreation).
+func TestAccCloudflareZeroTrustDLPSensitivityGroup_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	name := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_group.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+			},
+			{
+				Config: acctest.LoadTestCase("updated.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(name, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("tf-acc-%s-renamed", rnd))),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Updated description for acceptance test")),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_sensitivity_group/testdata/basic.tf
+++ b/internal/services/zero_trust_dlp_sensitivity_group/testdata/basic.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s"
+  description = "Acceptance test sensitivity group"
+}

--- a/internal/services/zero_trust_dlp_sensitivity_group/testdata/datasource_basic.tf
+++ b/internal/services/zero_trust_dlp_sensitivity_group/testdata/datasource_basic.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s"
+  description = "Acceptance test sensitivity group"
+}
+
+data "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+}

--- a/internal/services/zero_trust_dlp_sensitivity_group/testdata/updated.tf
+++ b/internal/services/zero_trust_dlp_sensitivity_group/testdata/updated.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-renamed"
+  description = "Updated description for acceptance test"
+}

--- a/internal/services/zero_trust_dlp_sensitivity_level/data_source_test.go
+++ b/internal/services/zero_trust_dlp_sensitivity_level/data_source_test.go
@@ -1,0 +1,48 @@
+package zero_trust_dlp_sensitivity_level_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestAccCloudflareZeroTrustDLPSensitivityLevelDataSource_Basic verifies the
+// data source reads the same attributes as the underlying resource.
+func TestAccCloudflareZeroTrustDLPSensitivityLevelDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level.%s", rnd)
+	dataSourceName := fmt.Sprintf("data.cloudflare_zero_trust_dlp_sensitivity_level.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("datasource_basic.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("id"),
+						dataSourceName, tfjsonpath.New("id"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("name"),
+						dataSourceName, tfjsonpath.New("name"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("description"),
+						dataSourceName, tfjsonpath.New("description"),
+						compare.ValuesSame()),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_sensitivity_level/resource_test.go
+++ b/internal/services/zero_trust_dlp_sensitivity_level/resource_test.go
@@ -1,0 +1,114 @@
+package zero_trust_dlp_sensitivity_level_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestAccCloudflareZeroTrustDLPSensitivityLevel_Basic verifies basic CRUD for
+// a sensitivity level nested under a sensitivity group.
+func TestAccCloudflareZeroTrustDLPSensitivityLevel_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	name := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level.%s", rnd)
+	groupName := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_group.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("account_id"),
+						knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("tf-acc-%s", rnd))),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Acceptance test sensitivity level")),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("sensitivity_group_id"),
+						knownvalue.NotNull()),
+				},
+			},
+			// Re-apply: no drift.
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Import: `<account_id>/<sensitivity_group_id>/<sensitivity_level_id>`.
+			// The import requires both path segments since the level is nested.
+			{
+				ResourceName: name,
+				ImportState:  true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					group, ok := state.RootModule().Resources[groupName]
+					if !ok {
+						return "", fmt.Errorf("group resource %s not found in state", groupName)
+					}
+					level, ok := state.RootModule().Resources[name]
+					if !ok {
+						return "", fmt.Errorf("level resource %s not found in state", name)
+					}
+					return fmt.Sprintf("%s/%s/%s",
+						accountID,
+						group.Primary.ID,
+						level.Primary.ID), nil
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccCloudflareZeroTrustDLPSensitivityLevel_Update verifies in-place update
+// of name and description on a sensitivity level.
+func TestAccCloudflareZeroTrustDLPSensitivityLevel_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	name := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+			},
+			{
+				Config: acctest.LoadTestCase("updated.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(name, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("tf-acc-%s-renamed", rnd))),
+					statecheck.ExpectKnownValue(name,
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Updated description")),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_sensitivity_level/testdata/basic.tf
+++ b/internal/services/zero_trust_dlp_sensitivity_level/testdata/basic.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-group"
+  description = "Parent group for sensitivity_level acceptance test"
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "tf-acc-%[1]s"
+  description          = "Acceptance test sensitivity level"
+}

--- a/internal/services/zero_trust_dlp_sensitivity_level/testdata/datasource_basic.tf
+++ b/internal/services/zero_trust_dlp_sensitivity_level/testdata/datasource_basic.tf
@@ -1,0 +1,18 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-group"
+  description = "Parent group for sensitivity_level data source test"
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "tf-acc-%[1]s"
+  description          = "Acceptance test sensitivity level"
+}
+
+data "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  sensitivity_level_id = cloudflare_zero_trust_dlp_sensitivity_level.%[1]s.id
+}

--- a/internal/services/zero_trust_dlp_sensitivity_level/testdata/updated.tf
+++ b/internal/services/zero_trust_dlp_sensitivity_level/testdata/updated.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s-group"
+  description = "Parent group for sensitivity_level acceptance test"
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "tf-acc-%[1]s-renamed"
+  description          = "Updated description"
+}

--- a/internal/services/zero_trust_dlp_sensitivity_level_order/data_source_test.go
+++ b/internal/services/zero_trust_dlp_sensitivity_level_order/data_source_test.go
@@ -1,0 +1,44 @@
+package zero_trust_dlp_sensitivity_level_order_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestAccCloudflareZeroTrustDLPSensitivityLevelOrderDataSource_Basic verifies
+// that the data source can read an order configured by the resource. We apply
+// the resource first, then a config that references the same group via the data
+// source, and confirm the data source's level_ids match the resource's.
+func TestAccCloudflareZeroTrustDLPSensitivityLevelOrderDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level_order.%s", rnd)
+	dataSourceName := fmt.Sprintf("data.cloudflare_zero_trust_dlp_sensitivity_level_order.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("datasource_basic.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// The data source's level_ids must match the resource's.
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("level_ids"),
+						dataSourceName, tfjsonpath.New("level_ids"),
+						compare.ValuesSame()),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_sensitivity_level_order/resource_test.go
+++ b/internal/services/zero_trust_dlp_sensitivity_level_order/resource_test.go
@@ -1,0 +1,170 @@
+package zero_trust_dlp_sensitivity_level_order_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+)
+
+// TestAccCloudflareZeroTrustDLPSensitivityLevelOrder_Basic verifies the
+// fundamental singleton lifecycle:
+//   - Create: the order resource has no POST endpoint; on first apply Terraform
+//     calls PUT /level_order with the desired list. State reflects that list.
+//   - Read: GET /level_order returns the same list; state stays stable.
+//   - Destroy: removing the resource just drops state (no API call).
+//
+// The test also covers Import, which is the only way to bring an existing order
+// into Terraform state since the singleton has no "create" step.
+func TestAccCloudflareZeroTrustDLPSensitivityLevelOrder_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	orderResourceName := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level_order.%s", rnd)
+	publicLevelResource := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level.%s_public", rnd)
+	internalLevelResource := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level.%s_internal", rnd)
+	confidentialLevelResource := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level.%s_confidential", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(orderResourceName,
+						tfjsonpath.New("account_id"),
+						knownvalue.StringExact(accountID)),
+					// The order resource's id is its sensitivity_group_id (per
+					// Stainless config: id_property: sensitivity_group_id).
+					statecheck.CompareValuePairs(
+						orderResourceName, tfjsonpath.New("id"),
+						orderResourceName, tfjsonpath.New("sensitivity_group_id"),
+						compare.ValuesSame()),
+					// level_ids must reflect the desired order with the
+					// resolved level UUIDs.
+					statecheck.CompareValuePairs(
+						orderResourceName, tfjsonpath.New("level_ids").AtSliceIndex(0),
+						publicLevelResource, tfjsonpath.New("id"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						orderResourceName, tfjsonpath.New("level_ids").AtSliceIndex(1),
+						internalLevelResource, tfjsonpath.New("id"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						orderResourceName, tfjsonpath.New("level_ids").AtSliceIndex(2),
+						confidentialLevelResource, tfjsonpath.New("id"),
+						compare.ValuesSame()),
+				},
+			},
+			// Re-apply: no changes expected.
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Import: the import ID is "<account_id>/<sensitivity_group_id>".
+			{
+				ResourceName:                         orderResourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdPrefix:                  fmt.Sprintf("%s/", accountID),
+				ImportStateVerifyIdentifierAttribute: "sensitivity_group_id",
+			},
+		},
+	})
+}
+
+// TestAccCloudflareZeroTrustDLPSensitivityLevelOrder_Reorder verifies that
+// updating `level_ids` to a new permutation produces a single PUT (no
+// recreation, no other field changes).
+func TestAccCloudflareZeroTrustDLPSensitivityLevelOrder_Reorder(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	orderResourceName := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level_order.%s", rnd)
+	publicLevelResource := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level.%s_public", rnd)
+	internalLevelResource := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level.%s_internal", rnd)
+	confidentialLevelResource := fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level.%s_confidential", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+			},
+			// Swap Internal and Confidential. Only level_ids should change in
+			// the plan; the resource should not be recreated.
+			{
+				Config: acctest.LoadTestCase("reordered.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(orderResourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(
+						orderResourceName, tfjsonpath.New("level_ids").AtSliceIndex(0),
+						publicLevelResource, tfjsonpath.New("id"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						orderResourceName, tfjsonpath.New("level_ids").AtSliceIndex(1),
+						confidentialLevelResource, tfjsonpath.New("id"),
+						compare.ValuesSame()),
+					statecheck.CompareValuePairs(
+						orderResourceName, tfjsonpath.New("level_ids").AtSliceIndex(2),
+						internalLevelResource, tfjsonpath.New("id"),
+						compare.ValuesSame()),
+				},
+			},
+		},
+	})
+}
+
+// TestAccCloudflareZeroTrustDLPSensitivityLevelOrder_RemoveFromConfig verifies
+// that removing the order resource from HCL does NOT call any API (the singleton
+// has no DELETE endpoint; its lifecycle is owned by the parent group). Terraform
+// just drops the resource from state.
+func TestAccCloudflareZeroTrustDLPSensitivityLevelOrder_RemoveFromConfig(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: apply with the order resource present.
+			{
+				Config: acctest.LoadTestCase("basic.tf", rnd, accountID),
+			},
+			// Step 2: same group + levels but no order resource. The Destroy
+			// implementation is a no-op (no API call). Terraform should drop the
+			// order resource from state without error and without affecting the
+			// remaining resources.
+			{
+				Config: acctest.LoadTestCase("without_order.tf", rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							fmt.Sprintf("cloudflare_zero_trust_dlp_sensitivity_level_order.%s", rnd),
+							plancheck.ResourceActionDestroy,
+						),
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_dlp_sensitivity_level_order/testdata/basic.tf
+++ b/internal/services/zero_trust_dlp_sensitivity_level_order/testdata/basic.tf
@@ -1,0 +1,38 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s"
+  description = "Acceptance test group for sensitivity_level_order"
+}
+
+# Levels are created serially via depends_on. The API assigns each new
+# level the next order position, but parallel creates collide because
+# they all attempt to claim the same default position.
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s_public" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "Public"
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s_internal" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "Internal"
+  depends_on           = [cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_public]
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s_confidential" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "Confidential"
+  depends_on           = [cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_internal]
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level_order" "%[1]s" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  level_ids = [
+    cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_public.id,
+    cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_internal.id,
+    cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_confidential.id,
+  ]
+}

--- a/internal/services/zero_trust_dlp_sensitivity_level_order/testdata/datasource_basic.tf
+++ b/internal/services/zero_trust_dlp_sensitivity_level_order/testdata/datasource_basic.tf
@@ -1,0 +1,34 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s"
+  description = "Acceptance test group for sensitivity_level_order data source"
+}
+
+# Levels are created serially via depends_on. See basic.tf for rationale.
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s_public" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "Public"
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s_internal" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "Internal"
+  depends_on           = [cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_public]
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level_order" "%[1]s" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  level_ids = [
+    cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_public.id,
+    cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_internal.id,
+  ]
+}
+
+data "cloudflare_zero_trust_dlp_sensitivity_level_order" "%[1]s" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  depends_on           = [cloudflare_zero_trust_dlp_sensitivity_level_order.%[1]s]
+}

--- a/internal/services/zero_trust_dlp_sensitivity_level_order/testdata/reordered.tf
+++ b/internal/services/zero_trust_dlp_sensitivity_level_order/testdata/reordered.tf
@@ -1,0 +1,39 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s"
+  description = "Acceptance test group for sensitivity_level_order"
+}
+
+# Levels are created serially via depends_on. The API assigns each new
+# level the next order position, but parallel creates collide because
+# they all attempt to claim the same default position.
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s_public" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "Public"
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s_internal" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "Internal"
+  depends_on           = [cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_public]
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s_confidential" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "Confidential"
+  depends_on           = [cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_internal]
+}
+
+# Confidential and Internal are swapped relative to basic.tf.
+resource "cloudflare_zero_trust_dlp_sensitivity_level_order" "%[1]s" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  level_ids = [
+    cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_public.id,
+    cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_confidential.id,
+    cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_internal.id,
+  ]
+}

--- a/internal/services/zero_trust_dlp_sensitivity_level_order/testdata/without_order.tf
+++ b/internal/services/zero_trust_dlp_sensitivity_level_order/testdata/without_order.tf
@@ -1,0 +1,33 @@
+resource "cloudflare_zero_trust_dlp_sensitivity_group" "%[1]s" {
+  account_id  = "%[2]s"
+  name        = "tf-acc-%[1]s"
+  description = "Acceptance test group for sensitivity_level_order"
+}
+
+# Levels are created serially via depends_on. The API assigns each new
+# level the next order position, but parallel creates collide because
+# they all attempt to claim the same default position.
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s_public" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "Public"
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s_internal" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "Internal"
+  depends_on           = [cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_public]
+}
+
+resource "cloudflare_zero_trust_dlp_sensitivity_level" "%[1]s_confidential" {
+  account_id           = "%[2]s"
+  sensitivity_group_id = cloudflare_zero_trust_dlp_sensitivity_group.%[1]s.id
+  name                 = "Confidential"
+  depends_on           = [cloudflare_zero_trust_dlp_sensitivity_level.%[1]s_internal]
+}
+
+# No `cloudflare_zero_trust_dlp_sensitivity_level_order` resource.
+# Used by destroy tests to verify removing the order resource doesn't
+# call any DELETE API (the order is a singleton owned by the parent
+# group; its lifecycle is read/update only).


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Add acceptance tests for six new DLP data classification resources:

- `cloudflare_zero_trust_dlp_sensitivity_group`
- `cloudflare_zero_trust_dlp_sensitivity_level` (nested under group)
- `cloudflare_zero_trust_dlp_sensitivity_level_order` (singleton)
- `cloudflare_zero_trust_dlp_data_tag_category`
- `cloudflare_zero_trust_dlp_data_tag` (nested under category)
- `cloudflare_zero_trust_dlp_data_class`

Each resource has a Basic test (apply + re-apply with empty-plan check + import) and an Update test (in-place rename). Each data source has a Basic test that compares values against the underlying resource. The `level_order` singleton additionally has Reorder and RemoveFromConfig tests.

Nested resources (`sensitivity_level`, `data_tag`) use `ImportStateIdFunc` to construct the `<account>/<parent>/<child>` import ID from state. Flat resources use `ImportStateIdPrefix`.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

```
TF_ACC=1 go test -count=1 -timeout 10m -v -run "TestAccCloudflareZeroTrustDLP" ./internal/services/zero_trust_dlp_<resource>/
```

Run against an account with DLP enabled. Total runtime ~5 minutes.

### Test output

```
=== zero_trust_dlp_sensitivity_group ===
=== RUN   TestAccCloudflareZeroTrustDLPSensitivityGroupDataSource_Basic
--- PASS: TestAccCloudflareZeroTrustDLPSensitivityGroupDataSource_Basic (16.37s)
=== RUN   TestAccCloudflareZeroTrustDLPSensitivityGroup_Basic
--- PASS: TestAccCloudflareZeroTrustDLPSensitivityGroup_Basic (16.76s)
=== RUN   TestAccCloudflareZeroTrustDLPSensitivityGroup_Update
--- PASS: TestAccCloudflareZeroTrustDLPSensitivityGroup_Update (17.37s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_dlp_sensitivity_group	52.658s

=== zero_trust_dlp_sensitivity_level ===
=== RUN   TestAccCloudflareZeroTrustDLPSensitivityLevelDataSource_Basic
--- PASS: TestAccCloudflareZeroTrustDLPSensitivityLevelDataSource_Basic (12.68s)
=== RUN   TestAccCloudflareZeroTrustDLPSensitivityLevel_Basic
--- PASS: TestAccCloudflareZeroTrustDLPSensitivityLevel_Basic (12.13s)
=== RUN   TestAccCloudflareZeroTrustDLPSensitivityLevel_Update
--- PASS: TestAccCloudflareZeroTrustDLPSensitivityLevel_Update (11.63s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_dlp_sensitivity_level	38.311s

=== zero_trust_dlp_sensitivity_level_order ===
=== RUN   TestAccCloudflareZeroTrustDLPSensitivityLevelOrderDataSource_Basic
--- PASS: TestAccCloudflareZeroTrustDLPSensitivityLevelOrderDataSource_Basic (14.54s)
=== RUN   TestAccCloudflareZeroTrustDLPSensitivityLevelOrder_Basic
--- PASS: TestAccCloudflareZeroTrustDLPSensitivityLevelOrder_Basic (18.72s)
=== RUN   TestAccCloudflareZeroTrustDLPSensitivityLevelOrder_Reorder
--- PASS: TestAccCloudflareZeroTrustDLPSensitivityLevelOrder_Reorder (21.23s)
=== RUN   TestAccCloudflareZeroTrustDLPSensitivityLevelOrder_RemoveFromConfig
--- PASS: TestAccCloudflareZeroTrustDLPSensitivityLevelOrder_RemoveFromConfig (28.50s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_dlp_sensitivity_level_order	84.867s

=== zero_trust_dlp_data_tag_category ===
=== RUN   TestAccCloudflareZeroTrustDLPDataTagCategoryDataSource_Basic
--- PASS: TestAccCloudflareZeroTrustDLPDataTagCategoryDataSource_Basic (11.08s)
=== RUN   TestAccCloudflareZeroTrustDLPDataTagCategory_Basic
--- PASS: TestAccCloudflareZeroTrustDLPDataTagCategory_Basic (12.00s)
=== RUN   TestAccCloudflareZeroTrustDLPDataTagCategory_Update
--- PASS: TestAccCloudflareZeroTrustDLPDataTagCategory_Update (13.16s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_dlp_data_tag_category	38.101s

=== zero_trust_dlp_data_tag ===
=== RUN   TestAccCloudflareZeroTrustDLPDataTagDataSource_Basic
--- PASS: TestAccCloudflareZeroTrustDLPDataTagDataSource_Basic (12.52s)
=== RUN   TestAccCloudflareZeroTrustDLPDataTag_Basic
--- PASS: TestAccCloudflareZeroTrustDLPDataTag_Basic (14.81s)
=== RUN   TestAccCloudflareZeroTrustDLPDataTag_Update
--- PASS: TestAccCloudflareZeroTrustDLPDataTag_Update (12.70s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_dlp_data_tag	42.179s

=== zero_trust_dlp_data_class ===
=== RUN   TestAccCloudflareZeroTrustDLPDataClassDataSource_Basic
--- PASS: TestAccCloudflareZeroTrustDLPDataClassDataSource_Basic (13.44s)
=== RUN   TestAccCloudflareZeroTrustDLPDataClass_Basic
--- PASS: TestAccCloudflareZeroTrustDLPDataClass_Basic (16.49s)
=== RUN   TestAccCloudflareZeroTrustDLPDataClass_Update
--- PASS: TestAccCloudflareZeroTrustDLPDataClass_Update (16.41s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_dlp_data_class	48.173s
```

## Additional context & links

- Jira: DLP-3462, DLP-5196 (parent epic RM-29020)
- Stainless config MR: cloudflare-config !937 (merged 2026-06-10)
- Stainless propagation PR: #7159 (merged 2026-06-11)
- Template PR for this work: #7058 (Tom's analogous `zero_trust_dlp_settings` PR)