### PR TITLE
fix: restore account_id and zone_id as required on 156 resources

### DIFF
--- a/internal/services/account_dns_settings/model.go
+++ b/internal/services/account_dns_settings/model.go
@@ -12,7 +12,7 @@ type AccountDNSSettingsResultEnvelope struct {
 }
 
 type AccountDNSSettingsModel struct {
-	AccountID      types.String                         `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID      types.String                         `tfsdk:"account_id" path:"account_id,required"`
 	EnforceDNSOnly types.Bool                           `tfsdk:"enforce_dns_only" json:"enforce_dns_only,optional"`
 	ZoneDefaults   *AccountDNSSettingsZoneDefaultsModel `tfsdk:"zone_defaults" json:"zone_defaults,optional"`
 }

--- a/internal/services/account_dns_settings/schema.go
+++ b/internal/services/account_dns_settings/schema.go
@@ -29,7 +29,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"enforce_dns_only": schema.BoolAttribute{

--- a/internal/services/account_dns_settings_internal_view/model.go
+++ b/internal/services/account_dns_settings_internal_view/model.go
@@ -14,7 +14,7 @@ type AccountDNSSettingsInternalViewResultEnvelope struct {
 
 type AccountDNSSettingsInternalViewModel struct {
 	ID           types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID    types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID    types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Name         types.String      `tfsdk:"name" json:"name,required"`
 	Zones        *[]types.String   `tfsdk:"zones" json:"zones,required"`
 	CreatedTime  timetypes.RFC3339 `tfsdk:"created_time" json:"created_time,computed" format:"date-time"`

--- a/internal/services/account_dns_settings_internal_view/schema.go
+++ b/internal/services/account_dns_settings_internal_view/schema.go
@@ -33,7 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/account_member/model.go
+++ b/internal/services/account_member/model.go
@@ -14,7 +14,7 @@ type AccountMemberResultEnvelope struct {
 
 type AccountMemberModel struct {
 	ID        types.String                                            `tfsdk:"id" json:"id,computed"`
-	AccountID types.String                                            `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String                                            `tfsdk:"account_id" path:"account_id,required"`
 	Email     types.String                                            `tfsdk:"email" json:"email,required"`
 	Status    types.String                                            `tfsdk:"status" json:"status,computed_optional"`
 	Roles     customfield.Set[types.String]                           `tfsdk:"roles" json:"roles,computed_optional,no_refresh"`

--- a/internal/services/account_member/schema.go
+++ b/internal/services/account_member/schema.go
@@ -39,7 +39,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Account identifier tag.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"email": schema.StringAttribute{

--- a/internal/services/account_subscription/model.go
+++ b/internal/services/account_subscription/model.go
@@ -15,7 +15,7 @@ type AccountSubscriptionResultEnvelope struct {
 
 type AccountSubscriptionModel struct {
 	ID                 types.String                                               `tfsdk:"id" json:"id,computed"`
-	AccountID          types.String                                               `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID          types.String                                               `tfsdk:"account_id" path:"account_id,required"`
 	Frequency          types.String                                               `tfsdk:"frequency" json:"frequency,computed_optional"`
 	RatePlan           customfield.NestedObject[AccountSubscriptionRatePlanModel] `tfsdk:"rate_plan" json:"rate_plan,computed_optional"`
 	Currency           types.String                                               `tfsdk:"currency" json:"currency,computed"`

--- a/internal/services/account_subscription/schema.go
+++ b/internal/services/account_subscription/schema.go
@@ -36,7 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"frequency": schema.StringAttribute{

--- a/internal/services/address_map/model.go
+++ b/internal/services/address_map/model.go
@@ -14,7 +14,7 @@ type AddressMapResultEnvelope struct {
 
 type AddressMapModel struct {
 	ID           types.String                   `tfsdk:"id" json:"id,computed"`
-	AccountID    types.String                   `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID    types.String                   `tfsdk:"account_id" path:"account_id,required"`
 	IPs          *[]types.String                `tfsdk:"ips" json:"ips,optional,no_refresh"`
 	Memberships  *[]*AddressMapMembershipsModel `tfsdk:"memberships" json:"memberships,optional"`
 	DefaultSNI   types.String                   `tfsdk:"default_sni" json:"default_sni,optional"`

--- a/internal/services/address_map/schema.go
+++ b/internal/services/address_map/schema.go
@@ -37,7 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier of a Cloudflare account.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"ips": schema.ListAttribute{

--- a/internal/services/ai_gateway/model.go
+++ b/internal/services/ai_gateway/model.go
@@ -15,7 +15,7 @@ type AIGatewayResultEnvelope struct {
 
 type AIGatewayModel struct {
 	ID                      types.String                                        `tfsdk:"id" json:"id,required"`
-	AccountID               types.String                                        `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID               types.String                                        `tfsdk:"account_id" path:"account_id,required"`
 	CacheInvalidateOnUpdate types.Bool                                          `tfsdk:"cache_invalidate_on_update" json:"cache_invalidate_on_update,required"`
 	CacheTTL                types.Int64                                         `tfsdk:"cache_ttl" json:"cache_ttl,required"`
 	CollectLogs             types.Bool                                          `tfsdk:"collect_logs" json:"collect_logs,required"`

--- a/internal/services/ai_gateway/schema.go
+++ b/internal/services/ai_gateway/schema.go
@@ -40,7 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown(), stringplanmodifier.RequiresReplace()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"cache_invalidate_on_update": schema.BoolAttribute{

--- a/internal/services/ai_gateway_dynamic_routing/model.go
+++ b/internal/services/ai_gateway_dynamic_routing/model.go
@@ -16,7 +16,7 @@ type AIGatewayDynamicRoutingResultEnvelope struct {
 
 type AIGatewayDynamicRoutingModel struct {
 	ID         types.String                                                     `tfsdk:"id" json:"id,computed"`
-	AccountID  types.String                                                     `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID  types.String                                                     `tfsdk:"account_id" path:"account_id,required"`
 	GatewayID  types.String                                                     `tfsdk:"gateway_id" path:"gateway_id,required"`
 	Elements   *[]*AIGatewayDynamicRoutingElementsModel                         `tfsdk:"elements" json:"elements,required"`
 	Name       types.String                                                     `tfsdk:"name" json:"name,required"`

--- a/internal/services/ai_gateway_dynamic_routing/schema.go
+++ b/internal/services/ai_gateway_dynamic_routing/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"gateway_id": schema.StringAttribute{

--- a/internal/services/ai_search_token/model.go
+++ b/internal/services/ai_search_token/model.go
@@ -14,7 +14,7 @@ type AISearchTokenResultEnvelope struct {
 
 type AISearchTokenModel struct {
 	ID         types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID  types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID  types.String      `tfsdk:"account_id" path:"account_id,required"`
 	CfAPIID    types.String      `tfsdk:"cf_api_id" json:"cf_api_id,required"`
 	CfAPIKey   types.String      `tfsdk:"cf_api_key" json:"cf_api_key,required,no_refresh"`
 	Name       types.String      `tfsdk:"name" json:"name,required"`

--- a/internal/services/ai_search_token/schema.go
+++ b/internal/services/ai_search_token/schema.go
@@ -24,7 +24,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"cf_api_id": schema.StringAttribute{

--- a/internal/services/api_shield_operation/model.go
+++ b/internal/services/api_shield_operation/model.go
@@ -17,7 +17,7 @@ type APIShieldOperationResultEnvelope struct {
 type APIShieldOperationModel struct {
 	ID          types.String                                              `tfsdk:"id" json:"-,computed"`
 	OperationID types.String                                              `tfsdk:"operation_id" json:"operation_id,computed"`
-	ZoneID      types.String                                              `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID      types.String                                              `tfsdk:"zone_id" path:"zone_id,required"`
 	Endpoint    types.String                                              `tfsdk:"endpoint" json:"endpoint,required"`
 	Host        types.String                                              `tfsdk:"host" json:"host,required"`
 	Method      types.String                                              `tfsdk:"method" json:"method,required"`

--- a/internal/services/api_shield_operation/schema.go
+++ b/internal/services/api_shield_operation/schema.go
@@ -44,7 +44,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"endpoint": schema.StringAttribute{

--- a/internal/services/api_shield_operation_schema_validation_settings/model.go
+++ b/internal/services/api_shield_operation_schema_validation_settings/model.go
@@ -10,7 +10,7 @@ import (
 type APIShieldOperationSchemaValidationSettingsModel struct {
 	ID               types.String `tfsdk:"id" json:"-,computed"`
 	OperationID      types.String `tfsdk:"operation_id" path:"operation_id,required"`
-	ZoneID           types.String `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID           types.String `tfsdk:"zone_id" path:"zone_id,required"`
 	MitigationAction types.String `tfsdk:"mitigation_action" json:"mitigation_action,optional"`
 }
 

--- a/internal/services/api_shield_operation_schema_validation_settings/schema.go
+++ b/internal/services/api_shield_operation_schema_validation_settings/schema.go
@@ -41,7 +41,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"mitigation_action": schema.StringAttribute{

--- a/internal/services/byo_ip_prefix/model.go
+++ b/internal/services/byo_ip_prefix/model.go
@@ -14,7 +14,7 @@ type ByoIPPrefixResultEnvelope struct {
 
 type ByoIPPrefixModel struct {
 	ID                       types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID                types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID                types.String      `tfsdk:"account_id" path:"account_id,required"`
 	ASN                      types.Int64       `tfsdk:"asn" json:"asn,required"`
 	CIDR                     types.String      `tfsdk:"cidr" json:"cidr,required"`
 	LOADocumentID            types.String      `tfsdk:"loa_document_id" json:"loa_document_id,optional"`

--- a/internal/services/byo_ip_prefix/schema.go
+++ b/internal/services/byo_ip_prefix/schema.go
@@ -39,7 +39,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier of a Cloudflare account.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"asn": schema.Int64Attribute{

--- a/internal/services/calls_sfu_app/model.go
+++ b/internal/services/calls_sfu_app/model.go
@@ -13,7 +13,7 @@ type CallsSFUAppResultEnvelope struct {
 }
 
 type CallsSFUAppModel struct {
-	AccountID types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String      `tfsdk:"account_id" path:"account_id,required"`
 	AppID     types.String      `tfsdk:"app_id" path:"app_id,optional"`
 	Name      types.String      `tfsdk:"name" json:"name,computed_optional"`
 	Created   timetypes.RFC3339 `tfsdk:"created" json:"created,computed" format:"date-time"`

--- a/internal/services/calls_sfu_app/schema.go
+++ b/internal/services/calls_sfu_app/schema.go
@@ -28,7 +28,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The account identifier tag.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"app_id": schema.StringAttribute{

--- a/internal/services/calls_turn_app/model.go
+++ b/internal/services/calls_turn_app/model.go
@@ -13,7 +13,7 @@ type CallsTURNAppResultEnvelope struct {
 }
 
 type CallsTURNAppModel struct {
-	AccountID types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String      `tfsdk:"account_id" path:"account_id,required"`
 	KeyID     types.String      `tfsdk:"key_id" path:"key_id,optional"`
 	Name      types.String      `tfsdk:"name" json:"name,computed_optional"`
 	Created   timetypes.RFC3339 `tfsdk:"created" json:"created,computed" format:"date-time"`

--- a/internal/services/calls_turn_app/schema.go
+++ b/internal/services/calls_turn_app/schema.go
@@ -28,7 +28,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The account identifier tag.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"key_id": schema.StringAttribute{

--- a/internal/services/certificate_pack/model.go
+++ b/internal/services/certificate_pack/model.go
@@ -15,7 +15,7 @@ type CertificatePackResultEnvelope struct {
 
 type CertificatePackModel struct {
 	ID                   types.String                                                           `tfsdk:"id" json:"id,computed"`
-	ZoneID               types.String                                                           `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID               types.String                                                           `tfsdk:"zone_id" path:"zone_id,required"`
 	CertificateAuthority types.String                                                           `tfsdk:"certificate_authority" json:"certificate_authority,required"`
 	Type                 types.String                                                           `tfsdk:"type" json:"type,required"`
 	ValidationMethod     types.String                                                           `tfsdk:"validation_method" json:"validation_method,required"`

--- a/internal/services/certificate_pack/schema.go
+++ b/internal/services/certificate_pack/schema.go
@@ -41,7 +41,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"certificate_authority": schema.StringAttribute{

--- a/internal/services/client_certificate/model.go
+++ b/internal/services/client_certificate/model.go
@@ -14,7 +14,7 @@ type ClientCertificateResultEnvelope struct {
 
 type ClientCertificateModel struct {
 	ID                   types.String                                                         `tfsdk:"id" json:"id,computed"`
-	ZoneID               types.String                                                         `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID               types.String                                                         `tfsdk:"zone_id" path:"zone_id,required"`
 	Csr                  types.String                                                         `tfsdk:"csr" json:"csr,required"`
 	ValidityDays         types.Int64                                                          `tfsdk:"validity_days" json:"validity_days,required"`
 	Reactivate           types.Bool                                                           `tfsdk:"reactivate" json:"reactivate,optional,no_refresh"`

--- a/internal/services/client_certificate/schema.go
+++ b/internal/services/client_certificate/schema.go
@@ -36,7 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"csr": schema.StringAttribute{

--- a/internal/services/cloudforce_one_request/model.go
+++ b/internal/services/cloudforce_one_request/model.go
@@ -14,7 +14,7 @@ type CloudforceOneRequestResultEnvelope struct {
 
 type CloudforceOneRequestModel struct {
 	ID            types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Content       types.String      `tfsdk:"content" json:"content,optional"`
 	Priority      types.String      `tfsdk:"priority" json:"priority,optional,no_refresh"`
 	RequestType   types.String      `tfsdk:"request_type" json:"request_type,optional,no_refresh"`

--- a/internal/services/cloudforce_one_request/schema.go
+++ b/internal/services/cloudforce_one_request/schema.go
@@ -34,7 +34,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"content": schema.StringAttribute{

--- a/internal/services/cloudforce_one_request_asset/model.go
+++ b/internal/services/cloudforce_one_request_asset/model.go
@@ -14,7 +14,7 @@ type CloudforceOneRequestAssetResultEnvelope struct {
 
 type CloudforceOneRequestAssetModel struct {
 	ID          types.Int64       `tfsdk:"id" json:"id,computed"`
-	AccountID   types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String      `tfsdk:"account_id" path:"account_id,required"`
 	RequestID   types.String      `tfsdk:"request_id" path:"request_id,required"`
 	Page        types.Int64       `tfsdk:"page" json:"page,required,no_refresh"`
 	PerPage     types.Int64       `tfsdk:"per_page" json:"per_page,required,no_refresh"`

--- a/internal/services/cloudforce_one_request_asset/schema.go
+++ b/internal/services/cloudforce_one_request_asset/schema.go
@@ -33,7 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"request_id": schema.StringAttribute{

--- a/internal/services/cloudforce_one_request_message/model.go
+++ b/internal/services/cloudforce_one_request_message/model.go
@@ -14,7 +14,7 @@ type CloudforceOneRequestMessageResultEnvelope struct {
 
 type CloudforceOneRequestMessageModel struct {
 	ID                types.Int64       `tfsdk:"id" json:"id,computed"`
-	AccountID         types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID         types.String      `tfsdk:"account_id" path:"account_id,required"`
 	RequestID         types.String      `tfsdk:"request_id" path:"request_id,required"`
 	Content           types.String      `tfsdk:"content" json:"content,optional"`
 	Author            types.String      `tfsdk:"author" json:"author,computed"`

--- a/internal/services/cloudforce_one_request_message/schema.go
+++ b/internal/services/cloudforce_one_request_message/schema.go
@@ -32,7 +32,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"request_id": schema.StringAttribute{

--- a/internal/services/cloudforce_one_request_priority/model.go
+++ b/internal/services/cloudforce_one_request_priority/model.go
@@ -14,7 +14,7 @@ type CloudforceOneRequestPriorityResultEnvelope struct {
 
 type CloudforceOneRequestPriorityModel struct {
 	ID            types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Priority      types.Int64       `tfsdk:"priority" json:"priority,required,no_refresh"`
 	Requirement   types.String      `tfsdk:"requirement" json:"requirement,required,no_refresh"`
 	TLP           types.String      `tfsdk:"tlp" json:"tlp,required"`

--- a/internal/services/cloudforce_one_request_priority/schema.go
+++ b/internal/services/cloudforce_one_request_priority/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"priority": schema.Int64Attribute{

--- a/internal/services/connectivity_directory_service/model.go
+++ b/internal/services/connectivity_directory_service/model.go
@@ -15,7 +15,7 @@ type ConnectivityDirectoryServiceResultEnvelope struct {
 type ConnectivityDirectoryServiceModel struct {
 	ID          types.String                                  `tfsdk:"id" json:"-,computed"`
 	ServiceID   types.String                                  `tfsdk:"service_id" json:"service_id,computed"`
-	AccountID   types.String                                  `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String                                  `tfsdk:"account_id" path:"account_id,required"`
 	Name        types.String                                  `tfsdk:"name" json:"name,required"`
 	Type        types.String                                  `tfsdk:"type" json:"type,required"`
 	Host        *ConnectivityDirectoryServiceHostModel        `tfsdk:"host" json:"host,required"`

--- a/internal/services/connectivity_directory_service/schema.go
+++ b/internal/services/connectivity_directory_service/schema.go
@@ -32,7 +32,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Account identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/content_scanning/model.go
+++ b/internal/services/content_scanning/model.go
@@ -12,7 +12,7 @@ type ContentScanningResultEnvelope struct {
 }
 
 type ContentScanningModel struct {
-	ZoneID   types.String `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID   types.String `tfsdk:"zone_id" path:"zone_id,required"`
 	Value    types.String `tfsdk:"value" json:"value,required"`
 	Modified types.String `tfsdk:"modified" json:"modified,computed"`
 }

--- a/internal/services/content_scanning/schema.go
+++ b/internal/services/content_scanning/schema.go
@@ -30,7 +30,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"zone_id": schema.StringAttribute{
 				Description:   "Defines an identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"value": schema.StringAttribute{

--- a/internal/services/content_scanning_expression/model.go
+++ b/internal/services/content_scanning_expression/model.go
@@ -13,7 +13,7 @@ type ContentScanningExpressionResultEnvelope struct {
 
 type ContentScanningExpressionModel struct {
 	ID     types.String                           `tfsdk:"id" json:"id,computed"`
-	ZoneID types.String                           `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID types.String                           `tfsdk:"zone_id" path:"zone_id,required"`
 	Body   *[]*ContentScanningExpressionBodyModel `tfsdk:"body" json:"body,required"`
 }
 

--- a/internal/services/content_scanning_expression/schema.go
+++ b/internal/services/content_scanning_expression/schema.go
@@ -32,7 +32,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Defines an identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"body": schema.ListNestedAttribute{

--- a/internal/services/custom_hostname/model.go
+++ b/internal/services/custom_hostname/model.go
@@ -15,7 +15,7 @@ type CustomHostnameResultEnvelope struct {
 
 type CustomHostnameModel struct {
 	ID                        types.String                                                           `tfsdk:"id" json:"id,computed"`
-	ZoneID                    types.String                                                           `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID                    types.String                                                           `tfsdk:"zone_id" path:"zone_id,required"`
 	Hostname                  types.String                                                           `tfsdk:"hostname" json:"hostname,required"`
 	SSL                       *CustomHostnameSSLModel                                                `tfsdk:"ssl" json:"ssl,optional"`
 	CustomOriginServer        types.String                                                           `tfsdk:"custom_origin_server" json:"custom_origin_server,optional"`

--- a/internal/services/custom_hostname/schema.go
+++ b/internal/services/custom_hostname/schema.go
@@ -37,7 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"hostname": schema.StringAttribute{

--- a/internal/services/custom_origin_trust_store/model.go
+++ b/internal/services/custom_origin_trust_store/model.go
@@ -14,7 +14,7 @@ type CustomOriginTrustStoreResultEnvelope struct {
 
 type CustomOriginTrustStoreModel struct {
 	ID          types.String      `tfsdk:"id" json:"id,computed"`
-	ZoneID      types.String      `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID      types.String      `tfsdk:"zone_id" path:"zone_id,required"`
 	Certificate types.String      `tfsdk:"certificate" json:"certificate,required"`
 	ExpiresOn   timetypes.RFC3339 `tfsdk:"expires_on" json:"expires_on,computed" format:"date-time"`
 	Issuer      types.String      `tfsdk:"issuer" json:"issuer,computed"`

--- a/internal/services/custom_origin_trust_store/schema.go
+++ b/internal/services/custom_origin_trust_store/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"certificate": schema.StringAttribute{

--- a/internal/services/custom_ssl/model.go
+++ b/internal/services/custom_ssl/model.go
@@ -15,7 +15,7 @@ type CustomSSLResultEnvelope struct {
 
 type CustomSSLModel struct {
 	ID                 types.String                                          `tfsdk:"id" json:"id,computed"`
-	ZoneID             types.String                                          `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID             types.String                                          `tfsdk:"zone_id" path:"zone_id,required"`
 	Type               types.String                                          `tfsdk:"type" json:"type,computed_optional,no_refresh"`
 	Certificate        types.String                                          `tfsdk:"certificate" json:"certificate,required,no_refresh"`
 	PrivateKey         types.String                                          `tfsdk:"private_key" json:"private_key,required,no_refresh"`

--- a/internal/services/custom_ssl/schema.go
+++ b/internal/services/custom_ssl/schema.go
@@ -40,7 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"type": schema.StringAttribute{

--- a/internal/services/d1_database/model.go
+++ b/internal/services/d1_database/model.go
@@ -15,7 +15,7 @@ type D1DatabaseResultEnvelope struct {
 type D1DatabaseModel struct {
 	ID                  types.String                    `tfsdk:"id" json:"-,computed"`
 	UUID                types.String                    `tfsdk:"uuid" json:"uuid,computed"`
-	AccountID           types.String                    `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID           types.String                    `tfsdk:"account_id" path:"account_id,required"`
 	Name                types.String                    `tfsdk:"name" json:"name,required"`
 	Jurisdiction        types.String                    `tfsdk:"jurisdiction" json:"jurisdiction,optional"`
 	PrimaryLocationHint types.String                    `tfsdk:"primary_location_hint" json:"primary_location_hint,optional,no_refresh"`

--- a/internal/services/d1_database/schema.go
+++ b/internal/services/d1_database/schema.go
@@ -39,7 +39,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Account identifier tag.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/dns_firewall/model.go
+++ b/internal/services/dns_firewall/model.go
@@ -15,7 +15,7 @@ type DNSFirewallResultEnvelope struct {
 
 type DNSFirewallModel struct {
 	ID                   types.String                                               `tfsdk:"id" json:"id,computed"`
-	AccountID            types.String                                               `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID            types.String                                               `tfsdk:"account_id" path:"account_id,required"`
 	DNSFirewallIPCount   types.Int64                                                `tfsdk:"dns_firewall_ip_count" json:"dns_firewall_ip_count,computed_optional,no_refresh"`
 	Name                 types.String                                               `tfsdk:"name" json:"name,required"`
 	UpstreamIPs          *[]types.String                                            `tfsdk:"upstream_ips" json:"upstream_ips,required"`

--- a/internal/services/dns_firewall/schema.go
+++ b/internal/services/dns_firewall/schema.go
@@ -41,7 +41,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"dns_firewall_ip_count": schema.Int64Attribute{

--- a/internal/services/dns_record/model.go
+++ b/internal/services/dns_record/model.go
@@ -16,7 +16,7 @@ type DNSRecordResultEnvelope struct {
 
 type DNSRecordModel struct {
 	ID                types.String                                     `tfsdk:"id" json:"id,computed"`
-	ZoneID            types.String                                     `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID            types.String                                     `tfsdk:"zone_id" path:"zone_id,required"`
 	Name              types.String                                     `tfsdk:"name" json:"name,required"`
 	Type              types.String                                     `tfsdk:"type" json:"type,required"`
 	Comment           types.String                                     `tfsdk:"comment" json:"comment,optional"`

--- a/internal/services/dns_record/schema.go
+++ b/internal/services/dns_record/schema.go
@@ -43,7 +43,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"comment": schema.StringAttribute{

--- a/internal/services/dns_zone_transfers_acl/model.go
+++ b/internal/services/dns_zone_transfers_acl/model.go
@@ -13,7 +13,7 @@ type DNSZoneTransfersACLResultEnvelope struct {
 
 type DNSZoneTransfersACLModel struct {
 	ID        types.String `tfsdk:"id" json:"id,computed"`
-	AccountID types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String `tfsdk:"account_id" path:"account_id,required"`
 	IPRange   types.String `tfsdk:"ip_range" json:"ip_range,required"`
 	Name      types.String `tfsdk:"name" json:"name,required"`
 }

--- a/internal/services/dns_zone_transfers_acl/schema.go
+++ b/internal/services/dns_zone_transfers_acl/schema.go
@@ -29,7 +29,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"ip_range": schema.StringAttribute{

--- a/internal/services/dns_zone_transfers_incoming/model.go
+++ b/internal/services/dns_zone_transfers_incoming/model.go
@@ -13,7 +13,7 @@ type DNSZoneTransfersIncomingResultEnvelope struct {
 
 type DNSZoneTransfersIncomingModel struct {
 	ID                 types.String    `tfsdk:"id" json:"id,computed"`
-	ZoneID             types.String    `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID             types.String    `tfsdk:"zone_id" path:"zone_id,required"`
 	Name               types.String    `tfsdk:"name" json:"name,required"`
 	Peers              *[]types.String `tfsdk:"peers" json:"peers,required"`
 	AutoRefreshSeconds types.Float64   `tfsdk:"auto_refresh_seconds" json:"auto_refresh_seconds,computed_optional"`

--- a/internal/services/dns_zone_transfers_incoming/schema.go
+++ b/internal/services/dns_zone_transfers_incoming/schema.go
@@ -36,7 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"zone_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/dns_zone_transfers_outgoing/model.go
+++ b/internal/services/dns_zone_transfers_outgoing/model.go
@@ -13,7 +13,7 @@ type DNSZoneTransfersOutgoingResultEnvelope struct {
 
 type DNSZoneTransfersOutgoingModel struct {
 	ID                  types.String    `tfsdk:"id" json:"id,computed"`
-	ZoneID              types.String    `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID              types.String    `tfsdk:"zone_id" path:"zone_id,required"`
 	Name                types.String    `tfsdk:"name" json:"name,required"`
 	Peers               *[]types.String `tfsdk:"peers" json:"peers,required"`
 	CheckedTime         types.String    `tfsdk:"checked_time" json:"checked_time,computed"`

--- a/internal/services/dns_zone_transfers_outgoing/schema.go
+++ b/internal/services/dns_zone_transfers_outgoing/schema.go
@@ -33,7 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"zone_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/dns_zone_transfers_peer/model.go
+++ b/internal/services/dns_zone_transfers_peer/model.go
@@ -13,7 +13,7 @@ type DNSZoneTransfersPeerResultEnvelope struct {
 
 type DNSZoneTransfersPeerModel struct {
 	ID         types.String  `tfsdk:"id" json:"id,computed"`
-	AccountID  types.String  `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID  types.String  `tfsdk:"account_id" path:"account_id,required"`
 	Name       types.String  `tfsdk:"name" json:"name,required"`
 	IP         types.String  `tfsdk:"ip" json:"ip,optional"`
 	IxfrEnable types.Bool    `tfsdk:"ixfr_enable" json:"ixfr_enable,optional"`

--- a/internal/services/dns_zone_transfers_peer/schema.go
+++ b/internal/services/dns_zone_transfers_peer/schema.go
@@ -29,7 +29,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/dns_zone_transfers_tsig/model.go
+++ b/internal/services/dns_zone_transfers_tsig/model.go
@@ -13,7 +13,7 @@ type DNSZoneTransfersTSIGResultEnvelope struct {
 
 type DNSZoneTransfersTSIGModel struct {
 	ID        types.String `tfsdk:"id" json:"id,computed"`
-	AccountID types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String `tfsdk:"account_id" path:"account_id,required"`
 	Algo      types.String `tfsdk:"algo" json:"algo,required"`
 	Name      types.String `tfsdk:"name" json:"name,required"`
 	Secret    types.String `tfsdk:"secret" json:"secret,required"`

--- a/internal/services/dns_zone_transfers_tsig/schema.go
+++ b/internal/services/dns_zone_transfers_tsig/schema.go
@@ -29,7 +29,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"algo": schema.StringAttribute{

--- a/internal/services/email_routing_address/model.go
+++ b/internal/services/email_routing_address/model.go
@@ -14,7 +14,7 @@ type EmailRoutingAddressResultEnvelope struct {
 
 type EmailRoutingAddressModel struct {
 	ID        types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Email     types.String      `tfsdk:"email" json:"email,required"`
 	Created   timetypes.RFC3339 `tfsdk:"created" json:"created,computed" format:"date-time"`
 	Modified  timetypes.RFC3339 `tfsdk:"modified" json:"modified,computed" format:"date-time"`

--- a/internal/services/email_routing_address/schema.go
+++ b/internal/services/email_routing_address/schema.go
@@ -32,7 +32,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"email": schema.StringAttribute{

--- a/internal/services/email_routing_rule/model.go
+++ b/internal/services/email_routing_rule/model.go
@@ -13,7 +13,7 @@ type EmailRoutingRuleResultEnvelope struct {
 
 type EmailRoutingRuleModel struct {
 	ID       types.String                      `tfsdk:"id" json:"id,computed"`
-	ZoneID   types.String                      `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID   types.String                      `tfsdk:"zone_id" path:"zone_id,required"`
 	Actions  *[]*EmailRoutingRuleActionsModel  `tfsdk:"actions" json:"actions,required"`
 	Matchers *[]*EmailRoutingRuleMatchersModel `tfsdk:"matchers" json:"matchers,required"`
 	Name     types.String                      `tfsdk:"name" json:"name,optional"`

--- a/internal/services/email_routing_rule/schema.go
+++ b/internal/services/email_routing_rule/schema.go
@@ -37,7 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"actions": schema.ListNestedAttribute{

--- a/internal/services/email_routing_settings/model.go
+++ b/internal/services/email_routing_settings/model.go
@@ -14,7 +14,7 @@ type EmailRoutingSettingsResultEnvelope struct {
 
 type EmailRoutingSettingsModel struct {
 	ID         types.String      `tfsdk:"id" json:"id,computed"`
-	ZoneID     types.String      `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID     types.String      `tfsdk:"zone_id" path:"zone_id,required"`
 	Created    timetypes.RFC3339 `tfsdk:"created" json:"created,computed" format:"date-time"`
 	Enabled    types.Bool        `tfsdk:"enabled" json:"enabled,computed"`
 	Modified   timetypes.RFC3339 `tfsdk:"modified" json:"modified,computed" format:"date-time"`

--- a/internal/services/email_routing_settings/schema.go
+++ b/internal/services/email_routing_settings/schema.go
@@ -34,7 +34,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"created": schema.StringAttribute{

--- a/internal/services/email_security_block_sender/model.go
+++ b/internal/services/email_security_block_sender/model.go
@@ -14,7 +14,7 @@ type EmailSecurityBlockSenderResultEnvelope struct {
 
 type EmailSecurityBlockSenderModel struct {
 	ID           types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID    types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID    types.String      `tfsdk:"account_id" path:"account_id,required"`
 	IsRegex      types.Bool        `tfsdk:"is_regex" json:"is_regex,required"`
 	Pattern      types.String      `tfsdk:"pattern" json:"pattern,required"`
 	PatternType  types.String      `tfsdk:"pattern_type" json:"pattern_type,required"`

--- a/internal/services/email_security_block_sender/schema.go
+++ b/internal/services/email_security_block_sender/schema.go
@@ -34,7 +34,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"is_regex": schema.BoolAttribute{

--- a/internal/services/email_security_impersonation_registry/model.go
+++ b/internal/services/email_security_impersonation_registry/model.go
@@ -14,7 +14,7 @@ type EmailSecurityImpersonationRegistryResultEnvelope struct {
 
 type EmailSecurityImpersonationRegistryModel struct {
 	ID                      types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID               types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID               types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Email                   types.String      `tfsdk:"email" json:"email,required"`
 	IsEmailRegex            types.Bool        `tfsdk:"is_email_regex" json:"is_email_regex,required"`
 	Name                    types.String      `tfsdk:"name" json:"name,required"`

--- a/internal/services/email_security_impersonation_registry/schema.go
+++ b/internal/services/email_security_impersonation_registry/schema.go
@@ -34,7 +34,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"email": schema.StringAttribute{

--- a/internal/services/email_security_trusted_domains/model.go
+++ b/internal/services/email_security_trusted_domains/model.go
@@ -14,7 +14,7 @@ type EmailSecurityTrustedDomainsResultEnvelope struct {
 
 type EmailSecurityTrustedDomainsModel struct {
 	ID           types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID    types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID    types.String      `tfsdk:"account_id" path:"account_id,required"`
 	IsRecent     types.Bool        `tfsdk:"is_recent" json:"is_recent,optional"`
 	IsRegex      types.Bool        `tfsdk:"is_regex" json:"is_regex,optional"`
 	IsSimilarity types.Bool        `tfsdk:"is_similarity" json:"is_similarity,optional"`

--- a/internal/services/email_security_trusted_domains/schema.go
+++ b/internal/services/email_security_trusted_domains/schema.go
@@ -32,7 +32,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"is_recent": schema.BoolAttribute{

--- a/internal/services/filter/model.go
+++ b/internal/services/filter/model.go
@@ -13,7 +13,7 @@ type FilterResultEnvelope struct {
 
 type FilterModel struct {
 	ID          types.String        `tfsdk:"id" json:"id,computed"`
-	ZoneID      types.String        `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID      types.String        `tfsdk:"zone_id" path:"zone_id,required"`
 	Body        *[]*FilterBodyModel `tfsdk:"body" json:"body,required,no_refresh"`
 	Description types.String        `tfsdk:"description" json:"description,optional"`
 	Expression  types.String        `tfsdk:"expression" json:"expression,optional"`

--- a/internal/services/filter/schema.go
+++ b/internal/services/filter/schema.go
@@ -33,7 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Defines an identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"body": schema.ListNestedAttribute{

--- a/internal/services/firewall_rule/model.go
+++ b/internal/services/firewall_rule/model.go
@@ -14,7 +14,7 @@ type FirewallRuleResultEnvelope struct {
 
 type FirewallRuleModel struct {
 	ID          types.String                   `tfsdk:"id" json:"id,computed"`
-	ZoneID      types.String                   `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID      types.String                   `tfsdk:"zone_id" path:"zone_id,required"`
 	Action      *FirewallRuleActionModel       `tfsdk:"action" json:"action,required,no_refresh"`
 	Filter      *FirewallRuleFilterModel       `tfsdk:"filter" json:"filter,required"`
 	Description types.String                   `tfsdk:"description" json:"description,computed"`

--- a/internal/services/firewall_rule/schema.go
+++ b/internal/services/firewall_rule/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Defines an identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"action": schema.SingleNestedAttribute{

--- a/internal/services/healthcheck/model.go
+++ b/internal/services/healthcheck/model.go
@@ -15,7 +15,7 @@ type HealthcheckResultEnvelope struct {
 
 type HealthcheckModel struct {
 	ID                   types.String                                         `tfsdk:"id" json:"id,computed"`
-	ZoneID               types.String                                         `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID               types.String                                         `tfsdk:"zone_id" path:"zone_id,required"`
 	Address              types.String                                         `tfsdk:"address" json:"address,required"`
 	Name                 types.String                                         `tfsdk:"name" json:"name,required"`
 	Description          types.String                                         `tfsdk:"description" json:"description,computed_optional"`

--- a/internal/services/healthcheck/schema.go
+++ b/internal/services/healthcheck/schema.go
@@ -40,7 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"address": schema.StringAttribute{

--- a/internal/services/hostname_tls_setting/model.go
+++ b/internal/services/hostname_tls_setting/model.go
@@ -16,7 +16,7 @@ type HostnameTLSSettingResultEnvelope struct {
 type HostnameTLSSettingModel struct {
 	ID        types.String                       `tfsdk:"id" json:"-,computed"`
 	SettingID types.String                       `tfsdk:"setting_id" path:"setting_id,required"`
-	ZoneID    types.String                       `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID    types.String                       `tfsdk:"zone_id" path:"zone_id,required"`
 	Hostname  types.String                       `tfsdk:"hostname" path:"hostname,required"`
 	Value     customfield.NormalizedDynamicValue `tfsdk:"value" json:"value,required"`
 	CreatedAt timetypes.RFC3339                  `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`

--- a/internal/services/hostname_tls_setting/schema.go
+++ b/internal/services/hostname_tls_setting/schema.go
@@ -57,7 +57,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"hostname": schema.StringAttribute{

--- a/internal/services/hyperdrive_config/model.go
+++ b/internal/services/hyperdrive_config/model.go
@@ -14,7 +14,7 @@ type HyperdriveConfigResultEnvelope struct {
 
 type HyperdriveConfigModel struct {
 	ID                    types.String                  `tfsdk:"id" json:"id,computed"`
-	AccountID             types.String                  `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID             types.String                  `tfsdk:"account_id" path:"account_id,required"`
 	Name                  types.String                  `tfsdk:"name" json:"name,required"`
 	Origin                *HyperdriveConfigOriginModel  `tfsdk:"origin" json:"origin,required"`
 	OriginConnectionLimit types.Int64                   `tfsdk:"origin_connection_limit" json:"origin_connection_limit,optional"`

--- a/internal/services/hyperdrive_config/schema.go
+++ b/internal/services/hyperdrive_config/schema.go
@@ -36,7 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Define configurations using a unique string identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/image/model.go
+++ b/internal/services/image/model.go
@@ -20,7 +20,7 @@ type ImageResultEnvelope struct {
 
 type ImageModel struct {
 	ID                types.String                   `tfsdk:"id" json:"id,required"`
-	AccountID         types.String                   `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID         types.String                   `tfsdk:"account_id" path:"account_id,required"`
 	File              types.String                   `tfsdk:"file" json:"file,optional,no_refresh"`
 	URL               types.String                   `tfsdk:"url" json:"url,optional,no_refresh"`
 	Creator           types.String                   `tfsdk:"creator" json:"creator,optional"`

--- a/internal/services/image/schema.go
+++ b/internal/services/image/schema.go
@@ -36,7 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Account identifier tag.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"file": schema.StringAttribute{

--- a/internal/services/image_variant/model.go
+++ b/internal/services/image_variant/model.go
@@ -14,7 +14,7 @@ type ImageVariantResultEnvelope struct {
 
 type ImageVariantModel struct {
 	ID                     types.String                                       `tfsdk:"id" json:"id,required"`
-	AccountID              types.String                                       `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID              types.String                                       `tfsdk:"account_id" path:"account_id,required"`
 	Options                *ImageVariantOptionsModel                          `tfsdk:"options" json:"options,required,no_refresh"`
 	NeverRequireSignedURLs types.Bool                                         `tfsdk:"never_require_signed_urls" json:"neverRequireSignedURLs,computed_optional,no_refresh"`
 	Variant                customfield.NestedObject[ImageVariantVariantModel] `tfsdk:"variant" json:"variant,computed"`

--- a/internal/services/image_variant/schema.go
+++ b/internal/services/image_variant/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Account identifier tag.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"options": schema.SingleNestedAttribute{

--- a/internal/services/keyless_certificate/model.go
+++ b/internal/services/keyless_certificate/model.go
@@ -15,7 +15,7 @@ type KeylessCertificateResultEnvelope struct {
 
 type KeylessCertificateModel struct {
 	ID           types.String                   `tfsdk:"id" json:"id,computed"`
-	ZoneID       types.String                   `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID       types.String                   `tfsdk:"zone_id" path:"zone_id,required"`
 	Certificate  types.String                   `tfsdk:"certificate" json:"certificate,required,no_refresh"`
 	BundleMethod types.String                   `tfsdk:"bundle_method" json:"bundle_method,computed_optional,no_refresh"`
 	Host         types.String                   `tfsdk:"host" json:"host,required"`

--- a/internal/services/keyless_certificate/schema.go
+++ b/internal/services/keyless_certificate/schema.go
@@ -72,7 +72,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"certificate": schema.StringAttribute{

--- a/internal/services/leaked_credential_check/model.go
+++ b/internal/services/leaked_credential_check/model.go
@@ -12,7 +12,7 @@ type LeakedCredentialCheckResultEnvelope struct {
 }
 
 type LeakedCredentialCheckModel struct {
-	ZoneID  types.String `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID  types.String `tfsdk:"zone_id" path:"zone_id,required"`
 	Enabled types.Bool   `tfsdk:"enabled" json:"enabled,optional"`
 }
 

--- a/internal/services/leaked_credential_check/schema.go
+++ b/internal/services/leaked_credential_check/schema.go
@@ -28,7 +28,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"zone_id": schema.StringAttribute{
 				Description:   "Defines an identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"enabled": schema.BoolAttribute{

--- a/internal/services/leaked_credential_check_rule/model.go
+++ b/internal/services/leaked_credential_check_rule/model.go
@@ -13,7 +13,7 @@ type LeakedCredentialCheckRuleResultEnvelope struct {
 
 type LeakedCredentialCheckRuleModel struct {
 	ID       types.String `tfsdk:"id" json:"id,computed"`
-	ZoneID   types.String `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID   types.String `tfsdk:"zone_id" path:"zone_id,required"`
 	Password types.String `tfsdk:"password" json:"password,optional"`
 	Username types.String `tfsdk:"username" json:"username,optional"`
 }

--- a/internal/services/leaked_credential_check_rule/schema.go
+++ b/internal/services/leaked_credential_check_rule/schema.go
@@ -33,7 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Defines an identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"password": schema.StringAttribute{

--- a/internal/services/list/model.go
+++ b/internal/services/list/model.go
@@ -14,7 +14,7 @@ type ListResultEnvelope struct {
 
 type ListModel struct {
 	ID                    types.String                               `tfsdk:"id" json:"id,computed"`
-	AccountID             types.String                               `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID             types.String                               `tfsdk:"account_id" path:"account_id,required"`
 	Kind                  types.String                               `tfsdk:"kind" json:"kind,required"`
 	Name                  types.String                               `tfsdk:"name" json:"name,required"`
 	Description           types.String                               `tfsdk:"description" json:"description,optional"`

--- a/internal/services/list/schema.go
+++ b/internal/services/list/schema.go
@@ -40,7 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "The Account ID for this resource.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"kind": schema.StringAttribute{

--- a/internal/services/list_item/model.go
+++ b/internal/services/list_item/model.go
@@ -14,7 +14,7 @@ type ListItemResultEnvelope struct {
 
 type ListItemModel struct {
 	ListID      types.String                                    `tfsdk:"list_id" path:"list_id,required"`
-	AccountID   types.String                                    `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String                                    `tfsdk:"account_id" path:"account_id,required"`
 	ID          types.String                                    `tfsdk:"id" json:"id,computed" path:"item_id,computed"`
 	ASN         types.Int64                                     `tfsdk:"asn" json:"asn,optional"`
 	Comment     types.String                                    `tfsdk:"comment" json:"comment,optional"`

--- a/internal/services/list_item/schema.go
+++ b/internal/services/list_item/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The Account ID for this resource.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"list_id": schema.StringAttribute{

--- a/internal/services/load_balancer/model.go
+++ b/internal/services/load_balancer/model.go
@@ -14,7 +14,7 @@ type LoadBalancerResultEnvelope struct {
 
 type LoadBalancerModel struct {
 	ID                        types.String                                                         `tfsdk:"id" json:"id,computed"`
-	ZoneID                    types.String                                                         `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID                    types.String                                                         `tfsdk:"zone_id" path:"zone_id,required"`
 	FallbackPool              types.String                                                         `tfsdk:"fallback_pool" json:"fallback_pool,required"`
 	Name                      types.String                                                         `tfsdk:"name" json:"name,required"`
 	DefaultPools              *[]types.String                                                      `tfsdk:"default_pools" json:"default_pools,required"`

--- a/internal/services/load_balancer/schema.go
+++ b/internal/services/load_balancer/schema.go
@@ -39,7 +39,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"zone_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"fallback_pool": schema.StringAttribute{

--- a/internal/services/load_balancer_monitor/model.go
+++ b/internal/services/load_balancer_monitor/model.go
@@ -13,7 +13,7 @@ type LoadBalancerMonitorResultEnvelope struct {
 
 type LoadBalancerMonitorModel struct {
 	ID              types.String                `tfsdk:"id" json:"id,computed"`
-	AccountID       types.String                `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID       types.String                `tfsdk:"account_id" path:"account_id,required"`
 	ConsecutiveDown types.Int64                 `tfsdk:"consecutive_down" json:"consecutive_down,optional"`
 	ConsecutiveUp   types.Int64                 `tfsdk:"consecutive_up" json:"consecutive_up,optional"`
 	Port            types.Int64                 `tfsdk:"port" json:"port,optional"`

--- a/internal/services/load_balancer_monitor/schema.go
+++ b/internal/services/load_balancer_monitor/schema.go
@@ -36,7 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"consecutive_down": schema.Int64Attribute{

--- a/internal/services/load_balancer_pool/model.go
+++ b/internal/services/load_balancer_pool/model.go
@@ -15,7 +15,7 @@ type LoadBalancerPoolResultEnvelope struct {
 
 type LoadBalancerPoolModel struct {
 	ID                 types.String                                                      `tfsdk:"id" json:"id,computed"`
-	AccountID          types.String                                                      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID          types.String                                                      `tfsdk:"account_id" path:"account_id,required"`
 	Name               types.String                                                      `tfsdk:"name" json:"name,required"`
 	Origins            *[]*LoadBalancerPoolOriginsModel                                  `tfsdk:"origins" json:"origins,required"`
 	Latitude           types.Float64                                                     `tfsdk:"latitude" json:"latitude,optional"`

--- a/internal/services/load_balancer_pool/schema.go
+++ b/internal/services/load_balancer_pool/schema.go
@@ -43,7 +43,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/magic_network_monitoring_configuration/model.go
+++ b/internal/services/magic_network_monitoring_configuration/model.go
@@ -12,7 +12,7 @@ type MagicNetworkMonitoringConfigurationResultEnvelope struct {
 }
 
 type MagicNetworkMonitoringConfigurationModel struct {
-	AccountID       types.String                                            `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID       types.String                                            `tfsdk:"account_id" path:"account_id,required"`
 	Name            types.String                                            `tfsdk:"name" json:"name,required"`
 	RouterIPs       *[]types.String                                         `tfsdk:"router_ips" json:"router_ips,optional"`
 	WARPDevices     *[]*MagicNetworkMonitoringConfigurationWARPDevicesModel `tfsdk:"warp_devices" json:"warp_devices,optional"`

--- a/internal/services/magic_network_monitoring_configuration/schema.go
+++ b/internal/services/magic_network_monitoring_configuration/schema.go
@@ -30,7 +30,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		}.String(),
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/magic_network_monitoring_rule/model.go
+++ b/internal/services/magic_network_monitoring_rule/model.go
@@ -13,7 +13,7 @@ type MagicNetworkMonitoringRuleResultEnvelope struct {
 
 type MagicNetworkMonitoringRuleModel struct {
 	ID                     types.String    `tfsdk:"id" json:"id,computed"`
-	AccountID              types.String    `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID              types.String    `tfsdk:"account_id" path:"account_id,required"`
 	AutomaticAdvertisement types.Bool      `tfsdk:"automatic_advertisement" json:"automatic_advertisement,required"`
 	Name                   types.String    `tfsdk:"name" json:"name,required"`
 	Type                   types.String    `tfsdk:"type" json:"type,required"`

--- a/internal/services/magic_network_monitoring_rule/schema.go
+++ b/internal/services/magic_network_monitoring_rule/schema.go
@@ -36,7 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"automatic_advertisement": schema.BoolAttribute{

--- a/internal/services/magic_transit_connector/model.go
+++ b/internal/services/magic_transit_connector/model.go
@@ -14,7 +14,7 @@ type MagicTransitConnectorResultEnvelope struct {
 
 type MagicTransitConnectorModel struct {
 	ID                           types.String                      `tfsdk:"id" json:"id,computed"`
-	AccountID                    types.String                      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID                    types.String                      `tfsdk:"account_id" path:"account_id,required"`
 	Device                       *MagicTransitConnectorDeviceModel `tfsdk:"device" json:"device,required"`
 	ProvisionLicense             types.Bool                        `tfsdk:"provision_license" json:"provision_license,optional,no_refresh"`
 	Activated                    types.Bool                        `tfsdk:"activated" json:"activated,computed_optional"`

--- a/internal/services/magic_transit_connector/schema.go
+++ b/internal/services/magic_transit_connector/schema.go
@@ -37,7 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Account identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"device": schema.SingleNestedAttribute{

--- a/internal/services/magic_transit_site/model.go
+++ b/internal/services/magic_transit_site/model.go
@@ -13,7 +13,7 @@ type MagicTransitSiteResultEnvelope struct {
 
 type MagicTransitSiteModel struct {
 	ID                   types.String                   `tfsdk:"id" json:"id,computed"`
-	AccountID            types.String                   `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID            types.String                   `tfsdk:"account_id" path:"account_id,required"`
 	HaMode               types.Bool                     `tfsdk:"ha_mode" json:"ha_mode,optional"`
 	Name                 types.String                   `tfsdk:"name" json:"name,required"`
 	ConnectorID          types.String                   `tfsdk:"connector_id" json:"connector_id,optional"`

--- a/internal/services/magic_transit_site/schema.go
+++ b/internal/services/magic_transit_site/schema.go
@@ -34,7 +34,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"ha_mode": schema.BoolAttribute{

--- a/internal/services/magic_wan_gre_tunnel/model.go
+++ b/internal/services/magic_wan_gre_tunnel/model.go
@@ -15,7 +15,7 @@ type MagicWANGRETunnelResultEnvelope struct {
 
 type MagicWANGRETunnelModel struct {
 	ID                     types.String                                                      `tfsdk:"id" json:"id,computed"`
-	AccountID              types.String                                                      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID              types.String                                                      `tfsdk:"account_id" path:"account_id,required"`
 	BGP                    *MagicWANGRETunnelBGPModel                                        `tfsdk:"bgp" json:"bgp,optional,no_refresh"`
 	CloudflareGREEndpoint  types.String                                                      `tfsdk:"cloudflare_gre_endpoint" json:"cloudflare_gre_endpoint,required,no_refresh"`
 	CustomerGREEndpoint    types.String                                                      `tfsdk:"customer_gre_endpoint" json:"customer_gre_endpoint,required,no_refresh"`

--- a/internal/services/magic_wan_gre_tunnel/schema.go
+++ b/internal/services/magic_wan_gre_tunnel/schema.go
@@ -43,7 +43,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"bgp": schema.SingleNestedAttribute{

--- a/internal/services/magic_wan_ipsec_tunnel/model.go
+++ b/internal/services/magic_wan_ipsec_tunnel/model.go
@@ -15,7 +15,7 @@ type MagicWANIPSECTunnelResultEnvelope struct {
 
 type MagicWANIPSECTunnelModel struct {
 	ID                     types.String                                                          `tfsdk:"id" json:"id,computed"`
-	AccountID              types.String                                                          `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID              types.String                                                          `tfsdk:"account_id" path:"account_id,required"`
 	CloudflareEndpoint     types.String                                                          `tfsdk:"cloudflare_endpoint" json:"cloudflare_endpoint,required,no_refresh"`
 	InterfaceAddress       types.String                                                          `tfsdk:"interface_address" json:"interface_address,required,no_refresh"`
 	Name                   types.String                                                          `tfsdk:"name" json:"name,required,no_refresh"`

--- a/internal/services/magic_wan_ipsec_tunnel/schema.go
+++ b/internal/services/magic_wan_ipsec_tunnel/schema.go
@@ -41,7 +41,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"cloudflare_endpoint": schema.StringAttribute{

--- a/internal/services/magic_wan_static_route/model.go
+++ b/internal/services/magic_wan_static_route/model.go
@@ -15,7 +15,7 @@ type MagicWANStaticRouteResultEnvelope struct {
 
 type MagicWANStaticRouteModel struct {
 	ID            types.String                                                    `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String                                                    `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String                                                    `tfsdk:"account_id" path:"account_id,required"`
 	Nexthop       types.String                                                    `tfsdk:"nexthop" json:"nexthop,required,no_refresh"`
 	Prefix        types.String                                                    `tfsdk:"prefix" json:"prefix,required,no_refresh"`
 	Priority      types.Int64                                                     `tfsdk:"priority" json:"priority,required,no_refresh"`

--- a/internal/services/magic_wan_static_route/schema.go
+++ b/internal/services/magic_wan_static_route/schema.go
@@ -36,7 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"nexthop": schema.StringAttribute{

--- a/internal/services/notification_policy/model.go
+++ b/internal/services/notification_policy/model.go
@@ -15,7 +15,7 @@ type NotificationPolicyResultEnvelope struct {
 
 type NotificationPolicyModel struct {
 	ID            types.String                       `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String                       `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String                       `tfsdk:"account_id" path:"account_id,required"`
 	AlertType     types.String                       `tfsdk:"alert_type" json:"alert_type,required"`
 	Name          types.String                       `tfsdk:"name" json:"name,required"`
 	Mechanisms    *NotificationPolicyMechanismsModel `tfsdk:"mechanisms" json:"mechanisms,required"`

--- a/internal/services/notification_policy/schema.go
+++ b/internal/services/notification_policy/schema.go
@@ -41,7 +41,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "The account id",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"alert_type": schema.StringAttribute{

--- a/internal/services/notification_policy_webhooks/model.go
+++ b/internal/services/notification_policy_webhooks/model.go
@@ -14,7 +14,7 @@ type NotificationPolicyWebhooksResultEnvelope struct {
 
 type NotificationPolicyWebhooksModel struct {
 	ID          types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID   types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Name        types.String      `tfsdk:"name" json:"name,required"`
 	URL         types.String      `tfsdk:"url" json:"url,required"`
 	Secret      types.String      `tfsdk:"secret" json:"secret,optional,no_refresh"`

--- a/internal/services/notification_policy_webhooks/schema.go
+++ b/internal/services/notification_policy_webhooks/schema.go
@@ -37,7 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "The account id",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/observatory_scheduled_test/model.go
+++ b/internal/services/observatory_scheduled_test/model.go
@@ -16,7 +16,7 @@ type ObservatoryScheduledTestResultEnvelope struct {
 type ObservatoryScheduledTestModel struct {
 	ID        types.String                                                    `tfsdk:"id" json:"-,computed"`
 	URL       types.String                                                    `tfsdk:"url" path:"url,required"`
-	ZoneID    types.String                                                    `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID    types.String                                                    `tfsdk:"zone_id" path:"zone_id,required"`
 	Frequency types.String                                                    `tfsdk:"frequency" json:"frequency,computed_optional"`
 	Region    types.String                                                    `tfsdk:"region" json:"region,computed_optional"`
 	Schedule  customfield.NestedObject[ObservatoryScheduledTestScheduleModel] `tfsdk:"schedule" json:"schedule,computed,no_refresh"`

--- a/internal/services/observatory_scheduled_test/schema.go
+++ b/internal/services/observatory_scheduled_test/schema.go
@@ -41,7 +41,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"frequency": schema.StringAttribute{

--- a/internal/services/page_rule/model.go
+++ b/internal/services/page_rule/model.go
@@ -13,7 +13,7 @@ type PageRuleResultEnvelope struct {
 
 type PageRuleModel struct {
 	ID         types.String      `tfsdk:"id" json:"id,computed"`
-	ZoneID     types.String      `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID     types.String      `tfsdk:"zone_id" path:"zone_id,required"`
 	Priority   types.Int64       `tfsdk:"priority" json:"priority,computed_optional"`
 	Status     types.String      `tfsdk:"status" json:"status,computed_optional"`
 	CreatedOn  timetypes.RFC3339 `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`

--- a/internal/services/page_rule/schema.go
+++ b/internal/services/page_rule/schema.go
@@ -77,7 +77,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"priority": schema.Int64Attribute{

--- a/internal/services/page_shield_policy/model.go
+++ b/internal/services/page_shield_policy/model.go
@@ -13,7 +13,7 @@ type PageShieldPolicyResultEnvelope struct {
 
 type PageShieldPolicyModel struct {
 	ID          types.String `tfsdk:"id" json:"id,computed"`
-	ZoneID      types.String `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID      types.String `tfsdk:"zone_id" path:"zone_id,required"`
 	Action      types.String `tfsdk:"action" json:"action,required"`
 	Description types.String `tfsdk:"description" json:"description,required"`
 	Enabled     types.Bool   `tfsdk:"enabled" json:"enabled,required"`

--- a/internal/services/page_shield_policy/schema.go
+++ b/internal/services/page_shield_policy/schema.go
@@ -37,7 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"action": schema.StringAttribute{

--- a/internal/services/pages_domain/model.go
+++ b/internal/services/pages_domain/model.go
@@ -15,7 +15,7 @@ type PagesDomainResultEnvelope struct {
 type PagesDomainModel struct {
 	ID                   types.String                                               `tfsdk:"id" json:"-,computed"`
 	Name                 types.String                                               `tfsdk:"name" json:"name,required"`
-	AccountID            types.String                                               `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID            types.String                                               `tfsdk:"account_id" path:"account_id,required"`
 	ProjectName          types.String                                               `tfsdk:"project_name" path:"project_name,required"`
 	CertificateAuthority types.String                                               `tfsdk:"certificate_authority" json:"certificate_authority,computed"`
 	CreatedOn            types.String                                               `tfsdk:"created_on" json:"created_on,computed"`

--- a/internal/services/pages_domain/schema.go
+++ b/internal/services/pages_domain/schema.go
@@ -39,7 +39,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"project_name": schema.StringAttribute{

--- a/internal/services/pages_project/model.go
+++ b/internal/services/pages_project/model.go
@@ -16,7 +16,7 @@ type PagesProjectResultEnvelope struct {
 type PagesProjectModel struct {
 	ID                   types.String                                                   `tfsdk:"id" json:"-,computed"`
 	Name                 types.String                                                   `tfsdk:"name" json:"name,required"`
-	AccountID            types.String                                                   `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID            types.String                                                   `tfsdk:"account_id" path:"account_id,required"`
 	ProductionBranch     types.String                                                   `tfsdk:"production_branch" json:"production_branch,required"`
 	BuildConfig          customfield.NestedObject[PagesProjectBuildConfigModel]         `tfsdk:"build_config" json:"build_config,computed_optional"`
 	Source               *PagesProjectSourceModel                                       `tfsdk:"source" json:"source,optional"`

--- a/internal/services/pages_project/schema.go
+++ b/internal/services/pages_project/schema.go
@@ -46,7 +46,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"production_branch": schema.StringAttribute{

--- a/internal/services/pipeline/model.go
+++ b/internal/services/pipeline/model.go
@@ -14,7 +14,7 @@ type PipelineResultEnvelope struct {
 
 type PipelineModel struct {
 	ID            types.String                                      `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String                                      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String                                      `tfsdk:"account_id" path:"account_id,required"`
 	Name          types.String                                      `tfsdk:"name" json:"name,required"`
 	Sql           types.String                                      `tfsdk:"sql" json:"sql,required"`
 	CreatedAt     types.String                                      `tfsdk:"created_at" json:"created_at,computed"`

--- a/internal/services/pipeline/schema.go
+++ b/internal/services/pipeline/schema.go
@@ -34,7 +34,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Specifies the public ID of the account.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/pipeline_sink/model.go
+++ b/internal/services/pipeline_sink/model.go
@@ -14,7 +14,7 @@ type PipelineSinkResultEnvelope struct {
 
 type PipelineSinkModel struct {
 	ID         types.String             `tfsdk:"id" json:"id,computed"`
-	AccountID  types.String             `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID  types.String             `tfsdk:"account_id" path:"account_id,required"`
 	Name       types.String             `tfsdk:"name" json:"name,required"`
 	Type       types.String             `tfsdk:"type" json:"type,required"`
 	Config     *PipelineSinkConfigModel `tfsdk:"config" json:"config,optional"`

--- a/internal/services/pipeline_sink/schema.go
+++ b/internal/services/pipeline_sink/schema.go
@@ -36,7 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Specifies the public ID of the account.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/pipeline_stream/model.go
+++ b/internal/services/pipeline_stream/model.go
@@ -15,7 +15,7 @@ type PipelineStreamResultEnvelope struct {
 
 type PipelineStreamModel struct {
 	ID            types.String                                               `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String                                               `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String                                               `tfsdk:"account_id" path:"account_id,required"`
 	Name          types.String                                               `tfsdk:"name" json:"name,required"`
 	Format        *PipelineStreamFormatModel                                 `tfsdk:"format" json:"format,optional"`
 	Schema        *PipelineStreamSchemaModel                                 `tfsdk:"schema" json:"schema,optional"`

--- a/internal/services/pipeline_stream/schema.go
+++ b/internal/services/pipeline_stream/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Specifies the public ID of the account.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/queue/model.go
+++ b/internal/services/queue/model.go
@@ -16,7 +16,7 @@ type QueueResultEnvelope struct {
 type QueueModel struct {
 	ID                  types.String                                      `tfsdk:"id" json:"-,computed"`
 	QueueID             types.String                                      `tfsdk:"queue_id" json:"queue_id,computed"`
-	AccountID           types.String                                      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID           types.String                                      `tfsdk:"account_id" path:"account_id,required"`
 	QueueName           types.String                                      `tfsdk:"queue_name" json:"queue_name,required"`
 	Settings            customfield.NestedObject[QueueSettingsModel]      `tfsdk:"settings" json:"settings,computed_optional"`
 	ConsumersTotalCount types.Float64                                     `tfsdk:"consumers_total_count" json:"consumers_total_count,computed"`

--- a/internal/services/queue/schema.go
+++ b/internal/services/queue/schema.go
@@ -40,7 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "A Resource identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"queue_name": schema.StringAttribute{

--- a/internal/services/r2_bucket/model.go
+++ b/internal/services/r2_bucket/model.go
@@ -14,7 +14,7 @@ type R2BucketResultEnvelope struct {
 type R2BucketModel struct {
 	ID           types.String `tfsdk:"id" json:"-,computed"`
 	Name         types.String `tfsdk:"name" json:"name,required"`
-	AccountID    types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID    types.String `tfsdk:"account_id" path:"account_id,required"`
 	Location     types.String `tfsdk:"location" json:"location,computed_optional"`
 	StorageClass types.String `tfsdk:"storage_class" json:"storage_class,computed_optional"`
 	CreationDate types.String `tfsdk:"creation_date" json:"creation_date,computed"`
@@ -24,7 +24,7 @@ type R2BucketModel struct {
 type CreateR2BucketModel struct {
 	ID           types.String `tfsdk:"id" json:"-,computed"`
 	Name         types.String `tfsdk:"name" json:"name,required"`
-	AccountID    types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID    types.String `tfsdk:"account_id" path:"account_id,required"`
 	Location     types.String `tfsdk:"location" json:"locationHint,computed_optional"`
 	Jurisdiction types.String `tfsdk:"jurisdiction" json:"-,computed_optional,no_refresh"`
 	StorageClass types.String `tfsdk:"storage_class" json:"storageClass,computed_optional"`

--- a/internal/services/r2_bucket/schema.go
+++ b/internal/services/r2_bucket/schema.go
@@ -68,7 +68,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Account ID.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"location": schema.StringAttribute{

--- a/internal/services/r2_data_catalog/model.go
+++ b/internal/services/r2_data_catalog/model.go
@@ -14,7 +14,7 @@ type R2DataCatalogResultEnvelope struct {
 
 type R2DataCatalogModel struct {
 	ID                types.String                                                  `tfsdk:"id" json:"id,computed"`
-	AccountID         types.String                                                  `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID         types.String                                                  `tfsdk:"account_id" path:"account_id,required"`
 	BucketName        types.String                                                  `tfsdk:"bucket_name" path:"bucket_name,required"`
 	Bucket            types.String                                                  `tfsdk:"bucket" json:"bucket,computed"`
 	CredentialStatus  types.String                                                  `tfsdk:"credential_status" json:"credential_status,computed"`

--- a/internal/services/r2_data_catalog/schema.go
+++ b/internal/services/r2_data_catalog/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Use this to identify the account.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"bucket_name": schema.StringAttribute{

--- a/internal/services/rate_limit/model.go
+++ b/internal/services/rate_limit/model.go
@@ -14,7 +14,7 @@ type RateLimitResultEnvelope struct {
 
 type RateLimitModel struct {
 	ID          types.String                                       `tfsdk:"id" json:"id,computed"`
-	ZoneID      types.String                                       `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID      types.String                                       `tfsdk:"zone_id" path:"zone_id,required"`
 	Period      types.Float64                                      `tfsdk:"period" json:"period,required"`
 	Threshold   types.Float64                                      `tfsdk:"threshold" json:"threshold,required"`
 	Action      *RateLimitActionModel                              `tfsdk:"action" json:"action,required"`

--- a/internal/services/rate_limit/schema.go
+++ b/internal/services/rate_limit/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Defines an identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"period": schema.Float64Attribute{

--- a/internal/services/registrar_domain/model.go
+++ b/internal/services/registrar_domain/model.go
@@ -12,7 +12,7 @@ type RegistrarDomainResultEnvelope struct {
 }
 
 type RegistrarDomainModel struct {
-	AccountID  types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID  types.String `tfsdk:"account_id" path:"account_id,required"`
 	DomainName types.String `tfsdk:"domain_name" path:"domain_name,required"`
 	AutoRenew  types.Bool   `tfsdk:"auto_renew" json:"auto_renew,optional,no_refresh"`
 	Locked     types.Bool   `tfsdk:"locked" json:"locked,optional,no_refresh"`

--- a/internal/services/registrar_domain/schema.go
+++ b/internal/services/registrar_domain/schema.go
@@ -19,7 +19,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"domain_name": schema.StringAttribute{

--- a/internal/services/schema_validation_operation_settings/model.go
+++ b/internal/services/schema_validation_operation_settings/model.go
@@ -13,7 +13,7 @@ type SchemaValidationOperationSettingsResultEnvelope struct {
 
 type SchemaValidationOperationSettingsModel struct {
 	OperationID      types.String `tfsdk:"operation_id" path:"operation_id,required"`
-	ZoneID           types.String `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID           types.String `tfsdk:"zone_id" path:"zone_id,required"`
 	MitigationAction types.String `tfsdk:"mitigation_action" json:"mitigation_action,required"`
 }
 

--- a/internal/services/schema_validation_operation_settings/schema.go
+++ b/internal/services/schema_validation_operation_settings/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"mitigation_action": schema.StringAttribute{

--- a/internal/services/schema_validation_schemas/model.go
+++ b/internal/services/schema_validation_schemas/model.go
@@ -15,7 +15,7 @@ type SchemaValidationSchemasResultEnvelope struct {
 type SchemaValidationSchemasModel struct {
 	ID                types.String      `tfsdk:"id" json:"-,computed"`
 	SchemaID          types.String      `tfsdk:"schema_id" json:"schema_id,computed"`
-	ZoneID            types.String      `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID            types.String      `tfsdk:"zone_id" path:"zone_id,required"`
 	Kind              types.String      `tfsdk:"kind" json:"kind,required"`
 	Name              types.String      `tfsdk:"name" json:"name,required"`
 	Source            types.String      `tfsdk:"source" json:"source,required"`

--- a/internal/services/schema_validation_schemas/schema.go
+++ b/internal/services/schema_validation_schemas/schema.go
@@ -41,7 +41,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"kind": schema.StringAttribute{

--- a/internal/services/schema_validation_settings/model.go
+++ b/internal/services/schema_validation_settings/model.go
@@ -12,7 +12,7 @@ type SchemaValidationSettingsResultEnvelope struct {
 }
 
 type SchemaValidationSettingsModel struct {
-	ZoneID                             types.String `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID                             types.String `tfsdk:"zone_id" path:"zone_id,required"`
 	ValidationDefaultMitigationAction  types.String `tfsdk:"validation_default_mitigation_action" json:"validation_default_mitigation_action,required"`
 	ValidationOverrideMitigationAction types.String `tfsdk:"validation_override_mitigation_action" json:"validation_override_mitigation_action,optional"`
 }

--- a/internal/services/schema_validation_settings/schema.go
+++ b/internal/services/schema_validation_settings/schema.go
@@ -30,7 +30,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"validation_default_mitigation_action": schema.StringAttribute{

--- a/internal/services/snippet/model.go
+++ b/internal/services/snippet/model.go
@@ -37,7 +37,7 @@ var SnippetFileType = snippetFileType{
 type SnippetModel struct {
 	ID          types.String          `tfsdk:"id" json:"-,computed"`
 	SnippetName types.String          `tfsdk:"snippet_name" path:"snippet_name,required"`
-	ZoneID      types.String          `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID      types.String          `tfsdk:"zone_id" path:"zone_id,required"`
 	Files       *[]SnippetFile        `tfsdk:"files" json:"files,metadata,required"`
 	Metadata    *SnippetMetadataModel `tfsdk:"metadata" json:"metadata,required,no_refresh"`
 	CreatedOn   timetypes.RFC3339     `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`

--- a/internal/services/snippet/schema.go
+++ b/internal/services/snippet/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Use this field to specify the unique ID of the zone.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"files": schema.ListAttribute{

--- a/internal/services/snippet_rules/model.go
+++ b/internal/services/snippet_rules/model.go
@@ -14,7 +14,7 @@ type SnippetRulesResultEnvelope struct {
 
 type SnippetRulesModel struct {
 	ID     types.String               `tfsdk:"id" json:"-,computed"`
-	ZoneID types.String               `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID types.String               `tfsdk:"zone_id" path:"zone_id,required"`
 	Rules  *[]*SnippetRulesRulesModel `tfsdk:"rules" json:"rules,required,no_refresh"`
 }
 

--- a/internal/services/snippet_rules/schema.go
+++ b/internal/services/snippet_rules/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Use this field to specify the unique ID of the zone.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown(), stringplanmodifier.RequiresReplace()},
 			},
 			"rules": schema.ListNestedAttribute{

--- a/internal/services/spectrum_application/model.go
+++ b/internal/services/spectrum_application/model.go
@@ -15,7 +15,7 @@ type SpectrumApplicationResultEnvelope struct {
 
 type SpectrumApplicationModel struct {
 	ID               types.String                                              `tfsdk:"id" json:"id,computed"`
-	ZoneID           types.String                                              `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID           types.String                                              `tfsdk:"zone_id" path:"zone_id,required"`
 	Protocol         types.String                                              `tfsdk:"protocol" json:"protocol,required"`
 	DNS              *SpectrumApplicationDNSModel                              `tfsdk:"dns" json:"dns,required"`
 	VirtualNetworkID types.String                                              `tfsdk:"virtual_network_id" json:"virtual_network_id,optional"`

--- a/internal/services/spectrum_application/schema.go
+++ b/internal/services/spectrum_application/schema.go
@@ -42,7 +42,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Zone identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"protocol": schema.StringAttribute{

--- a/internal/services/sso_connector/model.go
+++ b/internal/services/sso_connector/model.go
@@ -15,7 +15,7 @@ type SSOConnectorResultEnvelope struct {
 
 type SSOConnectorModel struct {
 	ID                 types.String                                            `tfsdk:"id" json:"id,computed"`
-	AccountID          types.String                                            `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID          types.String                                            `tfsdk:"account_id" path:"account_id,required"`
 	EmailDomain        types.String                                            `tfsdk:"email_domain" json:"email_domain,required"`
 	BeginVerification  types.Bool                                              `tfsdk:"begin_verification" json:"begin_verification,computed_optional,no_refresh"`
 	Enabled            types.Bool                                              `tfsdk:"enabled" json:"enabled,optional"`

--- a/internal/services/sso_connector/schema.go
+++ b/internal/services/sso_connector/schema.go
@@ -37,7 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Account identifier tag.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"email_domain": schema.StringAttribute{

--- a/internal/services/stream/model.go
+++ b/internal/services/stream/model.go
@@ -15,7 +15,7 @@ type StreamResultEnvelope struct {
 }
 
 type StreamModel struct {
-	AccountID             types.String                                   `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID             types.String                                   `tfsdk:"account_id" path:"account_id,required"`
 	Identifier            types.String                                   `tfsdk:"identifier" path:"identifier,optional"`
 	Creator               types.String                                   `tfsdk:"creator" json:"creator,optional"`
 	MaxDurationSeconds    types.Int64                                    `tfsdk:"max_duration_seconds" json:"maxDurationSeconds,optional"`

--- a/internal/services/stream/schema.go
+++ b/internal/services/stream/schema.go
@@ -37,7 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The account identifier tag.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"identifier": schema.StringAttribute{

--- a/internal/services/stream_audio_track/model.go
+++ b/internal/services/stream_audio_track/model.go
@@ -13,7 +13,7 @@ type StreamAudioTrackResultEnvelope struct {
 }
 
 type StreamAudioTrackModel struct {
-	AccountID       types.String                                             `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID       types.String                                             `tfsdk:"account_id" path:"account_id,required"`
 	Identifier      types.String                                             `tfsdk:"identifier" path:"identifier,required"`
 	AudioIdentifier types.String                                             `tfsdk:"audio_identifier" path:"audio_identifier,optional"`
 	Label           types.String                                             `tfsdk:"label" json:"label,optional,no_refresh"`

--- a/internal/services/stream_audio_track/schema.go
+++ b/internal/services/stream_audio_track/schema.go
@@ -30,7 +30,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The account identifier tag.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"identifier": schema.StringAttribute{

--- a/internal/services/stream_download/model.go
+++ b/internal/services/stream_download/model.go
@@ -13,7 +13,7 @@ type StreamDownloadResultEnvelope struct {
 }
 
 type StreamDownloadModel struct {
-	AccountID       types.String                                         `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID       types.String                                         `tfsdk:"account_id" path:"account_id,required"`
 	Identifier      types.String                                         `tfsdk:"identifier" path:"identifier,required"`
 	PercentComplete types.Float64                                        `tfsdk:"percent_complete" json:"percentComplete,computed,no_refresh"`
 	Status          types.String                                         `tfsdk:"status" json:"status,computed,no_refresh"`

--- a/internal/services/stream_download/schema.go
+++ b/internal/services/stream_download/schema.go
@@ -30,7 +30,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"identifier": schema.StringAttribute{

--- a/internal/services/stream_key/model.go
+++ b/internal/services/stream_key/model.go
@@ -14,7 +14,7 @@ type StreamKeyResultEnvelope struct {
 
 type StreamKeyModel struct {
 	ID        types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Created   timetypes.RFC3339 `tfsdk:"created" json:"created,computed" format:"date-time"`
 	Jwk       types.String      `tfsdk:"jwk" json:"jwk,computed,no_refresh"`
 	KeyID     types.String      `tfsdk:"key_id" json:"key_id,computed"`

--- a/internal/services/stream_key/schema.go
+++ b/internal/services/stream_key/schema.go
@@ -32,7 +32,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"created": schema.StringAttribute{

--- a/internal/services/stream_live_input/model.go
+++ b/internal/services/stream_live_input/model.go
@@ -15,7 +15,7 @@ type StreamLiveInputResultEnvelope struct {
 }
 
 type StreamLiveInputModel struct {
-	AccountID                types.String                                                 `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID                types.String                                                 `tfsdk:"account_id" path:"account_id,required"`
 	LiveInputIdentifier      types.String                                                 `tfsdk:"live_input_identifier" path:"live_input_identifier,optional"`
 	DefaultCreator           types.String                                                 `tfsdk:"default_creator" json:"defaultCreator,optional,no_refresh"`
 	DeleteRecordingAfterDays types.Float64                                                `tfsdk:"delete_recording_after_days" json:"deleteRecordingAfterDays,optional"`

--- a/internal/services/stream_live_input/schema.go
+++ b/internal/services/stream_live_input/schema.go
@@ -36,7 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"live_input_identifier": schema.StringAttribute{

--- a/internal/services/stream_watermark/model.go
+++ b/internal/services/stream_watermark/model.go
@@ -17,7 +17,7 @@ type StreamWatermarkResultEnvelope struct {
 }
 
 type StreamWatermarkModel struct {
-	AccountID      types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID      types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Identifier     types.String      `tfsdk:"identifier" path:"identifier,optional"`
 	URL            types.String      `tfsdk:"url" json:"url,optional,no_refresh"`
 	Name           types.String      `tfsdk:"name" json:"name,computed_optional"`

--- a/internal/services/stream_watermark/schema.go
+++ b/internal/services/stream_watermark/schema.go
@@ -32,7 +32,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The account identifier tag.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"identifier": schema.StringAttribute{

--- a/internal/services/stream_webhook/model.go
+++ b/internal/services/stream_webhook/model.go
@@ -13,7 +13,7 @@ type StreamWebhookResultEnvelope struct {
 }
 
 type StreamWebhookModel struct {
-	AccountID       types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID       types.String      `tfsdk:"account_id" path:"account_id,required"`
 	NotificationURL types.String      `tfsdk:"notification_url" json:"notificationUrl,optional"`
 	Modified        timetypes.RFC3339 `tfsdk:"modified" json:"modified,computed" format:"date-time"`
 	Secret          types.String      `tfsdk:"secret" json:"secret,computed"`

--- a/internal/services/stream_webhook/schema.go
+++ b/internal/services/stream_webhook/schema.go
@@ -27,7 +27,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
 				Description:   "The account identifier tag.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"notification_url": schema.StringAttribute{

--- a/internal/services/token_validation_config/model.go
+++ b/internal/services/token_validation_config/model.go
@@ -14,7 +14,7 @@ type TokenValidationConfigResultEnvelope struct {
 
 type TokenValidationConfigModel struct {
 	ID           types.String                           `tfsdk:"id" json:"id,computed"`
-	ZoneID       types.String                           `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID       types.String                           `tfsdk:"zone_id" path:"zone_id,required"`
 	TokenType    types.String                           `tfsdk:"token_type" json:"token_type,required"`
 	Credentials  *TokenValidationConfigCredentialsModel `tfsdk:"credentials" json:"credentials,required"`
 	Description  types.String                           `tfsdk:"description" json:"description,required"`

--- a/internal/services/token_validation_config/schema.go
+++ b/internal/services/token_validation_config/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"token_type": schema.StringAttribute{

--- a/internal/services/token_validation_rules/model.go
+++ b/internal/services/token_validation_rules/model.go
@@ -14,7 +14,7 @@ type TokenValidationRulesResultEnvelope struct {
 
 type TokenValidationRulesModel struct {
 	ID          types.String                       `tfsdk:"id" json:"id,computed"`
-	ZoneID      types.String                       `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID      types.String                       `tfsdk:"zone_id" path:"zone_id,required"`
 	Action      types.String                       `tfsdk:"action" json:"action,required"`
 	Description types.String                       `tfsdk:"description" json:"description,required"`
 	Enabled     types.Bool                         `tfsdk:"enabled" json:"enabled,required"`

--- a/internal/services/token_validation_rules/schema.go
+++ b/internal/services/token_validation_rules/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"action": schema.StringAttribute{

--- a/internal/services/turnstile_widget/model.go
+++ b/internal/services/turnstile_widget/model.go
@@ -15,7 +15,7 @@ type TurnstileWidgetResultEnvelope struct {
 type TurnstileWidgetModel struct {
 	ID             types.String      `tfsdk:"id" json:"-,computed"`
 	Sitekey        types.String      `tfsdk:"sitekey" json:"sitekey,computed"`
-	AccountID      types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID      types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Mode           types.String      `tfsdk:"mode" json:"mode,required"`
 	Name           types.String      `tfsdk:"name" json:"name,required"`
 	Domains        *[]types.String   `tfsdk:"domains" json:"domains,required"`

--- a/internal/services/turnstile_widget/schema.go
+++ b/internal/services/turnstile_widget/schema.go
@@ -43,7 +43,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"mode": schema.StringAttribute{

--- a/internal/services/user_agent_blocking_rule/model.go
+++ b/internal/services/user_agent_blocking_rule/model.go
@@ -13,7 +13,7 @@ type UserAgentBlockingRuleResultEnvelope struct {
 
 type UserAgentBlockingRuleModel struct {
 	ID            types.String                             `tfsdk:"id" json:"id,computed"`
-	ZoneID        types.String                             `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID        types.String                             `tfsdk:"zone_id" path:"zone_id,required"`
 	Mode          types.String                             `tfsdk:"mode" json:"mode,required"`
 	Configuration *UserAgentBlockingRuleConfigurationModel `tfsdk:"configuration" json:"configuration,required"`
 	Description   types.String                             `tfsdk:"description" json:"description,optional"`

--- a/internal/services/user_agent_blocking_rule/schema.go
+++ b/internal/services/user_agent_blocking_rule/schema.go
@@ -34,7 +34,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Defines an identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"mode": schema.StringAttribute{

--- a/internal/services/vulnerability_scanner_credential/model.go
+++ b/internal/services/vulnerability_scanner_credential/model.go
@@ -13,7 +13,7 @@ type VulnerabilityScannerCredentialResultEnvelope struct {
 
 type VulnerabilityScannerCredentialModel struct {
 	ID              types.String `tfsdk:"id" json:"id,computed"`
-	AccountID       types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID       types.String `tfsdk:"account_id" path:"account_id,required"`
 	CredentialSetID types.String `tfsdk:"credential_set_id" path:"credential_set_id,required"`
 	Location        types.String `tfsdk:"location" json:"location,required"`
 	LocationName    types.String `tfsdk:"location_name" json:"location_name,required"`

--- a/internal/services/vulnerability_scanner_credential/schema.go
+++ b/internal/services/vulnerability_scanner_credential/schema.go
@@ -26,7 +26,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"credential_set_id": schema.StringAttribute{

--- a/internal/services/vulnerability_scanner_credential_set/model.go
+++ b/internal/services/vulnerability_scanner_credential_set/model.go
@@ -13,7 +13,7 @@ type VulnerabilityScannerCredentialSetResultEnvelope struct {
 
 type VulnerabilityScannerCredentialSetModel struct {
 	ID        types.String `tfsdk:"id" json:"id,computed"`
-	AccountID types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String `tfsdk:"account_id" path:"account_id,required"`
 	Name      types.String `tfsdk:"name" json:"name,required"`
 }
 

--- a/internal/services/vulnerability_scanner_credential_set/schema.go
+++ b/internal/services/vulnerability_scanner_credential_set/schema.go
@@ -24,7 +24,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/vulnerability_scanner_target_environment/model.go
+++ b/internal/services/vulnerability_scanner_target_environment/model.go
@@ -13,7 +13,7 @@ type VulnerabilityScannerTargetEnvironmentResultEnvelope struct {
 
 type VulnerabilityScannerTargetEnvironmentModel struct {
 	ID          types.String                                      `tfsdk:"id" json:"id,computed"`
-	AccountID   types.String                                      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String                                      `tfsdk:"account_id" path:"account_id,required"`
 	Name        types.String                                      `tfsdk:"name" json:"name,required"`
 	Target      *VulnerabilityScannerTargetEnvironmentTargetModel `tfsdk:"target" json:"target,required"`
 	Description types.String                                      `tfsdk:"description" json:"description,optional"`

--- a/internal/services/vulnerability_scanner_target_environment/schema.go
+++ b/internal/services/vulnerability_scanner_target_environment/schema.go
@@ -26,7 +26,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/waiting_room/model.go
+++ b/internal/services/waiting_room/model.go
@@ -15,7 +15,7 @@ type WaitingRoomResultEnvelope struct {
 
 type WaitingRoomModel struct {
 	ID                         types.String                                                   `tfsdk:"id" json:"id,computed"`
-	ZoneID                     types.String                                                   `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID                     types.String                                                   `tfsdk:"zone_id" path:"zone_id,required"`
 	Host                       types.String                                                   `tfsdk:"host" json:"host,required"`
 	Name                       types.String                                                   `tfsdk:"name" json:"name,required"`
 	NewUsersPerMinute          types.Int64                                                    `tfsdk:"new_users_per_minute" json:"new_users_per_minute,required"`

--- a/internal/services/waiting_room/schema.go
+++ b/internal/services/waiting_room/schema.go
@@ -40,7 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"host": schema.StringAttribute{

--- a/internal/services/waiting_room_event/model.go
+++ b/internal/services/waiting_room_event/model.go
@@ -15,7 +15,7 @@ type WaitingRoomEventResultEnvelope struct {
 type WaitingRoomEventModel struct {
 	ID                    types.String      `tfsdk:"id" json:"id,computed"`
 	WaitingRoomID         types.String      `tfsdk:"waiting_room_id" path:"waiting_room_id,required"`
-	ZoneID                types.String      `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID                types.String      `tfsdk:"zone_id" path:"zone_id,required"`
 	EventEndTime          types.String      `tfsdk:"event_end_time" json:"event_end_time,required"`
 	EventStartTime        types.String      `tfsdk:"event_start_time" json:"event_start_time,required"`
 	Name                  types.String      `tfsdk:"name" json:"name,required"`

--- a/internal/services/waiting_room_event/schema.go
+++ b/internal/services/waiting_room_event/schema.go
@@ -40,7 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"event_end_time": schema.StringAttribute{

--- a/internal/services/waiting_room_rules/model.go
+++ b/internal/services/waiting_room_rules/model.go
@@ -14,7 +14,7 @@ type WaitingRoomRulesResultEnvelope struct {
 type WaitingRoomRulesModel struct {
 	ID            types.String                   `tfsdk:"id" json:"id,computed"`
 	WaitingRoomID types.String                   `tfsdk:"waiting_room_id" path:"waiting_room_id,required"`
-	ZoneID        types.String                   `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID        types.String                   `tfsdk:"zone_id" path:"zone_id,required"`
 	Rules         *[]*WaitingRoomRulesRulesModel `tfsdk:"rules" json:"rules,required"`
 }
 

--- a/internal/services/waiting_room_rules/schema.go
+++ b/internal/services/waiting_room_rules/schema.go
@@ -39,7 +39,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"rules": schema.ListNestedAttribute{

--- a/internal/services/web3_hostname/model.go
+++ b/internal/services/web3_hostname/model.go
@@ -14,7 +14,7 @@ type Web3HostnameResultEnvelope struct {
 
 type Web3HostnameModel struct {
 	ID          types.String      `tfsdk:"id" json:"id,computed"`
-	ZoneID      types.String      `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID      types.String      `tfsdk:"zone_id" path:"zone_id,required"`
 	Name        types.String      `tfsdk:"name" json:"name,required"`
 	Target      types.String      `tfsdk:"target" json:"target,required"`
 	Description types.String      `tfsdk:"description" json:"description,optional"`

--- a/internal/services/web3_hostname/schema.go
+++ b/internal/services/web3_hostname/schema.go
@@ -34,7 +34,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Specify the identifier of the hostname.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/web_analytics_rule/model.go
+++ b/internal/services/web_analytics_rule/model.go
@@ -14,7 +14,7 @@ type WebAnalyticsRuleResultEnvelope struct {
 
 type WebAnalyticsRuleModel struct {
 	ID        types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String      `tfsdk:"account_id" path:"account_id,required"`
 	RulesetID types.String      `tfsdk:"ruleset_id" path:"ruleset_id,required"`
 	Host      types.String      `tfsdk:"host" json:"host,optional"`
 	Inclusive types.Bool        `tfsdk:"inclusive" json:"inclusive,optional"`

--- a/internal/services/web_analytics_rule/schema.go
+++ b/internal/services/web_analytics_rule/schema.go
@@ -26,7 +26,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"ruleset_id": schema.StringAttribute{

--- a/internal/services/web_analytics_site/model.go
+++ b/internal/services/web_analytics_site/model.go
@@ -16,7 +16,7 @@ type WebAnalyticsSiteResultEnvelope struct {
 type WebAnalyticsSiteModel struct {
 	ID          types.String                                             `tfsdk:"id" json:"-,computed"`
 	SiteTag     types.String                                             `tfsdk:"site_tag" json:"site_tag,computed"`
-	AccountID   types.String                                             `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String                                             `tfsdk:"account_id" path:"account_id,required"`
 	AutoInstall types.Bool                                               `tfsdk:"auto_install" json:"auto_install,optional"`
 	Enabled     types.Bool                                               `tfsdk:"enabled" json:"enabled,optional,no_refresh"`
 	Host        types.String                                             `tfsdk:"host" json:"host,optional,no_refresh"`

--- a/internal/services/web_analytics_site/schema.go
+++ b/internal/services/web_analytics_site/schema.go
@@ -39,7 +39,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"auto_install": schema.BoolAttribute{

--- a/internal/services/worker/model.go
+++ b/internal/services/worker/model.go
@@ -15,7 +15,7 @@ type WorkerResultEnvelope struct {
 
 type WorkerModel struct {
 	ID            types.String                                          `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String                                          `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String                                          `tfsdk:"account_id" path:"account_id,required"`
 	Name          types.String                                          `tfsdk:"name" json:"name,required"`
 	Logpush       types.Bool                                            `tfsdk:"logpush" json:"logpush,computed_optional"`
 	Tags          customfield.Set[types.String]                         `tfsdk:"tags" json:"tags,computed_optional"`

--- a/internal/services/worker/schema.go
+++ b/internal/services/worker/schema.go
@@ -45,7 +45,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/worker_version/model.go
+++ b/internal/services/worker_version/model.go
@@ -16,7 +16,7 @@ type WorkerVersionResultEnvelope struct {
 
 type WorkerVersionModel struct {
 	ID                 types.String                                             `tfsdk:"id" json:"id,computed"`
-	AccountID          types.String                                             `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID          types.String                                             `tfsdk:"account_id" path:"account_id,required"`
 	WorkerID           types.String                                             `tfsdk:"worker_id" path:"worker_id,required"`
 	CompatibilityDate  types.String                                             `tfsdk:"compatibility_date" json:"compatibility_date,optional"`
 	MainModule         types.String                                             `tfsdk:"main_module" json:"main_module,optional"`

--- a/internal/services/worker_version/schema.go
+++ b/internal/services/worker_version/schema.go
@@ -42,7 +42,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"worker_id": schema.StringAttribute{

--- a/internal/services/workers_cron_trigger/model.go
+++ b/internal/services/workers_cron_trigger/model.go
@@ -14,7 +14,7 @@ type WorkersCronTriggerResultEnvelope struct {
 type WorkersCronTriggerModel struct {
 	ID         types.String                         `tfsdk:"id" json:"-,computed"`
 	ScriptName types.String                         `tfsdk:"script_name" path:"script_name,required"`
-	AccountID  types.String                         `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID  types.String                         `tfsdk:"account_id" path:"account_id,required"`
 	Schedules  *[]*WorkersCronTriggerSchedulesModel `tfsdk:"schedules" json:"schedules,required,no_refresh"`
 }
 

--- a/internal/services/workers_cron_trigger/schema.go
+++ b/internal/services/workers_cron_trigger/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"schedules": schema.ListNestedAttribute{

--- a/internal/services/workers_custom_domain/model.go
+++ b/internal/services/workers_custom_domain/model.go
@@ -13,7 +13,7 @@ type WorkersCustomDomainResultEnvelope struct {
 
 type WorkersCustomDomainModel struct {
 	ID          types.String `tfsdk:"id" json:"id,computed"`
-	AccountID   types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String `tfsdk:"account_id" path:"account_id,required"`
 	Hostname    types.String `tfsdk:"hostname" json:"hostname,required"`
 	Service     types.String `tfsdk:"service" json:"service,required"`
 	Environment types.String `tfsdk:"environment" json:"environment,computed_optional"`

--- a/internal/services/workers_custom_domain/schema.go
+++ b/internal/services/workers_custom_domain/schema.go
@@ -31,7 +31,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"hostname": schema.StringAttribute{

--- a/internal/services/workers_deployment/model.go
+++ b/internal/services/workers_deployment/model.go
@@ -15,7 +15,7 @@ type WorkersDeploymentResultEnvelope struct {
 
 type WorkersDeploymentModel struct {
 	ID          types.String                                                `tfsdk:"id" json:"id,computed"`
-	AccountID   types.String                                                `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String                                                `tfsdk:"account_id" path:"account_id,required"`
 	ScriptName  types.String                                                `tfsdk:"script_name" path:"script_name,required"`
 	Strategy    types.String                                                `tfsdk:"strategy" json:"strategy,required"`
 	Versions    *[]*WorkersDeploymentVersionsModel                          `tfsdk:"versions" json:"versions,required"`

--- a/internal/services/workers_deployment/schema.go
+++ b/internal/services/workers_deployment/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"script_name": schema.StringAttribute{

--- a/internal/services/workers_for_platforms_dispatch_namespace/model.go
+++ b/internal/services/workers_for_platforms_dispatch_namespace/model.go
@@ -15,7 +15,7 @@ type WorkersForPlatformsDispatchNamespaceResultEnvelope struct {
 type WorkersForPlatformsDispatchNamespaceModel struct {
 	ID             types.String      `tfsdk:"id" json:"-,computed"`
 	NamespaceName  types.String      `tfsdk:"namespace_name" json:"namespace_name,computed"`
-	AccountID      types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID      types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Name           types.String      `tfsdk:"name" json:"name,optional,no_refresh"`
 	CreatedBy      types.String      `tfsdk:"created_by" json:"created_by,computed"`
 	CreatedOn      timetypes.RFC3339 `tfsdk:"created_on" json:"created_on,computed" format:"date-time"`

--- a/internal/services/workers_for_platforms_dispatch_namespace/schema.go
+++ b/internal/services/workers_for_platforms_dispatch_namespace/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/workers_kv/model.go
+++ b/internal/services/workers_kv/model.go
@@ -18,7 +18,7 @@ type WorkersKVResultEnvelope struct {
 type WorkersKVModel struct {
 	ID          types.String         `tfsdk:"id" json:"-,computed"`
 	KeyName     types.String         `tfsdk:"key_name" path:"key_name,required"`
-	AccountID   types.String         `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String         `tfsdk:"account_id" path:"account_id,required"`
 	NamespaceID types.String         `tfsdk:"namespace_id" path:"namespace_id,required"`
 	Value       types.String         `tfsdk:"value" json:"value,required,no_refresh"`
 	Metadata    jsontypes.Normalized `tfsdk:"metadata" json:"metadata,optional,no_refresh"`

--- a/internal/services/workers_kv/schema.go
+++ b/internal/services/workers_kv/schema.go
@@ -37,7 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"namespace_id": schema.StringAttribute{

--- a/internal/services/workers_kv_namespace/model.go
+++ b/internal/services/workers_kv_namespace/model.go
@@ -13,7 +13,7 @@ type WorkersKVNamespaceResultEnvelope struct {
 
 type WorkersKVNamespaceModel struct {
 	ID                  types.String `tfsdk:"id" json:"id,computed"`
-	AccountID           types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID           types.String `tfsdk:"account_id" path:"account_id,required"`
 	Title               types.String `tfsdk:"title" json:"title,required"`
 	SupportsURLEncoding types.Bool   `tfsdk:"supports_url_encoding" json:"supports_url_encoding,computed"`
 }

--- a/internal/services/workers_kv_namespace/schema.go
+++ b/internal/services/workers_kv_namespace/schema.go
@@ -31,7 +31,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"title": schema.StringAttribute{

--- a/internal/services/workers_route/model.go
+++ b/internal/services/workers_route/model.go
@@ -13,7 +13,7 @@ type WorkersRouteResultEnvelope struct {
 
 type WorkersRouteModel struct {
 	ID      types.String `tfsdk:"id" json:"id,computed"`
-	ZoneID  types.String `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID  types.String `tfsdk:"zone_id" path:"zone_id,required"`
 	Pattern types.String `tfsdk:"pattern" json:"pattern,required"`
 	Script  types.String `tfsdk:"script" json:"script,optional"`
 }

--- a/internal/services/workers_route/schema.go
+++ b/internal/services/workers_route/schema.go
@@ -32,7 +32,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"pattern": schema.StringAttribute{

--- a/internal/services/workers_script/model.go
+++ b/internal/services/workers_script/model.go
@@ -37,7 +37,7 @@ type WorkersEnvironmentModel struct {
 type WorkersScriptModel struct {
 	ID               types.String                                                  `tfsdk:"id" json:"-,computed"`
 	ScriptName       types.String                                                  `tfsdk:"script_name" path:"script_name,required"`
-	AccountID        types.String                                                  `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID        types.String                                                  `tfsdk:"account_id" path:"account_id,required"`
 	Content          types.String                                                  `tfsdk:"content" json:"-"`
 	ContentFile      types.String                                                  `tfsdk:"content_file" json:"-"`
 	ContentSHA256    types.String                                                  `tfsdk:"content_sha256" json:"-"`

--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -48,7 +48,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"content": schema.StringAttribute{

--- a/internal/services/workers_script_subdomain/model.go
+++ b/internal/services/workers_script_subdomain/model.go
@@ -13,7 +13,7 @@ type WorkersScriptSubdomainResultEnvelope struct {
 
 type WorkersScriptSubdomainModel struct {
 	ID              types.String `tfsdk:"id" json:"-,computed"`
-	AccountID       types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID       types.String `tfsdk:"account_id" path:"account_id,required"`
 	ScriptName      types.String `tfsdk:"script_name" path:"script_name,required"`
 	Enabled         types.Bool   `tfsdk:"enabled" json:"enabled,required"`
 	PreviewsEnabled types.Bool   `tfsdk:"previews_enabled" json:"previews_enabled,computed_optional"`

--- a/internal/services/workers_script_subdomain/schema.go
+++ b/internal/services/workers_script_subdomain/schema.go
@@ -32,7 +32,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"script_name": schema.StringAttribute{

--- a/internal/services/workflow/model.go
+++ b/internal/services/workflow/model.go
@@ -16,7 +16,7 @@ type WorkflowResultEnvelope struct {
 type WorkflowModel struct {
 	ID                types.String                                     `tfsdk:"id" json:"-,computed"`
 	Name              types.String                                     `tfsdk:"name" json:"name,computed"`
-	AccountID         types.String                                     `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID         types.String                                     `tfsdk:"account_id" path:"account_id,required"`
 	WorkflowName      types.String                                     `tfsdk:"workflow_name" path:"workflow_name,required"`
 	ClassName         types.String                                     `tfsdk:"class_name" json:"class_name,required"`
 	ScriptName        types.String                                     `tfsdk:"script_name" json:"script_name,required"`

--- a/internal/services/workflow/schema.go
+++ b/internal/services/workflow/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"workflow_name": schema.StringAttribute{

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/model.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/model.go
@@ -15,7 +15,7 @@ type ZeroTrustAccessAIControlsMcpPortalResultEnvelope struct {
 
 type ZeroTrustAccessAIControlsMcpPortalModel struct {
 	ID               types.String                                                                 `tfsdk:"id" json:"id,required"`
-	AccountID        types.String                                                                 `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID        types.String                                                                 `tfsdk:"account_id" path:"account_id,required"`
 	Hostname         types.String                                                                 `tfsdk:"hostname" json:"hostname,required"`
 	Name             types.String                                                                 `tfsdk:"name" json:"name,required"`
 	Description      types.String                                                                 `tfsdk:"description" json:"description,optional"`

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/schema.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/schema.go
@@ -33,7 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown(), stringplanmodifier.RequiresReplace()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"hostname": schema.StringAttribute{

--- a/internal/services/zero_trust_access_ai_controls_mcp_server/model.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_server/model.go
@@ -16,7 +16,7 @@ type ZeroTrustAccessAIControlsMcpServerResultEnvelope struct {
 
 type ZeroTrustAccessAIControlsMcpServerModel struct {
 	ID                           types.String                                                                  `tfsdk:"id" json:"id,required"`
-	AccountID                    types.String                                                                  `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID                    types.String                                                                  `tfsdk:"account_id" path:"account_id,required"`
 	AuthType                     types.String                                                                  `tfsdk:"auth_type" json:"auth_type,required"`
 	Hostname                     types.String                                                                  `tfsdk:"hostname" json:"hostname,required"`
 	Name                         types.String                                                                  `tfsdk:"name" json:"name,required"`

--- a/internal/services/zero_trust_access_ai_controls_mcp_server/schema.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_server/schema.go
@@ -37,7 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown(), stringplanmodifier.RequiresReplace()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"auth_type": schema.StringAttribute{

--- a/internal/services/zero_trust_access_custom_page/model.go
+++ b/internal/services/zero_trust_access_custom_page/model.go
@@ -15,7 +15,7 @@ type ZeroTrustAccessCustomPageResultEnvelope struct {
 type ZeroTrustAccessCustomPageModel struct {
 	ID         types.String `tfsdk:"id" json:"-,computed"`
 	UID        types.String `tfsdk:"uid" json:"uid,computed"`
-	AccountID  types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID  types.String `tfsdk:"account_id" path:"account_id,required"`
 	CustomHTML types.String `tfsdk:"custom_html" json:"custom_html,required"`
 	Name       types.String `tfsdk:"name" json:"name,required"`
 	Type       types.String `tfsdk:"type" json:"type,required"`

--- a/internal/services/zero_trust_access_custom_page/schema.go
+++ b/internal/services/zero_trust_access_custom_page/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"custom_html": schema.StringAttribute{

--- a/internal/services/zero_trust_access_infrastructure_target/model.go
+++ b/internal/services/zero_trust_access_infrastructure_target/model.go
@@ -14,7 +14,7 @@ type ZeroTrustAccessInfrastructureTargetResultEnvelope struct {
 
 type ZeroTrustAccessInfrastructureTargetModel struct {
 	ID         types.String                                `tfsdk:"id" json:"id,computed"`
-	AccountID  types.String                                `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID  types.String                                `tfsdk:"account_id" path:"account_id,required"`
 	Hostname   types.String                                `tfsdk:"hostname" json:"hostname,required"`
 	IP         *ZeroTrustAccessInfrastructureTargetIPModel `tfsdk:"ip" json:"ip,required"`
 	CreatedAt  timetypes.RFC3339                           `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`

--- a/internal/services/zero_trust_access_infrastructure_target/schema.go
+++ b/internal/services/zero_trust_access_infrastructure_target/schema.go
@@ -25,7 +25,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Account identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"hostname": schema.StringAttribute{

--- a/internal/services/zero_trust_access_policy/model.go
+++ b/internal/services/zero_trust_access_policy/model.go
@@ -14,7 +14,7 @@ type ZeroTrustAccessPolicyResultEnvelope struct {
 
 type ZeroTrustAccessPolicyModel struct {
 	ID                           types.String                                                   `tfsdk:"id" json:"id,computed"`
-	AccountID                    types.String                                                   `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID                    types.String                                                   `tfsdk:"account_id" path:"account_id,required"`
 	Decision                     types.String                                                   `tfsdk:"decision" json:"decision,required"`
 	Name                         types.String                                                   `tfsdk:"name" json:"name,required"`
 	ApprovalRequired             types.Bool                                                     `tfsdk:"approval_required" json:"approval_required,optional"`

--- a/internal/services/zero_trust_access_policy/schema.go
+++ b/internal/services/zero_trust_access_policy/schema.go
@@ -40,7 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"decision": schema.StringAttribute{

--- a/internal/services/zero_trust_access_tag/model.go
+++ b/internal/services/zero_trust_access_tag/model.go
@@ -14,7 +14,7 @@ type ZeroTrustAccessTagResultEnvelope struct {
 type ZeroTrustAccessTagModel struct {
 	ID        types.String `tfsdk:"id" json:"-,computed"`
 	Name      types.String `tfsdk:"name" json:"name,required"`
-	AccountID types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String `tfsdk:"account_id" path:"account_id,required"`
 }
 
 func (m ZeroTrustAccessTagModel) MarshalJSON() (data []byte, err error) {

--- a/internal/services/zero_trust_access_tag/schema.go
+++ b/internal/services/zero_trust_access_tag/schema.go
@@ -29,7 +29,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 		},

--- a/internal/services/zero_trust_device_custom_profile/model.go
+++ b/internal/services/zero_trust_device_custom_profile/model.go
@@ -15,7 +15,7 @@ type ZeroTrustDeviceCustomProfileResultEnvelope struct {
 type ZeroTrustDeviceCustomProfileModel struct {
 	ID                         types.String                                                                     `tfsdk:"id" json:"-,computed"`
 	PolicyID                   types.String                                                                     `tfsdk:"policy_id" json:"policy_id,computed"`
-	AccountID                  types.String                                                                     `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID                  types.String                                                                     `tfsdk:"account_id" path:"account_id,required"`
 	Match                      types.String                                                                     `tfsdk:"match" json:"match,required"`
 	Name                       types.String                                                                     `tfsdk:"name" json:"name,required"`
 	Precedence                 types.Float64                                                                    `tfsdk:"precedence" json:"precedence,computed_optional"`

--- a/internal/services/zero_trust_device_custom_profile/schema.go
+++ b/internal/services/zero_trust_device_custom_profile/schema.go
@@ -43,7 +43,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"match": schema.StringAttribute{

--- a/internal/services/zero_trust_device_custom_profile_local_domain_fallback/model.go
+++ b/internal/services/zero_trust_device_custom_profile_local_domain_fallback/model.go
@@ -14,7 +14,7 @@ type ZeroTrustDeviceCustomProfileLocalDomainFallbackResultEnvelope struct {
 type ZeroTrustDeviceCustomProfileLocalDomainFallbackModel struct {
 	ID        types.String                                                    `tfsdk:"id" json:"-,computed"`
 	PolicyID  types.String                                                    `tfsdk:"policy_id" path:"policy_id,required"`
-	AccountID types.String                                                    `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String                                                    `tfsdk:"account_id" path:"account_id,required"`
 	Domains   *[]*ZeroTrustDeviceCustomProfileLocalDomainFallbackDomainsModel `tfsdk:"domains" json:"domains,required"`
 }
 

--- a/internal/services/zero_trust_device_custom_profile_local_domain_fallback/schema.go
+++ b/internal/services/zero_trust_device_custom_profile_local_domain_fallback/schema.go
@@ -33,7 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown(), stringplanmodifier.RequiresReplace()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"domains": schema.SetNestedAttribute{

--- a/internal/services/zero_trust_device_default_profile_certificates/model.go
+++ b/internal/services/zero_trust_device_default_profile_certificates/model.go
@@ -12,7 +12,7 @@ type ZeroTrustDeviceDefaultProfileCertificatesResultEnvelope struct {
 }
 
 type ZeroTrustDeviceDefaultProfileCertificatesModel struct {
-	ZoneID  types.String `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID  types.String `tfsdk:"zone_id" path:"zone_id,required"`
 	Enabled types.Bool   `tfsdk:"enabled" json:"enabled,required"`
 }
 

--- a/internal/services/zero_trust_device_default_profile_certificates/schema.go
+++ b/internal/services/zero_trust_device_default_profile_certificates/schema.go
@@ -25,7 +25,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		}.String(),
 		Attributes: map[string]schema.Attribute{
 			"zone_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"enabled": schema.BoolAttribute{

--- a/internal/services/zero_trust_device_ip_profile/model.go
+++ b/internal/services/zero_trust_device_ip_profile/model.go
@@ -13,7 +13,7 @@ type ZeroTrustDeviceIPProfileResultEnvelope struct {
 
 type ZeroTrustDeviceIPProfileModel struct {
 	ID          types.String `tfsdk:"id" json:"id,computed"`
-	AccountID   types.String `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String `tfsdk:"account_id" path:"account_id,required"`
 	Match       types.String `tfsdk:"match" json:"match,required"`
 	Name        types.String `tfsdk:"name" json:"name,required"`
 	Precedence  types.Int64  `tfsdk:"precedence" json:"precedence,required"`

--- a/internal/services/zero_trust_device_ip_profile/schema.go
+++ b/internal/services/zero_trust_device_ip_profile/schema.go
@@ -31,7 +31,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"match": schema.StringAttribute{

--- a/internal/services/zero_trust_device_managed_networks/model.go
+++ b/internal/services/zero_trust_device_managed_networks/model.go
@@ -14,7 +14,7 @@ type ZeroTrustDeviceManagedNetworksResultEnvelope struct {
 type ZeroTrustDeviceManagedNetworksModel struct {
 	ID        types.String                               `tfsdk:"id" json:"-,computed"`
 	NetworkID types.String                               `tfsdk:"network_id" json:"network_id,computed"`
-	AccountID types.String                               `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String                               `tfsdk:"account_id" path:"account_id,required"`
 	Name      types.String                               `tfsdk:"name" json:"name,required"`
 	Type      types.String                               `tfsdk:"type" json:"type,required"`
 	Config    *ZeroTrustDeviceManagedNetworksConfigModel `tfsdk:"config" json:"config,required"`

--- a/internal/services/zero_trust_device_managed_networks/schema.go
+++ b/internal/services/zero_trust_device_managed_networks/schema.go
@@ -37,7 +37,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/zero_trust_device_posture_integration/model.go
+++ b/internal/services/zero_trust_device_posture_integration/model.go
@@ -13,7 +13,7 @@ type ZeroTrustDevicePostureIntegrationResultEnvelope struct {
 
 type ZeroTrustDevicePostureIntegrationModel struct {
 	ID        types.String                                  `tfsdk:"id" json:"id,computed"`
-	AccountID types.String                                  `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String                                  `tfsdk:"account_id" path:"account_id,required"`
 	Interval  types.String                                  `tfsdk:"interval" json:"interval,required"`
 	Name      types.String                                  `tfsdk:"name" json:"name,required"`
 	Type      types.String                                  `tfsdk:"type" json:"type,required"`

--- a/internal/services/zero_trust_device_posture_integration/schema.go
+++ b/internal/services/zero_trust_device_posture_integration/schema.go
@@ -31,7 +31,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"interval": schema.StringAttribute{

--- a/internal/services/zero_trust_device_posture_rule/model.go
+++ b/internal/services/zero_trust_device_posture_rule/model.go
@@ -13,7 +13,7 @@ type ZeroTrustDevicePostureRuleResultEnvelope struct {
 
 type ZeroTrustDevicePostureRuleModel struct {
 	ID          types.String                             `tfsdk:"id" json:"id,computed"`
-	AccountID   types.String                             `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String                             `tfsdk:"account_id" path:"account_id,required"`
 	Name        types.String                             `tfsdk:"name" json:"name,optional"`
 	Type        types.String                             `tfsdk:"type" json:"type,required"`
 	Description types.String                             `tfsdk:"description" json:"description,computed_optional"`

--- a/internal/services/zero_trust_device_posture_rule/schema.go
+++ b/internal/services/zero_trust_device_posture_rule/schema.go
@@ -33,7 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/zero_trust_device_settings/model.go
+++ b/internal/services/zero_trust_device_settings/model.go
@@ -12,7 +12,7 @@ type ZeroTrustDeviceSettingsResultEnvelope struct {
 }
 
 type ZeroTrustDeviceSettingsModel struct {
-	AccountID                          types.String  `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID                          types.String  `tfsdk:"account_id" path:"account_id,required"`
 	DisableForTime                     types.Float64 `tfsdk:"disable_for_time" json:"disable_for_time,optional"`
 	ExternalEmergencySignalEnabled     types.Bool    `tfsdk:"external_emergency_signal_enabled" json:"external_emergency_signal_enabled,optional"`
 	ExternalEmergencySignalFingerprint types.String  `tfsdk:"external_emergency_signal_fingerprint" json:"external_emergency_signal_fingerprint,optional"`

--- a/internal/services/zero_trust_device_settings/schema.go
+++ b/internal/services/zero_trust_device_settings/schema.go
@@ -24,7 +24,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		}.String(),
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"disable_for_time": schema.Float64Attribute{

--- a/internal/services/zero_trust_device_subnet/model.go
+++ b/internal/services/zero_trust_device_subnet/model.go
@@ -14,7 +14,7 @@ type ZeroTrustDeviceSubnetResultEnvelope struct {
 
 type ZeroTrustDeviceSubnetModel struct {
 	ID               types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID        types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID        types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Name             types.String      `tfsdk:"name" json:"name,required"`
 	Network          types.String      `tfsdk:"network" json:"network,required"`
 	Comment          types.String      `tfsdk:"comment" json:"comment,computed_optional"`

--- a/internal/services/zero_trust_device_subnet/schema.go
+++ b/internal/services/zero_trust_device_subnet/schema.go
@@ -36,7 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Cloudflare account ID",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/zero_trust_dex_rule/model.go
+++ b/internal/services/zero_trust_dex_rule/model.go
@@ -14,7 +14,7 @@ type ZeroTrustDEXRuleResultEnvelope struct {
 
 type ZeroTrustDEXRuleModel struct {
 	ID            types.String                                                     `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String                                                     `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String                                                     `tfsdk:"account_id" path:"account_id,required"`
 	Match         types.String                                                     `tfsdk:"match" json:"match,required"`
 	Name          types.String                                                     `tfsdk:"name" json:"name,required"`
 	Description   types.String                                                     `tfsdk:"description" json:"description,optional"`

--- a/internal/services/zero_trust_dex_rule/schema.go
+++ b/internal/services/zero_trust_dex_rule/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"match": schema.StringAttribute{

--- a/internal/services/zero_trust_dex_test/model.go
+++ b/internal/services/zero_trust_dex_test/model.go
@@ -15,7 +15,7 @@ type ZeroTrustDEXTestResultEnvelope struct {
 type ZeroTrustDEXTestModel struct {
 	ID             types.String                                                      `tfsdk:"id" json:"-,computed"`
 	TestID         types.String                                                      `tfsdk:"test_id" json:"test_id,computed"`
-	AccountID      types.String                                                      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID      types.String                                                      `tfsdk:"account_id" path:"account_id,required"`
 	Enabled        types.Bool                                                        `tfsdk:"enabled" json:"enabled,required"`
 	Interval       types.String                                                      `tfsdk:"interval" json:"interval,required"`
 	Name           types.String                                                      `tfsdk:"name" json:"name,required"`

--- a/internal/services/zero_trust_dex_test/schema.go
+++ b/internal/services/zero_trust_dex_test/schema.go
@@ -41,7 +41,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"enabled": schema.BoolAttribute{

--- a/internal/services/zero_trust_dlp_custom_entry/model.go
+++ b/internal/services/zero_trust_dlp_custom_entry/model.go
@@ -16,7 +16,7 @@ type ZeroTrustDLPCustomEntryResultEnvelope struct {
 
 type ZeroTrustDLPCustomEntryModel struct {
 	ID            types.String                                                       `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String                                                       `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String                                                       `tfsdk:"account_id" path:"account_id,required"`
 	ProfileID     types.String                                                       `tfsdk:"profile_id" json:"profile_id,optional"`
 	Enabled       types.Bool                                                         `tfsdk:"enabled" json:"enabled,required"`
 	Name          types.String                                                       `tfsdk:"name" json:"name,required"`

--- a/internal/services/zero_trust_dlp_custom_entry/schema.go
+++ b/internal/services/zero_trust_dlp_custom_entry/schema.go
@@ -34,7 +34,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"profile_id": schema.StringAttribute{

--- a/internal/services/zero_trust_dlp_custom_profile/model.go
+++ b/internal/services/zero_trust_dlp_custom_profile/model.go
@@ -14,7 +14,7 @@ type ZeroTrustDLPCustomProfileResultEnvelope struct {
 
 type ZeroTrustDLPCustomProfileModel struct {
 	ID                  types.String                                        `tfsdk:"id" json:"id,computed"`
-	AccountID           types.String                                        `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID           types.String                                        `tfsdk:"account_id" path:"account_id,required"`
 	Name                types.String                                        `tfsdk:"name" json:"name,required"`
 	Description         types.String                                        `tfsdk:"description" json:"description,optional"`
 	DataClasses         *[]types.String                                     `tfsdk:"data_classes" json:"data_classes,optional"`

--- a/internal/services/zero_trust_dlp_custom_profile/schema.go
+++ b/internal/services/zero_trust_dlp_custom_profile/schema.go
@@ -40,7 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/zero_trust_dlp_dataset/model.go
+++ b/internal/services/zero_trust_dlp_dataset/model.go
@@ -14,7 +14,7 @@ type ZeroTrustDLPDatasetResultEnvelope struct {
 }
 
 type ZeroTrustDLPDatasetModel struct {
-	AccountID       types.String                                                  `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID       types.String                                                  `tfsdk:"account_id" path:"account_id,required"`
 	DatasetID       types.String                                                  `tfsdk:"dataset_id" path:"dataset_id,optional"`
 	EncodingVersion types.Int64                                                   `tfsdk:"encoding_version" json:"encoding_version,optional"`
 	Secret          types.Bool                                                    `tfsdk:"secret" json:"secret,optional"`

--- a/internal/services/zero_trust_dlp_dataset/schema.go
+++ b/internal/services/zero_trust_dlp_dataset/schema.go
@@ -32,7 +32,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		}.String(),
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"dataset_id": schema.StringAttribute{

--- a/internal/services/zero_trust_dlp_entry/model.go
+++ b/internal/services/zero_trust_dlp_entry/model.go
@@ -16,7 +16,7 @@ type ZeroTrustDLPEntryResultEnvelope struct {
 
 type ZeroTrustDLPEntryModel struct {
 	ID            types.String                                                 `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String                                                 `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String                                                 `tfsdk:"account_id" path:"account_id,required"`
 	ProfileID     types.String                                                 `tfsdk:"profile_id" json:"profile_id,optional"`
 	Enabled       types.Bool                                                   `tfsdk:"enabled" json:"enabled,required"`
 	Name          types.String                                                 `tfsdk:"name" json:"name,required"`

--- a/internal/services/zero_trust_dlp_entry/schema.go
+++ b/internal/services/zero_trust_dlp_entry/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"profile_id": schema.StringAttribute{

--- a/internal/services/zero_trust_dlp_integration_entry/model.go
+++ b/internal/services/zero_trust_dlp_integration_entry/model.go
@@ -16,7 +16,7 @@ type ZeroTrustDLPIntegrationEntryResultEnvelope struct {
 
 type ZeroTrustDLPIntegrationEntryModel struct {
 	ID            types.String                                                            `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String                                                            `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String                                                            `tfsdk:"account_id" path:"account_id,required"`
 	EntryID       types.String                                                            `tfsdk:"entry_id" json:"entry_id,required,no_refresh"`
 	ProfileID     types.String                                                            `tfsdk:"profile_id" json:"profile_id,optional"`
 	Enabled       types.Bool                                                              `tfsdk:"enabled" json:"enabled,required"`

--- a/internal/services/zero_trust_dlp_integration_entry/schema.go
+++ b/internal/services/zero_trust_dlp_integration_entry/schema.go
@@ -34,7 +34,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"entry_id": schema.StringAttribute{

--- a/internal/services/zero_trust_dlp_predefined_entry/model.go
+++ b/internal/services/zero_trust_dlp_predefined_entry/model.go
@@ -16,7 +16,7 @@ type ZeroTrustDLPPredefinedEntryResultEnvelope struct {
 
 type ZeroTrustDLPPredefinedEntryModel struct {
 	ID            types.String                                                           `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String                                                           `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String                                                           `tfsdk:"account_id" path:"account_id,required"`
 	EntryID       types.String                                                           `tfsdk:"entry_id" json:"entry_id,required,no_refresh"`
 	ProfileID     types.String                                                           `tfsdk:"profile_id" json:"profile_id,computed_optional"`
 	Enabled       types.Bool                                                             `tfsdk:"enabled" json:"enabled,required"`

--- a/internal/services/zero_trust_dlp_predefined_entry/schema.go
+++ b/internal/services/zero_trust_dlp_predefined_entry/schema.go
@@ -34,7 +34,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"entry_id": schema.StringAttribute{

--- a/internal/services/zero_trust_dlp_predefined_profile/model.go
+++ b/internal/services/zero_trust_dlp_predefined_profile/model.go
@@ -15,7 +15,7 @@ type ZeroTrustDLPPredefinedProfileResultEnvelope struct {
 type ZeroTrustDLPPredefinedProfileModel struct {
 	ID                  types.String                                                            `tfsdk:"id" json:"-,computed"`
 	ProfileID           types.String                                                            `tfsdk:"profile_id" path:"profile_id,required"`
-	AccountID           types.String                                                            `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID           types.String                                                            `tfsdk:"account_id" path:"account_id,required"`
 	EnabledEntries      *[]types.String                                                         `tfsdk:"enabled_entries" json:"enabled_entries,optional"`
 	AIContextEnabled    types.Bool                                                              `tfsdk:"ai_context_enabled" json:"ai_context_enabled,computed_optional"`
 	AllowedMatchCount   types.Int64                                                             `tfsdk:"allowed_match_count" json:"allowed_match_count,computed_optional"`

--- a/internal/services/zero_trust_dlp_predefined_profile/schema.go
+++ b/internal/services/zero_trust_dlp_predefined_profile/schema.go
@@ -40,7 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown(), stringplanmodifier.RequiresReplace()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"enabled_entries": schema.ListAttribute{

--- a/internal/services/zero_trust_dns_location/model.go
+++ b/internal/services/zero_trust_dns_location/model.go
@@ -15,7 +15,7 @@ type ZeroTrustDNSLocationResultEnvelope struct {
 
 type ZeroTrustDNSLocationModel struct {
 	ID                        types.String                                                    `tfsdk:"id" json:"id,computed"`
-	AccountID                 types.String                                                    `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID                 types.String                                                    `tfsdk:"account_id" path:"account_id,required"`
 	Name                      types.String                                                    `tfsdk:"name" json:"name,required"`
 	Endpoints                 *ZeroTrustDNSLocationEndpointsModel                             `tfsdk:"endpoints" json:"endpoints,optional"`
 	ClientDefault             types.Bool                                                      `tfsdk:"client_default" json:"client_default,computed_optional"`

--- a/internal/services/zero_trust_dns_location/schema.go
+++ b/internal/services/zero_trust_dns_location/schema.go
@@ -33,7 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{

--- a/internal/services/zero_trust_gateway_certificate/model.go
+++ b/internal/services/zero_trust_gateway_certificate/model.go
@@ -14,7 +14,7 @@ type ZeroTrustGatewayCertificateResultEnvelope struct {
 
 type ZeroTrustGatewayCertificateModel struct {
 	ID                 types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID          types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID          types.String      `tfsdk:"account_id" path:"account_id,required"`
 	ValidityPeriodDays types.Int64       `tfsdk:"validity_period_days" json:"validity_period_days,optional,no_refresh"`
 	Activate           types.Bool        `tfsdk:"activate" json:"activate,optional"`
 	BindingStatus      types.String      `tfsdk:"binding_status" json:"binding_status,computed"`

--- a/internal/services/zero_trust_gateway_certificate/schema.go
+++ b/internal/services/zero_trust_gateway_certificate/schema.go
@@ -28,7 +28,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown(), stringplanmodifier.RequiresReplace()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"validity_period_days": schema.Int64Attribute{

--- a/internal/services/zero_trust_gateway_pacfile/model.go
+++ b/internal/services/zero_trust_gateway_pacfile/model.go
@@ -14,7 +14,7 @@ type ZeroTrustGatewayPacfileResultEnvelope struct {
 
 type ZeroTrustGatewayPacfileModel struct {
 	ID          types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID   types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Slug        types.String      `tfsdk:"slug" json:"slug,optional"`
 	Contents    types.String      `tfsdk:"contents" json:"contents,required"`
 	Name        types.String      `tfsdk:"name" json:"name,required"`

--- a/internal/services/zero_trust_gateway_pacfile/schema.go
+++ b/internal/services/zero_trust_gateway_pacfile/schema.go
@@ -30,7 +30,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"slug": schema.StringAttribute{

--- a/internal/services/zero_trust_gateway_policy/model.go
+++ b/internal/services/zero_trust_gateway_policy/model.go
@@ -15,7 +15,7 @@ type ZeroTrustGatewayPolicyResultEnvelope struct {
 
 type ZeroTrustGatewayPolicyModel struct {
 	ID            types.String                                                      `tfsdk:"id" json:"id,computed"`
-	AccountID     types.String                                                      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID     types.String                                                      `tfsdk:"account_id" path:"account_id,required"`
 	Action        types.String                                                      `tfsdk:"action" json:"action,required"`
 	Name          types.String                                                      `tfsdk:"name" json:"name,required"`
 	Description   types.String                                                      `tfsdk:"description" json:"description,optional"`

--- a/internal/services/zero_trust_gateway_policy/schema.go
+++ b/internal/services/zero_trust_gateway_policy/schema.go
@@ -32,7 +32,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"action": schema.StringAttribute{

--- a/internal/services/zero_trust_gateway_proxy_endpoint/model.go
+++ b/internal/services/zero_trust_gateway_proxy_endpoint/model.go
@@ -14,7 +14,7 @@ type ZeroTrustGatewayProxyEndpointResultEnvelope struct {
 
 type ZeroTrustGatewayProxyEndpointModel struct {
 	ID        types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Kind      types.String      `tfsdk:"kind" json:"kind,computed_optional"`
 	Name      types.String      `tfsdk:"name" json:"name,required"`
 	IPs       *[]types.String   `tfsdk:"ips" json:"ips,optional"`

--- a/internal/services/zero_trust_gateway_proxy_endpoint/schema.go
+++ b/internal/services/zero_trust_gateway_proxy_endpoint/schema.go
@@ -26,7 +26,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"kind": schema.StringAttribute{

--- a/internal/services/zero_trust_list/model.go
+++ b/internal/services/zero_trust_list/model.go
@@ -14,7 +14,7 @@ type ZeroTrustListResultEnvelope struct {
 
 type ZeroTrustListModel struct {
 	ID          types.String                `tfsdk:"id" json:"id,computed"`
-	AccountID   types.String                `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID   types.String                `tfsdk:"account_id" path:"account_id,required"`
 	Type        types.String                `tfsdk:"type" json:"type,required"`
 	Name        types.String                `tfsdk:"name" json:"name,required"`
 	Items       *[]*ZeroTrustListItemsModel `tfsdk:"items" json:"items,optional"`

--- a/internal/services/zero_trust_list/schema.go
+++ b/internal/services/zero_trust_list/schema.go
@@ -27,7 +27,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"type": schema.StringAttribute{

--- a/internal/services/zero_trust_network_hostname_route/model.go
+++ b/internal/services/zero_trust_network_hostname_route/model.go
@@ -14,7 +14,7 @@ type ZeroTrustNetworkHostnameRouteResultEnvelope struct {
 
 type ZeroTrustNetworkHostnameRouteModel struct {
 	ID         types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID  types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID  types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Comment    types.String      `tfsdk:"comment" json:"comment,optional"`
 	Hostname   types.String      `tfsdk:"hostname" json:"hostname,optional"`
 	TunnelID   types.String      `tfsdk:"tunnel_id" json:"tunnel_id,optional"`

--- a/internal/services/zero_trust_network_hostname_route/schema.go
+++ b/internal/services/zero_trust_network_hostname_route/schema.go
@@ -36,7 +36,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Cloudflare account ID",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"comment": schema.StringAttribute{

--- a/internal/services/zero_trust_risk_behavior/model.go
+++ b/internal/services/zero_trust_risk_behavior/model.go
@@ -12,7 +12,7 @@ type ZeroTrustRiskBehaviorResultEnvelope struct {
 }
 
 type ZeroTrustRiskBehaviorModel struct {
-	AccountID types.String                                    `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID types.String                                    `tfsdk:"account_id" path:"account_id,required"`
 	Behaviors *map[string]ZeroTrustRiskBehaviorBehaviorsModel `tfsdk:"behaviors" json:"behaviors,required"`
 }
 

--- a/internal/services/zero_trust_risk_behavior/schema.go
+++ b/internal/services/zero_trust_risk_behavior/schema.go
@@ -27,7 +27,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		}.String(),
 		Attributes: map[string]schema.Attribute{
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"behaviors": schema.MapNestedAttribute{

--- a/internal/services/zero_trust_risk_scoring_integration/model.go
+++ b/internal/services/zero_trust_risk_scoring_integration/model.go
@@ -14,7 +14,7 @@ type ZeroTrustRiskScoringIntegrationResultEnvelope struct {
 
 type ZeroTrustRiskScoringIntegrationModel struct {
 	ID              types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID       types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID       types.String      `tfsdk:"account_id" path:"account_id,required"`
 	IntegrationType types.String      `tfsdk:"integration_type" json:"integration_type,required"`
 	TenantURL       types.String      `tfsdk:"tenant_url" json:"tenant_url,required"`
 	Active          types.Bool        `tfsdk:"active" json:"active,optional"`

--- a/internal/services/zero_trust_risk_scoring_integration/schema.go
+++ b/internal/services/zero_trust_risk_scoring_integration/schema.go
@@ -33,7 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"account_id": schema.StringAttribute{
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"integration_type": schema.StringAttribute{

--- a/internal/services/zero_trust_tunnel_cloudflared/model.go
+++ b/internal/services/zero_trust_tunnel_cloudflared/model.go
@@ -16,7 +16,7 @@ type ZeroTrustTunnelCloudflaredResultEnvelope struct {
 
 type ZeroTrustTunnelCloudflaredModel struct {
 	ID              types.String                                                             `tfsdk:"id" json:"id,computed"`
-	AccountID       types.String                                                             `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID       types.String                                                             `tfsdk:"account_id" path:"account_id,required"`
 	ConfigSrc       types.String                                                             `tfsdk:"config_src" json:"config_src,computed_optional"`
 	Name            types.String                                                             `tfsdk:"name" json:"name,required"`
 	TunnelSecret    types.String                                                             `tfsdk:"tunnel_secret" json:"tunnel_secret,optional,no_refresh"`

--- a/internal/services/zero_trust_tunnel_cloudflared/schema.go
+++ b/internal/services/zero_trust_tunnel_cloudflared/schema.go
@@ -41,7 +41,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Cloudflare account ID",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"config_src": schema.StringAttribute{

--- a/internal/services/zero_trust_tunnel_cloudflared_config/model.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_config/model.go
@@ -15,7 +15,7 @@ type ZeroTrustTunnelCloudflaredConfigResultEnvelope struct {
 type ZeroTrustTunnelCloudflaredConfigModel struct {
 	ID                 types.String                                 `tfsdk:"id" json:"-,computed"`
 	TunnelID           types.String                                 `tfsdk:"tunnel_id" path:"tunnel_id,required"`
-	AccountID          types.String                                 `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID          types.String                                 `tfsdk:"account_id" path:"account_id,required"`
 	Config             *ZeroTrustTunnelCloudflaredConfigConfigModel `tfsdk:"config" json:"config,computed_optional"`
 	CreatedAt          timetypes.RFC3339                            `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
 	Source             types.String                                 `tfsdk:"source" json:"source,computed_optional"`

--- a/internal/services/zero_trust_tunnel_cloudflared_config/schema.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_config/schema.go
@@ -45,7 +45,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"config": schema.SingleNestedAttribute{

--- a/internal/services/zero_trust_tunnel_cloudflared_route/model.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_route/model.go
@@ -14,7 +14,7 @@ type ZeroTrustTunnelCloudflaredRouteResultEnvelope struct {
 
 type ZeroTrustTunnelCloudflaredRouteModel struct {
 	ID               types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID        types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID        types.String      `tfsdk:"account_id" path:"account_id,required"`
 	Network          types.String      `tfsdk:"network" json:"network,required"`
 	TunnelID         types.String      `tfsdk:"tunnel_id" json:"tunnel_id,required"`
 	Comment          types.String      `tfsdk:"comment" json:"comment,computed_optional"`

--- a/internal/services/zero_trust_tunnel_cloudflared_route/schema.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_route/schema.go
@@ -33,7 +33,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Cloudflare account ID",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"network": schema.StringAttribute{

--- a/internal/services/zero_trust_tunnel_cloudflared_virtual_network/model.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_virtual_network/model.go
@@ -14,7 +14,7 @@ type ZeroTrustTunnelCloudflaredVirtualNetworkResultEnvelope struct {
 
 type ZeroTrustTunnelCloudflaredVirtualNetworkModel struct {
 	ID               types.String      `tfsdk:"id" json:"id,computed"`
-	AccountID        types.String      `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID        types.String      `tfsdk:"account_id" path:"account_id,required"`
 	IsDefault        types.Bool        `tfsdk:"is_default" json:"is_default,optional,no_refresh"`
 	Name             types.String      `tfsdk:"name" json:"name,required"`
 	Comment          types.String      `tfsdk:"comment" json:"comment,computed_optional"`

--- a/internal/services/zero_trust_tunnel_cloudflared_virtual_network/schema.go
+++ b/internal/services/zero_trust_tunnel_cloudflared_virtual_network/schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Cloudflare account ID",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"is_default": schema.BoolAttribute{

--- a/internal/services/zero_trust_tunnel_warp_connector/model.go
+++ b/internal/services/zero_trust_tunnel_warp_connector/model.go
@@ -16,7 +16,7 @@ type ZeroTrustTunnelWARPConnectorResultEnvelope struct {
 
 type ZeroTrustTunnelWARPConnectorModel struct {
 	ID              types.String                                                               `tfsdk:"id" json:"id,computed"`
-	AccountID       types.String                                                               `tfsdk:"account_id" path:"account_id,optional"`
+	AccountID       types.String                                                               `tfsdk:"account_id" path:"account_id,required"`
 	Ha              types.Bool                                                                 `tfsdk:"ha" json:"ha,computed_optional,no_refresh"`
 	Name            types.String                                                               `tfsdk:"name" json:"name,required"`
 	TunnelSecret    types.String                                                               `tfsdk:"tunnel_secret" json:"tunnel_secret,optional,no_refresh"`

--- a/internal/services/zero_trust_tunnel_warp_connector/schema.go
+++ b/internal/services/zero_trust_tunnel_warp_connector/schema.go
@@ -40,7 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"account_id": schema.StringAttribute{
 				Description:   "Cloudflare account ID",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"ha": schema.BoolAttribute{

--- a/internal/services/zone_dns_settings/model.go
+++ b/internal/services/zone_dns_settings/model.go
@@ -12,7 +12,7 @@ type ZoneDNSSettingsResultEnvelope struct {
 }
 
 type ZoneDNSSettingsModel struct {
-	ZoneID             types.String                     `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID             types.String                     `tfsdk:"zone_id" path:"zone_id,required"`
 	FlattenAllCNAMEs   types.Bool                       `tfsdk:"flatten_all_cnames" json:"flatten_all_cnames,optional"`
 	FoundationDNS      types.Bool                       `tfsdk:"foundation_dns" json:"foundation_dns,optional"`
 	MultiProvider      types.Bool                       `tfsdk:"multi_provider" json:"multi_provider,optional"`

--- a/internal/services/zone_dns_settings/schema.go
+++ b/internal/services/zone_dns_settings/schema.go
@@ -32,7 +32,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"flatten_all_cnames": schema.BoolAttribute{

--- a/internal/services/zone_lockdown/model.go
+++ b/internal/services/zone_lockdown/model.go
@@ -14,7 +14,7 @@ type ZoneLockdownResultEnvelope struct {
 
 type ZoneLockdownModel struct {
 	ID             types.String                        `tfsdk:"id" json:"id,computed"`
-	ZoneID         types.String                        `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID         types.String                        `tfsdk:"zone_id" path:"zone_id,required"`
 	Description    types.String                        `tfsdk:"description" json:"description,optional"`
 	Priority       types.Float64                       `tfsdk:"priority" json:"priority,optional,no_refresh"`
 	Paused         types.Bool                          `tfsdk:"paused" json:"paused,computed_optional"`

--- a/internal/services/zone_lockdown/schema.go
+++ b/internal/services/zone_lockdown/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Defines an identifier.",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"description": schema.StringAttribute{

--- a/internal/services/zone_setting/model.go
+++ b/internal/services/zone_setting/model.go
@@ -16,7 +16,7 @@ type ZoneSettingResultEnvelope struct {
 type ZoneSettingModel struct {
 	ID            types.String                       `tfsdk:"id" json:"-,computed"`
 	SettingID     types.String                       `tfsdk:"setting_id" path:"setting_id,required"`
-	ZoneID        types.String                       `tfsdk:"zone_id" path:"zone_id,optional"`
+	ZoneID        types.String                       `tfsdk:"zone_id" path:"zone_id,required"`
 	Value         customfield.NormalizedDynamicValue `tfsdk:"value" json:"value,required"`
 	Enabled       types.Bool                         `tfsdk:"enabled" json:"enabled,computed_optional"`
 	Editable      types.Bool                         `tfsdk:"editable" json:"editable,computed"`

--- a/internal/services/zone_setting/schema.go
+++ b/internal/services/zone_setting/schema.go
@@ -38,7 +38,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"zone_id": schema.StringAttribute{
 				Description:   "Identifier",
-				Optional:      true,
+				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"value": schema.DynamicAttribute{


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Reverts the regression from 8b732ad where account_id/zone_id were changed from Required to Optional across 172 resource schemas. 16 resources had already been fixed by prior custom code, leaving 156 resources to restore.

Changes per resource:
- schema.go: Optional: true -> Required: true
- model.go: path:"...,optional" -> path:"...,required"

Affected: 112 account_id resources, 44 zone_id resources.

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
