### PR TITLE
fix(workers_script): add missing propagation_policy to observability traces schema

### DIFF
--- a/internal/services/workers_script/migration/v500/model.go
+++ b/internal/services/workers_script/migration/v500/model.go
@@ -286,10 +286,11 @@ type TargetObservabilityLogsModel struct {
 }
 
 type TargetObservabilityTracesModel struct {
-	Destinations     *[]types.String `tfsdk:"destinations"`
-	Enabled          types.Bool      `tfsdk:"enabled"`
-	HeadSamplingRate types.Float64   `tfsdk:"head_sampling_rate"`
-	Persist          types.Bool      `tfsdk:"persist"`
+	Destinations      *[]types.String `tfsdk:"destinations"`
+	Enabled           types.Bool      `tfsdk:"enabled"`
+	HeadSamplingRate  types.Float64   `tfsdk:"head_sampling_rate"`
+	Persist           types.Bool      `tfsdk:"persist"`
+	PropagationPolicy types.String    `tfsdk:"propagation_policy"`
 }
 
 type TargetPlacementModel struct {

--- a/internal/services/workers_script/resource_test.go
+++ b/internal/services/workers_script/resource_test.go
@@ -907,6 +907,52 @@ func testAccCheckCloudflareWorkerScriptWithRatelimitBinding(rnd, accountID strin
 	return acctest.LoadTestCase("module_with_ratelimit.tf", rnd, accountID)
 }
 
+// TestAccCloudflareWorkerScript_ObservabilityTraces is a regression test for
+// https://github.com/cloudflare/terraform-provider-cloudflare/issues/7177.
+// It verifies that the observability.traces block (including propagation_policy)
+// is present in both the schema and the model, so that plan/refresh and import
+// do not fail with a "mismatch between struct and object type" error.
+func TestAccCloudflareWorkerScript_ObservabilityTraces(t *testing.T) {
+	t.Parallel()
+
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := resourcePrefix + rnd
+	name := "cloudflare_workers_script." + resourceName
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccCloudflareWorkerScriptWithObservabilityTraces(resourceName, accountID),
+				ExpectNonEmptyPlan: true,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("script_name"), knownvalue.StringExact(resourceName)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("observability").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("observability").AtMapKey("traces").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("observability").AtMapKey("traces").AtMapKey("head_sampling_rate"), knownvalue.Float64Exact(1)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("observability").AtMapKey("traces").AtMapKey("persist"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				ResourceName:            name,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"main_module", "startup_time_ms", "observability.head_sampling_rate", "observability.logs"},
+			},
+		},
+	})
+}
+
+func testAccCloudflareWorkerScriptWithObservabilityTraces(rnd, accountID string) string {
+	return acctest.LoadTestCase("module_with_observability_traces.tf", rnd, accountID, moduleContent)
+}
+
 func TestAccUpgradeWorkersScript_FromPublishedV5(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := resourcePrefix + rnd

--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -694,6 +694,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Optional:    true,
 								Default:     booldefault.StaticBool(true),
 							},
+							"propagation_policy": schema.StringAttribute{
+								Description: "Controls how inbound trace context (traceparent/tracestate) headers on incoming requests are handled. \"authenticated\" (default) honors inbound trace context only when accompanied by a valid trace auth token. \"accept\" unconditionally accepts inbound trace context. Requires the trace propagation feature to be enabled.\nAvailable values: \"authenticated\", \"accept\".",
+								Computed:    true,
+								Optional:    true,
+								PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+							},
 						},
 					},
 				},

--- a/internal/services/workers_script/testdata/module_with_observability_traces.tf
+++ b/internal/services/workers_script/testdata/module_with_observability_traces.tf
@@ -1,0 +1,15 @@
+resource "cloudflare_workers_script" "%[1]s" {
+  account_id  = "%[2]s"
+  script_name = "%[1]s"
+  content     = "%[3]s"
+  main_module = "worker.mjs"
+
+  observability = {
+    enabled = true
+    traces = {
+      enabled            = true
+      head_sampling_rate = 1
+      persist            = true
+    }
+  }
+}


### PR DESCRIPTION
Fixes #7177

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
TF_ACC=1 go test ./internal/services/workers_script/... -v

### Test output
<!-- Please paste the output of your acceptance test run below --> 
=== RUN   TestWorkersScriptDataSourceModelSchemaParity
=== PAUSE TestWorkersScriptDataSourceModelSchemaParity
=== RUN   TestWorkersScriptsDataSourceModelSchemaParity
=== PAUSE TestWorkersScriptsDataSourceModelSchemaParity
=== RUN   TestWorkersScriptModelSchemaParity
--- PASS: TestWorkersScriptModelSchemaParity (0.00s)
=== RUN   TestAccCloudflareWorkerScript_ServiceWorker
=== PAUSE TestAccCloudflareWorkerScript_ServiceWorker
=== RUN   TestAccCloudflareWorkerScript_ModuleUpload
    resource_test.go:156: issue: API behavior change has caused this test to start failing
--- SKIP: TestAccCloudflareWorkerScript_ModuleUpload (0.00s)
=== RUN   TestAcc_WorkerScriptWithContentFile
=== PAUSE TestAcc_WorkerScriptWithContentFile
=== RUN   TestAcc_WorkerScriptWithInvalidContentSHA256
=== PAUSE TestAcc_WorkerScriptWithInvalidContentSHA256
=== RUN   TestAccCloudflareWorkerScript_PythonWorker
=== PAUSE TestAccCloudflareWorkerScript_PythonWorker
=== RUN   TestAcc_WorkerScriptWithAssets
=== PAUSE TestAcc_WorkerScriptWithAssets
=== RUN   TestAccCloudflareWorkerScript_ModuleWithDurableObject
=== PAUSE TestAccCloudflareWorkerScript_ModuleWithDurableObject
=== RUN   TestAccCloudflareWorkerScript_AssetsConfigRunWorkerFirst
=== PAUSE TestAccCloudflareWorkerScript_AssetsConfigRunWorkerFirst
=== RUN   TestAccCloudflareWorkerScript_AssetsConfigRunWorkerFirstMigration
=== PAUSE TestAccCloudflareWorkerScript_AssetsConfigRunWorkerFirstMigration
=== RUN   TestAccCloudflareWorkerScript_UnmanagedSecretNoDrift
=== PAUSE TestAccCloudflareWorkerScript_UnmanagedSecretNoDrift
=== RUN   TestAccCloudflareWorkerScript_NoSecretsInConfigWithUnmanagedSecrets
=== PAUSE TestAccCloudflareWorkerScript_NoSecretsInConfigWithUnmanagedSecrets
=== RUN   TestAccCloudflareWorkerScript_RatelimitBinding
=== PAUSE TestAccCloudflareWorkerScript_RatelimitBinding
=== RUN   TestAccCloudflareWorkerScript_ObservabilityTraces
=== PAUSE TestAccCloudflareWorkerScript_ObservabilityTraces
=== RUN   TestAccUpgradeWorkersScript_FromPublishedV5
--- PASS: TestAccUpgradeWorkersScript_FromPublishedV5 (9.05s)
=== CONT  TestAccCloudflareWorkerScript_ObservabilityTraces
=== CONT  TestWorkersScriptDataSourceModelSchemaParity
=== CONT  TestAccCloudflareWorkerScript_ModuleWithDurableObject
=== CONT  TestAccCloudflareWorkerScript_UnmanagedSecretNoDrift
=== CONT  TestAccCloudflareWorkerScript_RatelimitBinding
=== CONT  TestAccCloudflareWorkerScript_AssetsConfigRunWorkerFirstMigration
--- PASS: TestWorkersScriptDataSourceModelSchemaParity (0.00s)
=== CONT  TestAcc_WorkerScriptWithAssets
=== CONT  TestAcc_WorkerScriptWithContentFile
=== CONT  TestAccCloudflareWorkerScript_PythonWorker
=== CONT  TestAccCloudflareWorkerScript_ServiceWorker
=== CONT  TestAccCloudflareWorkerScript_AssetsConfigRunWorkerFirst
=== CONT  TestAccCloudflareWorkerScript_NoSecretsInConfigWithUnmanagedSecrets
=== CONT  TestWorkersScriptsDataSourceModelSchemaParity
--- PASS: TestWorkersScriptsDataSourceModelSchemaParity (0.00s)
=== CONT  TestAcc_WorkerScriptWithInvalidContentSHA256
--- PASS: TestAcc_WorkerScriptWithInvalidContentSHA256 (0.37s)
--- PASS: TestAccCloudflareWorkerScript_RatelimitBinding (4.25s)
--- PASS: TestAccCloudflareWorkerScript_ModuleWithDurableObject (4.64s)
--- PASS: TestAccCloudflareWorkerScript_ObservabilityTraces (4.67s)
--- PASS: TestAccCloudflareWorkerScript_PythonWorker (6.22s)
--- PASS: TestAccCloudflareWorkerScript_NoSecretsInConfigWithUnmanagedSecrets (7.66s)
--- PASS: TestAccCloudflareWorkerScript_UnmanagedSecretNoDrift (8.31s)
--- PASS: TestAccCloudflareWorkerScript_AssetsConfigRunWorkerFirstMigration (11.23s)
--- PASS: TestAcc_WorkerScriptWithContentFile (12.72s)
--- PASS: TestAccCloudflareWorkerScript_ServiceWorker (14.29s)
--- PASS: TestAcc_WorkerScriptWithAssets (15.99s)
--- PASS: TestAccCloudflareWorkerScript_AssetsConfigRunWorkerFirst (18.43s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/workers_script    29.496s
=== RUN   TestWorkersScriptMigrationModelSchemaParity
=== PAUSE TestWorkersScriptMigrationModelSchemaParity
=== RUN   TestMigrateWorkersScript_FromV4Basic
--- PASS: TestMigrateWorkersScript_FromV4Basic (9.78s)
=== RUN   TestMigrateWorkersScript_FromV4WithBindings
--- PASS: TestMigrateWorkersScript_FromV4WithBindings (6.57s)
=== RUN   TestMigrateWorkersScript_FromV4SingleResource
--- PASS: TestMigrateWorkersScript_FromV4SingleResource (6.16s)
=== RUN   TestMigrateWorkersScript_FromV4MultipleBindingTypes
--- PASS: TestMigrateWorkersScript_FromV4MultipleBindingTypes (7.15s)
=== RUN   TestMigrateWorkersScript_FromV4ComplexBindings
--- PASS: TestMigrateWorkersScript_FromV4ComplexBindings (6.22s)
=== RUN   TestMigrateWorkersScript_Basic
=== RUN   TestMigrateWorkersScript_Basic/from_v4_latest
=== RUN   TestMigrateWorkersScript_Basic/from_v5
--- PASS: TestMigrateWorkersScript_Basic (13.30s)
    --- PASS: TestMigrateWorkersScript_Basic/from_v4_latest (7.75s)
    --- PASS: TestMigrateWorkersScript_Basic/from_v5 (5.55s)
=== RUN   TestMigrateWorkersScript_WithBinding
=== RUN   TestMigrateWorkersScript_WithBinding/from_v4_latest
=== RUN   TestMigrateWorkersScript_WithBinding/from_v5
--- PASS: TestMigrateWorkersScript_WithBinding (11.23s)
    --- PASS: TestMigrateWorkersScript_WithBinding/from_v4_latest (6.51s)
    --- PASS: TestMigrateWorkersScript_WithBinding/from_v5 (4.72s)
=== RUN   TestMigrateWorkersScript_MultipleBindingTypes
=== RUN   TestMigrateWorkersScript_MultipleBindingTypes/from_v4_latest
=== RUN   TestMigrateWorkersScript_MultipleBindingTypes/from_v5
--- PASS: TestMigrateWorkersScript_MultipleBindingTypes (13.09s)
    --- PASS: TestMigrateWorkersScript_MultipleBindingTypes/from_v4_latest (7.31s)
    --- PASS: TestMigrateWorkersScript_MultipleBindingTypes/from_v5 (5.77s)
=== CONT  TestWorkersScriptMigrationModelSchemaParity
--- PASS: TestWorkersScriptMigrationModelSchemaParity (0.00s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/workers_script/migration/v500     77.074s
## Additional context & links
