### PR TITLE
ci: add schema version check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,15 @@ env:
   GOPRIVATE: github.com/cloudflare/cloudflare-go/v7,github.com/stainless-sdks/cloudflare-go/v7
 
 jobs:
+  check-schema-versions:
+    runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-terraform' && 'depot-ubuntu-24.04' || 'lx64' }}
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check schema versions
+        run: ./scripts/check-schema-versions
+
   lint:
     runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-terraform' && 'depot-ubuntu-24.04' || 'lx64' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork

--- a/scripts/check-schema-versions
+++ b/scripts/check-schema-versions
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+MIN_VERSION=500
+errors=0
+
+for dir in internal/services/*/; do
+  schema="$dir/schema.go"
+  [ -f "$schema" ] || continue
+  grep -q 'func ResourceSchema' "$schema" || continue
+
+  svc=$(basename "$dir")
+  ver=$(grep 'Version:' "$schema" | head -1 | sed 's/[^0-9]//g')
+  ver=${ver:-0}
+
+  if [ "$ver" -lt "$MIN_VERSION" ]; then
+    echo "FAIL: $svc/schema.go has Version: $ver (expected >= $MIN_VERSION)"
+    errors=$((errors + 1))
+  fi
+done
+
+if [ "$errors" -gt 0 ]; then
+  echo ""
+  echo "$errors resource(s) missing Version >= $MIN_VERSION in schema.go"
+  echo "Every resource schema must set Version: $MIN_VERSION (or greater) to ensure state upgraders are wired correctly."
+  exit 1
+fi
+
+echo "All resource schemas have Version >= $MIN_VERSION"


### PR DESCRIPTION
## Summary

Adds a CI job that verifies every resource's `schema.go` has `Version` set to `>= 500`. This catches regressions where new or modified resources are added without the required schema version, which would break state upgrades for users (see #7181).

## Changes

- **`scripts/check-schema-versions`** -- bash script that scans all `internal/services/*/schema.go` files for a `ResourceSchema` function and verifies `Version >= 500`. Exits non-zero with a summary on failure.
- **`.github/workflows/ci.yml`** -- new `check-schema-versions` job that runs the script. Lightweight (no Go toolchain needed), runs in parallel with lint and test.

### Output

#### Failure
```
FAIL: connectivity_directory_service/schema.go has Version: 0 (expected >= 500)
FAIL: content_scanning/schema.go has Version: 3 (expected >= 500)

2 resource(s) missing Version >= 500 in schema.go
Every resource schema must set Version: 500 (or greater) to ensure state upgraders are wired correctly.
```

#### Success
```
All resource schemas have Version >= 500
```