### PR TITLE
feat(ruleset): add vary parameter to set_cache_settings action

### DIFF
--- a/docs/data-sources/ruleset.md
+++ b/docs/data-sources/ruleset.md
@@ -151,6 +151,7 @@ Available values: "off", "flexible", "full", "strict", "origin_pull".
 - `transformed_request_fields` (Attributes List) The transformed request fields to log. (see [below for nested schema](#nestedatt--rules--action_parameters--transformed_request_fields))
 - `uri` (Attributes) A URI rewrite. (see [below for nested schema](#nestedatt--rules--action_parameters--uri))
 - `values` (List of String) The cache tag values for set_cache_tags action.
+- `vary` (Attributes) Controls how cached responses vary based on request headers. At least one of `default` or `headers` must be set, and `default` is required when `headers` is set. (see [below for nested schema](#nestedatt--rules--action_parameters--vary))
 
 <a id="nestedatt--rules--action_parameters--algorithms"></a>
 ### Nested Schema for `rules.action_parameters.algorithms`
@@ -634,6 +635,35 @@ Read-Only:
 
 
 
+<a id="nestedatt--rules--action_parameters--vary"></a>
+### Nested Schema for `rules.action_parameters.vary`
+
+Read-Only:
+
+- `default` (Attributes) Controls how a single request header (or the default for all headers) contributes to the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--vary--default))
+- `headers` (Attributes Map) A mapping of lowercase request header names to their vary configuration. (see [below for nested schema](#nestedatt--rules--action_parameters--vary--headers))
+
+<a id="nestedatt--rules--action_parameters--vary--default"></a>
+### Nested Schema for `rules.action_parameters.vary.default`
+
+Read-Only:
+
+- `action` (String) How the header value is treated when building the cache key.
+Available values: "bypass", "passthrough", "normalize".
+
+
+<a id="nestedatt--rules--action_parameters--vary--headers"></a>
+### Nested Schema for `rules.action_parameters.vary.headers`
+
+Read-Only:
+
+- `action` (String) How the header value is treated when building the cache key.
+Available values: "bypass", "passthrough", "normalize".
+- `languages` (List of String) The set of languages to normalize against. Only valid for the `accept-language` header.
+- `media_types` (List of String) The set of media types to normalize against. Only valid for the `accept` header.
+
+
+
 
 <a id="nestedatt--rules--exposed_credential_check"></a>
 ### Nested Schema for `rules.exposed_credential_check`
@@ -665,5 +695,4 @@ Read-Only:
 - `requests_to_origin` (Boolean) Whether counting is only performed when an origin is reached.
 - `score_per_period` (Number) The score threshold per period for which the action will be executed the first time.
 - `score_response_header_name` (String) A response header name provided by the origin, which contains the score to increment rate limit counter with.
-
 

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -169,6 +169,7 @@ Available values: "off", "flexible", "full", "strict", "origin_pull".
 - `transformed_request_fields` (Attributes List) The transformed request fields to log. (see [below for nested schema](#nestedatt--rules--action_parameters--transformed_request_fields))
 - `uri` (Attributes) A URI rewrite. (see [below for nested schema](#nestedatt--rules--action_parameters--uri))
 - `values` (List of String) The cache tag values for set_cache_tags action.
+- `vary` (Attributes) Controls how cached responses vary based on request headers. `default` is required and applies to any Vary response header that does not have a per-header override. (see [below for nested schema](#nestedatt--rules--action_parameters--vary))
 
 <a id="nestedatt--rules--action_parameters--algorithms"></a>
 ### Nested Schema for `rules.action_parameters.algorithms`
@@ -720,6 +721,41 @@ Optional:
 
 
 
+<a id="nestedatt--rules--action_parameters--vary"></a>
+### Nested Schema for `rules.action_parameters.vary`
+
+Required:
+
+- `default` (Attributes) Controls how response Vary headers without a per-header override contribute to the cache key. (see [below for nested schema](#nestedatt--rules--action_parameters--vary--default))
+
+Optional:
+
+- `headers` (Attributes Map) A mapping of lowercase request header names to their vary configuration. (see [below for nested schema](#nestedatt--rules--action_parameters--vary--headers))
+
+<a id="nestedatt--rules--action_parameters--vary--default"></a>
+### Nested Schema for `rules.action_parameters.vary.default`
+
+Required:
+
+- `action` (String) How the header value is treated when building the cache key.
+Available values: "bypass", "passthrough", "normalize".
+
+
+<a id="nestedatt--rules--action_parameters--vary--headers"></a>
+### Nested Schema for `rules.action_parameters.vary.headers`
+
+Required:
+
+- `action` (String) How the header value is treated when building the cache key.
+Available values: "bypass", "passthrough", "normalize".
+
+Optional:
+
+- `languages` (List of String) The set of languages to normalize against. Only valid for the `accept-language` header.
+- `media_types` (List of String) The set of media types to normalize against. Only valid for the `accept` header.
+
+
+
 
 <a id="nestedatt--rules--exposed_credential_check"></a>
 ### Nested Schema for `rules.exposed_credential_check`
@@ -762,5 +798,3 @@ Import is supported using the following syntax:
 ```shell
 $ terraform import cloudflare_ruleset.example '<{accounts|zones}/{account_id|zone_id}>/<ruleset_id>'
 ```
-
-

--- a/internal/services/ruleset/data_source_model.go
+++ b/internal/services/ruleset/data_source_model.go
@@ -113,6 +113,7 @@ type RulesetRulesActionParametersDataSourceModel struct {
 	ReadTimeout              types.Int64                                                                                       `tfsdk:"read_timeout" json:"read_timeout,computed"`
 	RespectStrongEtags       types.Bool                                                                                        `tfsdk:"respect_strong_etags" json:"respect_strong_etags,computed"`
 	ServeStale               customfield.NestedObject[RulesetRulesActionParametersServeStaleDataSourceModel]                   `tfsdk:"serve_stale" json:"serve_stale,computed"`
+	Vary                     customfield.NestedObject[RulesetRulesActionParametersVaryDataSourceModel]                         `tfsdk:"vary" json:"vary,computed"`
 	StripETags               types.Bool                                                                                        `tfsdk:"strip_etags" json:"strip_etags,computed"`
 	StripLastModified        types.Bool                                                                                        `tfsdk:"strip_last_modified" json:"strip_last_modified,computed"`
 	StripSetCookie           types.Bool                                                                                        `tfsdk:"strip_set_cookie" json:"strip_set_cookie,computed"`
@@ -369,4 +370,19 @@ type RulesetRulesActionParametersSetCacheControlQualifiersDataSourceModel struct
 type RulesetRulesActionParametersSetCacheControlSimpleDataSourceModel struct {
 	Operation      types.String `tfsdk:"operation" json:"operation,computed"`
 	CloudflareOnly types.Bool   `tfsdk:"cloudflare_only" json:"cloudflare_only,computed,decode_null_to_zero"`
+}
+
+type RulesetRulesActionParametersVaryDataSourceModel struct {
+	Default customfield.NestedObject[RulesetRulesActionParametersVaryDefaultDataSourceModel]   `tfsdk:"default" json:"default,computed"`
+	Headers customfield.NestedObjectMap[RulesetRulesActionParametersVaryHeaderDataSourceModel] `tfsdk:"headers" json:"headers,computed"`
+}
+
+type RulesetRulesActionParametersVaryDefaultDataSourceModel struct {
+	Action types.String `tfsdk:"action" json:"action,computed"`
+}
+
+type RulesetRulesActionParametersVaryHeaderDataSourceModel struct {
+	Action     types.String                   `tfsdk:"action" json:"action,computed"`
+	MediaTypes customfield.List[types.String] `tfsdk:"media_types" json:"media_types,computed"`
+	Languages  customfield.List[types.String] `tfsdk:"languages" json:"languages,computed"`
 }

--- a/internal/services/ruleset/data_source_schema.go
+++ b/internal/services/ruleset/data_source_schema.go
@@ -1531,6 +1531,91 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 										},
 									},
 								},
+								"vary": schema.SingleNestedAttribute{
+									Description: "Controls how cached responses vary based on request headers. `default` is required and applies to any Vary response header that does not have a per-header override.",
+									Computed:    true,
+									Validators: []validator.Object{
+										customvalidator.RequiresOtherStringAttributeToBe(
+											path.MatchRelative().AtParent().AtParent().AtName("action"),
+											"set_cache_settings",
+										),
+									},
+									CustomType: customfield.NewNestedObjectType[RulesetRulesActionParametersVaryDataSourceModel](ctx),
+									Attributes: map[string]schema.Attribute{
+										"default": schema.SingleNestedAttribute{
+											Description: "Controls how response Vary headers without a per-header override contribute to the cache key.",
+											Computed:    true,
+											CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersVaryDefaultDataSourceModel](ctx),
+											Attributes: map[string]schema.Attribute{
+												"action": schema.StringAttribute{
+													Description: "How the header value is treated when building the cache key.\nAvailable values: \"bypass\", \"passthrough\", \"normalize\".",
+													Computed:    true,
+													Validators: []validator.String{
+														stringvalidator.OneOf("bypass", "passthrough", "normalize"),
+													},
+												},
+											},
+										},
+										"headers": schema.MapNestedAttribute{
+											Description: "A mapping of lowercase request header names to their vary configuration.",
+											Computed:    true,
+											Validators: []validator.Map{
+												mapvalidator.SizeAtMost(50),
+												mapvalidator.KeysAre(
+													stringvalidator.LengthBetween(1, 128),
+													stringvalidator.RegexMatches(
+														regexp.MustCompile("^[a-z0-9_-]+$"),
+														"header names must be lowercase and contain only letters, numbers, underscores, and hyphens",
+													),
+												),
+											},
+											CustomType: customfield.NewNestedObjectMapType[RulesetRulesActionParametersVaryHeaderDataSourceModel](ctx),
+											NestedObject: schema.NestedAttributeObject{
+												Attributes: map[string]schema.Attribute{
+													"action": schema.StringAttribute{
+														Description: "How the header value is treated when building the cache key.\nAvailable values: \"bypass\", \"passthrough\", \"normalize\".",
+														Computed:    true,
+														Validators: []validator.String{
+															stringvalidator.OneOf("bypass", "passthrough", "normalize"),
+														},
+													},
+													"media_types": schema.ListAttribute{
+														Description: "The set of media types to normalize against. Only valid for the `accept` header.",
+														Computed:    true,
+														CustomType:  customfield.NewListType[types.String](ctx),
+														ElementType: types.StringType,
+														Validators: []validator.List{
+															listvalidator.SizeAtMost(10),
+															listvalidator.ValueStringsAre(
+																stringvalidator.LengthBetween(1, 255),
+																stringvalidator.RegexMatches(
+																	regexp.MustCompile("^[ -~]+$"),
+																	"media types must contain only printable ASCII characters",
+																),
+															),
+														},
+													},
+													"languages": schema.ListAttribute{
+														Description: "The set of languages to normalize against. Only valid for the `accept-language` header.",
+														Computed:    true,
+														CustomType:  customfield.NewListType[types.String](ctx),
+														ElementType: types.StringType,
+														Validators: []validator.List{
+															listvalidator.SizeAtMost(20),
+															listvalidator.ValueStringsAre(
+																stringvalidator.LengthBetween(1, 64),
+																stringvalidator.RegexMatches(
+																	regexp.MustCompile("^[ -~]+$"),
+																	"languages must contain only printable ASCII characters",
+																),
+															),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
 								"strip_etags": schema.BoolAttribute{
 									Description: "Whether to strip the ETag header from the response.",
 									Computed:    true,

--- a/internal/services/ruleset/migration/v500/model.go
+++ b/internal/services/ruleset/migration/v500/model.go
@@ -335,6 +335,7 @@ type TargetV5ActionParametersModel struct {
 	SNI          *TargetV5SNIModel          `tfsdk:"sni"`
 	ServeStale   *TargetV5ServeStaleModel   `tfsdk:"serve_stale"`
 	URI          *TargetV5URIModel          `tfsdk:"uri"`
+	Vary         *TargetV5VaryModel         `tfsdk:"vary"`
 
 	// Nested object lists
 	Algorithms               []*TargetV5AlgorithmModel        `tfsdk:"algorithms"`
@@ -585,6 +586,21 @@ type TargetV5TargetURLModel struct {
 
 type TargetV5ServeStaleModel struct {
 	DisableStaleWhileUpdating types.Bool `tfsdk:"disable_stale_while_updating"`
+}
+
+type TargetV5VaryModel struct {
+	Default *TargetV5VaryDefaultModel           `tfsdk:"default"`
+	Headers map[string]*TargetV5VaryHeaderModel `tfsdk:"headers"`
+}
+
+type TargetV5VaryDefaultModel struct {
+	Action types.String `tfsdk:"action"`
+}
+
+type TargetV5VaryHeaderModel struct {
+	Action     types.String   `tfsdk:"action"`
+	MediaTypes []types.String `tfsdk:"media_types"`
+	Languages  []types.String `tfsdk:"languages"`
 }
 
 // Cache control directive models for set_cache_settings action

--- a/internal/services/ruleset/model.go
+++ b/internal/services/ruleset/model.go
@@ -103,6 +103,7 @@ type RulesetRulesActionParametersModel struct {
 	ReadTimeout              types.Int64                                                                             `tfsdk:"read_timeout" json:"read_timeout,optional"`
 	RespectStrongEtags       types.Bool                                                                              `tfsdk:"respect_strong_etags" json:"respect_strong_etags,optional"`
 	ServeStale               customfield.NestedObject[RulesetRulesActionParametersServeStaleModel]                   `tfsdk:"serve_stale" json:"serve_stale,optional"`
+	Vary                     customfield.NestedObject[RulesetRulesActionParametersVaryModel]                         `tfsdk:"vary" json:"vary,optional"`
 	StripETags               types.Bool                                                                              `tfsdk:"strip_etags" json:"strip_etags,optional"`
 	StripLastModified        types.Bool                                                                              `tfsdk:"strip_last_modified" json:"strip_last_modified,optional"`
 	StripSetCookie           types.Bool                                                                              `tfsdk:"strip_set_cookie" json:"strip_set_cookie,optional"`
@@ -358,4 +359,19 @@ type RulesetRulesActionParametersSetCacheControlQualifiersModel struct {
 type RulesetRulesActionParametersSetCacheControlSimpleModel struct {
 	Operation      types.String `tfsdk:"operation" json:"operation,required"`
 	CloudflareOnly types.Bool   `tfsdk:"cloudflare_only" json:"cloudflare_only,computed_optional,decode_null_to_zero"`
+}
+
+type RulesetRulesActionParametersVaryModel struct {
+	Default customfield.NestedObject[RulesetRulesActionParametersVaryDefaultModel]   `tfsdk:"default" json:"default,required"`
+	Headers customfield.NestedObjectMap[RulesetRulesActionParametersVaryHeaderModel] `tfsdk:"headers" json:"headers,optional"`
+}
+
+type RulesetRulesActionParametersVaryDefaultModel struct {
+	Action types.String `tfsdk:"action" json:"action,required"`
+}
+
+type RulesetRulesActionParametersVaryHeaderModel struct {
+	Action     types.String                   `tfsdk:"action" json:"action,required"`
+	MediaTypes customfield.List[types.String] `tfsdk:"media_types" json:"media_types,optional"`
+	Languages  customfield.List[types.String] `tfsdk:"languages" json:"languages,optional"`
 }

--- a/internal/services/ruleset/ruleset_test.go
+++ b/internal/services/ruleset/ruleset_test.go
@@ -5505,6 +5505,31 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 										"serve_stale": knownvalue.ObjectExact(map[string]knownvalue.Check{
 											"disable_stale_while_updating": knownvalue.Bool(false),
 										}),
+										"vary": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+											"default": knownvalue.ObjectExact(map[string]knownvalue.Check{
+												"action": knownvalue.StringExact("bypass"),
+											}),
+											"headers": knownvalue.MapExact(map[string]knownvalue.Check{
+												"accept": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+													"action": knownvalue.StringExact("normalize"),
+													"media_types": knownvalue.ListExact([]knownvalue.Check{
+														knownvalue.StringExact("image/webp"),
+														knownvalue.StringExact("image/avif"),
+													}),
+												}),
+												"accept-language": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+													"action": knownvalue.StringExact("normalize"),
+													"languages": knownvalue.ListExact([]knownvalue.Check{
+														knownvalue.StringExact("en"),
+														knownvalue.StringExact("de"),
+														knownvalue.StringExact("fr"),
+													}),
+												}),
+												"x-custom-header": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+													"action": knownvalue.StringExact("passthrough"),
+												}),
+											}),
+										}),
 									}),
 								}),
 							}),
@@ -5583,6 +5608,31 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 									"serve_stale": knownvalue.ObjectExact(map[string]knownvalue.Check{
 										"disable_stale_while_updating": knownvalue.Bool(false),
 									}),
+									"vary": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+										"default": knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"action": knownvalue.StringExact("bypass"),
+										}),
+										"headers": knownvalue.MapExact(map[string]knownvalue.Check{
+											"accept": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+												"action": knownvalue.StringExact("normalize"),
+												"media_types": knownvalue.ListExact([]knownvalue.Check{
+													knownvalue.StringExact("image/webp"),
+													knownvalue.StringExact("image/avif"),
+												}),
+											}),
+											"accept-language": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+												"action": knownvalue.StringExact("normalize"),
+												"languages": knownvalue.ListExact([]knownvalue.Check{
+													knownvalue.StringExact("en"),
+													knownvalue.StringExact("de"),
+													knownvalue.StringExact("fr"),
+												}),
+											}),
+											"x-custom-header": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+												"action": knownvalue.StringExact("passthrough"),
+											}),
+										}),
+									}),
 								}),
 							}),
 						}),
@@ -5657,6 +5707,31 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 									"respect_strong_etags":       knownvalue.Bool(true),
 									"serve_stale": knownvalue.ObjectExact(map[string]knownvalue.Check{
 										"disable_stale_while_updating": knownvalue.Bool(false),
+									}),
+									"vary": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+										"default": knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"action": knownvalue.StringExact("bypass"),
+										}),
+										"headers": knownvalue.MapExact(map[string]knownvalue.Check{
+											"accept": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+												"action": knownvalue.StringExact("normalize"),
+												"media_types": knownvalue.ListExact([]knownvalue.Check{
+													knownvalue.StringExact("image/webp"),
+													knownvalue.StringExact("image/avif"),
+												}),
+											}),
+											"accept-language": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+												"action": knownvalue.StringExact("normalize"),
+												"languages": knownvalue.ListExact([]knownvalue.Check{
+													knownvalue.StringExact("en"),
+													knownvalue.StringExact("de"),
+													knownvalue.StringExact("fr"),
+												}),
+											}),
+											"x-custom-header": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+												"action": knownvalue.StringExact("passthrough"),
+											}),
+										}),
 									}),
 								}),
 							}),
@@ -5721,6 +5796,7 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 										"serve_stale": knownvalue.ObjectExact(map[string]knownvalue.Check{
 											"disable_stale_while_updating": knownvalue.Bool(true),
 										}),
+										"vary": knownvalue.Null(),
 									}),
 								}),
 							}),
@@ -5776,6 +5852,7 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 									"serve_stale": knownvalue.ObjectExact(map[string]knownvalue.Check{
 										"disable_stale_while_updating": knownvalue.Bool(true),
 									}),
+									"vary": knownvalue.Null(),
 								}),
 							}),
 						}),
@@ -5828,6 +5905,7 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 									"serve_stale": knownvalue.ObjectExact(map[string]knownvalue.Check{
 										"disable_stale_while_updating": knownvalue.Bool(true),
 									}),
+									"vary": knownvalue.Null(),
 								}),
 							}),
 						}),
@@ -5910,6 +5988,23 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 								}),
 							}),
 						),
+						plancheck.ExpectKnownValue(
+							"cloudflare_ruleset.my_ruleset",
+							tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("action_parameters").AtMapKey("vary"),
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"default": knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"action": knownvalue.StringExact("bypass"),
+								}),
+								"headers": knownvalue.MapExact(map[string]knownvalue.Check{
+									"accept": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+										"action": knownvalue.StringExact("normalize"),
+										"media_types": knownvalue.ListExact([]knownvalue.Check{
+											knownvalue.StringExact("image/webp"),
+										}),
+									}),
+								}),
+							}),
+						),
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -6043,6 +6138,40 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 									"read_timeout":               knownvalue.Null(),
 									"respect_strong_etags":       knownvalue.Null(),
 									"serve_stale":                knownvalue.Null(),
+								}),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"cloudflare_ruleset.my_ruleset",
+						tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("action_parameters").AtMapKey("vary"),
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"default": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"action": knownvalue.StringExact("bypass"),
+							}),
+							"headers": knownvalue.MapExact(map[string]knownvalue.Check{
+								"accept": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+									"action": knownvalue.StringExact("normalize"),
+									"media_types": knownvalue.ListExact([]knownvalue.Check{
+										knownvalue.StringExact("image/webp"),
+									}),
+								}),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cloudflare_ruleset.my_ruleset",
+						tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("action_parameters").AtMapKey("vary"),
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"default": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"action": knownvalue.StringExact("bypass"),
+							}),
+							"headers": knownvalue.MapExact(map[string]knownvalue.Check{
+								"accept": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+									"action": knownvalue.StringExact("normalize"),
+									"media_types": knownvalue.ListExact([]knownvalue.Check{
+										knownvalue.StringExact("image/webp"),
+									}),
 								}),
 							}),
 						}),

--- a/internal/services/ruleset/schema.go
+++ b/internal/services/ruleset/schema.go
@@ -1542,6 +1542,91 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										},
 									},
 								},
+								"vary": schema.SingleNestedAttribute{
+									Description: "Controls how cached responses vary based on request headers. `default` is required and applies to any Vary response header that does not have a per-header override.",
+									Optional:    true,
+									Validators: []validator.Object{
+										customvalidator.RequiresOtherStringAttributeToBe(
+											path.MatchRelative().AtParent().AtParent().AtName("action"),
+											"set_cache_settings",
+										),
+									},
+									CustomType: customfield.NewNestedObjectType[RulesetRulesActionParametersVaryModel](ctx),
+									Attributes: map[string]schema.Attribute{
+										"default": schema.SingleNestedAttribute{
+											Description: "Controls how response Vary headers without a per-header override contribute to the cache key.",
+											Required:    true,
+											CustomType:  customfield.NewNestedObjectType[RulesetRulesActionParametersVaryDefaultModel](ctx),
+											Attributes: map[string]schema.Attribute{
+												"action": schema.StringAttribute{
+													Description: "How the header value is treated when building the cache key.\nAvailable values: \"bypass\", \"passthrough\", \"normalize\".",
+													Required:    true,
+													Validators: []validator.String{
+														stringvalidator.OneOf("bypass", "passthrough", "normalize"),
+													},
+												},
+											},
+										},
+										"headers": schema.MapNestedAttribute{
+											Description: "A mapping of lowercase request header names to their vary configuration.",
+											Optional:    true,
+											Validators: []validator.Map{
+												mapvalidator.SizeAtMost(50),
+												mapvalidator.KeysAre(
+													stringvalidator.LengthBetween(1, 128),
+													stringvalidator.RegexMatches(
+														regexp.MustCompile("^[a-z0-9_-]+$"),
+														"header names must be lowercase and contain only letters, numbers, underscores, and hyphens",
+													),
+												),
+											},
+											CustomType: customfield.NewNestedObjectMapType[RulesetRulesActionParametersVaryHeaderModel](ctx),
+											NestedObject: schema.NestedAttributeObject{
+												Attributes: map[string]schema.Attribute{
+													"action": schema.StringAttribute{
+														Description: "How the header value is treated when building the cache key.\nAvailable values: \"bypass\", \"passthrough\", \"normalize\".",
+														Required:    true,
+														Validators: []validator.String{
+															stringvalidator.OneOf("bypass", "passthrough", "normalize"),
+														},
+													},
+													"media_types": schema.ListAttribute{
+														Description: "The set of media types to normalize against. Only valid for the `accept` header.",
+														Optional:    true,
+														CustomType:  customfield.NewListType[types.String](ctx),
+														ElementType: types.StringType,
+														Validators: []validator.List{
+															listvalidator.SizeAtMost(10),
+															listvalidator.ValueStringsAre(
+																stringvalidator.LengthBetween(1, 255),
+																stringvalidator.RegexMatches(
+																	regexp.MustCompile("^[ -~]+$"),
+																	"media types must contain only printable ASCII characters",
+																),
+															),
+														},
+													},
+													"languages": schema.ListAttribute{
+														Description: "The set of languages to normalize against. Only valid for the `accept-language` header.",
+														Optional:    true,
+														CustomType:  customfield.NewListType[types.String](ctx),
+														ElementType: types.StringType,
+														Validators: []validator.List{
+															listvalidator.SizeAtMost(20),
+															listvalidator.ValueStringsAre(
+																stringvalidator.LengthBetween(1, 64),
+																stringvalidator.RegexMatches(
+																	regexp.MustCompile("^[ -~]+$"),
+																	"languages must contain only printable ASCII characters",
+																),
+															),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
 								"strip_etags": schema.BoolAttribute{
 									Description: "Whether to strip the ETag header from the response.",
 									Optional:    true,

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_SetCacheSettingsRules/3.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_SetCacheSettingsRules/3.tf
@@ -59,6 +59,24 @@ resource "cloudflare_ruleset" "my_ruleset" {
         serve_stale = {
           disable_stale_while_updating = false
         }
+        vary = {
+          default = {
+            action = "bypass"
+          }
+          headers = {
+            "accept" = {
+              action      = "normalize"
+              media_types = ["image/webp", "image/avif"]
+            }
+            "accept-language" = {
+              action    = "normalize"
+              languages = ["en", "de", "fr"]
+            }
+            "x-custom-header" = {
+              action = "passthrough"
+            }
+          }
+        }
       }
     }
   ]

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_SetCacheSettingsRules/5.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_SetCacheSettingsRules/5.tf
@@ -39,6 +39,17 @@ resource "cloudflare_ruleset" "my_ruleset" {
             }
           }
         }
+        vary = {
+          default = {
+            action = "bypass"
+          }
+          headers = {
+            "accept" = {
+              action      = "normalize"
+              media_types = ["image/webp"]
+            }
+          }
+        }
       }
     }
   ]


### PR DESCRIPTION
Add Terraform support for set_cache_settings.vary, including resource/data source models and generated docs. Match the final Rulesets API shape by keeping Vary action values case-sensitive, requiring `default` when `vary` is present, keeping `headers` optional, enforcing lowercase header names, and applying the documented header/media type/language limits.

Includes acceptance coverage for create/update/remove/re-add flows and provider-side validation for uppercase Vary header names.

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

```sh
TF_ACC=1 \
TF_ACC_TERRAFORM_PATH="$(which terraform)" \
CLOUDFLARE_ACCOUNT_ID="<account id>" \
CLOUDFLARE_ZONE_ID="<zone id>" \
CLOUDFLARE_DOMAIN="miniblog.dev" \
CLOUDFLARE_API_TOKEN="<redacted>" \
go test -v ./internal/services/ruleset \
  -run 'TestAccCloudflareRuleset_SetCacheSettings(Rules|VaryValidation)$' \
  -count=1 \
  -timeout 30m
```

### Test output

```text
=== RUN   TestAccCloudflareRuleset_SetCacheSettingsRules
--- PASS: TestAccCloudflareRuleset_SetCacheSettingsRules (55.07s)
=== RUN   TestAccCloudflareRuleset_SetCacheSettingsVaryValidation
--- PASS: TestAccCloudflareRuleset_SetCacheSettingsVaryValidation (0.24s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/ruleset	57.568s
```

## Additional context & links
