### PR TITLE
fix(zone): remove overly broad .cfapi.net sweeper pattern

### DIFF
--- a/internal/services/zone/resource_test.go
+++ b/internal/services/zone/resource_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/cloudflare/cloudflare-go/v7"
@@ -61,8 +60,7 @@ func testSweepCloudflareZone(r string) error {
 	}
 
 	for _, zone := range page.Result {
-		// Use standard filtering helper (also checked in isTestZone for zone-specific patterns)
-		if !utils.ShouldSweepResource(zone.Name) && !isTestZone(zone.Name) {
+		if !utils.ShouldSweepResource(zone.Name) {
 			continue
 		}
 
@@ -71,36 +69,13 @@ func testSweepCloudflareZone(r string) error {
 			ZoneID: cloudflare.F(zone.ID),
 		})
 		if err != nil {
-			tflog.Error(ctx, fmt.Sprintf("Failed to delete zone %s (%s): %s", zone.Name, zone.ID,err))
+			tflog.Error(ctx, fmt.Sprintf("Failed to delete zone %s (%s): %s", zone.Name, zone.ID, err))
 			continue
 		}
 		tflog.Info(ctx, fmt.Sprintf("Deleted zone: %s (%s)", zone.Name, zone.ID))
 	}
 
 	return nil
-}
-
-// isTestZone checks if a zone name matches test naming patterns
-func isTestZone(name string) bool {
-	// Use standard test resource naming convention
-	if utils.ShouldSweepResource(name) {
-		return true
-	}
-
-	// Match terraform.cfapi.net test domains (zone-specific pattern)
-	if strings.HasSuffix(name, ".terraform.cfapi.net") ||
-		name == "terraform.cfapi.net" {
-		return true
-	}
-
-	// Match .cfapi.net domains (from acceptance tests)
-	if strings.HasSuffix(name, ".cfapi.net") &&
-		!strings.Contains(name, "production") &&
-		!strings.Contains(name, "prod-") {
-		return true
-	}
-
-	return false
 }
 
 func TestAccCloudflareZone_Basic(t *testing.T) {

--- a/internal/services/zone/resource_test.go
+++ b/internal/services/zone/resource_test.go
@@ -78,6 +78,35 @@ func testSweepCloudflareZone(r string) error {
 	return nil
 }
 
+func TestZoneSweeper_NeverDeletesInfrastructureZones(t *testing.T) {
+	// Infrastructure zones that must never be swept.
+	protected := []string{
+		acctest.TestAccCloudflareZoneName,    // terraform.cfapi.net
+		acctest.TestAccCloudflareAltZoneName, // terraform2.cfapi.net
+		"terraform-alt.cfapi.net",            // CI ALT zone (CLOUDFLARE_ALT_DOMAIN)
+		"example.cfapi.net",                  // arbitrary .cfapi.net sibling
+		"example.com",                        // unrelated domain
+	}
+	for _, name := range protected {
+		if utils.ShouldSweepResource(name) {
+			t.Errorf("ShouldSweepResource(%q) = true, infrastructure zone would be deleted", name)
+		}
+	}
+
+	// Dynamically created test zones that must always be swept.
+	swept := []string{
+		fmt.Sprintf("%s.cfapi.net", utils.GenerateRandomResourceName()),
+		fmt.Sprintf("%s.terraform.cfapi.net", utils.GenerateRandomResourceName()),
+		fmt.Sprintf("%s.net", utils.GenerateRandomResourceName()),
+		fmt.Sprintf("sub.%s.cfapi.net", utils.GenerateRandomResourceName()),
+	}
+	for _, name := range swept {
+		if !utils.ShouldSweepResource(name) {
+			t.Errorf("ShouldSweepResource(%q) = false, test zone would leak", name)
+		}
+	}
+}
+
 func TestAccCloudflareZone_Basic(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	name := "cloudflare_zone." + rnd


### PR DESCRIPTION
## Problem

The zone sweeper's `isTestZone()` had a broad `.cfapi.net` suffix match that deleted permanent infrastructure zones. This deleted `terraform-alt.cfapi.net` (the ALT zone) during [CI run 27640049284](https://github.com/cloudflare/terraform-provider-cloudflare/actions/runs/27640049284/job/81742414069), breaking all `zone_subscription` acceptance tests.

## Fix

Remove `isTestZone()` entirely. The sweeper now uses only `ShouldSweepResource()`, which matches the `cftftest` prefix present in every generated test zone name. No other condition can trigger zone deletion.

Adds a unit test validating that infrastructure zones are never swept and generated test zones always are.