### PR TITLE
fix(load_balancer_pool): preserve origins order to prevent perpetual …

### DIFF
--- a/internal/services/load_balancer_pool/custom.go
+++ b/internal/services/load_balancer_pool/custom.go
@@ -1,0 +1,155 @@
+package load_balancer_pool
+
+import (
+	"sort"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+)
+
+// The Load Balancing API canonically returns a pool's origins sorted by name
+// (ORDER BY name), regardless of the order they were submitted in. The Terraform
+// resource models `origins` as an ordered ListNestedAttribute (Stainless cannot
+// emit a SetNestedAttribute here because the nested object contains purely
+// computed children such as `disabled_at` and `port`, whose values are unknown
+// at plan time and therefore cannot participate in set element identity).
+//
+// As a result, a config that lists origins in any order other than ascending by
+// name produces a perpetual diff on every plan/apply (the planned order never
+// matches the server's alphabetical order). See LB-5712 / GitHub #7179 (and the
+// earlier, incompletely-fixed #6140 / LB-5179).
+//
+// UnmarshalCustom / UnmarshalComputedCustom wrap the standard apijson unmarshal
+// and reorder the origins returned by the API back into the order the user
+// planned (captured from the envelope before unmarshal), matching by origin
+// identity (name, tie-broken by address). When there is no prior order to
+// align to (e.g. import), origins fall back to a canonical sort by name, which
+// matches the server's own ordering and is therefore stable.
+
+// UnmarshalCustom unmarshals an API response into env, then reorders origins to
+// match the order already present in env.Result.Origins (the prior state/plan).
+func UnmarshalCustom(data []byte, env *LoadBalancerPoolResultEnvelope) error {
+	snap := snapshotOriginOrder(env.Result.Origins)
+	if err := apijson.Unmarshal(data, env); err != nil {
+		return err
+	}
+	reorderOriginsFromSnapshot(env.Result.Origins, snap)
+	return nil
+}
+
+// UnmarshalComputedCustom is like UnmarshalCustom but uses apijson.UnmarshalComputed,
+// for the create/update paths where computed fields are populated from the response.
+func UnmarshalComputedCustom(data []byte, env *LoadBalancerPoolResultEnvelope) error {
+	snap := snapshotOriginOrder(env.Result.Origins)
+	if err := apijson.UnmarshalComputed(data, env); err != nil {
+		return err
+	}
+	reorderOriginsFromSnapshot(env.Result.Origins, snap)
+	return nil
+}
+
+// originOrderSnapshot captures the prior ordering of origins as plain-string
+// identity fingerprints.
+type originOrderSnapshot struct {
+	fingerprints []string
+}
+
+// originFingerprint builds a stable identity key for an origin: name + address.
+// Both are user-supplied and, in combination, unique within a pool.
+func originFingerprint(name, address string) string {
+	return name + "|" + address
+}
+
+func originFingerprintFromModel(o *LoadBalancerPoolOriginsModel) string {
+	if o == nil {
+		return "|"
+	}
+	return originFingerprint(o.Name.ValueString(), o.Address.ValueString())
+}
+
+// snapshotOriginOrder records the current origin order. Returns nil when there
+// are no prior origins to align to.
+func snapshotOriginOrder(origins *[]*LoadBalancerPoolOriginsModel) *originOrderSnapshot {
+	if origins == nil || len(*origins) == 0 {
+		return nil
+	}
+	snap := &originOrderSnapshot{
+		fingerprints: make([]string, len(*origins)),
+	}
+	for i, o := range *origins {
+		snap.fingerprints[i] = originFingerprintFromModel(o)
+	}
+	return snap
+}
+
+// reorderOriginsFromSnapshot reorders origins to match the prior snapshot. When
+// snap is nil (no prior order), it applies a canonical sort by name (matching
+// the API's own ORDER BY name) so the result is deterministic.
+func reorderOriginsFromSnapshot(origins *[]*LoadBalancerPoolOriginsModel, snap *originOrderSnapshot) {
+	if origins == nil || len(*origins) == 0 {
+		return
+	}
+
+	if snap == nil {
+		sortOriginsByName(origins)
+		return
+	}
+
+	// fingerprint -> desired position from prior order
+	priorIndex := make(map[string]int, len(snap.fingerprints))
+	for i, fp := range snap.fingerprints {
+		// First occurrence wins; duplicate identities are unexpected within a pool.
+		if _, ok := priorIndex[fp]; !ok {
+			priorIndex[fp] = i
+		}
+	}
+
+	os := *origins
+	sort.SliceStable(os, func(i, j int) bool {
+		fpI := originFingerprintFromModel(os[i])
+		fpJ := originFingerprintFromModel(os[j])
+		posI, okI := priorIndex[fpI]
+		posJ, okJ := priorIndex[fpJ]
+
+		switch {
+		case okI && okJ:
+			return posI < posJ
+		case okI:
+			return true // matched (known) origins before unmatched
+		case okJ:
+			return false
+		default:
+			// Both unmatched: canonical order by name.
+			return originLessByName(os[i], os[j])
+		}
+	})
+}
+
+// sortOriginsByName applies a canonical, deterministic sort by name (tie-broken
+// by address) matching the server's ORDER BY name.
+func sortOriginsByName(origins *[]*LoadBalancerPoolOriginsModel) {
+	os := *origins
+	sort.SliceStable(os, func(i, j int) bool {
+		return originLessByName(os[i], os[j])
+	})
+}
+
+func originLessByName(a, b *LoadBalancerPoolOriginsModel) bool {
+	na, nb := "", ""
+	if a != nil {
+		na = a.Name.ValueString()
+	}
+	if b != nil {
+		nb = b.Name.ValueString()
+	}
+	if na != nb {
+		return na < nb
+	}
+	aa, ab := "", ""
+	if a != nil {
+		aa = a.Address.ValueString()
+	}
+	if b != nil {
+		ab = b.Address.ValueString()
+	}
+	return aa < ab
+}

--- a/internal/services/load_balancer_pool/custom_internal_test.go
+++ b/internal/services/load_balancer_pool/custom_internal_test.go
@@ -1,0 +1,121 @@
+package load_balancer_pool
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func origin(name, address string) *LoadBalancerPoolOriginsModel {
+	return &LoadBalancerPoolOriginsModel{
+		Name:    types.StringValue(name),
+		Address: types.StringValue(address),
+	}
+}
+
+func names(origins *[]*LoadBalancerPoolOriginsModel) []string {
+	out := make([]string, 0, len(*origins))
+	for _, o := range *origins {
+		out = append(out, o.Name.ValueString())
+	}
+	return out
+}
+
+func eq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestReorderOriginsMatchesPlannedOrder is the core LB-5712 regression: the API
+// returns origins sorted ascending by name, but they must be reordered back to
+// the order the user planned so Terraform sees no diff.
+func TestReorderOriginsMatchesPlannedOrder(t *testing.T) {
+	// User planned descending order.
+	planned := &[]*LoadBalancerPoolOriginsModel{
+		origin("clusterB", "192.0.2.2"),
+		origin("clusterA", "192.0.2.1"),
+	}
+	snap := snapshotOriginOrder(planned)
+
+	// API returns ascending-by-name order.
+	apiResp := &[]*LoadBalancerPoolOriginsModel{
+		origin("clusterA", "192.0.2.1"),
+		origin("clusterB", "192.0.2.2"),
+	}
+	reorderOriginsFromSnapshot(apiResp, snap)
+
+	want := []string{"clusterB", "clusterA"}
+	if got := names(apiResp); !eq(got, want) {
+		t.Fatalf("reordered origins = %v, want %v", got, want)
+	}
+}
+
+// TestReorderOriginsNoSnapshotCanonicalSort verifies that with no prior order
+// (e.g. import), origins fall back to a deterministic canonical sort by name.
+func TestReorderOriginsNoSnapshotCanonicalSort(t *testing.T) {
+	apiResp := &[]*LoadBalancerPoolOriginsModel{
+		origin("clusterB", "192.0.2.2"),
+		origin("clusterA", "192.0.2.1"),
+	}
+	reorderOriginsFromSnapshot(apiResp, nil)
+
+	want := []string{"clusterA", "clusterB"}
+	if got := names(apiResp); !eq(got, want) {
+		t.Fatalf("canonical sort = %v, want %v", got, want)
+	}
+}
+
+// TestReorderOriginsAddedOriginSortsAfterMatched verifies that an origin present
+// in the API response but absent from the prior plan is placed after the matched
+// origins, in canonical name order, rather than dropped or causing instability.
+func TestReorderOriginsAddedOriginSortsAfterMatched(t *testing.T) {
+	planned := &[]*LoadBalancerPoolOriginsModel{
+		origin("clusterB", "192.0.2.2"),
+		origin("clusterA", "192.0.2.1"),
+	}
+	snap := snapshotOriginOrder(planned)
+
+	apiResp := &[]*LoadBalancerPoolOriginsModel{
+		origin("clusterA", "192.0.2.1"),
+		origin("clusterZ", "192.0.2.9"), // not in plan
+		origin("clusterB", "192.0.2.2"),
+	}
+	reorderOriginsFromSnapshot(apiResp, snap)
+
+	want := []string{"clusterB", "clusterA", "clusterZ"}
+	if got := names(apiResp); !eq(got, want) {
+		t.Fatalf("reordered origins = %v, want %v", got, want)
+	}
+}
+
+// TestReorderOriginsSameNameDifferentAddress verifies that identity uses both
+// name and address, so origins are matched precisely when names collide.
+func TestReorderOriginsSameNameDifferentAddress(t *testing.T) {
+	planned := &[]*LoadBalancerPoolOriginsModel{
+		origin("dup", "192.0.2.9"),
+		origin("dup", "192.0.2.1"),
+	}
+	snap := snapshotOriginOrder(planned)
+
+	apiResp := &[]*LoadBalancerPoolOriginsModel{
+		origin("dup", "192.0.2.1"),
+		origin("dup", "192.0.2.9"),
+	}
+	reorderOriginsFromSnapshot(apiResp, snap)
+
+	wantAddrs := []string{"192.0.2.9", "192.0.2.1"}
+	got := make([]string, 0, 2)
+	for _, o := range *apiResp {
+		got = append(got, o.Address.ValueString())
+	}
+	if !eq(got, wantAddrs) {
+		t.Fatalf("reordered addresses = %v, want %v", got, wantAddrs)
+	}
+}

--- a/internal/services/load_balancer_pool/resource.go
+++ b/internal/services/load_balancer_pool/resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cloudflare/cloudflare-go/v7"
 	"github.com/cloudflare/cloudflare-go/v7/load_balancers"
 	"github.com/cloudflare/cloudflare-go/v7/option"
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -85,7 +84,7 @@ func (r *LoadBalancerPoolResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.UnmarshalComputed(bytes, &env)
+	err = UnmarshalComputedCustom(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
@@ -134,7 +133,7 @@ func (r *LoadBalancerPoolResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.UnmarshalComputed(bytes, &env)
+	err = UnmarshalComputedCustom(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
@@ -178,7 +177,7 @@ func (r *LoadBalancerPoolResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	err = UnmarshalCustom(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
@@ -248,7 +247,7 @@ func (r *LoadBalancerPoolResource) ImportState(ctx context.Context, req resource
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	err = UnmarshalCustom(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return

--- a/internal/services/load_balancer_pool/resource_test.go
+++ b/internal/services/load_balancer_pool/resource_test.go
@@ -210,6 +210,48 @@ func TestAccCloudflareLoadBalancerPool_NoLoadSheddingDrift(t *testing.T) {
 	})
 }
 
+// TestAccCloudflareLoadBalancerPool_OriginsOrderNoDrift verifies that a pool
+// whose origins are declared in a non-alphabetical order does NOT produce drift
+// on a no-op re-apply. The Load Balancing API canonically returns origins sorted
+// ascending by name; without reordering the API response back to the planned
+// order, Terraform sees the reordered list as a change on every plan
+// (LB-5712 / GitHub #7179, previously #6140 / LB-5179).
+func TestAccCloudflareLoadBalancerPool_OriginsOrderNoDrift(t *testing.T) {
+	t.Parallel()
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_load_balancer_pool." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareLoadBalancerPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create a pool with origins in descending name order.
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigOriginsOrder(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "origins.#", "2"),
+					// Planned (descending) order must be preserved in state.
+					resource.TestCheckResourceAttr(name, "origins.0.name", "clusterB"),
+					resource.TestCheckResourceAttr(name, "origins.1.name", "clusterA"),
+				),
+			},
+			{
+				// Step 2: re-apply identical config. Must be a no-op. Without
+				// the response reordering, this would plan an in-place update
+				// because the API returns origins sorted ascending by name.
+				Config: testAccCheckCloudflareLoadBalancerPoolConfigOriginsOrder(rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(name, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccCloudflareLoadBalancerPool_OriginSteeringLeastOutstandingRequests(t *testing.T) {
 	// multiple instances of this config would conflict but we only use it once
 	t.Parallel()
@@ -589,6 +631,10 @@ func testAccManuallyDeleteLoadBalancerPool(name string, loadBalancerPool *cfold.
 // using IPs from 192.0.2.0/24 as per RFC5737.
 func testAccCheckCloudflareLoadBalancerPoolConfigBasic(id, accountID string) string {
 	return acctest.LoadTestCase("loadbalancerpoolconfigbasic.tf", id, accountID)
+}
+
+func testAccCheckCloudflareLoadBalancerPoolConfigOriginsOrder(id, accountID string) string {
+	return acctest.LoadTestCase("loadbalancerpoolconfigoriginsorder.tf", id, accountID)
 }
 
 func testAccCheckCloudflareLoadBalancerPoolConfigOriginSteeringLeastOutstandingRequests(id, accountID string) string {

--- a/internal/services/load_balancer_pool/testdata/loadbalancerpoolconfigoriginsorder.tf
+++ b/internal/services/load_balancer_pool/testdata/loadbalancerpoolconfigoriginsorder.tf
@@ -1,0 +1,23 @@
+
+resource "cloudflare_load_balancer_pool" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "my-tf-pool-order-%[1]s"
+
+  # Origins deliberately listed in DESCENDING name order. The API canonically
+  # returns them sorted ascending by name, so without the response-reordering
+  # fix this config produces a perpetual diff (LB-5712 / GitHub #7179).
+  origins = [
+    {
+      name    = "clusterB"
+      address = "192.0.2.2"
+      weight  = 0
+      enabled = true
+    },
+    {
+      name    = "clusterA"
+      address = "192.0.2.1"
+      weight  = 1
+      enabled = true
+    },
+  ]
+}


### PR DESCRIPTION
…drift

The Load Balancing API canonically returns a pool's origins sorted ascending by name (ORDER BY name), regardless of submitted order. The resource models `origins` as an ordered ListNestedAttribute (Stainless cannot emit a SetNestedAttribute because the nested object has purely-computed children, e.g. disabled_at/port, whose values are unknown at plan time and cannot participate in set element identity).

As a result, any config that lists origins in a non-alphabetical order produces a perpetual diff on every plan/apply.

Mirror the api_token pattern: reorder the API response back into the user's planned order during unmarshal, matching by origin identity (name, tie-broken by address). With no prior order (import), fall back to a deterministic canonical sort by name.

Fixes #7179 (previously #6140).

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
