### PR TITLE
resource/cloudflare_ruleset: allow edge_ttl.default of 0 for override origin

### DIFF
--- a/.changelog/edge-ttl-zero.txt
+++ b/.changelog/edge-ttl-zero.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/cloudflare_ruleset: allow `edge_ttl.default` of `0` for `override_origin` mode (no edge caching / always revalidate), which the Cloudflare API accepts
+```

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -473,7 +473,7 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 												},
 												"default": schema.Int64Attribute{
 													Optional:            true,
-													Validators:          []validator.Int64{int64validator.AtLeast(1)},
+													Validators:          []validator.Int64{int64validator.AtLeast(0)},
 													MarkdownDescription: "Default edge TTL.",
 												},
 											},

--- a/internal/framework/service/rulesets/validators.go
+++ b/internal/framework/service/rulesets/validators.go
@@ -34,11 +34,21 @@ func (v EdgeTTLValidator) ValidateObject(ctx context.Context, req validator.Obje
 	}
 
 	if parameter.Mode.ValueString() == "override_origin" {
-		if parameter.Default.ValueInt64() <= 0 {
+		// override_origin still requires a default to be set, but an explicit
+		// default of 0 is valid (no edge caching / always revalidate) and is
+		// accepted by the Cloudflare API. Only treat an unset default or a
+		// negative value as invalid. (Mirrors the v5 provider's AtLeast(0).)
+		if parameter.Default.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				req.Path,
 				errInvalidConfiguration,
 				fmt.Sprintf("using mode '%s' requires setting a default for ttl", parameter.Mode.ValueString()),
+			)
+		} else if parameter.Default.ValueInt64() < 0 {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				errInvalidConfiguration,
+				fmt.Sprintf("using mode '%s' requires a default ttl of 0 or greater", parameter.Mode.ValueString()),
 			)
 		}
 	} else if parameter.Mode.ValueString() == "bypass_by_default" {

--- a/internal/framework/service/rulesets/validators_test.go
+++ b/internal/framework/service/rulesets/validators_test.go
@@ -44,7 +44,7 @@ func TestEdgeTTLValidation(t *testing.T) {
 				}
 			})
 
-			t.Run("errors when invalid ttl is passed", func(t *testing.T) {
+			t.Run("errors when negative ttl is passed", func(t *testing.T) {
 				t.Parallel()
 
 				resp := &validator.ObjectResponse{}
@@ -53,7 +53,7 @@ func TestEdgeTTLValidation(t *testing.T) {
 
 				expected := &validator.ObjectResponse{
 					Diagnostics: diag.Diagnostics{
-						diag.NewAttributeErrorDiagnostic(path.Root("edge_ttl"), "invalid configuration", "using mode 'override_origin' requires setting a default for ttl"),
+						diag.NewAttributeErrorDiagnostic(path.Root("edge_ttl"), "invalid configuration", "using mode 'override_origin' requires a default ttl of 0 or greater"),
 					},
 				}
 				if diff := cmp.Diff(resp, expected); diff != "" {
@@ -66,6 +66,21 @@ func TestEdgeTTLValidation(t *testing.T) {
 
 				resp := &validator.ObjectResponse{}
 				req := constructEdgeTTLObjectRequest("override_origin", big.NewFloat(10))
+				edgeValidator.ValidateObject(ctx, req, resp)
+
+				expected := &validator.ObjectResponse{
+					Diagnostics: nil,
+				}
+				if diff := cmp.Diff(resp, expected); diff != "" {
+					t.Errorf("unexpected difference: %s", diff)
+				}
+			})
+
+			t.Run("passes when ttl of 0 is passed (no edge caching / always revalidate)", func(t *testing.T) {
+				t.Parallel()
+
+				resp := &validator.ObjectResponse{}
+				req := constructEdgeTTLObjectRequest("override_origin", big.NewFloat(0))
 				edgeValidator.ValidateObject(ctx, req, resp)
 
 				expected := &validator.ObjectResponse{


### PR DESCRIPTION
The schema validator (AtLeast(1)) and EdgeTTLValidator both rejected an edge_ttl.default of 0, even though the Cloudflare API accepts it (0 means no edge caching / always revalidate). This broke zone version cloning (Kamino) for any zone with a Cache Rule using 'Ignore cache-control header and use this TTL = 0'.

Relax the schema validator to AtLeast(0) and update EdgeTTLValidator so override_origin still requires a default to be set (IsNull check) while allowing an explicit 0; only negative values are rejected. Mirrors the v5 provider behaviour.

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
