### PR TITLE
fix(snippet): guard against nil Metadata in Read after import

### DIFF
--- a/internal/services/snippet/resource.go
+++ b/internal/services/snippet/resource.go
@@ -204,6 +204,9 @@ func (r *SnippetResource) Read(ctx context.Context, req resource.ReadRequest, re
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
+	if data.Metadata == nil {
+		data.Metadata = &SnippetMetadataModel{}
+	}
 	data.Metadata.MainModule = types.StringValue(res.Header.Get("Cf-Entrypoint"))
 	bytes, _ = io.ReadAll(res.Body)
 	err = data.UnmarshalMultipart(bytes, res.Header.Get("Content-Type"))

--- a/internal/services/snippet/resource_test.go
+++ b/internal/services/snippet/resource_test.go
@@ -157,6 +157,141 @@ func TestAccCloudflareSnippet_Basic(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareSnippet_Import(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	resourceName := "cloudflare_snippet." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareSnippetDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create the snippet
+			{
+				Config: testAccCloudflareSnippetConfig(rnd, zoneID),
+			},
+			// Step 2: Import and verify state matches config.
+			// This covers the nil-pointer dereference fix: ImportState
+			// leaves Metadata nil, then Read must handle that without
+			// crashing when it populates Metadata.MainModule from the
+			// Content.Get response header.
+			{
+				Config:            testAccCloudflareSnippetConfig(rnd, zoneID),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     zoneID + "/" + rnd,
+				ImportStateVerify: true,
+			},
+			// Step 3: Plan after import produces no diff, confirming
+			// that Read fully populated files and metadata from the
+			// Content.Get endpoint.
+			{
+				Config: testAccCloudflareSnippetConfig(rnd, zoneID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSnippet_ImportFieldValidation(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareSnippetDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with the basic config
+			{
+				Config: testAccCloudflareSnippetConfig(rnd, zoneID),
+			},
+			// Step 2: Import with field-level validation
+			{
+				ResourceName: "cloudflare_snippet." + rnd,
+				ImportState:  true,
+				ImportStateId: zoneID + "/" + rnd,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 instance state, got %d", len(states))
+					}
+					s := states[0]
+
+					if v := s.Attributes["zone_id"]; v != zoneID {
+						return fmt.Errorf("expected zone_id %q, got %q", zoneID, v)
+					}
+					if v := s.Attributes["snippet_name"]; v != rnd {
+						return fmt.Errorf("expected snippet_name %q, got %q", rnd, v)
+					}
+					if v := s.Attributes["metadata.main_module"]; v != "main.js" {
+						return fmt.Errorf("expected metadata.main_module %q, got %q", "main.js", v)
+					}
+					if v := s.Attributes["files.#"]; v != "1" {
+						return fmt.Errorf("expected 1 file, got %s", v)
+					}
+					if v := s.Attributes["files.0.name"]; v != "main.js" {
+						return fmt.Errorf("expected files.0.name %q, got %q", "main.js", v)
+					}
+					if v := s.Attributes["files.0.content"]; v == "" {
+						return fmt.Errorf("expected files.0.content to be non-empty")
+					}
+					if v := s.Attributes["created_on"]; v == "" {
+						return fmt.Errorf("expected created_on to be set")
+					}
+					if v := s.Attributes["modified_on"]; v == "" {
+						return fmt.Errorf("expected modified_on to be set")
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSnippet_ImportAfterUpdate(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	resourceName := "cloudflare_snippet." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareSnippetDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create
+			{
+				Config: testAccCloudflareSnippetConfig(rnd, zoneID),
+			},
+			// Step 2: Update content
+			{
+				Config: testAccCloudflareSnippetConfigUpdate(rnd, zoneID),
+			},
+			// Step 3: Import the updated resource
+			{
+				Config:            testAccCloudflareSnippetConfigUpdate(rnd, zoneID),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     zoneID + "/" + rnd,
+				ImportStateVerify: true,
+			},
+			// Step 4: Plan after import is clean
+			{
+				Config: testAccCloudflareSnippetConfigUpdate(rnd, zoneID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckCloudflareSnippetDestroy(s *terraform.State) error {
 	client := acctest.SharedClient()
 


### PR DESCRIPTION
## Summary

Fixes a nil pointer dereference (SIGSEGV crash) in `cloudflare_snippet` that occurs when running `terraform import`.

## Problem

The custom `Content.Get` call in `Read` dereferences `data.Metadata.MainModule` without a nil check. After `ImportState`, `Metadata` is `nil` because:

1. `ImportState` creates a fresh `new(SnippetModel)` (`Metadata` is nil)
2. `Snippets.Get` JSON response does not include `metadata`
3. `apijson.Unmarshal` skips the field (`no_refresh` tag)
4. State is saved with nil `Metadata`
5. `Read` loads state, unmarshal skips `Metadata` again
6. Line 207: `data.Metadata.MainModule = ...` -- nil pointer panic

Stack trace from customer:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3d7e7cd]
goroutine 1673 [running]:
...snippet.(*SnippetResource).Read(...)
    .../internal/services/snippet/resource.go:207 +0xb4d
```

## Fix

Initialize `Metadata` when nil before accessing `MainModule`:

```go
if data.Metadata == nil {
    data.Metadata = &SnippetMetadataModel{}
}
data.Metadata.MainModule = types.StringValue(res.Header.Get("Cf-Entrypoint"))
```

## Testing

- `go build ./internal/services/snippet/...` passes
- Nil dereference confirmed via standalone Go reproduction (fresh struct -> unmarshal without metadata -> assign to pointer field -> panic)