### PR TITLE
fix(docs): add .md extension to migration guide links

### DIFF
--- a/docs/guides/migrating-renamed-resources.md
+++ b/docs/guides/migrating-renamed-resources.md
@@ -7,7 +7,7 @@ description: Guide for handling renamed resources in the Cloudflare Provider
 ## Before you start
 
 -> For v4 to v5 migrations, the recommended approach is the
-[version 5 migration guide](version-5-migration) which uses built-in state
+[version 5 migration guide](version-5-migration.md) which uses built-in state
 upgraders that handle both configuration and state migration automatically.
 
 This guide covers general strategies for handling renamed resources across

--- a/docs/guides/version-5-migration.md
+++ b/docs/guides/version-5-migration.md
@@ -1706,12 +1706,12 @@ for details. If the diff is truly just cosmetic, you can safely ignore it.
 
 - [Version 5 Upgrade Guide][version 5 upgrade guide] -- Per-resource attribute
   change details and manual migration notes.
-- [Migrating Renamed Resources](migrating-renamed-resources) -- Detailed
+- [Migrating Renamed Resources](migrating-renamed-resources.md) -- Detailed
   guide for the import, state file, and two-phase swap approaches.
 - [tf-migrate] -- Source code and documentation for the HCL migration tool.
 - [Terraform moved blocks](https://developer.hashicorp.com/terraform/language/moved) --
   HashiCorp documentation on the `moved` block syntax.
 
-[version 5 upgrade guide]: version-5-upgrade
+[version 5 upgrade guide]: version-5-upgrade.md
 [tf-migrate]: https://github.com/cloudflare/tf-migrate
-[migrating renamed resources]: migrating-renamed-resources
+[migrating renamed resources]: migrating-renamed-resources.md

--- a/docs/guides/version-5-upgrade.md
+++ b/docs/guides/version-5-upgrade.md
@@ -58,7 +58,7 @@ sections, there is the need to migrate attributes and potentially the resource r
 ### Automatic (tf-migrate)
 
 -> For the recommended migration approach using built-in state upgraders, see the
-[version 5 migration guide](version-5-migration).
+[version 5 migration guide](version-5-migration.md).
 
 For automatic configuration (HCL) migrations, use [tf-migrate], the official
 Cloudflare Terraform Provider migration tool. It handles resource renames,
@@ -156,7 +156,7 @@ completes the migration in a single pass.
 ~> `tf-migrate` handles configuration (HCL) transformations only. State migration
 is handled automatically by the v5 provider's built-in state upgraders when you
 run `terraform plan` or `terraform apply`. See the
-[version 5 migration guide](version-5-migration) for details.
+[version 5 migration guide](version-5-migration.md) for details.
 
 ~> While all efforts have been made to ease the transition, some resources require
 manual steps after migration. tf-migrate prints actionable warnings with exact
@@ -251,7 +251,7 @@ If you are not using `tf-migrate`, you can do the equivalent state removal
 manually with `terraform state rm cloudflare_access_policy.example` before
 applying the inline policy configuration.
 
-See the [migration guide](version-5-migration#application-scoped-access-policies)
+See the [migration guide](version-5-migration.md#application-scoped-access-policies)
 for detailed instructions.
 
 ## cloudflare_access_rule
@@ -1477,9 +1477,9 @@ This has been removed. Users should instead use the:
   `cloudflare_zero_trust_access_application` carries its policies in its
   `policies` attribute, either inline or as a list of policy IDs. See the
   migration guide's
-  [Application-Scoped Access Policies](version-5-migration#application-scoped-access-policies)
+  [Application-Scoped Access Policies](version-5-migration.md#application-scoped-access-policies)
   section, including
-  [Keeping existing policies attached (in-place migration)](version-5-migration#keeping-existing-policies-attached-in-place-migration)
+  [Keeping existing policies attached (in-place migration)](version-5-migration.md#keeping-existing-policies-attached-in-place-migration)
   if your applications reference policy UUIDs.
 - `approval_group` is now a list of objects (`approval_group = [{ ... }]`) instead of multiple block attribute (`approval_group { ... }`).
 - `auth_context` is now a list of objects (`auth_context = [{ ... }]`) instead of multiple block attribute (`auth_context { ... }`).


### PR DESCRIPTION
## Summary

Relative links to `version-5-migration` (without the `.md` extension) in
`migrating-renamed-resources.md` and `version-5-upgrade.md` resolve correctly
on the Terraform Registry but 404 on GitHub.

Adding the `.md` extension fixes GitHub rendering while remaining compatible
with the Terraform Registry, which strips the extension automatically.

## Changes

- `docs/guides/migrating-renamed-resources.md`: 1 link fixed
- `docs/guides/version-5-upgrade.md`: 5 links fixed

All instances of `(version-5-migration)` and `(version-5-migration#...)`
updated to `(version-5-migration.md)` and `(version-5-migration.md#...)`.