### PR TITLE
MCP-203: fix perpetual drift in cloudflare_zero_trust_access_ai_controls_mcp_portal

### DIFF
--- a/docs/resources/zero_trust_access_ai_controls_mcp_portal.md
+++ b/docs/resources/zero_trust_access_ai_controls_mcp_portal.md
@@ -59,7 +59,7 @@ resource "cloudflare_zero_trust_access_ai_controls_mcp_portal" "example_zero_tru
 - `allow_code_mode` (Boolean) Allow remote code execution in Dynamic Workers (beta)
 - `description` (String)
 - `secure_web_gateway` (Boolean) Route outbound MCP traffic through Zero Trust Secure Web Gateway
-- `servers` (Attributes List) (see [below for nested schema](#nestedatt--servers))
+- `servers` (Attributes Set) (see [below for nested schema](#nestedatt--servers))
 
 ### Read-Only
 

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/flatten.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/flatten.go
@@ -1,0 +1,76 @@
+package zero_trust_access_ai_controls_mcp_portal
+
+import (
+	"encoding/json"
+)
+
+// injectServerIDs rewrites a raw portal API response so that each
+// servers[].id is also present under the key servers[].server_id.
+//
+// The portal API returns each attached server's identity under the JSON key
+// "id", but the resource schema and the Create/Update request body use
+// "server_id" for the same value. apijson maps a struct field to a single JSON
+// key for both read and write, so a plain unmarshal looking for "server_id"
+// finds nothing in a response that uses "id", leaving server_id null in state.
+//
+// Populating server_id BEFORE the unmarshal is required because servers is
+// modeled as a set: set elements are identified by their full object value, so
+// elements whose server_id is null would collapse together and could not be
+// matched against config by identity. Injecting the key lets apijson populate
+// server_id natively during (Computed)Unmarshal for Read, Import, Create, and
+// Update alike.
+//
+// Best effort: returns the input unchanged on any parse error, and never
+// overwrites a server_id that is already present.
+func injectServerIDs(body []byte) []byte {
+	var env map[string]json.RawMessage
+	if json.Unmarshal(body, &env) != nil {
+		return body
+	}
+	resRaw, ok := env["result"]
+	if !ok {
+		return body
+	}
+	var portal map[string]json.RawMessage
+	if json.Unmarshal(resRaw, &portal) != nil {
+		return body
+	}
+	serversRaw, ok := portal["servers"]
+	if !ok {
+		return body
+	}
+	var servers []map[string]json.RawMessage
+	if json.Unmarshal(serversRaw, &servers) != nil {
+		return body
+	}
+
+	changed := false
+	for _, s := range servers {
+		if _, has := s["server_id"]; has {
+			continue
+		}
+		if id, ok := s["id"]; ok {
+			s["server_id"] = id
+			changed = true
+		}
+	}
+	if !changed {
+		return body
+	}
+
+	ns, err := json.Marshal(servers)
+	if err != nil {
+		return body
+	}
+	portal["servers"] = ns
+	np, err := json.Marshal(portal)
+	if err != nil {
+		return body
+	}
+	env["result"] = np
+	out, err := json.Marshal(env)
+	if err != nil {
+		return body
+	}
+	return out
+}

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/flatten_internal_test.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/flatten_internal_test.go
@@ -1,0 +1,75 @@
+package zero_trust_access_ai_controls_mcp_portal
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestInjectServerIDs verifies the Read/Create/Update/Import fix that copies each
+// servers[].id into servers[].server_id in the raw response before unmarshal. The
+// portal API returns identity under "id"; the schema/write path use "server_id".
+// Injecting the key lets apijson populate server_id natively so the servers set is
+// keyed correctly rather than collapsing elements that differ only by a null
+// server_id.
+func TestInjectServerIDs(t *testing.T) {
+	serverIDs := func(body []byte) []string {
+		var env struct {
+			Result struct {
+				Servers []map[string]any `json:"servers"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal(body, &env); err != nil {
+			t.Fatalf("unmarshal result: %v", err)
+		}
+		out := make([]string, 0, len(env.Result.Servers))
+		for _, s := range env.Result.Servers {
+			if v, ok := s["server_id"].(string); ok {
+				out = append(out, v)
+			} else {
+				out = append(out, "<none>")
+			}
+		}
+		return out
+	}
+
+	t.Run("injects server_id from id, preserves order", func(t *testing.T) {
+		in := []byte(`{"result":{"id":"p","servers":[{"id":"alpha","name":"A"},{"id":"beta","name":"B"}]}}`)
+		got := serverIDs(injectServerIDs(in))
+		want := []string{"alpha", "beta"}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("servers[%d].server_id = %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("does not clobber an existing server_id", func(t *testing.T) {
+		in := []byte(`{"result":{"id":"p","servers":[{"id":"alpha","server_id":"explicit"}]}}`)
+		got := serverIDs(injectServerIDs(in))
+		if got[0] != "explicit" {
+			t.Errorf("server_id = %q, want %q (must not overwrite)", got[0], "explicit")
+		}
+	})
+
+	t.Run("no servers key leaves body unchanged", func(t *testing.T) {
+		in := []byte(`{"result":{"id":"p","name":"x"}}`)
+		if string(injectServerIDs(in)) != string(in) {
+			t.Errorf("expected unchanged body")
+		}
+	})
+
+	t.Run("unparseable body left unchanged", func(t *testing.T) {
+		in := []byte(`not json`)
+		if string(injectServerIDs(in)) != string(in) {
+			t.Errorf("expected unchanged body on parse error")
+		}
+	})
+
+	t.Run("server without id left without server_id", func(t *testing.T) {
+		in := []byte(`{"result":{"servers":[{"name":"A"}]}}`)
+		got := serverIDs(injectServerIDs(in))
+		if got[0] != "<none>" {
+			t.Errorf("expected no server_id injected when id absent, got %q", got[0])
+		}
+	})
+}

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/migrations.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/migrations.go
@@ -5,19 +5,124 @@ package zero_trust_access_ai_controls_mcp_portal
 import (
 	"context"
 
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var _ resource.ResourceWithUpgradeState = (*ZeroTrustAccessAIControlsMcpPortalResource)(nil)
 
+// zeroTrustAccessAIControlsMcpPortalModelV500 mirrors the pre-501 state shape,
+// where servers was modeled as a List instead of a Set. Only the Servers field
+// type differs from the current model; every other attribute is unchanged.
+type zeroTrustAccessAIControlsMcpPortalModelV500 struct {
+	ID               types.String                                                                 `tfsdk:"id"`
+	AccountID        types.String                                                                 `tfsdk:"account_id"`
+	Hostname         types.String                                                                 `tfsdk:"hostname"`
+	Name             types.String                                                                 `tfsdk:"name"`
+	Description      types.String                                                                 `tfsdk:"description"`
+	AllowCodeMode    types.Bool                                                                   `tfsdk:"allow_code_mode"`
+	SecureWebGateway types.Bool                                                                   `tfsdk:"secure_web_gateway"`
+	Servers          customfield.NestedObjectList[ZeroTrustAccessAIControlsMcpPortalServersModel] `tfsdk:"servers"`
+	CreatedAt        timetypes.RFC3339                                                            `tfsdk:"created_at"`
+	CreatedBy        types.String                                                                 `tfsdk:"created_by"`
+	ModifiedAt       timetypes.RFC3339                                                            `tfsdk:"modified_at"`
+	ModifiedBy       types.String                                                                 `tfsdk:"modified_by"`
+}
+
 func (r *ZeroTrustAccessAIControlsMcpPortalResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
-	targetSchema := ResourceSchema(ctx)
-	return map[int64]resource.StateUpgrader{
-		0: {
-			PriorSchema: &targetSchema,
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				resp.State.Raw = req.State.Raw
-			},
+	priorSchema := resourceSchemaV500(ctx)
+	upgrader := resource.StateUpgrader{
+		PriorSchema: &priorSchema,
+		StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+			var prior zeroTrustAccessAIControlsMcpPortalModelV500
+			resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			upgraded, diags := upgradeMcpPortalV500ToV501(ctx, prior)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, upgraded)...)
 		},
 	}
+
+	// The resource only ever shipped at schema version 500 (servers as a List),
+	// so 500 is the real prior version. The 0 entry is kept for safety: any such
+	// state is list-shaped too and converts identically.
+	return map[int64]resource.StateUpgrader{
+		0:   upgrader,
+		500: upgrader,
+	}
+}
+
+// upgradeMcpPortalV500ToV501 converts a pre-501 portal state (servers as a List)
+// to the current model (servers as a Set). It is a pure function so it can be
+// unit-tested without constructing a tfsdk.State.
+func upgradeMcpPortalV500ToV501(
+	ctx context.Context,
+	prior zeroTrustAccessAIControlsMcpPortalModelV500,
+) (ZeroTrustAccessAIControlsMcpPortalModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	upgraded := ZeroTrustAccessAIControlsMcpPortalModel{
+		ID:               prior.ID,
+		AccountID:        prior.AccountID,
+		Hostname:         prior.Hostname,
+		Name:             prior.Name,
+		Description:      prior.Description,
+		AllowCodeMode:    prior.AllowCodeMode,
+		SecureWebGateway: prior.SecureWebGateway,
+		CreatedAt:        prior.CreatedAt,
+		CreatedBy:        prior.CreatedBy,
+		ModifiedAt:       prior.ModifiedAt,
+		ModifiedBy:       prior.ModifiedBy,
+	}
+
+	switch {
+	case prior.Servers.IsNull():
+		upgraded.Servers = customfield.NullObjectSet[ZeroTrustAccessAIControlsMcpPortalServersModel](ctx)
+	case prior.Servers.IsUnknown():
+		upgraded.Servers = customfield.UnknownObjectSet[ZeroTrustAccessAIControlsMcpPortalServersModel](ctx)
+	default:
+		servers, d := prior.Servers.AsStructSliceT(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return upgraded, diags
+		}
+		set, d := customfield.NewObjectSet(ctx, servers)
+		diags.Append(d...)
+		if diags.HasError() {
+			return upgraded, diags
+		}
+		upgraded.Servers = set
+	}
+
+	return upgraded, diags
+}
+
+// resourceSchemaV500 returns the pre-501 resource schema, where servers was a
+// ListNestedAttribute. Used as the PriorSchema when upgrading state to 501. It
+// reuses the current nested-object definition so the two stay in sync.
+func resourceSchemaV500(ctx context.Context) schema.Schema {
+	s := ResourceSchema(ctx)
+	s.Version = 500
+
+	if set, ok := s.Attributes["servers"].(schema.SetNestedAttribute); ok {
+		s.Attributes["servers"] = schema.ListNestedAttribute{
+			Computed:     true,
+			Optional:     true,
+			CustomType:   customfield.NewNestedObjectListType[ZeroTrustAccessAIControlsMcpPortalServersModel](ctx),
+			NestedObject: set.NestedObject,
+		}
+	}
+
+	return s
 }

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/migrations_internal_test.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/migrations_internal_test.go
@@ -1,0 +1,75 @@
+package zero_trust_access_ai_controls_mcp_portal
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestUpgradeMcpPortalV500ToV501 verifies the list -> set state migration for the
+// servers attribute: every element is preserved (by server_id), scalar fields are
+// copied through, and the null/unknown cases are handled without error.
+func TestUpgradeMcpPortalV500ToV501(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("converts servers list to set preserving elements", func(t *testing.T) {
+		priorServers := []ZeroTrustAccessAIControlsMcpPortalServersModel{
+			{ServerID: types.StringValue("alpha"), DefaultDisabled: types.BoolValue(true), OnBehalf: types.BoolValue(true)},
+			{ServerID: types.StringValue("beta"), DefaultDisabled: types.BoolValue(false), OnBehalf: types.BoolValue(false)},
+		}
+		prior := zeroTrustAccessAIControlsMcpPortalModelV500{
+			ID:      types.StringValue("mcp-sandbox"),
+			Name:    types.StringValue("MCP Gateway (Sandbox)"),
+			Servers: customfield.NewObjectListMust(ctx, priorServers),
+		}
+
+		upgraded, diags := upgradeMcpPortalV500ToV501(ctx, prior)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+
+		if upgraded.ID.ValueString() != "mcp-sandbox" {
+			t.Errorf("id = %q, want %q", upgraded.ID.ValueString(), "mcp-sandbox")
+		}
+		if upgraded.Name.ValueString() != "MCP Gateway (Sandbox)" {
+			t.Errorf("name = %q, want %q", upgraded.Name.ValueString(), "MCP Gateway (Sandbox)")
+		}
+
+		got, d := upgraded.Servers.AsStructSliceT(ctx)
+		if d.HasError() {
+			t.Fatalf("AsStructSliceT: %v", d)
+		}
+		ids := make([]string, 0, len(got))
+		for _, s := range got {
+			ids = append(ids, s.ServerID.ValueString())
+		}
+		sort.Strings(ids)
+		want := []string{"alpha", "beta"}
+		if len(ids) != len(want) {
+			t.Fatalf("got %d servers, want %d", len(ids), len(want))
+		}
+		for i := range want {
+			if ids[i] != want[i] {
+				t.Errorf("server_id[%d] = %q, want %q", i, ids[i], want[i])
+			}
+		}
+	})
+
+	t.Run("null servers stays null", func(t *testing.T) {
+		prior := zeroTrustAccessAIControlsMcpPortalModelV500{
+			ID:      types.StringValue("p"),
+			Servers: customfield.NullObjectList[ZeroTrustAccessAIControlsMcpPortalServersModel](ctx),
+		}
+
+		upgraded, diags := upgradeMcpPortalV500ToV501(ctx, prior)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if !upgraded.Servers.IsNull() {
+			t.Errorf("expected servers to remain null")
+		}
+	})
+}

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/model.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/model.go
@@ -14,18 +14,18 @@ type ZeroTrustAccessAIControlsMcpPortalResultEnvelope struct {
 }
 
 type ZeroTrustAccessAIControlsMcpPortalModel struct {
-	ID               types.String                                                                 `tfsdk:"id" json:"id,required"`
-	AccountID        types.String                                                                 `tfsdk:"account_id" path:"account_id,required"`
-	Hostname         types.String                                                                 `tfsdk:"hostname" json:"hostname,required"`
-	Name             types.String                                                                 `tfsdk:"name" json:"name,required"`
-	Description      types.String                                                                 `tfsdk:"description" json:"description,optional"`
-	AllowCodeMode    types.Bool                                                                   `tfsdk:"allow_code_mode" json:"allow_code_mode,computed_optional"`
-	SecureWebGateway types.Bool                                                                   `tfsdk:"secure_web_gateway" json:"secure_web_gateway,computed_optional"`
-	Servers          customfield.NestedObjectList[ZeroTrustAccessAIControlsMcpPortalServersModel] `tfsdk:"servers" json:"servers,computed_optional"`
-	CreatedAt        timetypes.RFC3339                                                            `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
-	CreatedBy        types.String                                                                 `tfsdk:"created_by" json:"created_by,computed"`
-	ModifiedAt       timetypes.RFC3339                                                            `tfsdk:"modified_at" json:"modified_at,computed" format:"date-time"`
-	ModifiedBy       types.String                                                                 `tfsdk:"modified_by" json:"modified_by,computed"`
+	ID               types.String                                                                `tfsdk:"id" json:"id,required"`
+	AccountID        types.String                                                                `tfsdk:"account_id" path:"account_id,required"`
+	Hostname         types.String                                                                `tfsdk:"hostname" json:"hostname,required"`
+	Name             types.String                                                                `tfsdk:"name" json:"name,required"`
+	Description      types.String                                                                `tfsdk:"description" json:"description,optional"`
+	AllowCodeMode    types.Bool                                                                  `tfsdk:"allow_code_mode" json:"allow_code_mode,computed_optional"`
+	SecureWebGateway types.Bool                                                                  `tfsdk:"secure_web_gateway" json:"secure_web_gateway,computed_optional"`
+	Servers          customfield.NestedObjectSet[ZeroTrustAccessAIControlsMcpPortalServersModel] `tfsdk:"servers" json:"servers,computed_optional"`
+	CreatedAt        timetypes.RFC3339                                                           `tfsdk:"created_at" json:"created_at,computed" format:"date-time"`
+	CreatedBy        types.String                                                                `tfsdk:"created_by" json:"created_by,computed"`
+	ModifiedAt       timetypes.RFC3339                                                           `tfsdk:"modified_at" json:"modified_at,computed" format:"date-time"`
+	ModifiedBy       types.String                                                                `tfsdk:"modified_by" json:"modified_by,computed"`
 }
 
 func (m ZeroTrustAccessAIControlsMcpPortalModel) MarshalJSON() (data []byte, err error) {
@@ -37,7 +37,7 @@ func (m ZeroTrustAccessAIControlsMcpPortalModel) MarshalJSONForUpdate(state Zero
 }
 
 type ZeroTrustAccessAIControlsMcpPortalServersModel struct {
-	ServerID        types.String                                                     `tfsdk:"server_id" json:"server_id,required,no_refresh"`
+	ServerID        types.String                                                     `tfsdk:"server_id" json:"server_id,required"`
 	DefaultDisabled types.Bool                                                       `tfsdk:"default_disabled" json:"default_disabled,computed_optional"`
 	OnBehalf        types.Bool                                                       `tfsdk:"on_behalf" json:"on_behalf,computed_optional"`
 	UpdatedPrompts  *[]*ZeroTrustAccessAIControlsMcpPortalServersUpdatedPromptsModel `tfsdk:"updated_prompts" json:"updated_prompts,optional"`

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/resource.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/resource.go
@@ -85,6 +85,10 @@ func (r *ZeroTrustAccessAIControlsMcpPortalResource) Create(ctx context.Context,
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
+	// The portal API returns each attached server's identity under "id", but the
+	// resource schema/write path use "server_id". Map it before unmarshal so the
+	// servers set is keyed correctly (see injectServerIDs).
+	bytes = injectServerIDs(bytes)
 	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
@@ -134,6 +138,10 @@ func (r *ZeroTrustAccessAIControlsMcpPortalResource) Update(ctx context.Context,
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
+	// The portal API returns each attached server's identity under "id", but the
+	// resource schema/write path use "server_id". Map it before unmarshal so the
+	// servers set is keyed correctly (see injectServerIDs).
+	bytes = injectServerIDs(bytes)
 	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
@@ -174,6 +182,10 @@ func (r *ZeroTrustAccessAIControlsMcpPortalResource) Read(ctx context.Context, r
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
+	// The portal API returns each attached server's identity under "id", but the
+	// resource schema/write path use "server_id". Map it before unmarshal so the
+	// servers set is keyed correctly (see injectServerIDs).
+	bytes = injectServerIDs(bytes)
 	err = apijson.Unmarshal(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
@@ -244,6 +256,10 @@ func (r *ZeroTrustAccessAIControlsMcpPortalResource) ImportState(ctx context.Con
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
+	// The portal API returns each attached server's identity under "id", but the
+	// resource schema/write path use "server_id". Map it before unmarshal so the
+	// servers set is keyed correctly (see injectServerIDs).
+	bytes = injectServerIDs(bytes)
 	err = apijson.Unmarshal(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/resource_test.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/resource_test.go
@@ -12,7 +12,11 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestMain(m *testing.M) {
@@ -96,6 +100,63 @@ func TestAccZeroTrustAccessAIControlsMcpPortal_basic(t *testing.T) {
 				),
 			},
 			// ImportState testing
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["account_id"], rs.Primary.ID), nil
+				},
+			},
+		},
+	})
+}
+
+// TestAccZeroTrustAccessAIControlsMcpPortal_serversSetOrderIndependent covers the
+// servers drift fixes:
+//   - server_id is read back from the API (the API returns identity under "id";
+//     the schema/write path use "server_id"). Without the read-side mapping,
+//     server_id is null and every plan shows "+ server_id".
+//   - servers is a set keyed by server_id, so reordering servers[] in config
+//     produces no diff (the backend ignores client write order and returns a
+//     canonical order, so a list would churn).
+func TestAccZeroTrustAccessAIControlsMcpPortal_serversSetOrderIndependent(t *testing.T) {
+	resourceName := "cloudflare_zero_trust_access_ai_controls_mcp_portal.tf-test"
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	name := "Test Portal Servers Set"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareZeroTrustAccessAIControlsMcpPortalDestroy,
+		Steps: []resource.TestStep{
+			// Create with two servers in order [a, b]; server_id must be set.
+			{
+				Config: acctest.LoadTestCase("servers_set.tf", accountID, domain, name),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("servers"), knownvalue.SetSizeExact(2)),
+				},
+			},
+			// Re-apply identical config: no diff (server_id stable, no "+ server_id").
+			{
+				Config: acctest.LoadTestCase("servers_set.tf", accountID, domain, name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			// Reorder servers [b, a]: set semantics => still no diff.
+			{
+				Config: acctest.LoadTestCase("servers_set_reordered.tf", accountID, domain, name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			// Import round-trips with server_id populated.
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/schema.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/schema.go
@@ -19,7 +19,7 @@ var _ resource.ResourceWithConfigValidators = (*ZeroTrustAccessAIControlsMcpPort
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
-		Version: 500,
+		Version: 501,
 		MarkdownDescription: schemata.Description{
 			Scopes: []string{
 				"MCP Portals Read",
@@ -57,10 +57,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Optional:    true,
 				Default:     booldefault.StaticBool(false),
 			},
-			"servers": schema.ListNestedAttribute{
+			"servers": schema.SetNestedAttribute{
 				Computed:   true,
 				Optional:   true,
-				CustomType: customfield.NewNestedObjectListType[ZeroTrustAccessAIControlsMcpPortalServersModel](ctx),
+				CustomType: customfield.NewNestedObjectSetType[ZeroTrustAccessAIControlsMcpPortalServersModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"server_id": schema.StringAttribute{
@@ -121,9 +121,13 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"created_at": schema.StringAttribute{
 				Computed:   true,
 				CustomType: timetypes.RFC3339Type{},
+				// Immutable creation metadata: hold the stored value on update
+				// instead of planning it as (known after apply).
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"created_by": schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"modified_at": schema.StringAttribute{
 				Computed:   true,

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/testdata/servers_set.tf
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/testdata/servers_set.tf
@@ -1,0 +1,27 @@
+resource "cloudflare_zero_trust_access_ai_controls_mcp_server" "a" {
+  account_id = %[1]q
+  id         = "tf-test-srv-a"
+  name       = "tf-test-srv-a"
+  hostname   = "https://tf-test-srv-a.%[2]s/mcp"
+  auth_type  = "bearer"
+}
+
+resource "cloudflare_zero_trust_access_ai_controls_mcp_server" "b" {
+  account_id = %[1]q
+  id         = "tf-test-srv-b"
+  name       = "tf-test-srv-b"
+  hostname   = "https://tf-test-srv-b.%[2]s/mcp"
+  auth_type  = "bearer"
+}
+
+resource "cloudflare_zero_trust_access_ai_controls_mcp_portal" "tf-test" {
+  account_id = %[1]q
+  id         = "tf-test"
+  hostname   = %[2]q
+  name       = %[3]q
+
+  servers = [
+    { server_id = cloudflare_zero_trust_access_ai_controls_mcp_server.a.id },
+    { server_id = cloudflare_zero_trust_access_ai_controls_mcp_server.b.id },
+  ]
+}

--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/testdata/servers_set_reordered.tf
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/testdata/servers_set_reordered.tf
@@ -1,0 +1,29 @@
+resource "cloudflare_zero_trust_access_ai_controls_mcp_server" "a" {
+  account_id = %[1]q
+  id         = "tf-test-srv-a"
+  name       = "tf-test-srv-a"
+  hostname   = "https://tf-test-srv-a.%[2]s/mcp"
+  auth_type  = "bearer"
+}
+
+resource "cloudflare_zero_trust_access_ai_controls_mcp_server" "b" {
+  account_id = %[1]q
+  id         = "tf-test-srv-b"
+  name       = "tf-test-srv-b"
+  hostname   = "https://tf-test-srv-b.%[2]s/mcp"
+  auth_type  = "bearer"
+}
+
+resource "cloudflare_zero_trust_access_ai_controls_mcp_portal" "tf-test" {
+  account_id = %[1]q
+  id         = "tf-test"
+  hostname   = %[2]q
+  name       = %[3]q
+
+  # Same two servers, REVERSED order. With servers modeled as a set this must
+  # produce an empty plan (order-independent).
+  servers = [
+    { server_id = cloudflare_zero_trust_access_ai_controls_mcp_server.b.id },
+    { server_id = cloudflare_zero_trust_access_ai_controls_mcp_server.a.id },
+  ]
+}


### PR DESCRIPTION
Portal servers reported a change on every plan/apply even with no config changes.

- Model servers as a Set instead of a List: portal server membership has no author-controllable ordering (the backend ignores client write order and returns a canonical, account-global order), so an ordered List can never converge. Bump schema version 500 -> 501 with a state upgrader that converts existing list-shaped state to the new set.
- Read each server's identity back: the API returns it under servers[].id while the schema/write path use server_id. Map id -> server_id before unmarshal (injectServerIDs) and drop the no_refresh tag so Read/Import populate it.
- Hold created_at/created_by with UseStateForUnknown so immutable creation metadata stops planning as (known after apply) on unrelated updates.
- Regenerate docs (servers is now an Attributes Set).
- Add unit tests (injectServerIDs, list->set migration) and an order-independent acceptance test.

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
