### PR TITLE
docs(v5-migration): document session_duration behavior change for access policies

### DIFF
--- a/docs/guides/version-5-migration.md
+++ b/docs/guides/version-5-migration.md
@@ -401,6 +401,26 @@ values to `null` for optional fields (`isolation_required`,
 `purpose_justification_required`, `approval_required`). This prevents drift
 since the API treats `false` and `null` as equivalent.
 
+#### Zero Trust Access Policy `session_duration`
+
+In v4, the API applied an implicit default of `24h` for `session_duration`, so
+most configurations omitted it. In v5, the provider schema defaults to `24h`,
+but some Cloudflare accounts enforce a maximum session duration shorter than
+`24h` (for example, `18h`) via account-level security policies. If your
+policies relied on the implicit default and your account enforces a shorter
+maximum, the first `terraform apply` after migration will fail at the API level
+even though `terraform plan` succeeds.
+
+To avoid this, add an explicit `session_duration` to every
+`cloudflare_zero_trust_access_policy` resource:
+
+```hcl
+resource "cloudflare_zero_trust_access_policy" "example" {
+  # ...existing attributes...
+  session_duration = "18h"  # or your organization's required maximum
+}
+```
+
 #### Load Balancer field renames
 
 `cloudflare_load_balancer` resources will show field renames:

--- a/docs/guides/version-5-upgrade.md
+++ b/docs/guides/version-5-upgrade.md
@@ -254,6 +254,15 @@ applying the inline policy configuration.
 See the [migration guide](version-5-migration#application-scoped-access-policies)
 for detailed instructions.
 
+~> **`session_duration` must be set explicitly.** In v4, the API applied an
+implicit default of `24h` for `session_duration`. In v5, the provider schema
+defaults to `24h`, but some Cloudflare account-level security policies enforce
+a maximum of `18h`. If your policies relied on the implicit default and your
+account enforces a shorter maximum, add `session_duration = "18h"` (or your
+organization's required value) to every `cloudflare_zero_trust_access_policy`
+resource. Without this, `terraform apply` may fail at the API level even though
+`terraform plan` succeeds.
+
 ## cloudflare_access_rule
 
 - `configuration` is now a single nested attribute (`configuration = { ... }`) instead of a block (`configuration { ... }`).
@@ -1481,6 +1490,11 @@ This has been removed. Users should instead use the:
   section, including
   [Keeping existing policies attached (in-place migration)](version-5-migration#keeping-existing-policies-attached-in-place-migration)
   if your applications reference policy UUIDs.
+- `session_duration` now defaults to `24h` in the provider schema. In v4, this
+  value was set implicitly by the API and did not need to appear in HCL. If
+  your account enforces a maximum session duration shorter than `24h` (for
+  example, `18h`), you must set `session_duration` explicitly on every policy
+  resource to avoid API-level failures at apply time.
 - `approval_group` is now a list of objects (`approval_group = [{ ... }]`) instead of multiple block attribute (`approval_group { ... }`).
 - `auth_context` is now a list of objects (`auth_context = [{ ... }]`) instead of multiple block attribute (`auth_context { ... }`).
 - `azure` is now a single nested attribute (`azure = { ... }`) instead of a block (`azure { ... }`).

--- a/templates/guides/version-5-migration.md
+++ b/templates/guides/version-5-migration.md
@@ -401,6 +401,26 @@ values to `null` for optional fields (`isolation_required`,
 `purpose_justification_required`, `approval_required`). This prevents drift
 since the API treats `false` and `null` as equivalent.
 
+#### Zero Trust Access Policy `session_duration`
+
+In v4, the API applied an implicit default of `24h` for `session_duration`, so
+most configurations omitted it. In v5, the provider schema defaults to `24h`,
+but some Cloudflare accounts enforce a maximum session duration shorter than
+`24h` (for example, `18h`) via account-level security policies. If your
+policies relied on the implicit default and your account enforces a shorter
+maximum, the first `terraform apply` after migration will fail at the API level
+even though `terraform plan` succeeds.
+
+To avoid this, add an explicit `session_duration` to every
+`cloudflare_zero_trust_access_policy` resource:
+
+```hcl
+resource "cloudflare_zero_trust_access_policy" "example" {
+  # ...existing attributes...
+  session_duration = "18h"  # or your organization's required maximum
+}
+```
+
 #### Load Balancer field renames
 
 `cloudflare_load_balancer` resources will show field renames:

--- a/templates/guides/version-5-upgrade.md
+++ b/templates/guides/version-5-upgrade.md
@@ -254,6 +254,15 @@ applying the inline policy configuration.
 See the [migration guide](version-5-migration#application-scoped-access-policies)
 for detailed instructions.
 
+~> **`session_duration` must be set explicitly.** In v4, the API applied an
+implicit default of `24h` for `session_duration`. In v5, the provider schema
+defaults to `24h`, but some Cloudflare account-level security policies enforce
+a maximum of `18h`. If your policies relied on the implicit default and your
+account enforces a shorter maximum, add `session_duration = "18h"` (or your
+organization's required value) to every `cloudflare_zero_trust_access_policy`
+resource. Without this, `terraform apply` may fail at the API level even though
+`terraform plan` succeeds.
+
 ## cloudflare_access_rule
 
 - `configuration` is now a single nested attribute (`configuration = { ... }`) instead of a block (`configuration { ... }`).
@@ -1481,6 +1490,11 @@ This has been removed. Users should instead use the:
   section, including
   [Keeping existing policies attached (in-place migration)](version-5-migration#keeping-existing-policies-attached-in-place-migration)
   if your applications reference policy UUIDs.
+- `session_duration` now defaults to `24h` in the provider schema. In v4, this
+  value was set implicitly by the API and did not need to appear in HCL. If
+  your account enforces a maximum session duration shorter than `24h` (for
+  example, `18h`), you must set `session_duration` explicitly on every policy
+  resource to avoid API-level failures at apply time.
 - `approval_group` is now a list of objects (`approval_group = [{ ... }]`) instead of multiple block attribute (`approval_group { ... }`).
 - `auth_context` is now a list of objects (`auth_context = [{ ... }]`) instead of multiple block attribute (`auth_context { ... }`).
 - `azure` is now a single nested attribute (`azure = { ... }`) instead of a block (`azure { ... }`).


### PR DESCRIPTION
## Summary

In v4, `session_duration` on access policies was implicitly defaulted to `24h` by the API, so most HCL configurations omitted it. In v5, the provider schema defaults to `24h`, but accounts with security policies enforcing a shorter maximum (e.g. `18h`) will see API-level failures at `terraform apply` time -- even though `terraform plan` succeeds.

This adds documentation callouts to both the v5 upgrade guide and the v5 migration guide explaining the behavior change and recommending explicit `session_duration` on all `cloudflare_zero_trust_access_policy` resources.

## Changes

- **version-5-upgrade.md**: Added `session_duration` callout to both the `cloudflare_access_policy` (v4 name) and `cloudflare_zero_trust_access_policy` (v5 name) sections
- **version-5-migration.md**: Added a new "Zero Trust Access Policy `session_duration`" subsection under the existing normalization notes, with an HCL example

Both `templates/` source files and `docs/` rendered copies are updated.
