### PR TITLE
docs(v5-upgrade): document zone_id removal for access policies

### DIFF
--- a/docs/guides/version-5-migration.md
+++ b/docs/guides/version-5-migration.md
@@ -401,6 +401,26 @@ values to `null` for optional fields (`isolation_required`,
 `purpose_justification_required`, `approval_required`). This prevents drift
 since the API treats `false` and `null` as equivalent.
 
+#### Zero Trust Access Policy `zone_id` removal
+
+In v4, `cloudflare_access_policy` could be scoped to a zone using `zone_id`.
+In v5, all access policies are account-level only -- `zone_id` is not a valid
+attribute on `cloudflare_zero_trust_access_policy`. `tf-migrate` removes
+`zone_id` during migration. If the resource already has `account_id`, no action
+is needed. If the resource only had `zone_id`, `tf-migrate` emits a
+**MIGRATION WARNING** and you must manually add `account_id`:
+
+```hcl
+resource "cloudflare_zero_trust_access_policy" "example" {
+  account_id = var.cloudflare_account_id  # add this — zone_id is no longer valid
+  # ...existing attributes...
+}
+```
+
+Note that a zone ID and an account ID are different values. You cannot simply
+rename the attribute; you must supply the correct account ID for the account
+that owns the zone.
+
 #### Load Balancer field renames
 
 `cloudflare_load_balancer` resources will show field renames:
@@ -1706,12 +1726,12 @@ for details. If the diff is truly just cosmetic, you can safely ignore it.
 
 - [Version 5 Upgrade Guide][version 5 upgrade guide] -- Per-resource attribute
   change details and manual migration notes.
-- [Migrating Renamed Resources](migrating-renamed-resources.md) -- Detailed
+- [Migrating Renamed Resources](migrating-renamed-resources) -- Detailed
   guide for the import, state file, and two-phase swap approaches.
 - [tf-migrate] -- Source code and documentation for the HCL migration tool.
 - [Terraform moved blocks](https://developer.hashicorp.com/terraform/language/moved) --
   HashiCorp documentation on the `moved` block syntax.
 
-[version 5 upgrade guide]: version-5-upgrade.md
+[version 5 upgrade guide]: version-5-upgrade
 [tf-migrate]: https://github.com/cloudflare/tf-migrate
-[migrating renamed resources]: migrating-renamed-resources.md
+[migrating renamed resources]: migrating-renamed-resources

--- a/docs/guides/version-5-migration.md
+++ b/docs/guides/version-5-migration.md
@@ -712,6 +712,17 @@ config migration.** `tf-migrate` can automatically generate a `removed` block
 to drop the old state entry without destroying the remote policy, but you still
 must rewrite the policy as inline `policies` on the application resource.
 
+!> **Applying tf-migrate output without adding inline policies is destructive.**
+`tf-migrate` removes the standalone `cloudflare_access_policy` resource and
+generates a `removed` block, but does **not** add `policies` to the parent
+`cloudflare_zero_trust_access_application` resource. If you run
+`terraform apply` in this intermediate state, Terraform sends an empty
+`policies` value to the API, which detaches all policies from the application.
+Cloudflare then garbage-collects the orphaned app-scoped policies (they have no
+independent lifecycle). You **must** add `policies = [...]` to the parent
+application resource before applying. Recovery without this step requires
+reconstructing all policies from git history or backups.
+
 In v4, `cloudflare_access_policy` could be used for both account-level policies
 and application-scoped policies (when `application_id` was set). These two types
 use different API endpoints:

--- a/docs/guides/version-5-upgrade.md
+++ b/docs/guides/version-5-upgrade.md
@@ -241,7 +241,18 @@ must be removed from state, then rewritten inline on the application.
    deleting the remote policy).
 2. Add the policy configuration inline in your
    `cloudflare_zero_trust_access_application` resource's `policies` attribute.
-3. Run `terraform apply`.
+3. Run `terraform plan` and verify no unexpected policy detachments.
+4. Run `terraform apply`.
+
+!> **Do not apply tf-migrate output without adding inline policies first.**
+`tf-migrate` removes the standalone `cloudflare_access_policy` resource and
+generates a `removed` block, but does **not** add `policies` to the parent
+`cloudflare_zero_trust_access_application` resource. If you run
+`terraform apply` in this intermediate state, Terraform sends an empty
+`policies` value to the API, which detaches all policies from the application.
+Cloudflare then garbage-collects the orphaned app-scoped policies. You **must**
+add the `policies = [...]` attribute to the parent application resource before
+applying.
 
 On the first plan/apply, Terraform may show that the old policy
 "will no longer be managed by Terraform". This is expected when using a

--- a/docs/guides/version-5-upgrade.md
+++ b/docs/guides/version-5-upgrade.md
@@ -58,7 +58,7 @@ sections, there is the need to migrate attributes and potentially the resource r
 ### Automatic (tf-migrate)
 
 -> For the recommended migration approach using built-in state upgraders, see the
-[version 5 migration guide](version-5-migration.md).
+[version 5 migration guide](version-5-migration).
 
 For automatic configuration (HCL) migrations, use [tf-migrate], the official
 Cloudflare Terraform Provider migration tool. It handles resource renames,
@@ -156,7 +156,7 @@ completes the migration in a single pass.
 ~> `tf-migrate` handles configuration (HCL) transformations only. State migration
 is handled automatically by the v5 provider's built-in state upgraders when you
 run `terraform plan` or `terraform apply`. See the
-[version 5 migration guide](version-5-migration.md) for details.
+[version 5 migration guide](version-5-migration) for details.
 
 ~> While all efforts have been made to ease the transition, some resources require
 manual steps after migration. tf-migrate prints actionable warnings with exact
@@ -251,8 +251,34 @@ If you are not using `tf-migrate`, you can do the equivalent state removal
 manually with `terraform state rm cloudflare_access_policy.example` before
 applying the inline policy configuration.
 
-See the [migration guide](version-5-migration.md#application-scoped-access-policies)
+See the [migration guide](version-5-migration#application-scoped-access-policies)
 for detailed instructions.
+
+~> **Zone-scoped policies require `account_id`.** In v4,
+`cloudflare_access_policy` could be scoped to a zone using `zone_id`. In v5,
+all access policies are account-level only and `zone_id` is not a valid
+attribute on `cloudflare_zero_trust_access_policy`. If your v4 configuration
+used `zone_id` without `account_id`, you must add `account_id` after migration.
+`tf-migrate` removes `zone_id` and emits a warning when `account_id` is
+missing.
+
+```hcl
+# v4 (zone-scoped):
+resource "cloudflare_access_policy" "example" {
+  zone_id  = var.zone_id
+  name     = "My Policy"
+  decision = "allow"
+  # ...
+}
+
+# v5 (account_id required — add manually after migration):
+resource "cloudflare_zero_trust_access_policy" "example" {
+  account_id = var.cloudflare_account_id  # REQUIRED — zone_id is no longer valid
+  name       = "My Policy"
+  decision   = "allow"
+  # ...
+}
+```
 
 ## cloudflare_access_rule
 
@@ -1477,9 +1503,9 @@ This has been removed. Users should instead use the:
   `cloudflare_zero_trust_access_application` carries its policies in its
   `policies` attribute, either inline or as a list of policy IDs. See the
   migration guide's
-  [Application-Scoped Access Policies](version-5-migration.md#application-scoped-access-policies)
+  [Application-Scoped Access Policies](version-5-migration#application-scoped-access-policies)
   section, including
-  [Keeping existing policies attached (in-place migration)](version-5-migration.md#keeping-existing-policies-attached-in-place-migration)
+  [Keeping existing policies attached (in-place migration)](version-5-migration#keeping-existing-policies-attached-in-place-migration)
   if your applications reference policy UUIDs.
 - `approval_group` is now a list of objects (`approval_group = [{ ... }]`) instead of multiple block attribute (`approval_group { ... }`).
 - `auth_context` is now a list of objects (`auth_context = [{ ... }]`) instead of multiple block attribute (`auth_context { ... }`).

--- a/templates/guides/version-5-migration.md
+++ b/templates/guides/version-5-migration.md
@@ -401,6 +401,26 @@ values to `null` for optional fields (`isolation_required`,
 `purpose_justification_required`, `approval_required`). This prevents drift
 since the API treats `false` and `null` as equivalent.
 
+#### Zero Trust Access Policy `zone_id` removal
+
+In v4, `cloudflare_access_policy` could be scoped to a zone using `zone_id`.
+In v5, all access policies are account-level only -- `zone_id` is not a valid
+attribute on `cloudflare_zero_trust_access_policy`. `tf-migrate` removes
+`zone_id` during migration. If the resource already has `account_id`, no action
+is needed. If the resource only had `zone_id`, `tf-migrate` emits a
+**MIGRATION WARNING** and you must manually add `account_id`:
+
+```hcl
+resource "cloudflare_zero_trust_access_policy" "example" {
+  account_id = var.cloudflare_account_id  # add this — zone_id is no longer valid
+  # ...existing attributes...
+}
+```
+
+Note that a zone ID and an account ID are different values. You cannot simply
+rename the attribute; you must supply the correct account ID for the account
+that owns the zone.
+
 #### Load Balancer field renames
 
 `cloudflare_load_balancer` resources will show field renames:

--- a/templates/guides/version-5-upgrade.md
+++ b/templates/guides/version-5-upgrade.md
@@ -254,6 +254,32 @@ applying the inline policy configuration.
 See the [migration guide](version-5-migration#application-scoped-access-policies)
 for detailed instructions.
 
+~> **Zone-scoped policies require `account_id`.** In v4,
+`cloudflare_access_policy` could be scoped to a zone using `zone_id`. In v5,
+all access policies are account-level only and `zone_id` is not a valid
+attribute on `cloudflare_zero_trust_access_policy`. If your v4 configuration
+used `zone_id` without `account_id`, you must add `account_id` after migration.
+`tf-migrate` removes `zone_id` and emits a warning when `account_id` is
+missing.
+
+```hcl
+# v4 (zone-scoped):
+resource "cloudflare_access_policy" "example" {
+  zone_id  = var.zone_id
+  name     = "My Policy"
+  decision = "allow"
+  # ...
+}
+
+# v5 (account_id required — add manually after migration):
+resource "cloudflare_zero_trust_access_policy" "example" {
+  account_id = var.cloudflare_account_id  # REQUIRED — zone_id is no longer valid
+  name       = "My Policy"
+  decision   = "allow"
+  # ...
+}
+```
+
 ## cloudflare_access_rule
 
 - `configuration` is now a single nested attribute (`configuration = { ... }`) instead of a block (`configuration { ... }`).


### PR DESCRIPTION
## Summary

Documents the `zone_id` to `account_id` migration requirement for `cloudflare_access_policy` in the v5 upgrade and migration guides.

In v4, `cloudflare_access_policy` could be zone-scoped via `zone_id`. In v5, all access policies are account-level only and `zone_id` is not a valid attribute. Users must add `account_id` after migration.

## Changes

- **`templates/guides/version-5-upgrade.md`**: Added callout block with before/after HCL example under the `cloudflare_access_policy` section.
- **`templates/guides/version-5-migration.md`**: Added "Zero Trust Access Policy `zone_id` removal" subsection explaining the behavior and required manual action.
- **`docs/guides/`**: Synced rendered copies from templates.

## Related

- tf-migrate fix: https://github.com/cloudflare/tf-migrate/pull/309