### PR TITLE
feat: add `file` as valid RDP connection_rules in zt_access_application

### DIFF
--- a/internal/services/zero_trust_access_application/schema.go
+++ b/internal/services/zero_trust_access_application/schema.go
@@ -1013,7 +1013,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 											Optional:    true,
 											Validators: []validator.List{
 												listvalidator.ValueStringsAre(
-													stringvalidator.OneOfCaseInsensitive("text"),
+													stringvalidator.OneOfCaseInsensitive("text", "file"),
 												),
 											},
 											ElementType: types.StringType,
@@ -1023,7 +1023,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 											Optional:    true,
 											Validators: []validator.List{
 												listvalidator.ValueStringsAre(
-													stringvalidator.OneOfCaseInsensitive("text"),
+													stringvalidator.OneOfCaseInsensitive("text", "file"),
 												),
 											},
 											ElementType: types.StringType,


### PR DESCRIPTION

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`file` is a valid RDP connection_rules for allowed clipboard formats in `zero_trust_access_application`. Support in `zero_trust_access_policy` will be added once autogen picks up new OpenAPI schema

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
