### PR TITLE
fix(migrations): handle v4→v5 state upgrader schema drift (ruleset asset_name, lb_pool flatten_cname)

### DIFF
--- a/internal/services/load_balancer_pool/migration/v500/model.go
+++ b/internal/services/load_balancer_pool/migration/v500/model.go
@@ -40,13 +40,20 @@ type SourceCloudflareLoadBalancerPoolModel struct {
 
 // SourceOriginsModel represents a single origin within the pool from v4.x provider.
 // Stored in TypeSet, so in state it's an array of these objects.
+//
+// NOTE: flatten_cname is intentionally NOT included here. The v4 provider
+// (SDKv2 cloudflare_load_balancer_pool) has no flatten_cname attribute on
+// origins, so v4 state never contains it. Declaring it on this Source model
+// causes tftypes → struct conversion to fail with:
+//   "Struct defines fields not found in object: flatten_cname"
+// It appears on TargetLoadBalancerPoolOriginsModel (v5) below because v5
+// introduced the field.
 type SourceOriginsModel struct {
-	Name             types.String       `tfsdk:"name"`
-	Address          types.String       `tfsdk:"address"`
-	VirtualNetworkID types.String       `tfsdk:"virtual_network_id"`
-	Weight           types.Float64      `tfsdk:"weight"`
-	Enabled          types.Bool         `tfsdk:"enabled"`
-	FlattenCNAME     types.Bool                                     `tfsdk:"flatten_cname"`
+	Name             types.String        `tfsdk:"name"`
+	Address          types.String        `tfsdk:"address"`
+	VirtualNetworkID types.String        `tfsdk:"virtual_network_id"`
+	Weight           types.Float64       `tfsdk:"weight"`
+	Enabled          types.Bool          `tfsdk:"enabled"`
 	Header           []SourceHeaderModel `tfsdk:"header"` // TypeSet stored as array
 }
 

--- a/internal/services/ruleset/migration/v500/model.go
+++ b/internal/services/ruleset/migration/v500/model.go
@@ -43,6 +43,7 @@ type SourceV4RuleModel struct {
 // Note: In v4, this was a ListNestedBlock (MaxItems:1), stored as array in state.
 type SourceV4ActionParametersModel struct {
 	AdditionalCacheablePorts types.Set                    `tfsdk:"additional_cacheable_ports"`
+	AssetName                types.String                 `tfsdk:"asset_name"`
 	AutomaticHTTPSRewrites   types.Bool                   `tfsdk:"automatic_https_rewrites"`
 	AutoMinify               []*SourceV4AutoMinifyModel   `tfsdk:"autominify"`
 	BIC                      types.Bool                   `tfsdk:"bic"`

--- a/internal/services/ruleset/migration/v500/schema.go
+++ b/internal/services/ruleset/migration/v500/schema.go
@@ -72,6 +72,16 @@ func SourceV4RulesetSchema() schema.Schema {
 										ElementType: types.Int64Type,
 										Optional:    true,
 									},
+									// Added to the v4 provider in
+									// commit 3d97253 (2026-05-28) and shipped in v4.52.8.
+									// State written by any v4 provider from that point on
+									// contains asset_name (typically null unless configured),
+									// so this source schema must declare it or the
+									// v4 → v5 raw-state unmarshal fails with
+									// "unsupported attribute asset_name".
+									"asset_name": schema.StringAttribute{
+										Optional: true,
+									},
 									"automatic_https_rewrites": schema.BoolAttribute{
 										Optional: true,
 									},

--- a/internal/services/ruleset/migration/v500/transform.go
+++ b/internal/services/ruleset/migration/v500/transform.go
@@ -143,8 +143,12 @@ func transformActionParameters(ctx context.Context, src *SourceV4ActionParameter
 		Polish:                  src.Polish,
 		Ruleset:                 src.Ruleset,
 
+		// asset_name was added to the v4 provider in v4.52.8 (May 2026),
+		// so state written by any current v4 release contains it. Forward
+		// through directly rather than nulling it out.
+		AssetName: src.AssetName,
+
 		// New v5 fields absent in v4 — set to null
-		AssetName:              types.StringNull(),
 		ContentConverter:       types.BoolNull(),
 		RequestBodyBuffering:   types.StringNull(),
 		ResponseBodyBuffering:  types.StringNull(),

--- a/internal/services/snippet/resource.go
+++ b/internal/services/snippet/resource.go
@@ -204,6 +204,9 @@ func (r *SnippetResource) Read(ctx context.Context, req resource.ReadRequest, re
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
+	if data.Metadata == nil {
+		data.Metadata = &SnippetMetadataModel{}
+	}
 	data.Metadata.MainModule = types.StringValue(res.Header.Get("Cf-Entrypoint"))
 	bytes, _ = io.ReadAll(res.Body)
 	err = data.UnmarshalMultipart(bytes, res.Header.Get("Content-Type"))

--- a/internal/services/snippet/resource_test.go
+++ b/internal/services/snippet/resource_test.go
@@ -157,6 +157,141 @@ func TestAccCloudflareSnippet_Basic(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareSnippet_Import(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	resourceName := "cloudflare_snippet." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareSnippetDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create the snippet
+			{
+				Config: testAccCloudflareSnippetConfig(rnd, zoneID),
+			},
+			// Step 2: Import and verify state matches config.
+			// This covers the nil-pointer dereference fix: ImportState
+			// leaves Metadata nil, then Read must handle that without
+			// crashing when it populates Metadata.MainModule from the
+			// Content.Get response header.
+			{
+				Config:            testAccCloudflareSnippetConfig(rnd, zoneID),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     zoneID + "/" + rnd,
+				ImportStateVerify: true,
+			},
+			// Step 3: Plan after import produces no diff, confirming
+			// that Read fully populated files and metadata from the
+			// Content.Get endpoint.
+			{
+				Config: testAccCloudflareSnippetConfig(rnd, zoneID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSnippet_ImportFieldValidation(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareSnippetDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with the basic config
+			{
+				Config: testAccCloudflareSnippetConfig(rnd, zoneID),
+			},
+			// Step 2: Import with field-level validation
+			{
+				ResourceName: "cloudflare_snippet." + rnd,
+				ImportState:  true,
+				ImportStateId: zoneID + "/" + rnd,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 instance state, got %d", len(states))
+					}
+					s := states[0]
+
+					if v := s.Attributes["zone_id"]; v != zoneID {
+						return fmt.Errorf("expected zone_id %q, got %q", zoneID, v)
+					}
+					if v := s.Attributes["snippet_name"]; v != rnd {
+						return fmt.Errorf("expected snippet_name %q, got %q", rnd, v)
+					}
+					if v := s.Attributes["metadata.main_module"]; v != "main.js" {
+						return fmt.Errorf("expected metadata.main_module %q, got %q", "main.js", v)
+					}
+					if v := s.Attributes["files.#"]; v != "1" {
+						return fmt.Errorf("expected 1 file, got %s", v)
+					}
+					if v := s.Attributes["files.0.name"]; v != "main.js" {
+						return fmt.Errorf("expected files.0.name %q, got %q", "main.js", v)
+					}
+					if v := s.Attributes["files.0.content"]; v == "" {
+						return fmt.Errorf("expected files.0.content to be non-empty")
+					}
+					if v := s.Attributes["created_on"]; v == "" {
+						return fmt.Errorf("expected created_on to be set")
+					}
+					if v := s.Attributes["modified_on"]; v == "" {
+						return fmt.Errorf("expected modified_on to be set")
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudflareSnippet_ImportAfterUpdate(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	resourceName := "cloudflare_snippet." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareSnippetDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create
+			{
+				Config: testAccCloudflareSnippetConfig(rnd, zoneID),
+			},
+			// Step 2: Update content
+			{
+				Config: testAccCloudflareSnippetConfigUpdate(rnd, zoneID),
+			},
+			// Step 3: Import the updated resource
+			{
+				Config:            testAccCloudflareSnippetConfigUpdate(rnd, zoneID),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     zoneID + "/" + rnd,
+				ImportStateVerify: true,
+			},
+			// Step 4: Plan after import is clean
+			{
+				Config: testAccCloudflareSnippetConfigUpdate(rnd, zoneID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckCloudflareSnippetDestroy(s *terraform.State) error {
 	client := acctest.SharedClient()
 

--- a/skills/acceptance-tests/SKILL.md
+++ b/skills/acceptance-tests/SKILL.md
@@ -1,0 +1,384 @@
+---
+name: acceptance-tests
+description: Write and debug acceptance tests for Cloudflare's public Terraform provider. Use when contributing `resource_test.go`, `data_source_test.go`, `testdata/*.tf`, import-state checks, sweepers, or diagnosing `TF_ACC=1` failures. Do not use for ordinary Terraform HCL authoring.
+---
+
+# Cloudflare Terraform - Acceptance Tests
+
+Acceptance tests in this provider interact with real Cloudflare resources. This skill is for maintainers, product engineers, and external contributors changing the provider itself. It is not for ordinary Terraform users writing HCL that consumes the provider.
+
+These tests are hand-maintained alongside generated provider code, and correctness depends on repo-specific helpers, environment variables, import ID formats, test naming, and cleanup conventions.
+
+## Core Workflow
+
+1. Identify the service directory: `internal/services/<service>`.
+2. Inspect existing files before editing: `resource_test.go`, `data_source_test.go`, `testdata/*.tf`, schema/model files, and nearby services with similar scope.
+3. If tests do not exist, run `scripts/generate-acctest -dry-run <service>` first, then scaffold with `scripts/generate-acctest <service>` only when the paths are correct.
+4. Write valid Terraform config in `testdata/*.tf`; generated scaffold configs are placeholders and will fail until completed.
+5. Use `acctest.LoadTestCase(...)` to load `testdata` configs from Go tests.
+6. Add resource checks for required IDs, user-configured attributes, API-normalized attributes, and computed fields that prove the read path works.
+7. Add import-state verification when the resource supports import.
+8. Add or update a sweeper only when tests create remote resources that can be orphaned.
+9. Run targeted compile/unit checks first. Run `TF_ACC=1` tests only when credentials and the required account/zone fixtures are available.
+
+## Codegen Boundary
+
+Before editing provider implementation files, check the file header. If a file says it is generated, treat it as disposable output from the provider's code generation pipeline. Do not make durable fixes there unless the user explicitly asks for a temporary local patch.
+
+Acceptance-test files are hand-maintained and safe to edit: `resource_test.go`, `data_source_test.go`, and `testdata/*.tf`. Files under `migration/**` are safe only when the task is explicitly about migration tests.
+
+Generated-file headers may change as the provider's code generation system evolves. Detect generated files by the header, not by a specific generator name.
+
+## Example Services To Inspect
+
+Before inventing a new pattern, inspect existing tests with the same shape:
+
+- `internal/services/turnstile_widget/resource_test.go` for straightforward account-scoped resource tests with update and import verification.
+- `internal/services/vulnerability_scanner_credential/resource_test.go` for nested resources and composite `ImportStateIdFunc` import IDs.
+- `internal/services/logpush_dataset_field/data_source_test.go` for data source tests using `ConfigStateChecks`, `statecheck`, `knownvalue`, and `tfjsonpath`.
+- `internal/services/dns_record/resource_test.go` for extensive lifecycle checks, sweepers, API existence checks, and zone/domain fixtures.
+- `internal/services/waiting_room/resource_test.go` for explicit idempotency/no-op plan checks.
+
+Use these as references, not templates to copy blindly.
+
+Do not fabricate Cloudflare SDK methods; use pseudocode until real client calls are inspected.
+
+## Test Configs
+
+Prefer `acctest.LoadTestCase` for resource and data source configs:
+
+```go
+func testAccExampleConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("basic.tf", rnd, accountID)
+}
+```
+
+The corresponding `testdata/basic.tf` uses `fmt.Sprintf` placeholders:
+
+```hcl
+resource "cloudflare_example" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+}
+```
+
+Use inline `fmt.Sprintf` only for very small one-off configs. Use `//go:embed` mostly for migration tests with multiple v4/v5 fixture files.
+
+## Naming And Cleanup
+
+All remote resources created by acceptance tests should use `utils.GenerateRandomResourceName()` unless the API requires a different format. This produces names with the shared test prefix used by sweepers.
+
+Sweepers must filter with `utils.ShouldSweepResource(name)` before deleting anything:
+
+```go
+if !utils.ShouldSweepResource(remote.Name) {
+	continue
+}
+```
+
+Never write a sweeper that deletes all resources in an account or zone by default. The only broad-delete path should be the existing explicit danger-mode behavior in `utils.ShouldSweepResource`.
+
+## PreCheck Selection
+
+Always include credential precheck:
+
+```go
+PreCheck: func() { acctest.TestAccPreCheck(t) },
+```
+
+Add scope-specific prechecks based on the config. Common helpers:
+
+| Helper | Required environment variable |
+| --- | --- |
+| `acctest.TestAccPreCheck_AccountID(t)` | `CLOUDFLARE_ACCOUNT_ID` |
+| `acctest.TestAccPreCheck_ZoneID(t)` | `CLOUDFLARE_ZONE_ID` |
+| `acctest.TestAccPreCheck_Domain(t)` | `CLOUDFLARE_DOMAIN` |
+| `acctest.TestAccPreCheck_AlternateZoneID(t)` | `CLOUDFLARE_ALT_ZONE_ID` |
+| `acctest.TestAccPreCheck_AlternateDomain(t)` | `CLOUDFLARE_ALT_DOMAIN` |
+| `acctest.TestAccPreCheck_Email(t)` | `CLOUDFLARE_EMAIL` |
+| `acctest.TestAccPreCheck_APIToken(t)` | `CLOUDFLARE_API_TOKEN` |
+| `acctest.TestAccPreCheck_APIKey(t)` | `CLOUDFLARE_API_KEY` |
+
+Check `internal/acctest/acctest.go` for specialized prechecks before adding new environment handling.
+
+## Resource Test Structure
+
+Use protocol v6 provider factories:
+
+```go
+resource.Test(t, resource.TestCase{
+	PreCheck: func() {
+		acctest.TestAccPreCheck(t)
+		acctest.TestAccPreCheck_AccountID(t)
+	},
+	ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+	Steps: []resource.TestStep{
+		{
+			Config: testAccExampleConfig(rnd, accountID),
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
+				resource.TestCheckResourceAttr(resourceName, "name", rnd),
+				resource.TestCheckResourceAttrSet(resourceName, "id"),
+			),
+		},
+	},
+})
+```
+
+Use `resource.ParallelTest` only when the resource and backing API are safe for parallel creation, update, and deletion in the shared test account or zone. Singleton resources, per-zone settings, ordered resources, and APIs with eventual consistency often need sequential tests.
+
+Test names are not perfectly uniform across the repo. Some use `TestAccCloudflare<Service>_...`; others use shorter names such as `TestAcc<Service>_...`. Follow the existing service naming style when a test file already exists, and use `^TestAcc` as the broad targeted pattern.
+
+## Data Source Tests
+
+Data source tests usually verify that config inputs and read results are present in state. For simple data sources, `ConfigStateChecks` with `statecheck.ExpectKnownValue` can be clearer than `resource.ComposeTestCheckFunc`:
+
+```go
+resource.Test(t, resource.TestCase{
+	PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+	ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+	Steps: []resource.TestStep{
+		{
+			Config: testAccExampleDataSourceConfig(rnd, accountID),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+				statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+			},
+		},
+	},
+})
+```
+
+Use data source tests to cover lookup behavior that resource tests do not prove: account vs zone inputs, list filters, or lookup by name.
+
+## Attribute Checks
+
+Check attributes that prove the full lifecycle works:
+
+- Required scope fields such as `account_id` or `zone_id`.
+- User-provided fields from config.
+- Important computed fields with `resource.TestCheckResourceAttrSet`.
+- API-normalized fields when normalization is expected and stable.
+- Collection sizes with `field.#` when order is not the behavior under test.
+
+Prefer constants for shared schema keys:
+
+- `consts.AccountIDSchemaKey`
+- `consts.ZoneIDSchemaKey`
+
+Avoid asserting unstable timestamps, API-generated ordering, secrets, or fields known to vary between create/read/import unless the test is specifically about that behavior.
+
+## Import-State Checks
+
+Add import verification when the resource docs and implementation support import:
+
+```go
+{
+	ResourceName:        resourceName,
+	ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+	ImportState:         true,
+	ImportStateVerify:   true,
+}
+```
+
+Choose the prefix based on resource scope. Account-scoped resources usually use `accountID/`; zone-scoped resources usually use `zoneID/`. Confirm against existing tests for the same resource family or the resource import docs.
+
+Use `ImportStateVerifyIgnore` for fields that cannot round-trip through import:
+
+- Write-only or sensitive values.
+- Values intentionally omitted by API reads.
+- API-computed timestamps.
+- Deprecated compatibility fields.
+- Fields normalized differently by create and read.
+
+Do not add broad ignore lists without explaining the API behavior in the test or by following an existing pattern in the service.
+
+For a named service failure, inspect that service's current tests and schema before recommending field-specific `ImportStateVerifyIgnore`; do not guess likely ignore fields from general API intuition.
+
+For composite import IDs that need values from multiple resources, use `ImportStateIdFunc` instead of trying to precompute the ID before apply:
+
+```go
+{
+	ResourceName:            resourceName,
+	ImportState:             true,
+	ImportStateVerify:       true,
+	ImportStateIdFunc: func(s *terraform.State) (string, error) {
+		parent, ok := s.RootModule().Resources[parentResourceName]
+		if !ok {
+			return "", fmt.Errorf("parent resource %q not found in state", parentResourceName)
+		}
+
+		child, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("child resource %q not found in state", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s/%s", accountID, parent.Primary.ID, child.Primary.ID), nil
+	},
+}
+```
+
+This pattern is common for nested Cloudflare APIs where the Terraform resource ID alone is not sufficient to import the object.
+
+Only add `ImportStateVerifyIgnore` to this step when you can name the field-specific API reason. For example, API token and credential values are write-only and are not returned by API reads, so `value` may need to be ignored. Do not copy ignore lists from unrelated resources.
+
+## Plan And Idempotency Checks
+
+Add plan checks when the behavior under test is specifically about update actions, replacement avoidance, or no-drift idempotency. Do not add plan checks as a blanket workaround for unstable tests.
+
+Useful patterns:
+
+- `plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate)` to prove an update happens rather than replacement.
+- `plancheck.ExpectEmptyPlan()` after reapplying identical config to prove idempotency.
+- `PlanOnly: true` plus `ExpectNonEmptyPlan: false` for an explicit no-op plan step.
+- `plancheck.ExpectKnownValue(...)` when asserting a planned value before apply is more useful than checking final state only.
+
+When adding `ExpectNonEmptyPlan: true` or `plancheck.ExpectNonEmptyPlan()`, document why the non-empty plan is expected. Non-empty plans are usually a smell unless the test is explicitly covering replacement, API behavior, or a known provider limitation.
+
+For post-apply drift, first capture the exact planned diff. Use a repeated-config step with `plancheck.ExpectEmptyPlan()` or a `PlanOnly: true` / `ExpectNonEmptyPlan: false` step to prove idempotency. Use `PostApplyPostRefresh` checks only when the drift is specifically after refresh.
+
+## CheckDestroy
+
+Use `CheckDestroy` when the API has a reliable get/list endpoint that proves deletion. Iterate Terraform state resources, skip other types, and query the API using IDs from state.
+
+Do not add `CheckDestroy` for singleton resources or settings that are reset rather than deleted. For these, either omit `CheckDestroy` or assert reset behavior in a follow-up read/plan step if the existing service patterns do that.
+
+## Sweepers
+
+Add `TestMain` when registering sweepers:
+
+```go
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+```
+
+Register sweepers in `init()`:
+
+```go
+func init() {
+	resource.AddTestSweepers("cloudflare_example", &resource.Sweeper{
+		Name: "cloudflare_example",
+		F:    testSweepCloudflareExample,
+	})
+}
+```
+
+Sweeper rules:
+
+- Return early if required scope env vars are missing.
+- List remote resources using the provider's Cloudflare client helpers.
+- Delete only resources passing `utils.ShouldSweepResource`.
+- Log failures and continue when deleting one stale resource should not prevent the rest from being swept.
+- Run `scripts/lint-sweepers` after adding or changing sweepers.
+
+## Credentials And Environment
+
+Acceptance tests require `TF_ACC=1` plus Cloudflare credentials. The base credential precheck accepts supported credential forms, but many tests need account/zone/domain variables.
+
+Check `contributing/environment-variable-dictionary.md` and `internal/acctest/acctest.go` for current environment variables.
+
+Common variables:
+
+```sh
+TF_ACC=1
+CLOUDFLARE_API_TOKEN=...
+CLOUDFLARE_API_KEY=...
+CLOUDFLARE_EMAIL=...
+CLOUDFLARE_ACCOUNT_ID=...
+CLOUDFLARE_ZONE_ID=...
+CLOUDFLARE_DOMAIN=...
+```
+
+Some older API paths require API key and email instead of API token. Follow existing tests in the same service family before changing credential behavior.
+
+If a test requires optional external fixtures that most contributors will not have, prefer `t.Skip` with a clear missing-variable message. Use `t.Fatal` for standard required fixtures that the acceptance test cannot meaningfully run without, such as account or zone IDs after the matching precheck has been selected.
+
+## Verification
+
+Start with checks that do not require real API access:
+
+```sh
+go test ./internal/services/<service> -run '^TestAcc' -count=0
+```
+
+Run targeted acceptance tests only when credentials are configured:
+
+```sh
+TF_ACC=1 go test ./internal/services/<service> -run '^TestAcc.*Basic$' -v -count=1 -timeout 30m
+```
+
+Repo script equivalents:
+
+```sh
+./scripts/test ./internal/services/<service>
+TF_ACC=1 ./scripts/test ./internal/services/<service> -run '^TestAcc' -count=1
+```
+
+Run formatting after edits:
+
+```sh
+./scripts/format
+```
+
+If credentials are unavailable, run targeted compile checks and report that `TF_ACC=1` verification was not performed.
+
+For dangling resources, prefer targeted sweep commands:
+
+```sh
+go test ./internal/services/<service> -v -sweep=all -sweep-run='cloudflare_<service>' -timeout 10m
+./scripts/sweep --resource <service> --dry-run
+```
+
+Only use dangerous sweep modes with explicit user approval.
+
+## Debugging Failures
+
+Schema/config errors:
+
+- Re-read the service docs or schema.
+- Verify `testdata/*.tf` uses v5 resource names and current attribute names.
+- Remove read-only fields from config.
+- Confirm `fmt.Sprintf` placeholder ordering in `acctest.LoadTestCase` calls.
+
+Import failures:
+
+- Confirm import ID format from docs or neighboring tests.
+- Add `ImportStateVerifyIgnore` only for fields that cannot round-trip.
+- Compare post-import state with temporary `acctest.DumpState` in `resource.ComposeTestCheckFunc(...)` if needed, then remove it before finalizing unless the user wants debug output kept.
+
+Non-empty plans after apply:
+
+- Check whether the API normalizes empty strings, empty collections, ordering, casing, or defaults.
+- Prefer fixing config or provider behavior over weakening the test. If provider behavior must change, respect the codegen boundary instead of patching generated read logic directly.
+- Use plan checks only when an existing service pattern shows the diff is expected.
+- Do not use `ImportStateVerifyIgnore` for ordinary apply drift; it only affects import verification.
+
+Destroy failures:
+
+- Determine whether the resource is a singleton/resettable setting rather than deletable.
+- Check eventual consistency and API delete behavior.
+- Add or fix sweepers if resources can be orphaned.
+
+## Migration Tests Are Related But Separate
+
+Do not turn a normal acceptance-test task into a migration-test rewrite unless the user explicitly asks about v4 to v5 migration, state upgraders, `tf-migrate`, or files under `migration/v500`.
+
+When the task is explicitly migration-related, inspect existing migration tests and helpers in `internal/acctest/acctest.go` before writing new patterns. Migration tests use specialized helpers such as `MigrationV2TestStep`, `MigrationV2TestStepWithPlan`, `MigrationV2TestStepWithStateNormalization`, and resource-specific helpers.
+
+## Common Pitfalls
+
+- Editing generated provider files instead of hand-maintained tests or codegen inputs.
+- Leaving generated scaffold placeholders in `resource_test.go` or `testdata/*.tf`.
+- Using fixed resource names that sweepers will not clean up.
+- Adding a sweeper that does not call `utils.ShouldSweepResource`.
+- Forgetting `TestMain` when adding a sweeper.
+- Using `account_id` when a resource is zone-scoped, or `zone_id` when it is account-scoped.
+- Guessing import ID formats instead of checking docs or nearby tests.
+- Asserting API-generated timestamps or unstable collection order.
+- Running broad `TF_ACC=1 ./scripts/test` instead of a targeted service test while iterating.
+- Mutating global Terraform CLI config such as `~/.terraformrc` without explicit user approval.
+
+## Evaluating This Skill
+
+When iterating on this skill, use realistic prompts and compare agent output with and without the skill. Start with the eval prompts in `evals/evals.json`, then add cases from real provider PRs when agents miss conventions or produce unsafe tests.

--- a/skills/acceptance-tests/evals/evals.json
+++ b/skills/acceptance-tests/evals/evals.json
@@ -1,0 +1,52 @@
+{
+  "skill_name": "acceptance-tests",
+  "evals": [
+    {
+      "id": "resource-basic-import-sweeper",
+      "prompt": "Add acceptance tests for a new account-scoped Cloudflare Terraform provider resource under internal/services/example_widget. It should create, update, import, and clean up real API resources.",
+      "expected_output": "The agent inspects the service first, uses repo acceptance-test helpers, creates or updates resource_test.go and testdata, includes scoped prechecks, uses random test names, adds import verification, and adds a safe sweeper only if needed.",
+      "assertions": [
+        "Mentions inspecting internal/services/example_widget before editing",
+        "Uses acctest.LoadTestCase for testdata configs or explains why not",
+        "Uses utils.GenerateRandomResourceName for remote resource names",
+        "Includes acctest.TestAccPreCheck and acctest.TestAccPreCheck_AccountID",
+        "Includes import-state verification or explains why import is unsupported",
+        "If adding a sweeper, filters deletes through utils.ShouldSweepResource",
+        "Does not edit generated provider implementation files as the durable fix"
+      ]
+    },
+    {
+      "id": "composite-import-id",
+      "prompt": "Fix the acceptance test import step for a nested resource where the import ID is account_id/parent_id/child_id and parent_id is only known after apply.",
+      "expected_output": "The agent uses ImportStateIdFunc to read IDs from terraform.State after apply instead of guessing or precomputing the import ID.",
+      "assertions": [
+        "Uses ImportStateIdFunc",
+        "Reads parent and child IDs from terraform.State resources",
+        "Checks that state resources exist before dereferencing Primary.ID",
+        "Builds the import ID as account_id/parent_id/child_id",
+        "Adds ImportStateVerifyIgnore only for fields with a specific non-round-tripping reason"
+      ]
+    },
+    {
+      "id": "not-consumer-hcl",
+      "prompt": "Write Terraform HCL for a user who wants to create a Cloudflare DNS record in their own infrastructure repo.",
+      "expected_output": "The skill should not be used. The answer should focus on consumer Terraform configuration and provider docs, not provider acceptance-test files, sweepers, or TF_ACC.",
+      "assertions": [
+        "Does not suggest editing resource_test.go or testdata in terraform-provider-cloudflare",
+        "Does not mention TF_ACC acceptance-test execution as the main workflow",
+        "Focuses on user-facing Terraform HCL and current provider docs"
+      ]
+    },
+    {
+      "id": "not-provider-error-support",
+      "prompt": "I'm getting an unsupported argument error from terraform plan for my Cloudflare config. Can you help me fix it?",
+      "expected_output": "The skill should not be used unless the user is modifying provider acceptance tests. The answer should retrieve or inspect the provider schema/docs and help fix the user's Terraform configuration.",
+      "assertions": [
+        "Does not frame the task as writing provider acceptance tests",
+        "Does not suggest TF_ACC or acceptance-test prechecks as the main path",
+        "Focuses on provider schema/docs and the user's Terraform configuration",
+        "Mentions acceptance tests only if the user is contributing a provider fix"
+      ]
+    }
+  ]
+}

--- a/skills/check-deprecation/SKILL.md
+++ b/skills/check-deprecation/SKILL.md
@@ -15,6 +15,8 @@ Deprecation markers change often. Prefer retrieved docs over pre-trained knowled
 | Registry JSON API - docs (primary) | `https://registry.terraform.io/v1/providers/cloudflare/cloudflare/{version}/docs?path={url-encoded-path}` | Full markdown |
 | GitHub raw docs (fallback) | `https://raw.githubusercontent.com/cloudflare/terraform-provider-cloudflare/{tag-or-main}/docs/{category}/{title}.md` | Use matching tag for pinned versions; use `main` only for latest/unpinned checks |
 | Local provider repo (fallback when available) | `internal/services/<service>/*schema*.go` | Framework `DeprecationMessage` values that may not appear in generated docs |
+| Cloudflare API deprecations (replacement context only) | `https://developers.cloudflare.com/fundamentals/api/reference/deprecations/` | Dated log of deprecated Cloudflare APIs/fields with replacement products. Use only for replacement guidance after the Terraform doc confirms deprecation — never to pick Terraform attribute names. |
+| Cloudflare developer docs (replacement context only) | Whichever `developers.cloudflare.com/*` URL the deprecation description links to | Product docs for the replacement service. Same scoping as above. |
 
 Do **not** fetch `https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/...`; it is a JavaScript SPA shell for non-browser clients.
 
@@ -30,7 +32,8 @@ Do **not** fetch `https://registry.terraform.io/providers/cloudflare/cloudflare/
 8. **For attribute questions**, scan the full `## Schema` attribute block for the named attribute, including nested schema sections and continuation lines, using both patterns below.
 9. **If running inside this provider repo**, also check local schema files for `DeprecationMessage` before saying something is not deprecated. Some schema-level deprecations may be present in Go but missing from generated docs.
 10. **If the user named a specific attribute** that doesn't exist in the schema, say so. The user may have a typo, wrong category, or wrong provider version.
-11. **Be explicit about what you found.** If nothing is deprecated, say so.
+11. **If the user asks what to use instead** (not just "is this deprecated?"), and only after the Terraform doc confirms deprecation: fetch any `developers.cloudflare.com/*` URL in the deprecation description, and grep the [API deprecations page](https://developers.cloudflare.com/fundamentals/api/reference/deprecations/) for the attribute or API name. Report the deprecation and end-of-life dates when present. If the replacement is another Terraform resource, confirm it in the Registry before naming it.
+12. **Be explicit about what you found.** If nothing is deprecated, say so.
 
 ## How deprecation is marked
 
@@ -53,6 +56,8 @@ Answer deprecation status only. Do not suggest HCL edits, `moved` blocks, import
 
 ## Example
 
-> **User:** "I'm getting a deprecation warning on `notification_email` for `cloudflare_load_balancer_pool`. Is it deprecated?"
+> **User:** "I'm getting a deprecation warning on `notification_email` for `cloudflare_load_balancer_pool`. What should I use instead?"
 >
-> Fetch the `load_balancer_pool` resource or data source doc from the Registry, depending on the user's context. Scan the `## Schema` block for `notification_email`. Reply with what you found - quote the deprecation description verbatim if it's deprecated, or confirm it isn't if you find no markers.
+> Fetch the `load_balancer_pool` resource doc. The `## Schema` block shows `notification_email` is deprecated and points at `https://developers.cloudflare.com/fundamentals/notifications/`. Fetch that page for replacement context, and grep the API deprecations page for the 2023-04-03 date. Reply:
+>
+> > `notification_email` was deprecated on 2023-04-03. Cloudflare moved health-check notifications to their centralized Notifications service ([docs](https://developers.cloudflare.com/fundamentals/notifications/)) — configure notifications there instead. There is no drop-in Terraform attribute replacement on `cloudflare_load_balancer_pool`; the migration is a workflow change, not a rename.

--- a/skills/check-deprecation/SKILL.md
+++ b/skills/check-deprecation/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: check-deprecation
+description: Checks whether a Cloudflare Terraform resource, data source, or attribute is deprecated. Use ONLY when deprecation, removal, replacement, or a Terraform deprecation warning is the main question. Biases towards Terraform Registry retrieval over pre-trained knowledge.
+---
+
+# Cloudflare Terraform - Check Deprecation
+
+Deprecation markers change often. Prefer retrieved docs over pre-trained knowledge.
+
+## Retrieval Sources
+
+| Source | URL | Returns |
+|--------|-----|---------|
+| Registry JSON API - index (primary) | `https://registry.terraform.io/v1/providers/cloudflare/cloudflare` | Docs index - find the exact `path` by `title` + `category`, e.g. `docs/resources/dns_record.md` |
+| Registry JSON API - docs (primary) | `https://registry.terraform.io/v1/providers/cloudflare/cloudflare/{version}/docs?path={url-encoded-path}` | Full markdown |
+| GitHub raw docs (fallback) | `https://raw.githubusercontent.com/cloudflare/terraform-provider-cloudflare/{tag-or-main}/docs/{category}/{title}.md` | Use matching tag for pinned versions; use `main` only for latest/unpinned checks |
+| Local provider repo (fallback when available) | `internal/services/<service>/*schema*.go` | Framework `DeprecationMessage` values that may not appear in generated docs |
+
+Do **not** fetch `https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/...`; it is a JavaScript SPA shell for non-browser clients.
+
+## Procedure
+
+1. **Identify** whether the target is a resource, data source, or unknown, plus the optional attribute name.
+2. **Determine provider version** from user context when available: `.terraform.lock.hcl`, then `required_providers`, otherwise latest Registry version.
+3. **Normalize** the name: parse addresses like `data.cloudflare_zone.example.permissions` into category `data-sources`, type `zone`, attribute `permissions`; strip `data.cloudflare_` or `cloudflare_`, lowercase, keep only `[a-z0-9_]`.
+4. **Find docs path** in the Registry index. If category is known, search only `resources` or `data-sources`; otherwise check both and disambiguate if both exist.
+5. **Fetch docs** from the Registry JSON API with the exact URL-encoded `path` from the index (for example `docs%2Fresources%2Fdns_record.md`) or use the GitHub fallback if the Registry is unreachable/truncated.
+6. **If the target isn't in the docs index**, fetch `version-5-migration` / `version-5-upgrade` and quote the relevant rename/removal entry if present; otherwise say no replacement was found in docs.
+7. **For whole-resource or whole-data-source questions**, scan page prose outside code blocks for `\bdeprecated\b` before checking attributes.
+8. **For attribute questions**, scan the full `## Schema` attribute block for the named attribute, including nested schema sections and continuation lines, using both patterns below.
+9. **If running inside this provider repo**, also check local schema files for `DeprecationMessage` before saying something is not deprecated. Some schema-level deprecations may be present in Go but missing from generated docs.
+10. **If the user named a specific attribute** that doesn't exist in the schema, say so. The user may have a typo, wrong category, or wrong provider version.
+11. **Be explicit about what you found.** If nothing is deprecated, say so.
+
+## How deprecation is marked
+
+Scan for both explicit type markers and description-only field/block deprecations:
+
+```
+- `old_attribute` (String, Deprecated) Use new_attribute instead.
+- `legacy_field` (String) This field is deprecated, use modern_field instead.
+```
+
+Match `\bdeprecated\b` (word-boundary, case-insensitive) in the attribute block so words like "undeprecated" don't false-match. For attributes, scan only schema attribute blocks - not code blocks, examples, or unrelated guide prose. An attribute block starts at a bullet like ``- `name` (...)`` and continues until the next attribute bullet or heading.
+
+If text says only an enum value is deprecated, report that distinction. Example: `Note: UNKNOWN is deprecated` means the `UNKNOWN` value is deprecated, not necessarily the whole attribute.
+
+For whole-resource or whole-data-source questions, scan non-code page prose separately and report page-level deprecation text only if it clearly refers to the resource/data source itself, not just an attribute inside the schema.
+
+When you find a deprecated attribute, quote its description verbatim. Do not infer replacement resources or attributes unless the docs explicitly name them.
+
+Answer deprecation status only. Do not suggest HCL edits, `moved` blocks, imports, or state commands unless fetched docs explicitly provide that guidance.
+
+## Example
+
+> **User:** "I'm getting a deprecation warning on `notification_email` for `cloudflare_load_balancer_pool`. Is it deprecated?"
+>
+> Fetch the `load_balancer_pool` resource or data source doc from the Registry, depending on the user's context. Scan the `## Schema` block for `notification_email`. Reply with what you found - quote the deprecation description verbatim if it's deprecated, or confirm it isn't if you find no markers.

--- a/skills/get-provider-resources/SKILL.md
+++ b/skills/get-provider-resources/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: get-provider-resources
+description: Lists Cloudflare Terraform provider resources, data sources, and guides from the public Registry. Use when the user is looking for a `cloudflare_*` resource, doesn't remember its exact name, or needs to map a Cloudflare product to a Terraform resource.
+---
+
+# Cloudflare Terraform — List Provider Resources, Data Sources, and Guides
+
+Your pre-trained knowledge of which Cloudflare resources exist is likely stale — resources are added, renamed, and consolidated across provider versions. **Prefer retrieval over pre-training.**
+
+Provider repository: https://github.com/cloudflare/terraform-provider-cloudflare
+
+## Retrieval Sources
+
+**Registry JSON API (primary)**
+- `https://registry.terraform.io/v1/providers/cloudflare/cloudflare`
+- Returns the full `docs` array — every resource, data source, guide, and overview page.
+
+**Pinned-version index**
+- `https://registry.terraform.io/v1/providers/cloudflare/cloudflare/{version}`
+- Same shape, scoped to a specific version. Use when the user is pinned to an older provider — substitute their version (e.g. `5.15.0`) into the URL.
+- To discover the user's pinned version, check their `required_providers` block (in their `*.tf` files) for the version constraint, or `.terraform.lock.hcl` for the exact resolved version.
+
+**GitHub repo `docs/` (fallback)**
+- `https://github.com/cloudflare/terraform-provider-cloudflare/tree/main/docs`
+- Subdirectories: `resources/`, `data-sources/`, `guides/`.
+- Same content as the Registry, browseable when the Registry is unreachable.
+- List files via the GitHub API: `https://api.github.com/repos/cloudflare/terraform-provider-cloudflare/contents/docs/resources`.
+- Use the `main` branch (not `master` — `master` URLs will 404).
+
+Do **not** fetch `https://registry.terraform.io/providers/cloudflare/cloudflare/latest/...` URLs — they serve a JavaScript-gated SPA and return an empty shell to non-browser clients.
+
+## Procedure
+
+1. GET the registry index.
+2. Parse the JSON. Each `docs` entry has `{ id, title, path, slug, category, subcategory, language }`.
+3. Filter by `category`:
+   - `"resources"` — declarable, manageable resources (e.g. `cloudflare_dns_record`)
+   - `"data-sources"` — read-only lookups (e.g. `data.cloudflare_zone`)
+   - `"guides"` — long-form contributor docs (migration guides, upgrade guides, conventions)
+   - `"overview"` — provider-level overview page (auth, getting started)
+4. Match against `title` values. Titles omit the `cloudflare_` prefix — reattach it when presenting to the user.
+5. Return at most 5-10 matches sorted by relevance. For broad queries ("what storage resources exist?"), summarize by namespace prefix instead of listing every entry.
+
+## Resource discovery workflow
+
+When the user asks "is there a Cloudflare resource for X?" and the obvious `title` search returns nothing, **don't conclude the resource doesn't exist** — Cloudflare consolidates many features into single resources keyed by a discriminator. Follow this procedure before answering "no":
+
+1. **Direct search.** Look for `title` substrings matching the user's intent (e.g. "rate limiting" → search `rate`, `limit`).
+2. **Consolidation check.** If no direct match, try the known consolidation points:
+   - **WAF / rate limiting / redirects / caching / transforms** → `cloudflare_ruleset` with the matching `phase` (~25 phases — fetch the `ruleset` doc to see them all)
+   - **Access apps / policies / groups / identity providers / tunnels** → `cloudflare_zero_trust_*` namespace
+   - **Magic WAN tunnels / static routes** → `cloudflare_magic_wan_*` namespace
+   - **Workers (script / route / custom domain / KV / cron)** → `cloudflare_workers_*` namespace (plural, not `worker_*` — that's v4)
+   - **Zone-level settings** → `cloudflare_zone_setting` (singular, one resource per setting; `cloudflare_zone_settings_override` is v4 only)
+3. **Migration check.** If the user named a resource that doesn't appear (e.g. `cloudflare_record`, `cloudflare_access_application`), it was likely renamed in v5. Fetch `version-5-migration` (in the `guides` category) and consult the rename table.
+4. **Only then** conclude the resource doesn't exist. Be explicit that you checked direct names, consolidation points, and rename tables.
+
+## The `guides` category is high-value
+
+Whenever the user is doing anything beyond a single-resource question — upgrading provider versions, migrating from v4, troubleshooting "this used to work", or asking about provider auth — **scan the `guides` category first**. The guides cover material that isn't in any individual resource doc: cross-resource migration paths, renamed resources, the official `tf-migrate` CLI, and known-issue rescue procedures.
+
+Two key guides serve different purposes and are easy to confuse:
+
+- **`version-5-migration`** — the end-to-end migration workflow (state upgraders, `moved` blocks, `tf-migrate` CLI, the `Auto`/`Manual` resource-rename table, and the **known-issues / perpetual-diff table**). Start here for "how do I migrate?" and "why does my plan keep showing the same diff?"
+- **`version-5-upgrade`** — per-resource attribute change reference. Start here for "what changed about resource X between v4 and v5?"
+
+## Example
+
+> **User:** "Is there a Cloudflare resource for WAF custom rules?"
+>
+> Filter resources, search for `waf` and `rule`. Closest match: `ruleset` (no dedicated `waf_custom_rule`).
+>
+> Fetch the `ruleset` doc from the Registry to confirm the `phase` value, then reply:
+> > WAF custom rules use **`cloudflare_ruleset`** with `phase = "http_request_firewall_custom"`. The `ruleset` resource is consolidated — it also handles rate limiting, redirects, caching, and transforms, keyed by `phase`.


### PR DESCRIPTION
## Summary

Two silent regressions in the v4→v5 state upgraders that surface when a full
v4-apply → v5-plan pipeline actually runs. They've been dormant since May
because the tf-migrate e2e workflow was running against pre-existing state (no-op
refresh), so the state upgraders were never exercised. They fire the moment CI
recreates resources from an empty state — which is what we hit today.

Both are one-file logic fixes; existing migration test suites keep passing.

## 1. Ruleset — v4 source schema missing `asset_name`

The `asset_name` attribute on `action_parameters` was added to the v4 provider
in [3d97253 (2026-05-28)][1] and shipped in v4.52.8. Any v4 provider from that
release onward writes state containing `asset_name` (typically null unless the
user configures it).

The v4→v5 state upgrader parses the incoming raw JSON using
`SourceV4RulesetSchema()`. That schema was last touched in March and doesn't
declare `asset_name`, so raw-state unmarshal fails with:

```
Could not parse raw state as v4 format:
AttributeName("rules").ElementKeyInt(0).AttributeName("action_parameters").ElementKeyInt(0).AttributeName("asset_name"):
unsupported attribute "asset_name"
```

Fix:
- Add `asset_name` to `SourceV4RulesetSchema` (`schema.go`).
- Add `AssetName types.String` to `SourceV4ActionParametersModel` (`model.go`).
- In `transformActionParameters` (`transform.go`), forward `src.AssetName`
  through to the v5 model instead of nulling it out (the code was assuming
  asset_name didn't exist in v4).

[1]: https://github.com/cloudflare/terraform-provider-cloudflare/commit/3d972534

## 2. Load balancer pool — `SourceOriginsModel` has a phantom `flatten_cname`

The v4 provider's `cloudflare_load_balancer_pool` origins block has no
`flatten_cname` attribute (verified against v4.52.7 and v4.52.8: 0 hits).
So v4 state never contains it.

But `SourceOriginsModel` (the v4-side model used to parse that state)
declares `FlattenCNAME types.Bool`. When the framework tries to convert
the object into the struct, it fails:

```
An unexpected error was encountered trying to convert tftypes.Value into
v500.SourceOriginsModel. This is always an error in the provider.
mismatch between struct and object: Struct defines fields not found in object: flatten_cname.
```

Also confirmed by inspecting the v500 migration schema
(`internal/services/load_balancer_pool/migration/v500/schema.go`), which
correctly does **not** declare `flatten_cname` under `origins`.

Fix:
- Remove `FlattenCNAME` from `SourceOriginsModel` in
  `internal/services/load_balancer_pool/migration/v500/model.go`.
- Leave it on `TargetLoadBalancerPoolOriginsModel` (v5) since v5 introduced
  the attribute.

## Verification

- `go build ./...` — clean.
- `go test ./internal/services/ruleset/migration/...` — ok.
- `go test ./internal/services/load_balancer_pool/migration/...` — ok.

## Impact

Unblocks the tf-migrate e2e workflow, which is currently failing at v5-plan
with 27 ruleset unmarshal errors + 24 load_balancer_pool value-conversion
errors — both caused by these two schema drift bugs.