### PR TITLE
feat(d1_database): add CRUD acceptance tests

### DIFF
--- a/internal/services/d1_database/data_source_test.go
+++ b/internal/services/d1_database/data_source_test.go
@@ -1,0 +1,109 @@
+package d1_database_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+// TestAccCloudflareD1DatabaseDataSource_ByID verifies looking up a D1 database
+// data source by database_id.
+func TestAccCloudflareD1DatabaseDataSource_ByID(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_d1_database." + rnd
+	dataSourceName := "data.cloudflare_d1_database." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareD1DatabaseDataSourceByID(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("uuid"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("version"), knownvalue.StringExact("production")),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("created_at"), knownvalue.NotNull()),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "uuid", resourceName, "uuid"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "version", resourceName, "version"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareD1DatabaseDataSource_ByName verifies looking up a D1
+// database data source using the filter block with a name match.
+func TestAccCloudflareD1DatabaseDataSource_ByName(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_d1_database." + rnd
+	dataSourceName := "data.cloudflare_d1_database." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareD1DatabaseDataSourceByName(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("uuid"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("version"), knownvalue.StringExact("production")),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "uuid", resourceName, "uuid"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareD1DatabasesDataSource_List verifies the plural list data
+// source returns results after creating a D1 database.
+func TestAccCloudflareD1DatabasesDataSource_List(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	dataSourceName := "data.cloudflare_d1_databases." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareD1DatabasesDataSourceList(rnd, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+				},
+			},
+		},
+	})
+}
+
+// Config helpers
+
+func testAccCloudflareD1DatabaseDataSourceByID(rnd, accountID string) string {
+	return acctest.LoadTestCase("d1databasedatasourcebyid.tf", rnd, accountID)
+}
+
+func testAccCloudflareD1DatabaseDataSourceByName(rnd, accountID string) string {
+	return acctest.LoadTestCase("d1databasedatasourcebyname.tf", rnd, accountID)
+}
+
+func testAccCloudflareD1DatabasesDataSourceList(rnd, accountID string) string {
+	return acctest.LoadTestCase("d1databaseslist.tf", rnd, accountID)
+}

--- a/internal/services/d1_database/resource_test.go
+++ b/internal/services/d1_database/resource_test.go
@@ -7,10 +7,18 @@ import (
 	"testing"
 
 	cfv1 "github.com/cloudflare/cloudflare-go"
+	"github.com/cloudflare/cloudflare-go/v7"
+	"github.com/cloudflare/cloudflare-go/v7/d1"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestMain(m *testing.M) {
@@ -71,7 +79,38 @@ func init() {
 	})
 }
 
+func testAccCheckCloudflareD1DatabaseDestroy(s *terraform.State) error {
+	client := acctest.SharedClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_d1_database" {
+			continue
+		}
+
+		accountID := rs.Primary.Attributes[consts.AccountIDSchemaKey]
+		_, err := client.D1.Database.Get(
+			context.Background(),
+			rs.Primary.ID,
+			d1.DatabaseGetParams{
+				AccountID: cloudflare.F(accountID),
+			},
+		)
+		if err == nil {
+			return fmt.Errorf("d1 database %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+// TestAccCloudflareD1Database_Basic verifies basic create and read of a D1
+// database with only the required attributes (account_id, name).
+//
+// Skip: read_replication is Optional-only in the current schema, but the API
+// always returns it in responses, causing refresh drift. Blocked on BUGS-2016
+// codegen fix (PR #7183).
 func TestAccCloudflareD1Database_Basic(t *testing.T) {
+	t.Skip("BUGS-2016: read_replication drift -- waiting for codegen fix on next (PR #7183)")
 	rnd := utils.GenerateRandomResourceName()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	resourceName := "cloudflare_d1_database." + rnd
@@ -79,25 +118,177 @@ func TestAccCloudflareD1Database_Basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareD1DatabaseDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckCloudflareD1DatabaseBasic(rnd, accountID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rnd),
+					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "version", "production"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("uuid"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("created_at"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("version"), knownvalue.StringExact("production")),
+				},
 			},
-			// {
-			// 	ResourceName:        resourceName,
-			// 	ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
-			// 	ImportState:         true,
-			// 	ImportStateVerify:   true,
-			// },
+			{
+				ResourceName:        resourceName,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
 		},
 	})
 }
 
+// TestAccCloudflareD1Database_ReadReplication verifies creating a D1 database
+// with read_replication set to "disabled", then updating it to "auto", and
+// back to "disabled".
+func TestAccCloudflareD1Database_ReadReplication(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_d1_database." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareD1DatabaseDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with read_replication disabled
+			{
+				Config: testAccCheckCloudflareD1DatabaseReadReplication(rnd, accountID, "disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rnd),
+					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(resourceName, "read_replication.mode", "disabled"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("read_replication").AtMapKey("mode"), knownvalue.StringExact("disabled")),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"file_size"},
+			},
+			// Step 2: Update to auto
+			{
+				Config: testAccCheckCloudflareD1DatabaseReadReplication(rnd, accountID, "auto"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "read_replication.mode", "auto"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("read_replication").AtMapKey("mode"), knownvalue.StringExact("auto")),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"file_size"},
+			},
+			// Step 3: Update back to disabled
+			{
+				Config: testAccCheckCloudflareD1DatabaseReadReplication(rnd, accountID, "disabled"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "read_replication.mode", "disabled"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareD1Database_NoDrift verifies that re-applying the same
+// config produces an empty plan (no perpetual drift).
+//
+// Skip: read_replication is Optional-only in the current schema, but the API
+// always returns it in responses, causing refresh drift. Blocked on BUGS-2016
+// codegen fix (PR #7183).
+func TestAccCloudflareD1Database_NoDrift(t *testing.T) {
+	t.Skip("BUGS-2016: read_replication drift -- waiting for codegen fix on next (PR #7183)")
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_d1_database." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareD1DatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareD1DatabaseBasic(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rnd),
+				),
+			},
+			// Re-apply the same config and verify no changes are planned
+			{
+				Config:             testAccCheckCloudflareD1DatabaseBasic(rnd, accountID),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestAccCloudflareD1Database_ReadReplicationNoDrift verifies that a database
+// created with read_replication does not show perpetual drift. This is the
+// regression test for BUGS-2016.
+//
+// Skip: The codegen fix (x-stainless-terraform-configurability: computed_optional
+// on read-replication-details-for-request) is on origin/generated but has not
+// synced to next yet. Remove this skip once codegen sync PR #7183 merges and
+// read_replication is marked Computed+Optional in schema.go.
+func TestAccCloudflareD1Database_ReadReplicationNoDrift(t *testing.T) {
+	t.Skip("BUGS-2016: waiting for codegen fix to land on next (PR #7183)")
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_d1_database." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareD1DatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareD1DatabaseReadReplication(rnd, accountID, "disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "read_replication.mode", "disabled"),
+				),
+			},
+			// Re-apply the same config and verify no drift
+			{
+				Config:             testAccCheckCloudflareD1DatabaseReadReplication(rnd, accountID, "disabled"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Config helpers
+
 func testAccCheckCloudflareD1DatabaseBasic(rnd, accountID string) string {
 	return acctest.LoadTestCase("d1databasebasic.tf", rnd, accountID)
+}
+
+func testAccCheckCloudflareD1DatabaseReadReplication(rnd, accountID, mode string) string {
+	return acctest.LoadTestCase("d1databasereadreplication.tf", rnd, accountID, mode)
 }

--- a/internal/services/d1_database/testdata/d1databasedatasourcebyid.tf
+++ b/internal/services/d1_database/testdata/d1databasedatasourcebyid.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_d1_database" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+  read_replication = {
+    mode = "disabled"
+  }
+}
+
+data "cloudflare_d1_database" "%[1]s" {
+  account_id  = "%[2]s"
+  database_id = cloudflare_d1_database.%[1]s.id
+}

--- a/internal/services/d1_database/testdata/d1databasedatasourcebyname.tf
+++ b/internal/services/d1_database/testdata/d1databasedatasourcebyname.tf
@@ -1,0 +1,14 @@
+resource "cloudflare_d1_database" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+  read_replication = {
+    mode = "disabled"
+  }
+}
+
+data "cloudflare_d1_database" "%[1]s" {
+  account_id = "%[2]s"
+  filter = {
+    name = cloudflare_d1_database.%[1]s.name
+  }
+}

--- a/internal/services/d1_database/testdata/d1databasereadreplication.tf
+++ b/internal/services/d1_database/testdata/d1databasereadreplication.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_d1_database" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+  read_replication = {
+    mode = "%[3]s"
+  }
+}

--- a/internal/services/d1_database/testdata/d1databaseslist.tf
+++ b/internal/services/d1_database/testdata/d1databaseslist.tf
@@ -1,0 +1,13 @@
+resource "cloudflare_d1_database" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+  read_replication = {
+    mode = "disabled"
+  }
+}
+
+data "cloudflare_d1_databases" "%[1]s" {
+  account_id = "%[2]s"
+  name       = cloudflare_d1_database.%[1]s.name
+  depends_on = [cloudflare_d1_database.%[1]s]
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Add acceptance tests for `d1_database` resource. _Note:_ There is a fix currently in codegen to the read_replication drift. These tests are skipped until that change lands.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
```
=== RUN   TestAccCloudflareD1DatabaseDataSource_ByID
=== PAUSE TestAccCloudflareD1DatabaseDataSource_ByID
=== RUN   TestAccCloudflareD1DatabaseDataSource_ByName
=== PAUSE TestAccCloudflareD1DatabaseDataSource_ByName
=== RUN   TestAccCloudflareD1DatabasesDataSource_List
=== PAUSE TestAccCloudflareD1DatabasesDataSource_List
=== RUN   TestAccCloudflareD1Database_Basic
    resource_test.go:113: BUGS-2016: read_replication drift -- waiting for codegen fix on next (PR #7183)
--- SKIP: TestAccCloudflareD1Database_Basic (0.00s)
=== RUN   TestAccCloudflareD1Database_ReadReplication
=== PAUSE TestAccCloudflareD1Database_ReadReplication
=== RUN   TestAccCloudflareD1Database_NoDrift
    resource_test.go:225: BUGS-2016: read_replication drift -- waiting for codegen fix on next (PR #7183)
--- SKIP: TestAccCloudflareD1Database_NoDrift (0.00s)
=== RUN   TestAccCloudflareD1Database_ReadReplicationNoDrift
    resource_test.go:260: BUGS-2016: waiting for codegen fix to land on next (PR #7183)
--- SKIP: TestAccCloudflareD1Database_ReadReplicationNoDrift (0.00s)
=== RUN   TestAccCloudflareD1Database_Jurisdiction
=== PAUSE TestAccCloudflareD1Database_Jurisdiction
=== RUN   TestAccCloudflareD1Database_PrimaryLocationHint
=== PAUSE TestAccCloudflareD1Database_PrimaryLocationHint
=== RUN   TestAccCloudflareD1Database_ReplaceName
--- PASS: TestAccCloudflareD1Database_ReplaceName (8.28s)
=== CONT  TestAccCloudflareD1Database_Jurisdiction
=== CONT  TestAccCloudflareD1Database_ReadReplication
=== CONT  TestAccCloudflareD1DatabaseDataSource_ByName
=== CONT  TestAccCloudflareD1DatabasesDataSource_List
=== CONT  TestAccCloudflareD1DatabaseDataSource_ByID
=== CONT  TestAccCloudflareD1Database_PrimaryLocationHint
--- PASS: TestAccCloudflareD1DatabasesDataSource_List (4.63s)
--- PASS: TestAccCloudflareD1DatabaseDataSource_ByName (4.75s)
--- PASS: TestAccCloudflareD1DatabaseDataSource_ByID (4.84s)
--- PASS: TestAccCloudflareD1Database_PrimaryLocationHint (5.21s)
--- PASS: TestAccCloudflareD1Database_Jurisdiction (6.25s)
--- PASS: TestAccCloudflareD1Database_ReadReplication (10.41s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/d1_database	20.701s
```