### PR TITLE
test(organization): un-skip org create acceptance tests now that account is eligible

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -273,6 +273,16 @@ func TestAccPreCheck_BYOIPPrefix(t *testing.T) {
 	}
 }
 
+// TestAccPreCheck_Organization skips the test unless the organization test
+// credentials are configured. Only the `organization` acceptance-test matrix
+// entry injects CLOUDFLARE_ORGANIZATION_ID, so gating on it lets these tests
+// self-skip on every other runner instead of failing.
+func TestAccPreCheck_Organization(t *testing.T) {
+	if v := os.Getenv("CLOUDFLARE_ORGANIZATION_ID"); v == "" {
+		t.Skip("Skipping acceptance test as CLOUDFLARE_ORGANIZATION_ID is not set")
+	}
+}
+
 // Test helper method checking all required Hyperdrive configurations are present.
 func TestAccPreCheck_Hyperdrive(t *testing.T) {
 	if v := os.Getenv("CLOUDFLARE_HYPERDRIVE_DATABASE_NAME"); v == "" {

--- a/internal/services/organization/resource_test.go
+++ b/internal/services/organization/resource_test.go
@@ -64,14 +64,13 @@ func testSweepCloudflareOrgs(_ string) error {
 
 // TestAccCloudflareOrganization_Basic tests the basic CRUD operations for organization resource
 func TestAccCloudflareOrganization_Basic(t *testing.T) {
-	t.Skip("User is not eligible to create an organization:  no_enterprise_accounts")
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_organization." + rnd
 	orgName := rnd
 	updatedOrgName := rnd + "-updated"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck:                 func() { acctest.TestAccPreCheck(t); acctest.TestAccPreCheck_Organization(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckCloudflareOrganizationDestroy,
 		Steps: []resource.TestStep{
@@ -113,13 +112,12 @@ func TestAccCloudflareOrganization_Basic(t *testing.T) {
 
 // TestAccCloudflareOrganization_WithProfile tests organization creation with profile information
 func TestAccCloudflareOrganization_WithProfile(t *testing.T) {
-	t.Skip("User is not eligible to create an organization:  no_enterprise_accounts")
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_organization." + rnd
 	orgName := rnd
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		PreCheck:                 func() { acctest.TestAccPreCheck(t); acctest.TestAccPreCheck_Organization(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckCloudflareOrganizationDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
## Why

The `cloudflare_organization` acceptance tests (`TestAccCloudflareOrganization_Basic` and `_WithProfile`) were unconditionally skipped as the CI test user (`orgs-terraform-user@cfapi.net`) was not eligible to create an organization since it had no access an enterprise account. The orgs test account has now been provisioned as a contract customer, so the eligibility gate is satisfied and the skips can be removed.

## What to hold in your head while reviewing

`CLOUDFLARE_ORGANIZATION_ID` is injected only by the `organization` entry of the acceptance-test matrix. To avoid these tests failing on every other runner, both now gate their `PreCheck` on a new `TestAccPreCheck_Organization` helper (same idea as `TestAccPreCheck_CrowdStrike` / `_BYOIPPrefix` / `_Hyperdrive`) so they run on the org runner and are skipped elsewhere.

The acceptance suite runs only on `workflow_dispatch` and `release-please` pushes, not per-PR, so this does not change CI behaviour on ordinary PRs.