### PR TITLE
feat(workers): add write-only secret support for Access IdP and bindings

### DIFF
--- a/docs/resources/worker_version.md
+++ b/docs/resources/worker_version.md
@@ -206,6 +206,8 @@ Available values: "eu", "fedramp", "fedramp-high".
 - `simple` (Attributes) The rate limit configuration. (see [below for nested schema](#nestedatt--bindings--simple))
 - `store_id` (String) ID of the store containing the secret.
 - `text` (String, Sensitive) The text value to use.
+- `text_wo` (String, Sensitive, Write-Only) Write-only text value to use. Requires Terraform 1.11+.
+- `text_wo_version` (Number) Version trigger for `text_wo` updates.
 - `tunnel_id` (String) UUID of the Cloudflare Tunnel to bind to. Mutually exclusive with network_id.
 - `usages` (Set of String) Allowed operations with the key. [Learn more](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#keyUsages).
 - `version_id` (String) Identifier for the version to inherit the binding from, which can be the version ID or the literal "latest" to inherit from the latest version. Defaults to inheriting the binding from the latest version.

--- a/docs/resources/workers_script.md
+++ b/docs/resources/workers_script.md
@@ -245,6 +245,8 @@ Available values: "eu", "fedramp", "fedramp-high".
 - `simple` (Attributes) A simple rate limit. (see [below for nested schema](#nestedatt--bindings--simple))
 - `store_id` (String) ID of the store containing the secret.
 - `text` (String, Sensitive) The text value to use.
+- `text_wo` (String, Sensitive, Write-Only) Write-only text value to use. Requires Terraform 1.11+.
+- `text_wo_version` (Number) Version trigger for `text_wo` updates.
 - `tunnel_id` (String) UUID of the Cloudflare Tunnel to bind to. Mutually exclusive with network_id.
 - `usages` (Set of String) Allowed operations with the key. [Learn more](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#keyUsages).
 - `version_id` (String) Identifier for the version to inherit the binding from, which can be the version ID or the literal "latest" to inherit from the latest version. Defaults to inheriting the binding from the latest version.

--- a/docs/resources/zero_trust_access_identity_provider.md
+++ b/docs/resources/zero_trust_access_identity_provider.md
@@ -80,6 +80,8 @@ Optional:
 - `claims` (List of String) Custom claims
 - `client_id` (String) Your OAuth Client ID
 - `client_secret` (String, Sensitive) Your OAuth Client Secret
+- `client_secret_wo` (String, Sensitive, Write-Only) Write-only OAuth Client Secret. Requires Terraform 1.11+.
+- `client_secret_wo_version` (Number) Version trigger for `client_secret_wo` updates.
 - `conditional_access_enabled` (Boolean) Should Cloudflare try to load authentication contexts from your account
 - `directory_id` (String) Your Azure directory uuid
 - `email_attribute_name` (String) The attribute name for email in the SAML response.

--- a/internal/services/worker_version/model.go
+++ b/internal/services/worker_version/model.go
@@ -153,6 +153,8 @@ type WorkerVersionBindingsModel struct {
 	Json                        jsontypes.Normalized                `tfsdk:"json" json:"json,optional"`
 	CertificateID               types.String                        `tfsdk:"certificate_id" json:"certificate_id,optional"`
 	Text                        types.String                        `tfsdk:"text" json:"text,optional"`
+	TextWO                      types.String                        `tfsdk:"text_wo" json:"-,optional"`
+	TextWOVersion               types.Int64                         `tfsdk:"text_wo_version" json:"-,optional"`
 	Pipeline                    types.String                        `tfsdk:"pipeline" json:"pipeline,optional"`
 	QueueName                   types.String                        `tfsdk:"queue_name" json:"queue_name,optional"`
 	Simple                      *WorkerVersionBindingsSimpleModel   `tfsdk:"simple" json:"simple,optional"`

--- a/internal/services/worker_version/resource.go
+++ b/internal/services/worker_version/resource.go
@@ -122,6 +122,8 @@ func (r *WorkerVersionResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	applyWriteOnlyBindingText(data)
+
 	dataBytes, err := data.MarshalJSON()
 	if err != nil {
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
@@ -418,4 +420,28 @@ func (r *WorkerVersionResource) ImportState(ctx context.Context, req resource.Im
 
 func (r *WorkerVersionResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, _ *resource.ModifyPlanResponse) {
 
+}
+
+func applyWriteOnlyBindingText(data *WorkerVersionModel) {
+	if data == nil || data.Bindings.IsNull() || data.Bindings.IsUnknown() {
+		return
+	}
+
+	var bindings []WorkerVersionBindingsModel
+	diags := data.Bindings.ElementsAs(context.Background(), &bindings, true)
+	if diags.HasError() {
+		return
+	}
+
+	for i := range bindings {
+		if !bindings[i].TextWO.IsNull() && !bindings[i].TextWO.IsUnknown() {
+			bindings[i].Text = bindings[i].TextWO
+		}
+	}
+
+	updated, diags := customfield.NewObjectList(context.Background(), bindings)
+	if diags.HasError() {
+		return
+	}
+	data.Bindings = updated
 }

--- a/internal/services/worker_version/schema.go
+++ b/internal/services/worker_version/schema.go
@@ -555,6 +555,22 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Description: "The text value to use.",
 							Optional:    true,
 							Sensitive:   true,
+							Validators: []validator.String{
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("text_wo")),
+							},
+						},
+						"text_wo": schema.StringAttribute{
+							Description: "Write-only text value to use. Requires Terraform 1.11+.",
+							Optional:    true,
+							Sensitive:   true,
+							WriteOnly:   true,
+							Validators: []validator.String{
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("text")),
+							},
+						},
+						"text_wo_version": schema.Int64Attribute{
+							Description: "Version trigger for text_wo updates.",
+							Optional:    true,
 						},
 						"pipeline": schema.StringAttribute{
 							Description: "Name of the Pipeline to bind to.",

--- a/internal/services/workers_script/model.go
+++ b/internal/services/workers_script/model.go
@@ -98,7 +98,7 @@ func (r WorkersScriptModel) MarshalMultipart() (data []byte, formDataContentType
 }
 
 type WorkersScriptMetadataModel struct {
-	Annotations        customfield.NestedObject[WorkersScriptMetadataAnnotationsModel] `tfsdk:"annotations" json:"annotations,computed_optional"`
+	Annotations        customfield.NestedObject[WorkersScriptMetadataAnnotationsModel]  `tfsdk:"annotations" json:"annotations,computed_optional"`
 	Assets             *WorkersScriptMetadataAssetsModel                                `tfsdk:"assets" json:"assets,optional"`
 	Bindings           customfield.NestedObjectList[WorkersScriptMetadataBindingsModel] `tfsdk:"bindings" json:"bindings,computed_optional"`
 	BodyPart           types.String                                                     `tfsdk:"body_part" json:"body_part,optional"`
@@ -154,6 +154,8 @@ type WorkersScriptMetadataBindingsModel struct {
 	Json                        jsontypes.Normalized                        `tfsdk:"json" json:"json,optional"`
 	CertificateID               types.String                                `tfsdk:"certificate_id" json:"certificate_id,optional"`
 	Text                        types.String                                `tfsdk:"text" json:"text,optional"`
+	TextWO                      types.String                                `tfsdk:"text_wo" json:"-,optional"`
+	TextWOVersion               types.Int64                                 `tfsdk:"text_wo_version" json:"-,optional"`
 	Pipeline                    types.String                                `tfsdk:"pipeline" json:"pipeline,optional"`
 	QueueName                   types.String                                `tfsdk:"queue_name" json:"queue_name,optional"`
 	Simple                      *WorkersScriptMetadataBindingsSimpleModel   `tfsdk:"simple" json:"simple,optional"`

--- a/internal/services/workers_script/resource.go
+++ b/internal/services/workers_script/resource.go
@@ -107,6 +107,8 @@ func (r *WorkersScriptResource) Create(ctx context.Context, req resource.CreateR
 		data.Content = types.StringValue(content)
 	}
 
+	applyWriteOnlyBindingText(data)
+
 	dataBytes, formDataContentType, err := data.MarshalMultipart()
 	if err != nil {
 		resp.Diagnostics.AddError("failed to serialize multipart http request", err.Error())
@@ -200,6 +202,8 @@ func (r *WorkersScriptResource) Update(ctx context.Context, req resource.UpdateR
 		}
 		data.Content = types.StringValue(content)
 	}
+
+	applyWriteOnlyBindingText(data)
 
 	dataBytes, formDataContentType, err := data.MarshalMultipart()
 	if err != nil {
@@ -486,4 +490,28 @@ func (r *WorkersScriptResource) ModifyPlan(ctx context.Context, req resource.Mod
 	// To prevent this, we must explicitly mark any computed attributes we know can change as unknown.
 	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("modified_on"), timetypes.NewRFC3339Unknown())...)
 	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("has_assets"), types.BoolUnknown())...)
+}
+
+func applyWriteOnlyBindingText(data *WorkersScriptModel) {
+	if data == nil || data.Bindings.IsNull() || data.Bindings.IsUnknown() {
+		return
+	}
+
+	var bindings []WorkersScriptMetadataBindingsModel
+	diags := data.Bindings.ElementsAs(context.Background(), &bindings, true)
+	if diags.HasError() {
+		return
+	}
+
+	for i := range bindings {
+		if !bindings[i].TextWO.IsNull() && !bindings[i].TextWO.IsUnknown() {
+			bindings[i].Text = bindings[i].TextWO
+		}
+	}
+
+	updated, diags := customfield.NewObjectList(context.Background(), bindings)
+	if diags.HasError() {
+		return
+	}
+	data.Bindings = updated
 }

--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -220,10 +220,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								),
 							},
 						},
-								"dataset": schema.StringAttribute{
-						Description: "The name of the dataset to bind to.",
-						Optional:    true,
-					},
+						"dataset": schema.StringAttribute{
+							Description: "The name of the dataset to bind to.",
+							Optional:    true,
+						},
 						"id": schema.StringAttribute{
 							Description: "Identifier of the D1 database to bind to.",
 							Optional:    true,
@@ -294,6 +294,22 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Description: "The text value to use.",
 							Optional:    true,
 							Sensitive:   true,
+							Validators: []validator.String{
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("text_wo")),
+							},
+						},
+						"text_wo": schema.StringAttribute{
+							Description: "Write-only text value to use. Requires Terraform 1.11+.",
+							Optional:    true,
+							Sensitive:   true,
+							WriteOnly:   true,
+							Validators: []validator.String{
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("text")),
+							},
+						},
+						"text_wo_version": schema.Int64Attribute{
+							Description: "Version trigger for text_wo updates.",
+							Optional:    true,
 						},
 						"pipeline": schema.StringAttribute{
 							Description: "Name of the Pipeline to bind to.",
@@ -695,9 +711,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								Default:     booldefault.StaticBool(true),
 							},
 							"propagation_policy": schema.StringAttribute{
-								Description: "Controls how inbound trace context (traceparent/tracestate) headers on incoming requests are handled. \"authenticated\" (default) honors inbound trace context only when accompanied by a valid trace auth token. \"accept\" unconditionally accepts inbound trace context. Requires the trace propagation feature to be enabled.\nAvailable values: \"authenticated\", \"accept\".",
-								Computed:    true,
-								Optional:    true,
+								Description:   "Controls how inbound trace context (traceparent/tracestate) headers on incoming requests are handled. \"authenticated\" (default) honors inbound trace context only when accompanied by a valid trace auth token. \"accept\" unconditionally accepts inbound trace context. Requires the trace propagation feature to be enabled.\nAvailable values: \"authenticated\", \"accept\".",
+								Computed:      true,
+								Optional:      true,
 								PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 							},
 						},

--- a/internal/services/zero_trust_access_identity_provider/model.go
+++ b/internal/services/zero_trust_access_identity_provider/model.go
@@ -39,6 +39,8 @@ type ZeroTrustAccessIdentityProviderConfigModel struct {
 	Claims                   *[]types.String                                                `tfsdk:"claims" json:"claims,optional"`
 	ClientID                 types.String                                                   `tfsdk:"client_id" json:"client_id,optional"`
 	ClientSecret             types.String                                                   `tfsdk:"client_secret" json:"client_secret,optional"`
+	ClientSecretWO           types.String                                                   `tfsdk:"client_secret_wo" json:"-,optional"`
+	ClientSecretWOVersion    types.Int64                                                    `tfsdk:"client_secret_wo_version" json:"-,optional"`
 	ConditionalAccessEnabled types.Bool                                                     `tfsdk:"conditional_access_enabled" json:"conditional_access_enabled,optional"`
 	DirectoryID              types.String                                                   `tfsdk:"directory_id" json:"directory_id,optional"`
 	EmailClaimName           types.String                                                   `tfsdk:"email_claim_name" json:"email_claim_name,optional"`

--- a/internal/services/zero_trust_access_identity_provider/resource.go
+++ b/internal/services/zero_trust_access_identity_provider/resource.go
@@ -65,6 +65,8 @@ func (r *ZeroTrustAccessIdentityProviderResource) Create(ctx context.Context, re
 		return
 	}
 
+	applyWriteOnlyClientSecret(data)
+
 	dataBytes, err := data.MarshalJSON()
 	if err != nil {
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
@@ -118,6 +120,8 @@ func (r *ZeroTrustAccessIdentityProviderResource) Update(ctx context.Context, re
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	applyWriteOnlyClientSecret(data)
 
 	dataBytes, err := data.MarshalJSONForUpdate(*state)
 	if err != nil {
@@ -312,4 +316,14 @@ func (r *ZeroTrustAccessIdentityProviderResource) ImportState(ctx context.Contex
 
 func (r *ZeroTrustAccessIdentityProviderResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res *resource.ModifyPlanResponse) {
 	modifyPlan(ctx, req, res)
+}
+
+func applyWriteOnlyClientSecret(data *ZeroTrustAccessIdentityProviderModel) {
+	if data == nil || data.Config == nil {
+		return
+	}
+
+	if !data.Config.ClientSecretWO.IsNull() && !data.Config.ClientSecretWO.IsUnknown() {
+		data.Config.ClientSecret = data.Config.ClientSecretWO
+	}
 }

--- a/internal/services/zero_trust_access_identity_provider/schema.go
+++ b/internal/services/zero_trust_access_identity_provider/schema.go
@@ -97,6 +97,22 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Description: "Your OAuth Client Secret",
 						Optional:    true,
 						Sensitive:   true,
+						Validators: []validator.String{
+							stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("client_secret_wo")),
+						},
+					},
+					"client_secret_wo": schema.StringAttribute{
+						Description: "Write-only OAuth Client Secret. Requires Terraform 1.11+.",
+						Optional:    true,
+						Sensitive:   true,
+						WriteOnly:   true,
+						Validators: []validator.String{
+							stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("client_secret")),
+						},
+					},
+					"client_secret_wo_version": schema.Int64Attribute{
+						Description: "Version trigger for client_secret_wo updates.",
+						Optional:    true,
 					},
 					"conditional_access_enabled": schema.BoolAttribute{
 						Description: "Should Cloudflare try to load authentication contexts from your account",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Add write-only support for secret-bearing fields while preserving backwards compatibility:

- `cloudflare_zero_trust_access_identity_provider`
  - add `config.client_secret_wo` (write-only, sensitive)
  - add `config.client_secret_wo_version`
  - prefer `client_secret_wo` when constructing create/update payloads
- `cloudflare_workers_script` and `cloudflare_worker_version`
  - add `bindings[*].text_wo` (write-only, sensitive)
  - add `bindings[*].text_wo_version`
  - map `text_wo` into API payload `text` for create/update
- keep legacy secret fields (`client_secret`, `text`) and enforce conflict validation between legacy and `_wo` fields
- update docs for all new attributes

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

Targeted package tests used for this change:

```sh
go test ./internal/services/zero_trust_access_identity_provider ./internal/services/workers_script ./internal/services/worker_version
```

### Test output

```text
ok  github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_access_identity_provider  1.828s
ok  github.com/cloudflare/terraform-provider-cloudflare/internal/services/workers_script                        3.269s
ok  github.com/cloudflare/terraform-provider-cloudflare/internal/services/worker_version                        2.600s
```
