### PR TITLE
fix(zero_trust_list): handle ambiguous schema_version=0 state (v4 vs v5)

### DIFF
--- a/internal/services/zero_trust_list/migration/v500/handler.go
+++ b/internal/services/zero_trust_list/migration/v500/handler.go
@@ -1,11 +1,133 @@
 package v500
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
+
+// UpgradeFromV0Ambiguous handles schema_version=0 state that is AMBIGUOUS between
+// v4 SDKv2 format (cloudflare_teams_list) and v5 production format.
+//
+// Both v4 and some early/beta v5 builds wrote cloudflare_zero_trust_list state at
+// schema_version=0, with incompatible representations of "items":
+//   - v4: "items" is a list of strings, plus a separate "items_with_description"
+//     list of {value, description} objects.
+//   - v5: "items" is a set of {value, description} objects; no
+//     "items_with_description"; carries computed fields (list_count, created_at).
+//
+// migrations.go registers this with PriorSchema=nil so the framework skips
+// pre-decoding req.State. Pre-decoding v5 object-format items against the v4
+// string schema fails with "AttributeName(\"items\").ElementKeyInt(0):
+// unsupported type json.Delim sent as tftypes.String". Both paths therefore
+// operate on req.RawState.JSON.
+//
+// Detection: presence of "items_with_description" (or string-typed "items"
+// elements) identifies v4; otherwise the state is already v5 and only needs a
+// version bump.
+func UpgradeFromV0Ambiguous(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading cloudflare_zero_trust_list state from schema_version=0 (detecting v4 vs v5 format)")
+
+	isV4, err := detectV4ZeroTrustListState(req)
+	if err != nil {
+		tflog.Warn(ctx, "Could not detect zero_trust_list state format, defaulting to v5 no-op", map[string]interface{}{
+			"error": err.Error(),
+		})
+	}
+
+	if isV4 {
+		tflog.Info(ctx, "Detected v4 zero_trust_list format, performing transformation via raw state")
+		upgradeFromV4ViaRawState(ctx, req, resp)
+		return
+	}
+
+	// v5 format: re-decode raw JSON with the target schema. req.State is nil
+	// (PriorSchema=nil), so use req.RawState directly for a no-op version bump.
+	tflog.Info(ctx, "Detected v5 zero_trust_list format, performing no-op version bump via raw state")
+	if req.RawState == nil {
+		resp.Diagnostics.AddError("Missing raw state", "RawState was nil during zero_trust_list v0 upgrade")
+		return
+	}
+	targetType := resp.State.Schema.Type().TerraformType(ctx)
+	rawValue, unmarshalErr := req.RawState.Unmarshal(targetType)
+	if unmarshalErr != nil {
+		resp.Diagnostics.AddError(
+			"Failed to unmarshal v5 zero_trust_list state",
+			"Could not parse raw state as v5 format: "+unmarshalErr.Error(),
+		)
+		return
+	}
+	resp.State.Raw = rawValue
+	tflog.Info(ctx, "zero_trust_list state version bump from 0 to 500 completed")
+}
+
+// upgradeFromV4ViaRawState parses req.RawState with the v4 schema (since
+// PriorSchema is nil and req.State is therefore unavailable) and delegates to
+// UpgradeFromV4.
+func upgradeFromV4ViaRawState(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	if req.RawState == nil {
+		resp.Diagnostics.AddError("Missing raw state", "RawState was nil during v4 zero_trust_list upgrade")
+		return
+	}
+
+	v4Schema := SourceTeamsListSchema()
+	v4Type := v4Schema.Type().TerraformType(ctx)
+
+	rawValue, err := req.RawState.Unmarshal(v4Type)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to unmarshal v4 zero_trust_list state",
+			"Could not parse raw state as v4 format: "+err.Error(),
+		)
+		return
+	}
+
+	syntheticState := &tfsdk.State{Raw: rawValue, Schema: v4Schema}
+	syntheticReq := resource.UpgradeStateRequest{
+		RawState: req.RawState,
+		State:    syntheticState,
+	}
+
+	UpgradeFromV4(ctx, syntheticReq, resp)
+}
+
+// detectV4ZeroTrustListState returns true if the raw schema_version=0 state is in
+// the v4 cloudflare_teams_list format. v4 carries an "items_with_description"
+// field and/or stores "items" as a list of strings; v5 stores "items" as a list
+// of {value, description} objects and never has "items_with_description".
+func detectV4ZeroTrustListState(req resource.UpgradeStateRequest) (bool, error) {
+	if req.RawState == nil || len(req.RawState.JSON) == 0 {
+		return false, nil
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(req.RawState.JSON, &raw); err != nil {
+		return false, err
+	}
+
+	// v4-only field.
+	if _, ok := raw["items_with_description"]; ok {
+		return true, nil
+	}
+
+	// Fall back to inspecting the first "items" element: a JSON string => v4,
+	// a JSON object => v5.
+	if itemsRaw, ok := raw["items"]; ok {
+		var elems []json.RawMessage
+		if err := json.Unmarshal(itemsRaw, &elems); err == nil && len(elems) > 0 {
+			first := bytes.TrimSpace(elems[0])
+			if len(first) > 0 && first[0] == '"' {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
 
 // UpgradeFromV4 handles v4 state at schema_version=0.
 // Merges items + items_with_description into unified items set.

--- a/internal/services/zero_trust_list/migration/v500/handler_internal_test.go
+++ b/internal/services/zero_trust_list/migration/v500/handler_internal_test.go
@@ -1,0 +1,79 @@
+package v500
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// TestDetectV4ZeroTrustListState is a regression guard for the schema_version=0
+// state-upgrade crash (#7133 follow-up): v5 object-format `items` stamped at
+// version 0 was routed through the v4 string PriorSchema and failed with
+// "AttributeName(\"items\").ElementKeyInt(0): unsupported type json.Delim sent
+// as tftypes.String". The detector must classify such state as v5 (false) so
+// UpgradeFromV0Ambiguous takes the no-op re-decode path instead of the v4
+// string transform.
+func TestDetectV4ZeroTrustListState(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want bool
+	}{
+		{
+			name: "v5 object items at version 0 (crash trigger)",
+			json: `{"name":"x","type":"IP","items":[{"value":"1.1.1.1","description":null},{"value":"8.8.8.8","description":"dns"}]}`,
+			want: false,
+		},
+		{
+			name: "v4 string items with items_with_description key",
+			json: `{"name":"x","type":"IP","items":["1.1.1.1","2.2.2.2"],"items_with_description":[]}`,
+			want: true,
+		},
+		{
+			name: "v4 string items, no items_with_description key (string fallback)",
+			json: `{"name":"x","type":"IP","items":["1.1.1.1"]}`,
+			want: true,
+		},
+		{
+			name: "v4 items_with_description populated, items absent",
+			json: `{"name":"x","type":"SERIAL","items_with_description":[{"value":"abc","description":"laptop"}]}`,
+			want: true,
+		},
+		{
+			name: "v5 empty/null items",
+			json: `{"name":"x","type":"IP","items":null}`,
+			want: false,
+		},
+		{
+			name: "v5 no items key at all",
+			json: `{"name":"x","type":"IP"}`,
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := resource.UpgradeStateRequest{
+				RawState: &tfprotov6.RawState{JSON: []byte(tc.json)},
+			}
+			got, err := detectV4ZeroTrustListState(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("detectV4ZeroTrustListState(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectV4ZeroTrustListState_NilRawState(t *testing.T) {
+	got, err := detectV4ZeroTrustListState(resource.UpgradeStateRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Fatalf("nil RawState should not be classified as v4")
+	}
+}

--- a/internal/services/zero_trust_list/migrations.go
+++ b/internal/services/zero_trust_list/migrations.go
@@ -35,13 +35,17 @@ func (r *ZeroTrustListResource) MoveState(ctx context.Context) []resource.StateM
 // 2: v5 production state (v5.0-v5.18) -> no-op
 func (r *ZeroTrustListResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	targetSchema := ResourceSchema(ctx)
-	sourceSchema := v500.SourceTeamsListSchema()
 
 	return map[int64]resource.StateUpgrader{
-		// v4 SDKv2 provider (schema_version=0) -- merge items + items_with_description
+		// schema_version=0 -- AMBIGUOUS between v4 SDKv2 (cloudflare_teams_list)
+		// and v5 production format. PriorSchema is nil so the framework skips
+		// pre-decoding req.State; pre-decoding v5 object-format `items` against
+		// the v4 string schema fails with "unsupported type json.Delim sent as
+		// tftypes.String". UpgradeFromV0Ambiguous detects the format from raw
+		// JSON: v4 => merge items + items_with_description; v5 => no-op bump.
 		0: {
-			PriorSchema:   &sourceSchema,
-			StateUpgrader: v500.UpgradeFromV4,
+			PriorSchema:   nil,
+			StateUpgrader: v500.UpgradeFromV0Ambiguous,
 		},
 		// v5 intermediate state (version=1) -- no-op
 		1: {


### PR DESCRIPTION
This MR replicates the fix to resource state errors in ZT lists that was applied in https://github.com/terragrunt-cloudflare-modules/terraform-provider-cloudflare/pull/2. Please refer to the aforementioned PR for more information.

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Acceptance test run results (see 

- [X] I have added or updated acceptance tests for my changes
- [X] I have run acceptance tests for my changes and included the results below