### PR TITLE
feat(workers_custom_domain): add acceptance tests for resource, data sources, and import

### DIFF
--- a/internal/services/workers_custom_domain/data_source_test.go
+++ b/internal/services/workers_custom_domain/data_source_test.go
@@ -1,0 +1,95 @@
+package workers_custom_domain_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareWorkersCustomDomainDataSource_ByID(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	hostname := rnd + "." + zoneName
+	resourceName := "cloudflare_workers_custom_domain." + rnd
+	dataSourceName := "data.cloudflare_workers_custom_domain." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareWorkersCustomDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareWorkersCustomDomainDataSourceByIDConfig(rnd, accountID, hostname, zoneID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Check the resource was created properly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service"), knownvalue.StringExact("mute-truth-fdb1")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+
+					// Check the data source fetches the domain correctly by ID
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("service"), knownvalue.StringExact("mute-truth-fdb1")),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("domain_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudflareWorkersCustomDomainDataSource_ByFilter(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	hostname := rnd + "." + zoneName
+	resourceName := "cloudflare_workers_custom_domain." + rnd
+	dataSourceName := "data.cloudflare_workers_custom_domain." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareWorkersCustomDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareWorkersCustomDomainDataSourceByFilterConfig(rnd, accountID, hostname, zoneID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Check the resource was created properly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service"), knownvalue.StringExact("mute-truth-fdb1")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+
+					// Check the data source fetches the domain correctly by filter
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("service"), knownvalue.StringExact("mute-truth-fdb1")),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("domain_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+func testAccCloudflareWorkersCustomDomainDataSourceByIDConfig(rnd, accountID, hostname, zoneID string) string {
+	return acctest.LoadTestCase("datasource_by_id.tf", rnd, accountID, hostname, zoneID)
+}
+
+func testAccCloudflareWorkersCustomDomainDataSourceByFilterConfig(rnd, accountID, hostname, zoneID string) string {
+	return acctest.LoadTestCase("datasource_by_filter.tf", rnd, accountID, hostname, zoneID)
+}

--- a/internal/services/workers_custom_domain/data_source_test.go
+++ b/internal/services/workers_custom_domain/data_source_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccCloudflareWorkersCustomDomainDataSource_ByID(t *testing.T) {
+	t.Parallel()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := utils.GenerateRandomResourceName()
@@ -40,7 +41,9 @@ func TestAccCloudflareWorkersCustomDomainDataSource_ByID(t *testing.T) {
 					// Check the data source fetches the domain correctly by ID
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname)),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("service"), knownvalue.StringExact("mute-truth-fdb1")),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("environment"), knownvalue.StringExact("production")),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("zone_name"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("domain_id"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
 				},
@@ -50,6 +53,7 @@ func TestAccCloudflareWorkersCustomDomainDataSource_ByID(t *testing.T) {
 }
 
 func TestAccCloudflareWorkersCustomDomainDataSource_ByFilter(t *testing.T) {
+	t.Parallel()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := utils.GenerateRandomResourceName()
@@ -77,7 +81,9 @@ func TestAccCloudflareWorkersCustomDomainDataSource_ByFilter(t *testing.T) {
 					// Check the data source fetches the domain correctly by filter
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname)),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("service"), knownvalue.StringExact("mute-truth-fdb1")),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("environment"), knownvalue.StringExact("production")),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("zone_name"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("domain_id"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
 				},

--- a/internal/services/workers_custom_domain/list_data_source_test.go
+++ b/internal/services/workers_custom_domain/list_data_source_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccCloudflareWorkersCustomDomainsDataSource_List(t *testing.T) {
+	t.Parallel()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := utils.GenerateRandomResourceName()
@@ -41,8 +42,10 @@ func TestAccCloudflareWorkersCustomDomainsDataSource_List(t *testing.T) {
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result"), knownvalue.ListSizeExact(1)),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result").AtSliceIndex(0).AtMapKey("hostname"), knownvalue.StringExact(hostname)),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result").AtSliceIndex(0).AtMapKey("service"), knownvalue.StringExact("mute-truth-fdb1")),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result").AtSliceIndex(0).AtMapKey("environment"), knownvalue.StringExact("production")),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result").AtSliceIndex(0).AtMapKey("id"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result").AtSliceIndex(0).AtMapKey("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result").AtSliceIndex(0).AtMapKey("zone_name"), knownvalue.NotNull()),
 				},
 			},
 		},

--- a/internal/services/workers_custom_domain/list_data_source_test.go
+++ b/internal/services/workers_custom_domain/list_data_source_test.go
@@ -1,0 +1,54 @@
+package workers_custom_domain_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCloudflareWorkersCustomDomainsDataSource_List(t *testing.T) {
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	hostname := rnd + "." + zoneName
+	resourceName := "cloudflare_workers_custom_domain." + rnd
+	dataSourceName := "data.cloudflare_workers_custom_domains." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareWorkersCustomDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareWorkersCustomDomainsListDataSourceConfig(rnd, accountID, hostname, zoneID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Check the resource was created properly
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service"), knownvalue.StringExact("mute-truth-fdb1")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+
+					// Check the list data source returns results
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result").AtSliceIndex(0).AtMapKey("hostname"), knownvalue.StringExact(hostname)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result").AtSliceIndex(0).AtMapKey("service"), knownvalue.StringExact("mute-truth-fdb1")),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result").AtSliceIndex(0).AtMapKey("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("result").AtSliceIndex(0).AtMapKey("zone_id"), knownvalue.StringExact(zoneID)),
+				},
+			},
+		},
+	})
+}
+
+func testAccCloudflareWorkersCustomDomainsListDataSourceConfig(rnd, accountID, hostname, zoneID string) string {
+	return acctest.LoadTestCase("list_datasource.tf", rnd, accountID, hostname, zoneID)
+}

--- a/internal/services/workers_custom_domain/resource_test.go
+++ b/internal/services/workers_custom_domain/resource_test.go
@@ -2,7 +2,9 @@ package workers_custom_domain_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
 
@@ -17,10 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-)
-
-const (
-	scriptContent = `addEventListener('fetch', event => {event.respondWith(new Response('test'))});`
 )
 
 func TestMain(m *testing.M) {
@@ -44,7 +42,7 @@ func testSweepCloudflareWorkersCustomDomains(r string) error {
 		return nil
 	}
 
-	domains, err := client.Workers.Domains.List(ctx, workers.DomainListParams{
+	page, err := client.Workers.Domains.List(ctx, workers.DomainListParams{
 		AccountID: cloudflare.F(accountID),
 	})
 	if err != nil {
@@ -52,31 +50,34 @@ func testSweepCloudflareWorkersCustomDomains(r string) error {
 		return fmt.Errorf("failed to fetch workers custom domains: %w", err)
 	}
 
-	if len(domains.Result) == 0 {
-		tflog.Info(ctx, "No workers custom domains to sweep")
-		return nil
-	}
+	for page != nil && len(page.Result) > 0 {
+		for _, domain := range page.Result {
+			if !utils.ShouldSweepResource(domain.Hostname) {
+				continue
+			}
 
-	for _, domain := range domains.Result {
-		if !utils.ShouldSweepResource(domain.Hostname) {
-			continue
+			tflog.Info(ctx, fmt.Sprintf("Deleting workers custom domain: %s (account: %s)", domain.Hostname, accountID))
+			_, err := client.Workers.Domains.Delete(ctx, domain.ID, workers.DomainDeleteParams{
+				AccountID: cloudflare.F(accountID),
+			})
+			if err != nil {
+				tflog.Error(ctx, fmt.Sprintf("Failed to delete workers custom domain %s: %s", domain.ID, err))
+				continue
+			}
+			tflog.Info(ctx, fmt.Sprintf("Deleted workers custom domain: %s", domain.ID))
 		}
 
-		tflog.Info(ctx, fmt.Sprintf("Deleting workers custom domain: %s (account: %s)", domain.Hostname, accountID))
-		_, err := client.Workers.Domains.Delete(ctx, domain.ID, workers.DomainDeleteParams{
-			AccountID: cloudflare.F(accountID),
-		})
+		page, err = page.GetNextPage()
 		if err != nil {
-			tflog.Error(ctx, fmt.Sprintf("Failed to delete workers custom domain %s: %s", domain.ID, err))
-			continue
+			break
 		}
-		tflog.Info(ctx, fmt.Sprintf("Deleted workers custom domain: %s", domain.ID))
 	}
 
 	return nil
 }
 
 func TestAccCloudflareWorkersCustomDomain_Basic(t *testing.T) {
+	t.Parallel()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := utils.GenerateRandomResourceName()
@@ -113,7 +114,47 @@ func TestAccCloudflareWorkersCustomDomain_Basic(t *testing.T) {
 	})
 }
 
+func TestAccCloudflareWorkersCustomDomain_RecreateOnHostnameChange(t *testing.T) {
+	t.Parallel()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_workers_custom_domain." + rnd
+	hostname1 := rnd + "." + zoneName
+	hostname2 := rnd + "-new." + zoneName
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareWorkersCustomDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareWorkersCustomDomainConfig(rnd, accountID, hostname1, zoneID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname1)),
+				},
+			},
+			{
+				Config: testAccCloudflareWorkersCustomDomainConfig(rnd, accountID, hostname2, zoneID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname2)),
+				},
+			},
+		},
+	})
+}
+
 func TestAccCloudflareWorkersCustomDomain_WithZoneName(t *testing.T) {
+	t.Parallel()
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_workers_custom_domain." + rnd
@@ -143,6 +184,7 @@ func TestAccCloudflareWorkersCustomDomain_WithZoneName(t *testing.T) {
 }
 
 func TestAccCloudflareWorkersCustomDomain_MinimalConfig(t *testing.T) {
+	t.Parallel()
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := utils.GenerateRandomResourceName()
 	resourceName := "cloudflare_workers_custom_domain." + rnd
@@ -188,13 +230,18 @@ func testAccCheckCloudflareWorkersCustomDomainDestroy(s *terraform.State) error 
 		if err == nil {
 			return fmt.Errorf("workers custom domain with id %s still exists", rs.Primary.ID)
 		}
+
+		var apierr *cloudflare.Error
+		if errors.As(err, &apierr) && apierr.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("error checking if workers custom domain %s was destroyed: %w", rs.Primary.ID, err)
+		}
 	}
 
 	return nil
 }
 
 func testAccCloudflareWorkersCustomDomainConfig(rnd, accountID, hostname, zoneID string) string {
-	return acctest.LoadTestCase("workerdomainattach.tf", rnd, scriptContent, accountID, hostname, zoneID)
+	return acctest.LoadTestCase("workerdomainattach.tf", rnd, accountID, hostname, zoneID)
 }
 
 func testAccCloudflareWorkersCustomDomainWithZoneNameConfig(rnd, accountID, hostname, zoneName string) string {
@@ -206,6 +253,7 @@ func testAccCloudflareWorkersCustomDomainMinimalConfig(rnd, accountID, hostname 
 }
 
 func TestAccUpgradeWorkersCustomDomain_FromPublishedV5(t *testing.T) {
+	t.Parallel()
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
 	rnd := utils.GenerateRandomResourceName()

--- a/internal/services/workers_custom_domain/resource_test.go
+++ b/internal/services/workers_custom_domain/resource_test.go
@@ -6,15 +6,17 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/cloudflare-go"
-	cfv3 "github.com/cloudflare/cloudflare-go/v7"
+	"github.com/cloudflare/cloudflare-go/v7"
 	"github.com/cloudflare/cloudflare-go/v7/workers"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 const (
@@ -43,7 +45,7 @@ func testSweepCloudflareWorkersCustomDomains(r string) error {
 	}
 
 	domains, err := client.Workers.Domains.List(ctx, workers.DomainListParams{
-		AccountID: cfv3.F(accountID),
+		AccountID: cloudflare.F(accountID),
 	})
 	if err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Failed to fetch workers custom domains: %s", err))
@@ -56,14 +58,13 @@ func testSweepCloudflareWorkersCustomDomains(r string) error {
 	}
 
 	for _, domain := range domains.Result {
-		// Use standard filtering helper on the hostname field
 		if !utils.ShouldSweepResource(domain.Hostname) {
 			continue
 		}
 
 		tflog.Info(ctx, fmt.Sprintf("Deleting workers custom domain: %s (account: %s)", domain.Hostname, accountID))
 		_, err := client.Workers.Domains.Delete(ctx, domain.ID, workers.DomainDeleteParams{
-			AccountID: cfv3.F(accountID),
+			AccountID: cloudflare.F(accountID),
 		})
 		if err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to delete workers custom domain %s: %s", domain.ID, err))
@@ -75,12 +76,11 @@ func testSweepCloudflareWorkersCustomDomains(r string) error {
 	return nil
 }
 
-func TestAccCloudflareWorkerDomain_Attach(t *testing.T) {
+func TestAccCloudflareWorkersCustomDomain_Basic(t *testing.T) {
 	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
 	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
-	var domain cloudflare.WorkersDomain
 	rnd := utils.GenerateRandomResourceName()
-	name := "cloudflare_workers_custom_domain." + rnd
+	resourceName := "cloudflare_workers_custom_domain." + rnd
 	hostname := rnd + "." + zoneName
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
@@ -90,80 +90,91 @@ func TestAccCloudflareWorkerDomain_Attach(t *testing.T) {
 			acctest.TestAccPreCheck_AccountID(t)
 		},
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckCloudflareWorkerDomainDestroy,
+		CheckDestroy:             testAccCheckCloudflareWorkersCustomDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudflareWorkerDomainAttach(rnd, accountID, hostname, zoneID),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudflareWorkerDomainExists(name, &domain),
-					resource.TestCheckResourceAttr(name, "hostname", hostname),
-					// resource.TestCheckResourceAttr(name, "service", rnd),
-					resource.TestCheckResourceAttr(name, "service", "mute-truth-fdb1"), // while we fix workers_script
-				),
+				Config: testAccCloudflareWorkersCustomDomainConfig(rnd, accountID, hostname, zoneID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service"), knownvalue.StringExact("mute-truth-fdb1")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.StringExact(zoneID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("environment"), knownvalue.StringExact("production")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+				},
 			},
-			// {
-			// 	ImportState:         true,
-			// 	ImportStateVerify:   true,
-			// 	ResourceName:        name,
-			// 	ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
-			// },
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", accountID),
+			},
 		},
 	})
 }
 
-func getDomainFromApi(accountID, domainID string) (cloudflare.WorkersDomain, error) {
-	if accountID == "" {
-		return cloudflare.WorkersDomain{}, fmt.Errorf("accountID is required to get a domain")
-	}
-	if domainID == "" {
-		return cloudflare.WorkersDomain{}, fmt.Errorf("domainID is required to get a domain")
-	}
+func TestAccCloudflareWorkersCustomDomain_WithZoneName(t *testing.T) {
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_workers_custom_domain." + rnd
+	hostname := rnd + "." + zoneName
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
-	client, clientErr := acctest.SharedV1Client() // TODO(terraform): replace with SharedV2Clent
-	if clientErr != nil {
-		tflog.Error(context.TODO(), fmt.Sprintf("failed to create Cloudflare client: %s", clientErr))
-	}
-	domain, err := client.GetWorkersDomain(context.Background(), cloudflare.AccountIdentifier(accountID), domainID)
-	if err != nil {
-		fmt.Print(err.Error())
-		return cloudflare.WorkersDomain{}, err
-	}
-
-	return domain, nil
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareWorkersCustomDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareWorkersCustomDomainWithZoneNameConfig(rnd, accountID, hostname, zoneName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service"), knownvalue.StringExact("mute-truth-fdb1")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_name"), knownvalue.StringExact(zoneName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
 }
 
-func testAccCheckCloudflareWorkerDomainExists(resourceName string, domain *cloudflare.WorkersDomain) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("not found: %s", resourceName)
-		}
+func TestAccCloudflareWorkersCustomDomain_MinimalConfig(t *testing.T) {
+	zoneName := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := "cloudflare_workers_custom_domain." + rnd
+	hostname := rnd + "." + zoneName
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Worker Domain ID is set")
-		}
-
-		accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-		domainID := rs.Primary.ID
-		foundDomain, err := getDomainFromApi(accountID, domainID)
-		if err != nil {
-			return err
-		}
-
-		if foundDomain.ID != domainID {
-			return fmt.Errorf("worker domain with id %s not found", domainID)
-		}
-
-		*domain = foundDomain
-		return nil
-	}
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareWorkersCustomDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudflareWorkersCustomDomainMinimalConfig(rnd, accountID, hostname),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("hostname"), knownvalue.StringExact(hostname)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("service"), knownvalue.StringExact("mute-truth-fdb1")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					// zone_id and zone_name should be computed from the hostname
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_name"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
 }
 
-func testAccCheckCloudflareWorkerDomainAttach(rnd, accountID string, hostname string, zoneID string) string {
-	return acctest.LoadTestCase("workerdomainattach.tf", rnd, scriptContent, accountID, hostname, zoneID)
-}
-
-func testAccCheckCloudflareWorkerDomainDestroy(s *terraform.State) error {
+func testAccCheckCloudflareWorkersCustomDomainDestroy(s *terraform.State) error {
+	client := acctest.SharedClient()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
 	for _, rs := range s.RootModule().Resources {
@@ -171,18 +182,27 @@ func testAccCheckCloudflareWorkerDomainDestroy(s *terraform.State) error {
 			continue
 		}
 
-		client, clientErr := acctest.SharedV1Client() // TODO(terraform): replace with SharedV2Clent
-		if clientErr != nil {
-			tflog.Error(context.TODO(), fmt.Sprintf("failed to create Cloudflare client: %s", clientErr))
-		}
-		r, _ := client.GetWorkersDomain(context.Background(), cloudflare.AccountIdentifier(accountID), rs.Primary.ID)
-
-		if r.ID != "" {
-			return fmt.Errorf("worker domain with id %s still exists", rs.Primary.ID)
+		_, err := client.Workers.Domains.Get(context.Background(), rs.Primary.ID, workers.DomainGetParams{
+			AccountID: cloudflare.F(accountID),
+		})
+		if err == nil {
+			return fmt.Errorf("workers custom domain with id %s still exists", rs.Primary.ID)
 		}
 	}
 
 	return nil
+}
+
+func testAccCloudflareWorkersCustomDomainConfig(rnd, accountID, hostname, zoneID string) string {
+	return acctest.LoadTestCase("workerdomainattach.tf", rnd, scriptContent, accountID, hostname, zoneID)
+}
+
+func testAccCloudflareWorkersCustomDomainWithZoneNameConfig(rnd, accountID, hostname, zoneName string) string {
+	return acctest.LoadTestCase("workerdomainattach_zonename.tf", rnd, accountID, hostname, zoneName)
+}
+
+func testAccCloudflareWorkersCustomDomainMinimalConfig(rnd, accountID, hostname string) string {
+	return acctest.LoadTestCase("workerdomainattach_minimal.tf", rnd, accountID, hostname)
 }
 
 func TestAccUpgradeWorkersCustomDomain_FromPublishedV5(t *testing.T) {
@@ -192,7 +212,7 @@ func TestAccUpgradeWorkersCustomDomain_FromPublishedV5(t *testing.T) {
 	hostname := rnd + "." + zoneName
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
-	config := testAccCheckCloudflareWorkerDomainAttach(rnd, accountID, hostname, zoneID)
+	config := testAccCloudflareWorkersCustomDomainConfig(rnd, accountID, hostname, zoneID)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/services/workers_custom_domain/testdata/datasource_by_filter.tf
+++ b/internal/services/workers_custom_domain/testdata/datasource_by_filter.tf
@@ -1,0 +1,15 @@
+resource "cloudflare_workers_custom_domain" "%[1]s" {
+	zone_id = "%[4]s"
+	account_id = "%[2]s"
+	hostname = "%[3]s"
+	service = "mute-truth-fdb1"
+	environment = "production"
+}
+
+data "cloudflare_workers_custom_domain" "%[1]s" {
+	account_id = "%[2]s"
+	filter = {
+		hostname = cloudflare_workers_custom_domain.%[1]s.hostname
+		service = "mute-truth-fdb1"
+	}
+}

--- a/internal/services/workers_custom_domain/testdata/datasource_by_id.tf
+++ b/internal/services/workers_custom_domain/testdata/datasource_by_id.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_workers_custom_domain" "%[1]s" {
+	zone_id = "%[4]s"
+	account_id = "%[2]s"
+	hostname = "%[3]s"
+	service = "mute-truth-fdb1"
+	environment = "production"
+}
+
+data "cloudflare_workers_custom_domain" "%[1]s" {
+	account_id = "%[2]s"
+	domain_id = cloudflare_workers_custom_domain.%[1]s.id
+}

--- a/internal/services/workers_custom_domain/testdata/list_datasource.tf
+++ b/internal/services/workers_custom_domain/testdata/list_datasource.tf
@@ -1,0 +1,13 @@
+resource "cloudflare_workers_custom_domain" "%[1]s" {
+	zone_id = "%[4]s"
+	account_id = "%[2]s"
+	hostname = "%[3]s"
+	service = "mute-truth-fdb1"
+	environment = "production"
+}
+
+data "cloudflare_workers_custom_domains" "%[1]s" {
+	account_id = "%[2]s"
+	hostname = cloudflare_workers_custom_domain.%[1]s.hostname
+	service = "mute-truth-fdb1"
+}

--- a/internal/services/workers_custom_domain/testdata/workerdomainattach.tf
+++ b/internal/services/workers_custom_domain/testdata/workerdomainattach.tf
@@ -1,15 +1,7 @@
-
-# resource "cloudflare_workers_script" "%[1]s-script" {
-#   account_id = "%[3]s"
-#   name = "%[1]s"
-#   content = "%[2]s"
-# }
-
 resource "cloudflare_workers_custom_domain" "%[1]s" {
-	zone_id = "%[5]s"
-	account_id = "%[3]s"
-	hostname = "%[4]s"
+	account_id = "%[2]s"
+	hostname = "%[3]s"
 	service = "mute-truth-fdb1"
+	zone_id = "%[4]s"
 	environment = "production"
-	# depends_on = [cloudflare_workers_script.%[1]s-script]
 }

--- a/internal/services/workers_custom_domain/testdata/workerdomainattach_minimal.tf
+++ b/internal/services/workers_custom_domain/testdata/workerdomainattach_minimal.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_workers_custom_domain" "%[1]s" {
+	account_id = "%[2]s"
+	hostname = "%[3]s"
+	service = "mute-truth-fdb1"
+}

--- a/internal/services/workers_custom_domain/testdata/workerdomainattach_zonename.tf
+++ b/internal/services/workers_custom_domain/testdata/workerdomainattach_zonename.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_workers_custom_domain" "%[1]s" {
+	account_id = "%[2]s"
+	hostname = "%[3]s"
+	service = "mute-truth-fdb1"
+	zone_name = "%[4]s"
+	environment = "production"
+}


### PR DESCRIPTION
## Summary

Adds comprehensive acceptance tests for the `cloudflare_workers_custom_domain` resource, singular data source, and list data source.

## Test results

All acceptance tests pass:
```
TF_ACC=1 go test -v -timeout 30m ./internal/services/workers_custom_domain/ -run 'TestAcc'
```

```
=== RUN   TestAccCloudflareWorkersCustomDomainDataSource_ByID
=== PAUSE TestAccCloudflareWorkersCustomDomainDataSource_ByID
=== RUN   TestAccCloudflareWorkersCustomDomainDataSource_ByFilter
=== PAUSE TestAccCloudflareWorkersCustomDomainDataSource_ByFilter
=== RUN   TestAccCloudflareWorkersCustomDomainsDataSource_List
=== PAUSE TestAccCloudflareWorkersCustomDomainsDataSource_List
=== RUN   TestAccCloudflareWorkersCustomDomain_Basic
=== PAUSE TestAccCloudflareWorkersCustomDomain_Basic
=== RUN   TestAccCloudflareWorkersCustomDomain_RecreateOnHostnameChange
=== PAUSE TestAccCloudflareWorkersCustomDomain_RecreateOnHostnameChange
=== RUN   TestAccCloudflareWorkersCustomDomain_WithZoneName
=== PAUSE TestAccCloudflareWorkersCustomDomain_WithZoneName
=== RUN   TestAccCloudflareWorkersCustomDomain_MinimalConfig
=== PAUSE TestAccCloudflareWorkersCustomDomain_MinimalConfig
=== RUN   TestAccUpgradeWorkersCustomDomain_FromPublishedV5
=== PAUSE TestAccUpgradeWorkersCustomDomain_FromPublishedV5
=== CONT  TestAccCloudflareWorkersCustomDomainDataSource_ByID
=== CONT  TestAccCloudflareWorkersCustomDomain_RecreateOnHostnameChange
=== CONT  TestAccUpgradeWorkersCustomDomain_FromPublishedV5
=== CONT  TestAccCloudflareWorkersCustomDomainsDataSource_List
=== CONT  TestAccCloudflareWorkersCustomDomain_Basic
=== CONT  TestAccCloudflareWorkersCustomDomainDataSource_ByFilter
=== CONT  TestAccCloudflareWorkersCustomDomain_MinimalConfig
=== CONT  TestAccCloudflareWorkersCustomDomain_WithZoneName
--- PASS: TestAccCloudflareWorkersCustomDomain_WithZoneName (4.13s)
--- PASS: TestAccCloudflareWorkersCustomDomain_MinimalConfig (4.60s)
--- PASS: TestAccCloudflareWorkersCustomDomainDataSource_ByID (4.89s)
--- PASS: TestAccCloudflareWorkersCustomDomainsDataSource_List (5.06s)
--- PASS: TestAccCloudflareWorkersCustomDomain_Basic (5.24s)
--- PASS: TestAccCloudflareWorkersCustomDomain_RecreateOnHostnameChange (6.83s)
--- PASS: TestAccCloudflareWorkersCustomDomainDataSource_ByFilter (7.03s)
--- PASS: TestAccUpgradeWorkersCustomDomain_FromPublishedV5 (20.18s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/workers_custom_domain	22.206s
```