### PR TITLE
ci: add 30m timeout to unit test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
     name: Unit Tests (shard ${{ matrix.shard }})
     runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-terraform' && 'depot-ubuntu-24.04' || 'lx64' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -72,5 +73,5 @@ jobs:
           # Get all packages and select this shard (1-indexed)
           packages=$(go list ./... | awk "NR % 16 == (${{ matrix.shard }} - 1)")
           if [ -n "$packages" ]; then
-            echo "$packages" | xargs go test
+            echo "$packages" | xargs go test -timeout 25m
           fi


### PR DESCRIPTION
Unit test shards occasionally stall for hours with no failure signal (example: https://github.com/cloudflare/terraform-provider-cloudflare/actions/runs/28972395639/job/86148108260). GitHub Actions defaults to a 6-hour job timeout, so a hung shard burns runner time until a human notices.

## Changes

- **Job-level timeout** (`timeout-minutes: 30`): GitHub Actions hard-kills the job at 30 minutes regardless of what is running.
- **Go-level timeout** (`go test -timeout 25m`): Go's test runner detects the hang first at 25 minutes and emits a panic with a full goroutine stack trace, making the stalled test identifiable before the runner kills the process.

The 5-minute gap between the two layers ensures Go always gets a chance to produce a useful diagnostic.