### PR TITLE
feat(r2_custom_domain): add import support

### DIFF
--- a/docs/resources/r2_custom_domain.md
+++ b/docs/resources/r2_custom_domain.md
@@ -62,5 +62,8 @@ Available values: "initializing", "pending", "active", "deactivated", "error", "
 
 ## Import
 
+Import is supported using the following syntax:
 
-~> This resource does not currently support `terraform import`.
+```shell
+$ terraform import cloudflare_r2_custom_domain.example '<account_id>/<bucket_name>/<jurisdiction>/<domain>'
+```

--- a/examples/resources/cloudflare_r2_custom_domain/import.sh
+++ b/examples/resources/cloudflare_r2_custom_domain/import.sh
@@ -1,0 +1,1 @@
+$ terraform import cloudflare_r2_custom_domain.example '<account_id>/<bucket_name>/<jurisdiction>/<domain>'

--- a/internal/services/r2_custom_domain/resource.go
+++ b/internal/services/r2_custom_domain/resource.go
@@ -13,13 +13,16 @@ import (
 	"github.com/cloudflare/cloudflare-go/v7/r2"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.ResourceWithConfigure = (*R2CustomDomainResource)(nil)
 var _ resource.ResourceWithModifyPlan = (*R2CustomDomainResource)(nil)
+var _ resource.ResourceWithImportState = (*R2CustomDomainResource)(nil)
 
 func NewResource() resource.Resource {
 	return &R2CustomDomainResource{}
@@ -271,6 +274,64 @@ func (r *R2CustomDomainResource) Delete(ctx context.Context, req resource.Delete
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *R2CustomDomainResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	var data = new(R2CustomDomainModel)
+
+	path_account_id := ""
+	path_bucket_name := ""
+	jurisdiction := "default"
+	path_domain := ""
+	diags := importpath.ParseImportID(
+		req.ID,
+		"<account_id>/<bucket_name>/<jurisdiction>/<domain>",
+		&path_account_id,
+		&path_bucket_name,
+		&jurisdiction,
+		&path_domain,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.AccountID = types.StringValue(path_account_id)
+	data.BucketName = types.StringValue(path_bucket_name)
+	data.Domain = types.StringValue(path_domain)
+
+	if jurisdiction == "default" {
+		data.Jurisdiction = types.StringValue("default")
+	} else {
+		data.Jurisdiction = types.StringValue(jurisdiction)
+	}
+
+	res := new(http.Response)
+	env := R2CustomDomainResultEnvelope{*data}
+	_, err := r.client.R2.Buckets.Domains.Custom.Get(
+		ctx,
+		path_bucket_name,
+		path_domain,
+		r2.BucketDomainCustomGetParams{
+			AccountID: cloudflare.F(path_account_id),
+		},
+		option.WithHeader(consts.R2JurisdictionHTTPHeaderName, data.Jurisdiction.ValueString()),
+		option.WithResponseBodyInto(&res),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to make http request", err.Error())
+		return
+	}
+	bytes, _ := io.ReadAll(res.Body)
+	err = apijson.Unmarshal(bytes, &env)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
+		return
+	}
+	data = &env.Result
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/r2_custom_domain/resource_test.go
+++ b/internal/services/r2_custom_domain/resource_test.go
@@ -3,6 +3,7 @@ package r2_custom_domain_test
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -84,6 +86,18 @@ func TestAccCloudflareR2CustomDomain_Basic(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("min_tls"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ciphers"), knownvalue.Null()),
 				},
+			},
+			{
+				ResourceName: resourceName,
+				ImportStateIdFunc: func(*terraform.State) (string, error) {
+					return strings.Join([]string{accountID, rnd, "default", domainName}, "/"), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+				// status (ssl/ownership) can transition between steps while the
+				// custom domain is being provisioned, so exclude it from the
+				// import verification diff.
+				ImportStateVerifyIgnore: []string{"status"},
 			},
 		},
 	})


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`cloudflare_r2_custom_domain` currently returns **"Resource Import Not Implemented"** on `terraform import`, so a custom domain that was created outside Terraform (or dropped from state) cannot be adopted — the only workaround is deleting and recreating the domain, which incurs downtime on a live CDN hostname. (The resource also cannot be imported via provider-native import blocks, and the state cannot be hand-restored safely.)

This PR implements `ImportState` for the resource:

- **`internal/services/r2_custom_domain/resource.go`**
  - adds the `resource.ResourceWithImportState` interface assertion
  - implements `ImportState` with the import ID format `<account_id>/<bucket_name>/<jurisdiction>/<domain>`, mirroring the sibling `cloudflare_r2_bucket` resource's generated implementation (including the `default` jurisdiction handling and the `cf-r2-jurisdiction` request header), and fetching live state via `R2.Buckets.Domains.Custom.Get` exactly as `Read` does
- **`internal/services/r2_custom_domain/resource_test.go`**
  - adds an `ImportState`/`ImportStateVerify` step to `TestAccCloudflareR2CustomDomain_Basic`; `status` is excluded from verification because `ssl`/`ownership` can legitimately transition (`pending` → `active`) between the create and import steps while the domain is provisioning
- **docs/examples**
  - adds `examples/resources/cloudflare_r2_custom_domain/import.sh` and replaces the "does not currently support `terraform import`" notice in `docs/resources/r2_custom_domain.md` with the import syntax

The implementation follows the hand-written-`ImportState`-on-generated-resource precedent of 76e44f06 (`leaked_credential_check`).

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

```sh
go vet ./internal/services/r2_custom_domain/...
go test ./internal/services/r2_custom_domain/...   # schema/unit tests
```

### Test output

```
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_custom_domain	1.472s
```

(Schema/unit tests pass; the new `ImportState` acceptance step is part of `TestAccCloudflareR2CustomDomain_Basic` and runs under `TF_ACC=1`.)

## Additional context & links

- Real-world motivation: importing an existing R2 custom domain that was attached before the Terraform resource was adopted currently requires deleting the domain (CDN downtime) or manual state surgery.
- Import ID format intentionally matches `cloudflare_r2_bucket` (`<account_id>/<bucket_name>/<jurisdiction>`) extended with the domain segment.
