### PR TITLE
docs: cloudflare_zone_subscription example, remove readonly attributes

### DIFF
--- a/examples/resources/cloudflare_zone_subscription/resource.tf
+++ b/examples/resources/cloudflare_zone_subscription/resource.tf
@@ -3,11 +3,5 @@ resource "cloudflare_zone_subscription" "example_zone_subscription" {
   frequency = "monthly"
   rate_plan = {
     id = "free"
-    currency = "USD"
-    externally_managed = false
-    is_contract = false
-    public_name = "Business Plan"
-    scope = "zone"
-    sets = ["string"]
   }
 }


### PR DESCRIPTION
Removing read-only (according to docs) attributes from the example for cloudflare_zone_subscription, they cannot be set

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
The doc example for cloudflare_zone_subscription is wrong as it tries to set read-only attributes.