### PR TITLE
fix(image_variant): fix nested variant response deserialization

### DIFF
--- a/internal/services/image_variant/data_source_test.go
+++ b/internal/services/image_variant/data_source_test.go
@@ -1,0 +1,40 @@
+package image_variant_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccCloudflareImageVariantDataSource_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	datasourceName := "data.cloudflare_image_variant." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageVariantDataSourceConfig(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "variant_id", rnd),
+					resource.TestCheckResourceAttr(datasourceName, "variant.options.fit", "scale-down"),
+					resource.TestCheckResourceAttr(datasourceName, "variant.options.height", "480"),
+					resource.TestCheckResourceAttr(datasourceName, "variant.options.width", "640"),
+					resource.TestCheckResourceAttr(datasourceName, "variant.options.metadata", "keep"),
+				),
+			},
+		},
+	})
+}
+
+func testAccImageVariantDataSourceConfig(rnd, accountID string) string {
+	return acctest.LoadTestCase("datasource_basic.tf", rnd, accountID)
+}

--- a/internal/services/image_variant/model.go
+++ b/internal/services/image_variant/model.go
@@ -4,20 +4,22 @@ package image_variant
 
 import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-type ImageVariantResultEnvelope struct {
-	Result ImageVariantModel `json:"result"`
+type ImageVariantWriteResultEnvelope struct {
+	Result ImageVariantWriteResult `json:"result"`
+}
+
+type ImageVariantWriteResult struct {
+	Variant ImageVariantModel `json:"variant"`
 }
 
 type ImageVariantModel struct {
-	ID                     types.String                                       `tfsdk:"id" json:"id,required"`
-	AccountID              types.String                                       `tfsdk:"account_id" path:"account_id,required"`
-	Options                *ImageVariantOptionsModel                          `tfsdk:"options" json:"options,required,no_refresh"`
-	NeverRequireSignedURLs types.Bool                                         `tfsdk:"never_require_signed_urls" json:"neverRequireSignedURLs,computed_optional,no_refresh"`
-	Variant                customfield.NestedObject[ImageVariantVariantModel] `tfsdk:"variant" json:"variant,computed"`
+	ID                     types.String              `tfsdk:"id" json:"id,required"`
+	AccountID              types.String              `tfsdk:"account_id" path:"account_id,required"`
+	Options                *ImageVariantOptionsModel `tfsdk:"options" json:"options,required"`
+	NeverRequireSignedURLs types.Bool                `tfsdk:"never_require_signed_urls" json:"neverRequireSignedURLs,computed_optional"`
 }
 
 func (m ImageVariantModel) MarshalJSON() (data []byte, err error) {
@@ -33,17 +35,4 @@ type ImageVariantOptionsModel struct {
 	Height   types.Float64 `tfsdk:"height" json:"height,required"`
 	Metadata types.String  `tfsdk:"metadata" json:"metadata,required"`
 	Width    types.Float64 `tfsdk:"width" json:"width,required"`
-}
-
-type ImageVariantVariantModel struct {
-	ID                     types.String                                              `tfsdk:"id" json:"id,computed"`
-	Options                customfield.NestedObject[ImageVariantVariantOptionsModel] `tfsdk:"options" json:"options,computed"`
-	NeverRequireSignedURLs types.Bool                                                `tfsdk:"never_require_signed_urls" json:"neverRequireSignedURLs,computed"`
-}
-
-type ImageVariantVariantOptionsModel struct {
-	Fit      types.String  `tfsdk:"fit" json:"fit,computed"`
-	Height   types.Float64 `tfsdk:"height" json:"height,computed"`
-	Metadata types.String  `tfsdk:"metadata" json:"metadata,computed"`
-	Width    types.Float64 `tfsdk:"width" json:"width,computed"`
 }

--- a/internal/services/image_variant/resource.go
+++ b/internal/services/image_variant/resource.go
@@ -70,7 +70,8 @@ func (r *ImageVariantResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 	res := new(http.Response)
-	env := ImageVariantResultEnvelope{*data}
+	env := ImageVariantWriteResultEnvelope{}
+	env.Result.Variant = *data
 	_, err = r.client.Images.V1.Variants.New(
 		ctx,
 		images.V1VariantNewParams{
@@ -90,7 +91,7 @@ func (r *ImageVariantResource) Create(ctx context.Context, req resource.CreateRe
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
 	}
-	data = &env.Result
+	data = &env.Result.Variant
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -118,7 +119,8 @@ func (r *ImageVariantResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 	res := new(http.Response)
-	env := ImageVariantResultEnvelope{*data}
+	env := ImageVariantWriteResultEnvelope{}
+	env.Result.Variant = *data
 	_, err = r.client.Images.V1.Variants.Edit(
 		ctx,
 		data.ID.ValueString(),
@@ -139,7 +141,7 @@ func (r *ImageVariantResource) Update(ctx context.Context, req resource.UpdateRe
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
 	}
-	data = &env.Result
+	data = &env.Result.Variant
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -154,7 +156,8 @@ func (r *ImageVariantResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	res := new(http.Response)
-	env := ImageVariantResultEnvelope{*data}
+	env := ImageVariantWriteResultEnvelope{}
+	env.Result.Variant = *data
 	_, err := r.client.Images.V1.Variants.Get(
 		ctx,
 		data.ID.ValueString(),
@@ -179,7 +182,7 @@ func (r *ImageVariantResource) Read(ctx context.Context, req resource.ReadReques
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
 	}
-	data = &env.Result
+	data = &env.Result.Variant
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -229,7 +232,8 @@ func (r *ImageVariantResource) ImportState(ctx context.Context, req resource.Imp
 	data.ID = types.StringValue(path_variant_id)
 
 	res := new(http.Response)
-	env := ImageVariantResultEnvelope{*data}
+	env := ImageVariantWriteResultEnvelope{}
+	env.Result.Variant = *data
 	_, err := r.client.Images.V1.Variants.Get(
 		ctx,
 		path_variant_id,
@@ -249,7 +253,7 @@ func (r *ImageVariantResource) ImportState(ctx context.Context, req resource.Imp
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
 	}
-	data = &env.Result
+	data = &env.Result.Variant
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/image_variant/resource_test.go
+++ b/internal/services/image_variant/resource_test.go
@@ -1,0 +1,169 @@
+package image_variant_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v7"
+	"github.com/cloudflare/cloudflare-go/v7/images"
+	"github.com/cloudflare/cloudflare-go/v7/option"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/acctest"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func TestAccCloudflareImageVariant_Basic(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_image_variant." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareImageVariantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageVariantBasic(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", rnd),
+					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(resourceName, "options.fit", "scale-down"),
+					resource.TestCheckResourceAttr(resourceName, "options.height", "480"),
+					resource.TestCheckResourceAttr(resourceName, "options.width", "640"),
+					resource.TestCheckResourceAttr(resourceName, "options.metadata", "keep"),
+					resource.TestCheckResourceAttr(resourceName, "never_require_signed_urls", "false"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccCloudflareImageVariant_Update is the regression test for the nested
+// response deserialization bug: after an Update, options.fit/metadata used
+// to come back null unless masked by a no_refresh tag. This asserts the
+// genuinely-refreshed values are correct after a real Update call.
+func TestAccCloudflareImageVariant_Update(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_image_variant." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareImageVariantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageVariantUpdateInitial(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", rnd),
+					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(resourceName, "options.fit", "scale-down"),
+					resource.TestCheckResourceAttr(resourceName, "options.height", "480"),
+					resource.TestCheckResourceAttr(resourceName, "options.width", "640"),
+					resource.TestCheckResourceAttr(resourceName, "options.metadata", "keep"),
+					resource.TestCheckResourceAttr(resourceName, "never_require_signed_urls", "false"),
+				),
+			},
+			{
+				Config: testAccImageVariantUpdateModified(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", rnd),
+					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(resourceName, "options.fit", "contain"),
+					resource.TestCheckResourceAttr(resourceName, "options.height", "1080"),
+					resource.TestCheckResourceAttr(resourceName, "options.width", "1920"),
+					resource.TestCheckResourceAttr(resourceName, "options.metadata", "copyright"),
+					resource.TestCheckResourceAttr(resourceName, "never_require_signed_urls", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudflareImageVariant_Import(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_image_variant." + rnd
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareImageVariantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageVariantBasic(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", rnd),
+					resource.TestCheckResourceAttr(resourceName, consts.AccountIDSchemaKey, accountID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					return fmt.Sprintf("%s/%s", accountID, rnd), nil
+				},
+			},
+		},
+	})
+}
+
+func testAccImageVariantBasic(rnd, accountID string) string {
+	return acctest.LoadTestCase("basic.tf", rnd, accountID)
+}
+
+func testAccImageVariantUpdateInitial(rnd, accountID string) string {
+	return acctest.LoadTestCase("update_initial.tf", rnd, accountID)
+}
+
+func testAccImageVariantUpdateModified(rnd, accountID string) string {
+	return acctest.LoadTestCase("update_modified.tf", rnd, accountID)
+}
+
+func testAccCheckCloudflareImageVariantDestroy(s *terraform.State) error {
+	client := acctest.SharedClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudflare_image_variant" {
+			continue
+		}
+
+		res := new(http.Response)
+		_, err := client.Images.V1.Variants.Get(
+			context.Background(),
+			rs.Primary.ID,
+			images.V1VariantGetParams{
+				AccountID: cloudflare.F(rs.Primary.Attributes[consts.AccountIDSchemaKey]),
+			},
+			option.WithResponseBodyInto(&res),
+		)
+		// If we get a 404, the resource is properly destroyed
+		if res != nil && res.StatusCode == 404 {
+			continue
+		}
+		if err == nil {
+			return fmt.Errorf("image variant %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}

--- a/internal/services/image_variant/schema.go
+++ b/internal/services/image_variant/schema.go
@@ -5,7 +5,6 @@ package image_variant
 import (
 	"context"
 
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/schemata"
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -87,65 +86,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:    true,
 				Optional:    true,
 				Default:     booldefault.StaticBool(false),
-			},
-			"variant": schema.SingleNestedAttribute{
-				Computed:   true,
-				CustomType: customfield.NewNestedObjectType[ImageVariantVariantModel](ctx),
-				Attributes: map[string]schema.Attribute{
-					"id": schema.StringAttribute{
-						Computed: true,
-					},
-					"options": schema.SingleNestedAttribute{
-						Description: "Allows you to define image resizing sizes for different use cases.",
-						Computed:    true,
-						CustomType:  customfield.NewNestedObjectType[ImageVariantVariantOptionsModel](ctx),
-						Attributes: map[string]schema.Attribute{
-							"fit": schema.StringAttribute{
-								Description: "The fit property describes how the width and height dimensions should be interpreted.\nAvailable values: \"scale-down\", \"contain\", \"cover\", \"crop\", \"pad\".",
-								Computed:    true,
-								Validators: []validator.String{
-									stringvalidator.OneOfCaseInsensitive(
-										"scale-down",
-										"contain",
-										"cover",
-										"crop",
-										"pad",
-									),
-								},
-							},
-							"height": schema.Float64Attribute{
-								Description: "Maximum height in image pixels.",
-								Computed:    true,
-								Validators: []validator.Float64{
-									float64validator.AtLeast(1),
-								},
-							},
-							"metadata": schema.StringAttribute{
-								Description: "What EXIF data should be preserved in the output image.\nAvailable values: \"keep\", \"copyright\", \"none\".",
-								Computed:    true,
-								Validators: []validator.String{
-									stringvalidator.OneOfCaseInsensitive(
-										"keep",
-										"copyright",
-										"none",
-									),
-								},
-							},
-							"width": schema.Float64Attribute{
-								Description: "Maximum width in image pixels.",
-								Computed:    true,
-								Validators: []validator.Float64{
-									float64validator.AtLeast(1),
-								},
-							},
-						},
-					},
-					"never_require_signed_urls": schema.BoolAttribute{
-						Description: "Indicates whether the variant can access an image without a signature, regardless of image access control.",
-						Computed:    true,
-						Default:     booldefault.StaticBool(false),
-					},
-				},
 			},
 		},
 	}

--- a/internal/services/image_variant/testdata/basic.tf
+++ b/internal/services/image_variant/testdata/basic.tf
@@ -1,0 +1,11 @@
+resource "cloudflare_image_variant" "%[1]s" {
+  account_id = "%[2]s"
+  id         = "%[1]s"
+
+  options = {
+    fit      = "scale-down"
+    height   = 480
+    width    = 640
+    metadata = "keep"
+  }
+}

--- a/internal/services/image_variant/testdata/datasource_basic.tf
+++ b/internal/services/image_variant/testdata/datasource_basic.tf
@@ -1,0 +1,16 @@
+resource "cloudflare_image_variant" "%[1]s" {
+  account_id = "%[2]s"
+  id         = "%[1]s"
+
+  options = {
+    fit      = "scale-down"
+    height   = 480
+    width    = 640
+    metadata = "keep"
+  }
+}
+
+data "cloudflare_image_variant" "%[1]s" {
+  account_id = "%[2]s"
+  variant_id = cloudflare_image_variant.%[1]s.id
+}

--- a/internal/services/image_variant/testdata/update_initial.tf
+++ b/internal/services/image_variant/testdata/update_initial.tf
@@ -1,0 +1,13 @@
+resource "cloudflare_image_variant" "%[1]s" {
+  account_id = "%[2]s"
+  id         = "%[1]s"
+
+  options = {
+    fit      = "scale-down"
+    height   = 480
+    width    = 640
+    metadata = "keep"
+  }
+
+  never_require_signed_urls = false
+}

--- a/internal/services/image_variant/testdata/update_modified.tf
+++ b/internal/services/image_variant/testdata/update_modified.tf
@@ -1,0 +1,13 @@
+resource "cloudflare_image_variant" "%[1]s" {
+  account_id = "%[2]s"
+  id         = "%[1]s"
+
+  options = {
+    fit      = "contain"
+    height   = 1080
+    width    = 1920
+    metadata = "copyright"
+  }
+
+  never_require_signed_urls = true
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

**HAND-PATCH: needs reseal** 
This fixes generated files (`model.go`, `resource.go`, `schema.go`) directly, because the root cause is inside Stainless's own generator, not in our OpenAPI spec or Stainless config. Confirmed via a real preview build (config fix tested, verified via actual generated artifact to have zero effect). See IMAGES-1782 / APIX-1226 for the full history of attempted upstream fixes.

The API returns image variant responses with data nested under `result.variant`, but Create/Read/Update/ImportState were deserializing against a flat envelope, so `options.fit`/`metadata` came back null after any Update unless masked by a `no_refresh` tag on the affected fields.

Switches to `ImageVariantWriteResultEnvelope`, which correctly parses the nested `result.variant` shape, and removes the now-redundant computed `variant` field from the resource schema/model.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

```
TF_ACC=1 CLOUDFLARE_API_TOKEN=<token> CLOUDFLARE_ACCOUNT_ID=<account_id> \
  go test ./internal/services/image_variant/... -run "TestAccCloudflareImageVariant" -v -timeout 5m
```

### Test output

```
=== RUN   TestAccCloudflareImageVariantDataSource_Basic
--- PASS: TestAccCloudflareImageVariantDataSource_Basic (8.44s)
=== RUN   TestAccCloudflareImageVariant_Basic
--- PASS: TestAccCloudflareImageVariant_Basic (4.71s)
--- PASS: TestAccCloudflareImageVariant_Import (6.44s)
--- PASS: TestAccCloudflareImageVariant_Update (7.90s)
PASS
```

## Additional context & links

Supersedes #6918 (same underlying fix, redone on top of current `main`, with acceptance tests actually run and passing against a real account).
Ref IMAGES-1782 / APIX-1226.