### PR TITLE
fix(hyperdrive_config): keep modified_on unknown during updates

### DIFF
--- a/internal/services/hyperdrive_config/custom.go
+++ b/internal/services/hyperdrive_config/custom.go
@@ -129,7 +129,7 @@ func modifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resou
 	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
 }
 
-// originsEqual compares two origin models, ignoring write-only fields
+// originsEqual compares all configurable fields in two origin models.
 func originsEqual(a, b *HyperdriveConfigOriginModel) bool {
 	if a == nil && b == nil {
 		return true
@@ -139,12 +139,13 @@ func originsEqual(a, b *HyperdriveConfigOriginModel) bool {
 	}
 	return a.Database.Equal(b.Database) &&
 		a.Host.Equal(b.Host) &&
+		a.Password.Equal(b.Password) &&
 		a.Port.Equal(b.Port) &&
 		a.Scheme.Equal(b.Scheme) &&
 		a.User.Equal(b.User) &&
-		a.AccessClientID.Equal(b.AccessClientID)
-	// Note: Password and AccessClientSecret are intentionally not compared
-	// as they are write-only and we preserve them from state
+		a.AccessClientID.Equal(b.AccessClientID) &&
+		a.AccessClientSecret.Equal(b.AccessClientSecret) &&
+		a.ServiceID.Equal(b.ServiceID)
 }
 
 // cachingEqual compares two caching models
@@ -183,4 +184,3 @@ func mtlsEqual(a, b *HyperdriveConfigMTLSModel) bool {
 		a.MTLSCertificateID.Equal(b.MTLSCertificateID) &&
 		a.Sslmode.Equal(b.Sslmode)
 }
-

--- a/internal/services/hyperdrive_config/custom_test.go
+++ b/internal/services/hyperdrive_config/custom_test.go
@@ -1,10 +1,145 @@
 package hyperdrive_config
 
 import (
+	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func TestModifyPlanModifiedOn(t *testing.T) {
+	ctx := context.Background()
+
+	createdOn, diags := timetypes.NewRFC3339Value("2026-07-15T06:00:00Z")
+	if diags.HasError() {
+		t.Fatalf("failed to create created_on value: %v", diags)
+	}
+	modifiedOn, diags := timetypes.NewRFC3339Value("2026-07-15T07:00:00Z")
+	if diags.HasError() {
+		t.Fatalf("failed to create modified_on value: %v", diags)
+	}
+
+	newModel := func(mtls *HyperdriveConfigMTLSModel, created, modified timetypes.RFC3339) *HyperdriveConfigModel {
+		return &HyperdriveConfigModel{
+			ID:        types.StringValue("hyperdrive-id"),
+			AccountID: types.StringValue("account-id"),
+			Name:      types.StringValue("example"),
+			Origin: &HyperdriveConfigOriginModel{
+				Database:           types.StringValue("example"),
+				Host:               types.StringNull(),
+				Password:           types.StringValue("password"),
+				Port:               types.Int64Null(),
+				Scheme:             types.StringValue("postgresql"),
+				User:               types.StringValue("example"),
+				AccessClientID:     types.StringNull(),
+				AccessClientSecret: types.StringValue("access-secret"),
+				ServiceID:          types.StringValue("vpc-service-id"),
+			},
+			OriginConnectionLimit: types.Int64Value(20),
+			Caching: &HyperdriveConfigCachingModel{
+				Disabled:             types.BoolValue(false),
+				MaxAge:               types.Int64Null(),
+				StaleWhileRevalidate: types.Int64Null(),
+			},
+			MTLS:       mtls,
+			CreatedOn:  created,
+			ModifiedOn: modified,
+		}
+	}
+
+	tests := []struct {
+		name                    string
+		mutate                  func(state, plan *HyperdriveConfigModel)
+		expectModifiedOnUnknown bool
+	}{
+		{
+			name: "no configuration changes",
+		},
+		{
+			name: "password added after import",
+			mutate: func(state, _ *HyperdriveConfigModel) {
+				state.Origin.Password = types.StringNull()
+			},
+			expectModifiedOnUnknown: true,
+		},
+		{
+			name: "access client secret added",
+			mutate: func(state, _ *HyperdriveConfigModel) {
+				state.Origin.AccessClientSecret = types.StringNull()
+			},
+			expectModifiedOnUnknown: true,
+		},
+		{
+			name: "service ID changed",
+			mutate: func(_, plan *HyperdriveConfigModel) {
+				plan.Origin.ServiceID = types.StringValue("new-vpc-service-id")
+			},
+			expectModifiedOnUnknown: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stateData := newModel(
+				&HyperdriveConfigMTLSModel{
+					CACertificateID:   types.StringNull(),
+					MTLSCertificateID: types.StringNull(),
+					Sslmode:           types.StringNull(),
+				},
+				createdOn,
+				modifiedOn,
+			)
+			planData := newModel(
+				nil,
+				timetypes.NewRFC3339Unknown(),
+				timetypes.NewRFC3339Unknown(),
+			)
+			if test.mutate != nil {
+				test.mutate(stateData, planData)
+			}
+
+			schema := ResourceSchema(ctx)
+			state := tfsdk.State{Schema: schema}
+			if diags := state.Set(ctx, stateData); diags.HasError() {
+				t.Fatalf("failed to build state: %v", diags)
+			}
+			plan := tfsdk.Plan{Schema: schema}
+			if diags := plan.Set(ctx, planData); diags.HasError() {
+				t.Fatalf("failed to build plan: %v", diags)
+			}
+
+			resp := &resource.ModifyPlanResponse{Plan: plan}
+			modifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, State: state}, resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("modifyPlan returned diagnostics: %v", resp.Diagnostics)
+			}
+
+			var updatedPlan *HyperdriveConfigModel
+			if diags := resp.Plan.Get(ctx, &updatedPlan); diags.HasError() {
+				t.Fatalf("failed to read updated plan: %v", diags)
+			}
+			if updatedPlan == nil {
+				t.Fatal("expected a populated updated plan")
+			}
+			if updatedPlan.CreatedOn.IsUnknown() || updatedPlan.CreatedOn.ValueString() != createdOn.ValueString() {
+				t.Fatalf("expected created_on to be preserved as %q, got %q", createdOn.ValueString(), updatedPlan.CreatedOn.ValueString())
+			}
+
+			if test.expectModifiedOnUnknown {
+				if !updatedPlan.ModifiedOn.IsUnknown() {
+					t.Fatalf("expected modified_on to remain unknown during update, got %q", updatedPlan.ModifiedOn.ValueString())
+				}
+				return
+			}
+			if updatedPlan.ModifiedOn.IsUnknown() || updatedPlan.ModifiedOn.ValueString() != modifiedOn.ValueString() {
+				t.Fatalf("expected modified_on to be preserved as %q, got %q", modifiedOn.ValueString(), updatedPlan.ModifiedOn.ValueString())
+			}
+		})
+	}
+}
 
 func TestPreserveWriteOnlyFields(t *testing.T) {
 	t.Parallel()
@@ -198,4 +333,3 @@ func TestPreserveWriteOnlyFields(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #7258.

Hyperdrive preserves the prior `modified_on` value only when an update contains
no effective configuration changes. The origin comparison omitted `password`,
`access_client_secret`, and `service_id`, so changes to those fields could be
classified as a no-op and constrain `modified_on` to its stale value.

Compare every configurable origin field and add schema-backed regression tests
that verify real origin changes leave `modified_on` unknown while a true no-op
plan retains the prior value.

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

Not run. Hyperdrive acceptance tests require live Cloudflare credentials and
resources. The regression was validated with provider-level schema-backed unit
tests and a package build:

```sh
go build -mod=readonly ./internal/services/hyperdrive_config/...
go test -mod=readonly -p=4 -v ./internal/services/hyperdrive_config/... -count=1
```

### Test output

```text
$ go build -mod=readonly ./internal/services/hyperdrive_config/...
(no output; exit status 0)

$ go test -mod=readonly -p=4 -v ./internal/services/hyperdrive_config/... -count=1
=== RUN   TestModifyPlanModifiedOn
=== RUN   TestModifyPlanModifiedOn/no_configuration_changes
=== RUN   TestModifyPlanModifiedOn/password_added_after_import
=== RUN   TestModifyPlanModifiedOn/access_client_secret_added
=== RUN   TestModifyPlanModifiedOn/service_ID_changed
--- PASS: TestModifyPlanModifiedOn (0.01s)
    --- PASS: TestModifyPlanModifiedOn/no_configuration_changes (0.00s)
    --- PASS: TestModifyPlanModifiedOn/password_added_after_import (0.00s)
    --- PASS: TestModifyPlanModifiedOn/access_client_secret_added (0.00s)
    --- PASS: TestModifyPlanModifiedOn/service_ID_changed (0.00s)
--- PASS: TestPreserveWriteOnlyFields (0.00s)
--- PASS: TestHyperdriveConfigDataSourceModelSchemaParity (0.00s)
--- PASS: TestHyperdriveConfigsDataSourceModelSchemaParity (0.00s)
--- PASS: TestHyperdriveConfigModelSchemaParity (0.00s)
PASS
ok  github.com/cloudflare/terraform-provider-cloudflare/internal/services/hyperdrive_config  0.107s
```

## Additional context & links

No Terraform schema or state-format changes are included.