### PR TITLE
fix(email_routing_settings): add missing support_subaddress to schema

### DIFF
--- a/internal/services/email_routing_settings/schema.go
+++ b/internal/services/email_routing_settings/schema.go
@@ -72,6 +72,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					),
 				},
 			},
+			"support_subaddress": schema.BoolAttribute{
+				Description: "Whether subaddressing (RFC 5233 plus-addressing) is enabled for this zone's Email Routing.",
+				Optional:    true,
+			},
 			"tag": schema.StringAttribute{
 				Description:        "Email Routing settings tag. (Deprecated, replaced by Email Routing settings identifier)",
 				Computed:           true,


### PR DESCRIPTION
<!--
Title: fix(email_routing_settings): add missing support_subaddress to schema
-->

Fixes #7301

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adds `support_subaddress` to `ResourceSchema()`, matching the model's `json:"support_subaddress,optional"` tag (`Optional: true`, no `Computed`). The field was already present in `EmailRoutingSettingsModel` but missing from the schema.

Note this resource's generated `TestEmailRoutingSettingsModelSchemaParity` only walks schema attributes and checks each has a matching model field — it doesn't check the reverse (model fields missing from the schema), so it can't actually catch this bug by itself. I first tried `Computed: true` to match the resource's other read-only fields, and the test caught that mismatch (see below) even though it wouldn't have caught the original missing-attribute bug.

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

Couldn't get the full repo building locally (`internal/services` drags in cloudflare-go/v7 across ~600 resource packages, too heavy for the machine I had on hand). Put together a minimal repro instead — just this package's `model.go`/`schema.go` plus the handful of internal packages they depend on — and ran the real `resource_schema_test.go` against that.

### Steps to run acceptance tests

```
go test ./internal/services/email_routing_settings/... -run TestEmailRoutingSettingsModelSchemaParity -v
```

### Test output

First attempt, `support_subaddress` as `Computed: true` (wrong — doesn't match the model tag):

```
=== RUN   TestEmailRoutingSettingsModelSchemaParity
=== PAUSE TestEmailRoutingSettingsModelSchemaParity
=== CONT  TestEmailRoutingSettingsModelSchemaParity
    integrity.go:126: mismatch at ".@EmailRoutingSettingsModel.support_subaddress": expected "computed", received "support_subaddress,optional"
--- FAIL: TestEmailRoutingSettingsModelSchemaParity (0.00s)
FAIL
```

With `Optional: true` (this PR):

```
=== RUN   TestEmailRoutingSettingsModelSchemaParity
=== PAUSE TestEmailRoutingSettingsModelSchemaParity
=== CONT  TestEmailRoutingSettingsModelSchemaParity
--- PASS: TestEmailRoutingSettingsModelSchemaParity (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/email_routing_settings	0.002s
```