### PR TITLE
fix(zero_trust_device_custom_profile): stop split tunnel entries inheriting a mutually exclusive field

### DIFF
--- a/internal/services/zero_trust_device_custom_profile/custom.go
+++ b/internal/services/zero_trust_device_custom_profile/custom.go
@@ -89,6 +89,20 @@ type splitTunnelEntry interface {
 	ZeroTrustDeviceCustomProfileExcludeModel | ZeroTrustDeviceCustomProfileIncludeModel
 }
 
+// mutuallyExclusiveKey maps a split tunnel entry attribute to the attribute it
+// cannot be combined with. An entry addresses either an IP range or a hostname,
+// never both.
+var mutuallyExclusiveKey = map[string]string{
+	"address": "host",
+	"host":    "address",
+}
+
+// isSet reports whether an attribute holds a usable value, as opposed to being
+// absent or not yet resolved.
+func isSet(val attr.Value) bool {
+	return val != nil && !val.IsNull() && !val.IsUnknown()
+}
+
 // normalizeSplitTunnelList resolves unknown nested attributes in exclude/include
 // list elements. For each element, if address/host/description is unknown, it is
 // resolved to the corresponding state value (for existing entries at the same
@@ -99,6 +113,12 @@ type splitTunnelEntry interface {
 // may be applied for one plan-apply cycle; the next read corrects them. This is
 // acceptable because the API does not compute these fields — the worst case is
 // a single extra apply with null values that get overwritten by the API response.
+//
+// The exception is address/host, which are mutually exclusive: the API rejects
+// the whole request with "cannot update split tunnels: host and Address both
+// cannot be present" if it receives both. Inheriting one from a state entry of
+// the other kind therefore fails the apply instead of costing an extra cycle,
+// so mutuallyExclusiveKey is consulted before falling back to state.
 func normalizeSplitTunnelList[T splitTunnelEntry](
 	ctx context.Context,
 	planList customfield.NestedObjectList[T],
@@ -148,7 +168,14 @@ func normalizeSplitTunnelList[T splitTunnelEntry](
 				// Try to use state value; fall back to null.
 				// NOTE: all nested attributes in exclude/include models are strings;
 				// update this fallback if non-string Optional+Computed fields are added.
-				if stateAttrs != nil {
+				//
+				// An unknown attribute whose mutually exclusive counterpart is set
+				// in the plan resolves to null, never to a state value: the state
+				// entry at this index may be of the other kind, and sending both
+				// address and host makes the API reject the request.
+				if other, ok := mutuallyExclusiveKey[key]; ok && isSet(attrs[other]) {
+					newAttrs[key] = basetypes.NewStringNull()
+				} else if stateAttrs != nil {
 					if sv, exists := stateAttrs[key]; exists {
 						newAttrs[key] = sv
 					} else {

--- a/internal/services/zero_trust_device_custom_profile/custom_test.go
+++ b/internal/services/zero_trust_device_custom_profile/custom_test.go
@@ -215,3 +215,63 @@ func TestNormalizeSplitTunnelList_NoChangeWhenAllKnown(t *testing.T) {
 		t.Error("expected unchanged list when all attributes are known")
 	}
 }
+
+// A host entry must not inherit `address` from the state entry that happens to
+// share its index. The two are mutually exclusive and the API rejects the whole
+// request with "cannot update split tunnels: host and Address both cannot be
+// present", so an index collision fails the apply rather than costing an extra
+// plan-apply cycle.
+func TestNormalizeSplitTunnelList_HostEntryDoesNotInheritAddressFromState(t *testing.T) {
+	ctx := context.Background()
+
+	// User prepends a host entry to a list that previously held only addresses.
+	planEntries := []ZeroTrustDeviceCustomProfileIncludeModel{
+		{
+			Address:     types.StringUnknown(),
+			Description: types.StringValue("Example Host"),
+			Host:        types.StringValue("example.com"),
+		},
+		{
+			Address:     types.StringValue("172.64.128.0/20"),
+			Description: types.StringValue("Gateway initial resolved IPs"),
+			Host:        types.StringUnknown(),
+		},
+	}
+	planList := customfield.NewObjectListMust(ctx, planEntries)
+
+	// State holds only the address entry, so index 0 is of the other kind.
+	stateEntries := []ZeroTrustDeviceCustomProfileIncludeModel{
+		{
+			Address:     types.StringValue("172.64.128.0/20"),
+			Description: types.StringValue("Gateway initial resolved IPs"),
+			Host:        types.StringNull(),
+		},
+	}
+	stateList := customfield.NewObjectListMust(ctx, stateEntries)
+
+	result, diags := normalizeSplitTunnelList(ctx, planList, stateList)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	elements := result.Elements()
+	if len(elements) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(elements))
+	}
+
+	host := elements[0].(types.Object).Attributes()
+	if !host["address"].IsNull() {
+		t.Errorf("expected address to be null on a host entry, got %v", host["address"])
+	}
+	if host["host"].(types.String).ValueString() != "example.com" {
+		t.Errorf("expected host to be preserved, got %v", host["host"])
+	}
+
+	address := elements[1].(types.Object).Attributes()
+	if !address["host"].IsNull() {
+		t.Errorf("expected host to be null on an address entry, got %v", address["host"])
+	}
+	if address["address"].(types.String).ValueString() != "172.64.128.0/20" {
+		t.Errorf("expected address to be preserved, got %v", address["address"])
+	}
+}


### PR DESCRIPTION
## What

`normalizeSplitTunnelList` resolves unknown nested attributes in `include`/`exclude` by falling back to the state entry **at the same index**. The existing note acknowledges the matching is positional and argues the worst case is one extra plan-apply cycle:

```go
// NOTE: Matching is index-based (plan element i ↔ state element i), not
// identity-based. ... the worst case is a single extra apply with null
// values that get overwritten by the API response.
```

That holds for `description`, but not for `address`/`host`. Those are mutually exclusive, and the API rejects the whole request when it receives both, so the apply fails instead of self-correcting.

## Reproduction

Given an existing profile whose `include` holds only address entries, add a `host` entry ahead of them:

```hcl
resource "cloudflare_zero_trust_device_custom_profile" "example" {
  account_id = var.account_id
  name       = "example"
  precedence = 100
  match      = "identity.email == \"user@example.com\""

  include = [
    { host    = "example.com", description = "Example host" },
    { address = "172.64.128.0/20", description = "Gateway initial resolved IPs" },
  ]
}
```

`plan[0]` has an unknown `address` and `state[0]` is the `172.64.128.0/20` entry, so the host entry inherits that address and both fields go out in the same object:

```
Error: failed to make http request

PATCH "https://api.cloudflare.com/client/v4/accounts/<redacted>/devices/policy/<redacted>":
400 Bad Request
{"result":null,"success":false,"errors":[{"code":2049,"message":"cannot update split tunnels: host and Address both cannot be present"}],"messages":[]}
```

Moving the `host` entry to the end, so the indices line up with state, makes the same apply succeed. That is the only workaround today, and it means the config order has to track whatever order the API returns.

The API itself accepts mixed lists as long as each entry carries one field or the other. Creating the same entry through the dashboard produces:

```json
[
  {"address": "172.64.128.0/20","description": "Gateway initial resolved IPs"},
  {"host":    "example.com",  "description": "Example Host"}
]
```

## Fix

Resolve an unknown attribute to null when its mutually exclusive counterpart is already set in the plan, before considering the state fallback. Positional matching is left as is for `description`, where the existing reasoning still applies.

## Tests

Adds `TestNormalizeSplitTunnelList_HostEntryDoesNotInheritAddressFromState`, which reproduces the index collision above and asserts neither entry gains the counterpart field. Existing tests in the package pass unchanged.

```
go test ./internal/services/zero_trust_device_custom_profile/ -run TestNormalizeSplitTunnelList
ok  github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_device_custom_profile
```

Provider version where this was observed: v5.23.0.

Possibly related, same resource family and also serialization-shaped: #6991, #6988.
