### PR TITLE
fix(workers_script): add missing "worker_loader" binding type with acceptance test

### DIFF
--- a/docs/resources/workers_script.md
+++ b/docs/resources/workers_script.md
@@ -242,7 +242,7 @@ Required:
 
 - `name` (String) A JavaScript variable name for the binding.
 - `type` (String) The kind of resource that the binding provides.
-Available values: "ai", "ai_search", "ai_search_namespace", "analytics_engine", "assets", "browser", "d1", "data_blob", "dispatch_namespace", "durable_object_namespace", "hyperdrive", "inherit", "images", "json", "kv_namespace", "media", "mtls_certificate", "plain_text", "pipelines", "queue", "ratelimit", "r2_bucket", "secret_text", "send_email", "service", "text_blob", "vectorize", "version_metadata", "secrets_store_secret", "secret_key", "workflow", "wasm_module", "vpc_service", "vpc_network".
+Available values: "ai", "ai_search", "ai_search_namespace", "analytics_engine", "assets", "browser", "d1", "data_blob", "dispatch_namespace", "durable_object_namespace", "hyperdrive", "inherit", "images", "json", "kv_namespace", "media", "mtls_certificate", "plain_text", "pipelines", "queue", "ratelimit", "r2_bucket", "secret_text", "send_email", "service", "text_blob", "vectorize", "version_metadata", "secrets_store_secret", "secret_key", "workflow", "wasm_module", "vpc_service", "vpc_network", "worker_loader".
 
 Optional:
 

--- a/internal/services/workers_script/resource_test.go
+++ b/internal/services/workers_script/resource_test.go
@@ -1307,6 +1307,48 @@ func testAccCheckCloudflareWorkerScriptWithRatelimitBinding(rnd, accountID strin
 	return acctest.LoadTestCase("module_with_ratelimit.tf", rnd, accountID)
 }
 
+// TestAccCloudflareWorkerScript_WorkerLoaderBinding verifies that a worker_loader binding type
+// is accepted and applied correctly on cloudflare_workers_script.
+// This is a regression test for the missing "worker_loader" type in the schema validator.
+func TestAccCloudflareWorkerScript_WorkerLoaderBinding(t *testing.T) {
+	t.Parallel()
+
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := resourcePrefix + rnd
+	name := "cloudflare_workers_script." + resourceName
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareWorkerScriptWithWorkerLoaderBinding(resourceName, accountID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("script_name"), knownvalue.StringExact(resourceName)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("bindings"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("bindings").AtSliceIndex(0).AtMapKey("name"), knownvalue.StringExact("LOADER")),
+					statecheck.ExpectKnownValue(name, tfjsonpath.New("bindings").AtSliceIndex(0).AtMapKey("type"), knownvalue.StringExact("worker_loader")),
+				},
+			},
+			{
+				ResourceName:            name,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", accountID),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"main_module", "startup_time_ms"},
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareWorkerScriptWithWorkerLoaderBinding(rnd, accountID string) string {
+	return acctest.LoadTestCase("module_with_worker_loader.tf", rnd, accountID)
+}
+
 // TestAccCloudflareWorkerScript_ObservabilityTraces is a regression test for
 // https://github.com/cloudflare/terraform-provider-cloudflare/issues/7177.
 // It verifies that the observability.traces block (including propagation_policy)

--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -178,7 +178,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Required:    true,
 						},
 						"type": schema.StringAttribute{
-							Description: "The kind of resource that the binding provides.\nAvailable values: \"ai\", \"ai_search\", \"ai_search_namespace\", \"analytics_engine\", \"assets\", \"browser\", \"d1\", \"data_blob\", \"dispatch_namespace\", \"durable_object_namespace\", \"hyperdrive\", \"inherit\", \"images\", \"json\", \"kv_namespace\", \"media\", \"mtls_certificate\", \"plain_text\", \"pipelines\", \"queue\", \"ratelimit\", \"r2_bucket\", \"secret_text\", \"send_email\", \"service\", \"text_blob\", \"vectorize\", \"version_metadata\", \"secrets_store_secret\", \"secret_key\", \"workflow\", \"wasm_module\", \"vpc_service\", \"vpc_network\".",
+							Description: "The kind of resource that the binding provides.\nAvailable values: \"ai\", \"ai_search\", \"ai_search_namespace\", \"analytics_engine\", \"assets\", \"browser\", \"d1\", \"data_blob\", \"dispatch_namespace\", \"durable_object_namespace\", \"hyperdrive\", \"inherit\", \"images\", \"json\", \"kv_namespace\", \"media\", \"mtls_certificate\", \"plain_text\", \"pipelines\", \"queue\", \"ratelimit\", \"r2_bucket\", \"secret_text\", \"send_email\", \"service\", \"text_blob\", \"vectorize\", \"version_metadata\", \"secrets_store_secret\", \"secret_key\", \"workflow\", \"wasm_module\", \"vpc_service\", \"vpc_network\", \"worker_loader\".",
 							Required:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOfCaseInsensitive(
@@ -217,6 +217,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"wasm_module",
 									"vpc_service",
 									"vpc_network",
+									"worker_loader",
 								),
 							},
 						},

--- a/internal/services/workers_script/testdata/module_with_worker_loader.tf
+++ b/internal/services/workers_script/testdata/module_with_worker_loader.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_workers_script" "%[1]s" {
+  account_id  = "%[2]s"
+  script_name = "%[1]s"
+  content     = "export default { fetch() { return new Response('Hello world'); } };"
+  main_module = "worker.mjs"
+  bindings = [
+    {
+      name = "LOADER"
+      type = "worker_loader"
+    }
+  ]
+}


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

The `cloudflare_workers_script` resource reads a `worker_loader` binding from a
deployed Worker into state, but the schema validator rejects the same type in
configuration with `Invalid Attribute Value Match`. Any Worker with a Worker
Loader binding therefore shows a permanent plan diff that proposes removal of a
binding the configuration cannot declare.

This change mirrors #6912, which fixed the same defect class for the
`ratelimit` type:

- Add `worker_loader` to the `OneOfCaseInsensitive` validator list and to the
  `type` attribute description in `internal/services/workers_script/schema.go`.
- Update the matching description in `docs/resources/workers_script.md`.
- Add an acceptance test and a test fixture.

A `worker_loader` binding needs only `name` and `type`. Both attributes already
exist in the model and the Read path already decodes the type, so no model
changes are needed.

`schema.go` is generated by Stainless. This is a hand patch, as in #6912, so
the OpenAPI spec may need reconciliation.

Fixes #7309

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

```shell
CLOUDFLARE_API_TOKEN=<token> CLOUDFLARE_ACCOUNT_ID=<account id> TF_ACC=1 go test -run TestAccCloudflareWorkerScript_WorkerLoaderBinding -v -timeout 30m ./internal/services/workers_script/
```

### Test output

```text
=== RUN   TestAccCloudflareWorkerScript_WorkerLoaderBinding
=== PAUSE TestAccCloudflareWorkerScript_WorkerLoaderBinding
=== CONT  TestAccCloudflareWorkerScript_WorkerLoaderBinding
--- PASS: TestAccCloudflareWorkerScript_WorkerLoaderBinding (6.31s)
PASS
ok      github.com/cloudflare/terraform-provider-cloudflare/internal/services/workers_script   8.596s
```

## Additional context & links

The equivalent Wrangler configuration for this binding is
`worker_loaders = [{ binding = "LOADER" }]`.
