### PR TITLE
feat(ruleset): add warnings to apply

### DIFF
--- a/internal/services/ruleset/resource.go
+++ b/internal/services/ruleset/resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/cloudflare/cloudflare-go/v7"
 	"github.com/cloudflare/cloudflare-go/v7/option"
@@ -15,6 +16,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/tidwall/gjson"
@@ -94,6 +96,7 @@ func (r *RulesetResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
+	addRulesetWarnings(&resp.Diagnostics, bytes)
 	bytes = transformQueryStringJSON(bytes)
 	err = apijsoncustom.UnmarshalComputed(bytes, &env)
 	if err != nil {
@@ -146,6 +149,7 @@ func (r *RulesetResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
+	addRulesetWarnings(&resp.Diagnostics, bytes)
 	bytes = transformQueryStringJSON(bytes)
 	err = apijsoncustom.UnmarshalComputed(bytes, &env)
 	if err != nil {
@@ -429,4 +433,20 @@ func transformQueryStringJSON(jsonBytes []byte) []byte {
 		return []byte(jsonStr)
 	}
 	return jsonBytes
+}
+
+// addRulesetWarnings surfaces the warnings the API reports alongside a ruleset
+func addRulesetWarnings(diagnostics *diag.Diagnostics, body []byte) {
+	for _, message := range gjson.GetBytes(body, "messages").Array() {
+		text := strings.TrimPrefix(message.Get("message").String(), "warning: ")
+		if text == "" {
+			continue
+		}
+
+		if pointer := message.Get("source.pointer").String(); pointer != "" {
+			text += "\n\nSource: " + pointer
+		}
+
+		diagnostics.AddWarning("Ruleset validation warning", text)
+	}
 }

--- a/internal/services/ruleset/ruleset_test.go
+++ b/internal/services/ruleset/ruleset_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/cloudflare/cloudflare-go/v7"
@@ -488,6 +489,30 @@ func TestAccCloudflareRuleset_Description(t *testing.T) {
 						"data.cloudflare_ruleset.my_ruleset",
 						tfjsonpath.New("description"),
 						knownvalue.StringExact("My ruleset description"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudflareRuleset_WarningOnUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigFile:      config.TestNameFile("1.tf"),
+				ConfigVariables: configVariables,
+			},
+			{
+				ConfigFile:      config.TestNameFile("2.tf"),
+				ConfigVariables: configVariables,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"cloudflare_ruleset.my_ruleset",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact(strings.Repeat("0123456789", 410)),
 					),
 				},
 			},

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_WarningOnUpdate/1.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_WarningOnUpdate/1.tf
@@ -1,0 +1,13 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "custom"
+
+  rules = [{
+    action     = "block"
+    expression = "http.host eq \"never-matches.example\""
+  }]
+}

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_WarningOnUpdate/2.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_WarningOnUpdate/2.tf
@@ -1,0 +1,15 @@
+variable "zone_id" {}
+
+resource "cloudflare_ruleset" "my_ruleset" {
+  zone_id = var.zone_id
+  name    = "My ruleset"
+  phase   = "http_request_firewall_custom"
+  kind    = "custom"
+
+  description = join("", [for i in range(410) : "0123456789"])
+
+  rules = [{
+    action     = "block"
+    expression = "http.host eq \"never-matches.example\""
+  }]
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Currently, warnings in Cloudflare Rulesets are not surfaced when running `terraform apply`. This change reports any warnings that the Rulesets API returns during the apply phase to the user.
## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->
```
export TF_ACC=1
export CLOUDFLARE_API_TOKEN=<token>
export CLOUDFLARE_ACCOUNT_ID=<account id>
export CLOUDFLARE_ZONE_ID=<zone id>
go test ./internal/services/ruleset/ -run TestAccCloudflareRuleset_WarningOnUpdate -v
```
### Test output
<!-- Please paste the output of your acceptance test run below --> 
```
=== RUN   TestAccCloudflareRuleset_WarningOnUpdate
--- PASS: TestAccCloudflareRuleset_WarningOnUpdate (12.60s)
PASS
```
## Additional context & links
