### PR TITLE
feat(zero_trust_access_application): support new worker destination types

### DIFF
--- a/docs/data-sources/zero_trust_access_application.md
+++ b/docs/data-sources/zero_trust_access_application.md
@@ -119,9 +119,10 @@ Read-Only:
 - `l4_protocol` (String) The L4 protocol of the destination. When omitted, both UDP and TCP traffic will match.
 Available values: "tcp", "udp".
 - `port_range` (String) The port range of the destination. Can be a single port or a range of ports. When omitted, all ports will match.
-- `type` (String) Available values: "public", "private".
+- `type` (String) Available values: "public", "private", "via_mcp_server_portal", "worker", "preview_worker", "all_workers", "all_preview_workers".
 - `uri` (String) The URI of the destination. Public destinations' URIs can include a domain and path with [wildcards](https://developers.cloudflare.com/cloudflare-one/policies/access/app-paths/).
 - `vnet_id` (String) The VNET ID to match the destination. When omitted, all VNETs will match.
+- `worker_id` (String) The ID of the Cloudflare Worker to protect with Access. Required when type is `worker` or `preview_worker`.
 
 
 <a id="nestedatt--footer_links"></a>

--- a/docs/data-sources/zero_trust_access_applications.md
+++ b/docs/data-sources/zero_trust_access_applications.md
@@ -122,9 +122,10 @@ Read-Only:
 - `l4_protocol` (String) The L4 protocol of the destination. When omitted, both UDP and TCP traffic will match.
 Available values: "tcp", "udp".
 - `port_range` (String) The port range of the destination. Can be a single port or a range of ports. When omitted, all ports will match.
-- `type` (String) Available values: "public", "private".
+- `type` (String) Available values: "public", "private", "via_mcp_server_portal", "worker", "preview_worker", "all_workers", "all_preview_workers".
 - `uri` (String) The URI of the destination. Public destinations' URIs can include a domain and path with [wildcards](https://developers.cloudflare.com/cloudflare-one/policies/access/app-paths/).
 - `vnet_id` (String) The VNET ID to match the destination. When omitted, all VNETs will match.
+- `worker_id` (String) The ID of the Cloudflare Worker to protect with Access. Required when type is `worker` or `preview_worker`.
 
 
 <a id="nestedatt--result--footer_links"></a>

--- a/docs/resources/zero_trust_access_application.md
+++ b/docs/resources/zero_trust_access_application.md
@@ -190,9 +190,10 @@ Optional:
 Available values: "tcp", "udp".
 - `mcp_server_id` (String) A MCP server id configured in ai-controls. Access will secure the MCP server if accessed through a MCP portal.
 - `port_range` (String) The port range of the destination. Can be a single port or a range of ports. When omitted, all ports will match.
-- `type` (String) Available values: "public", "private".
+- `type` (String) Available values: "public", "private", "via_mcp_server_portal", "worker", "preview_worker", "all_workers", "all_preview_workers".
 - `uri` (String) The URI of the destination. Public destinations' URIs can include a domain and path with [wildcards](https://developers.cloudflare.com/cloudflare-one/policies/access/app-paths/).
 - `vnet_id` (String) The VNET ID to match the destination. When omitted, all VNETs will match.
+- `worker_id` (String) The ID of the Cloudflare Worker to protect with Access. Required when type is `worker` or `preview_worker`.
 
 
 <a id="nestedatt--footer_links"></a>

--- a/internal/services/zero_trust_access_application/data_source_model.go
+++ b/internal/services/zero_trust_access_application/data_source_model.go
@@ -123,6 +123,7 @@ type ZeroTrustAccessApplicationDestinationsDataSourceModel struct {
 	PortRange   types.String `tfsdk:"port_range" json:"port_range,computed"`
 	VnetID      types.String `tfsdk:"vnet_id" json:"vnet_id,computed"`
 	McpServerID types.String `tfsdk:"mcp_server_id" json:"mcp_server_id,optional"`
+	WorkerID    types.String `tfsdk:"worker_id" json:"worker_id,computed"`
 }
 
 type ZeroTrustAccessApplicationFooterLinksDataSourceModel struct {

--- a/internal/services/zero_trust_access_application/data_source_schema.go
+++ b/internal/services/zero_trust_access_application/data_source_schema.go
@@ -250,10 +250,10 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
-							Description: `Available values: "public", "private".`,
+							Description: `Available values: "public", "private", "via_mcp_server_portal", "worker", "preview_worker", "all_workers", "all_preview_workers".`,
 							Computed:    true,
 							Validators: []validator.String{
-								stringvalidator.OneOfCaseInsensitive("public", "private", "via_mcp_server_portal"),
+								stringvalidator.OneOfCaseInsensitive("public", "private", "via_mcp_server_portal", "worker", "preview_worker", "all_workers", "all_preview_workers"),
 							},
 						},
 						"uri": schema.StringAttribute{
@@ -286,6 +286,10 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 						"mcp_server_id": schema.StringAttribute{
 							Description: "A MCP server id configured in ai-controls. Access will secure the MCP server if accessed through a MCP portal.",
 							Optional:    true,
+						},
+						"worker_id": schema.StringAttribute{
+							Description: "The ID of the Cloudflare Worker to protect with Access. Required when type is `worker` or `preview_worker`.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/services/zero_trust_access_application/list_data_source_model.go
+++ b/internal/services/zero_trust_access_application/list_data_source_model.go
@@ -119,6 +119,7 @@ type ZeroTrustAccessApplicationsDestinationsDataSourceModel struct {
 	PortRange   types.String `tfsdk:"port_range" json:"port_range,computed"`
 	VnetID      types.String `tfsdk:"vnet_id" json:"vnet_id,computed"`
 	McpServerID types.String `tfsdk:"mcp_server_id" json:"mcp_server_id,optional"`
+	WorkerID    types.String `tfsdk:"worker_id" json:"worker_id,computed"`
 }
 
 type ZeroTrustAccessApplicationsPoliciesDataSourceModel struct {

--- a/internal/services/zero_trust_access_application/list_data_source_schema.go
+++ b/internal/services/zero_trust_access_application/list_data_source_schema.go
@@ -207,10 +207,10 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"type": schema.StringAttribute{
-										Description: `Available values: "public", "private".`,
+										Description: `Available values: "public", "private", "via_mcp_server_portal", "worker", "preview_worker", "all_workers", "all_preview_workers".`,
 										Computed:    true,
 										Validators: []validator.String{
-											stringvalidator.OneOfCaseInsensitive("public", "private", "via_mcp_server_portal"),
+											stringvalidator.OneOfCaseInsensitive("public", "private", "via_mcp_server_portal", "worker", "preview_worker", "all_workers", "all_preview_workers"),
 										},
 									},
 									"uri": schema.StringAttribute{
@@ -243,6 +243,10 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 									"mcp_server_id": schema.StringAttribute{
 										Description: "A MCP server id configured in ai-controls. Access will secure the MCP server if accessed through a MCP portal.",
 										Optional:    true,
+									},
+									"worker_id": schema.StringAttribute{
+										Description: "The ID of the Cloudflare Worker to protect with Access. Required when type is `worker` or `preview_worker`.",
+										Computed:    true,
 									},
 								},
 							},

--- a/internal/services/zero_trust_access_application/model.go
+++ b/internal/services/zero_trust_access_application/model.go
@@ -216,6 +216,7 @@ type ZeroTrustAccessApplicationDestinationsModel struct {
 	PortRange   types.String `tfsdk:"port_range" json:"port_range,optional"`
 	VnetID      types.String `tfsdk:"vnet_id" json:"vnet_id,optional"`
 	McpServerID types.String `tfsdk:"mcp_server_id" json:"mcp_server_id,optional"`
+	WorkerID    types.String `tfsdk:"worker_id" json:"worker_id,optional"`
 }
 
 type ZeroTrustAccessApplicationLandingPageDesignModel struct {

--- a/internal/services/zero_trust_access_application/resource_test.go
+++ b/internal/services/zero_trust_access_application/resource_test.go
@@ -1607,6 +1607,24 @@ func TestAccCloudflareAccessApplicationWithInvalidPrivateDestination(t *testing.
 	})
 }
 
+func TestAccCloudflareAccessApplicationWithInvalidWorkerDestination(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccessApplicationWithInvalidWorkerDestination(rnd, accountID),
+				ExpectError: regexp.MustCompile(`"destinations\[0]\.worker_id" can only be set if "<\.type" is one of: "worker", "preview_worker"`),
+			},
+		},
+	})
+}
+
 func TestAccCloudflareAccessApplicationWithDestinations(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 
@@ -1637,6 +1655,44 @@ func TestAccCloudflareAccessApplicationWithDestinations(t *testing.T) {
 			{
 				// Ensures no diff on last plan
 				Config:   testAccessApplicationWithDestinations(rnd, domain, cloudflare.AccountIdentifier(accountID)),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudflareAccessApplicationWithWorkerDestinations(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+
+	name := fmt.Sprintf("cloudflare_zero_trust_access_application.%s", rnd)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareAccessApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccessApplicationWithWorkerDestinations(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, consts.AccountIDSchemaKey, accountID),
+					resource.TestCheckResourceAttr(name, "name", rnd),
+					resource.TestCheckResourceAttr(name, "destinations.#", "2"),
+					resource.TestCheckResourceAttr(name, "destinations.0.type", "worker"),
+					// worker_id is the Worker's server-assigned immutable id, so
+					// assert it is set rather than to a known value.
+					resource.TestCheckResourceAttrSet(name, "destinations.0.worker_id"),
+					resource.TestCheckResourceAttr(name, "destinations.1.type", "preview_worker"),
+					resource.TestCheckResourceAttrSet(name, "destinations.1.worker_id"),
+					// Both destinations point at the same Worker.
+					resource.TestCheckResourceAttrPair(name, "destinations.0.worker_id", name, "destinations.1.worker_id"),
+				),
+			},
+			{
+				// Ensures no diff on last plan
+				Config:   testAccessApplicationWithWorkerDestinations(rnd, accountID),
 				PlanOnly: true,
 			},
 		},
@@ -1725,8 +1781,16 @@ func testAccessApplicationWithInvalidPrivateDestination(resourceID, accountID st
 	return acctest.LoadTestCase("accessapplicationconfiginvalidprivatedestination.tf", resourceID, accountID)
 }
 
+func testAccessApplicationWithInvalidWorkerDestination(resourceID, accountID string) string {
+	return acctest.LoadTestCase("accessapplicationconfiginvalidworkerdestination.tf", resourceID, accountID)
+}
+
 func testAccessApplicationWithDestinations(rnd string, domain string, identifier *cloudflare.ResourceContainer) string {
 	return acctest.LoadTestCase("accessapplicationconfigwithdestinations.tf", rnd, domain, identifier.Type, identifier.Identifier)
+}
+
+func testAccessApplicationWithWorkerDestinations(rnd, accountID string) string {
+	return acctest.LoadTestCase("accessapplicationconfigwithworkerdestinations.tf", rnd, accountID)
 }
 
 func testAccessApplicationMisconfiguredCORSAllowAllOriginsWithCredentials(resourceID, zone, zoneID string) string {

--- a/internal/services/zero_trust_access_application/schema.go
+++ b/internal/services/zero_trust_access_application/schema.go
@@ -550,12 +550,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
-							Description: `Available values: "public", "private".`,
+							Description: `Available values: "public", "private", "via_mcp_server_portal", "worker", "preview_worker", "all_workers", "all_preview_workers".`,
 							Optional:    true,
 							Computed:    true,
 							Default:     stringdefault.StaticString("public"),
 							Validators: []validator.String{
-								stringvalidator.OneOfCaseInsensitive("public", "private", "via_mcp_server_portal"),
+								stringvalidator.OneOfCaseInsensitive("public", "private", "via_mcp_server_portal", "worker", "preview_worker", "all_workers", "all_preview_workers"),
 							},
 						},
 						"uri": schema.StringAttribute{
@@ -608,6 +608,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								customvalidator.RequiresOtherStringAttributeToBeOneOf(path.MatchRelative().AtParent().AtName("type"), "via_mcp_server_portal"),
 								customvalidator.RequiredWhenOtherStringIsOneOf(path.MatchRelative().AtParent().AtName("type"), "via_mcp_server_portal"),
 								customvalidator.RequiresOtherStringAttributeToBeOneOf(path.MatchRoot("type"), "mcp"),
+							},
+						},
+						"worker_id": schema.StringAttribute{
+							Description: "The ID of the Cloudflare Worker to protect with Access. Required when type is `worker` or `preview_worker`.",
+							Optional:    true,
+							Validators: []validator.String{
+								customvalidator.RequiresOtherStringAttributeToBeOneOf(path.MatchRelative().AtParent().AtName("type"), "worker", "preview_worker"),
+								customvalidator.RequiredWhenOtherStringIsOneOf(path.MatchRelative().AtParent().AtName("type"), "worker", "preview_worker"),
 							},
 						},
 					},

--- a/internal/services/zero_trust_access_application/testdata/accessapplicationconfiginvalidworkerdestination.tf
+++ b/internal/services/zero_trust_access_application/testdata/accessapplicationconfiginvalidworkerdestination.tf
@@ -1,0 +1,13 @@
+resource "cloudflare_zero_trust_access_application" "%[1]s" {
+  account_id                = "%[2]s"
+  name                      = "%[1]s"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+  destinations = [
+    {
+      "type" : "private",
+      "worker_id" : "abc123"
+    }
+  ]
+}

--- a/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwithworkerdestinations.tf
+++ b/internal/services/zero_trust_access_application/testdata/accessapplicationconfigwithworkerdestinations.tf
@@ -1,0 +1,30 @@
+resource "cloudflare_worker" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "%[1]s"
+
+  subdomain = {
+    enabled          = true
+    previews_enabled = true
+  }
+}
+
+resource "cloudflare_zero_trust_access_application" "%[1]s" {
+  account_id                = "%[2]s"
+  name                      = "%[1]s"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+
+  # The Access `worker_id` is the Worker's immutable id, which the newer
+  # `cloudflare_worker` resource exposes directly as its `id`.
+  destinations = [
+    {
+      type      = "worker"
+      worker_id = cloudflare_worker.%[1]s.id
+    },
+    {
+      type      = "preview_worker"
+      worker_id = cloudflare_worker.%[1]s.id
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

Access apps have been opted out of auto-generation, so we have to write updates by hand.

## Changes being requested
Adds support for the new worker, preview_worker, all_workers, all_preview_workers destination types for Access.

## Acceptance test run results

- [X] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
