### PR TITLE
feat(queue_consumer): add import support

### DIFF
--- a/docs/resources/queue_consumer.md
+++ b/docs/resources/queue_consumer.md
@@ -69,5 +69,8 @@ Optional:
 
 ## Import
 
+Import is supported using the following syntax:
 
-~> This resource does not currently support `terraform import`.
+```shell
+$ terraform import cloudflare_queue_consumer.example '<account_id>/<queue_id>/<consumer_id>'
+```

--- a/examples/resources/cloudflare_queue_consumer/import.sh
+++ b/examples/resources/cloudflare_queue_consumer/import.sh
@@ -1,0 +1,1 @@
+$ terraform import cloudflare_queue_consumer.example '<account_id>/<queue_id>/<consumer_id>'

--- a/internal/services/queue_consumer/resource.go
+++ b/internal/services/queue_consumer/resource.go
@@ -12,13 +12,16 @@ import (
 	"github.com/cloudflare/cloudflare-go/v7/option"
 	"github.com/cloudflare/cloudflare-go/v7/queues"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.ResourceWithConfigure = (*QueueConsumerResource)(nil)
 var _ resource.ResourceWithModifyPlan = (*QueueConsumerResource)(nil)
+var _ resource.ResourceWithImportState = (*QueueConsumerResource)(nil)
 
 func NewResource() resource.Resource {
 	return &QueueConsumerResource{}
@@ -207,6 +210,56 @@ func (r *QueueConsumerResource) Delete(ctx context.Context, req resource.DeleteR
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *QueueConsumerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	var data = new(QueueConsumerModel)
+
+	path_account_id := ""
+	path_queue_id := ""
+	path_consumer_id := ""
+	diags := importpath.ParseImportID(
+		req.ID,
+		"<account_id>/<queue_id>/<consumer_id>",
+		&path_account_id,
+		&path_queue_id,
+		&path_consumer_id,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.AccountID = types.StringValue(path_account_id)
+	data.QueueID = types.StringValue(path_queue_id)
+	data.ConsumerID = types.StringValue(path_consumer_id)
+
+	res := new(http.Response)
+	env := QueueConsumerResultEnvelope{*data}
+	_, err := r.client.Queues.Consumers.Get(
+		ctx,
+		path_queue_id,
+		path_consumer_id,
+		queues.ConsumerGetParams{
+			AccountID: cloudflare.F(path_account_id),
+		},
+		option.WithResponseBodyInto(&res),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to make http request", err.Error())
+		return
+	}
+	bytes, _ := io.ReadAll(res.Body)
+	err = apijson.Unmarshal(bytes, &env)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
+		return
+	}
+	data = &env.Result
+	FixInconsistentCRUDResponses(ctx, data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/services/queue_consumer/resource.go
+++ b/internal/services/queue_consumer/resource.go
@@ -236,29 +236,27 @@ func (r *QueueConsumerResource) ImportState(ctx context.Context, req resource.Im
 	data.QueueID = types.StringValue(path_queue_id)
 	data.ConsumerID = types.StringValue(path_consumer_id)
 
-	res := new(http.Response)
-	env := QueueConsumerResultEnvelope{*data}
-	_, err := r.client.Queues.Consumers.Get(
+	consumer, err := r.client.Queues.Consumers.Get(
 		ctx,
 		path_queue_id,
 		path_consumer_id,
 		queues.ConsumerGetParams{
 			AccountID: cloudflare.F(path_account_id),
 		},
-		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to make http request", err.Error())
 		return
 	}
-	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	err = apijson.UnmarshalRoot([]byte(consumer.JSON.RawJSON()), data)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
 	}
-	data = &env.Result
+	if consumer.DeadLetterQueue != "" {
+		data.DeadLetterQueue = types.StringValue(consumer.DeadLetterQueue)
+	}
 	FixInconsistentCRUDResponses(ctx, data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/services/queue_consumer/resource_test.go
+++ b/internal/services/queue_consumer/resource_test.go
@@ -121,6 +121,13 @@ func TestAccCloudflareQueueConsumer_Worker_UpdateDeadLetterQueue(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dead_letter_queue"), knownvalue.StringExact(dlq2)),
 				},
 			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "consumer_id",
+				ImportStateIdFunc:                    testAccCloudflareQueueConsumerImportStateIDFunc(resourceName, accountID),
+			},
 		},
 	})
 }
@@ -283,16 +290,7 @@ func TestAccCloudflareQueueConsumer_Worker(t *testing.T) {
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "consumer_id",
-				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					rs, ok := s.RootModule().Resources[resourceName]
-					if !ok {
-						return "", fmt.Errorf("queue consumer resource not found: %s", resourceName)
-					}
-
-					queueID := rs.Primary.Attributes["queue_id"]
-					consumerID := rs.Primary.Attributes["consumer_id"]
-					return fmt.Sprintf("%s/%s/%s", accountID, queueID, consumerID), nil
-				},
+				ImportStateIdFunc:                    testAccCloudflareQueueConsumerImportStateIDFunc(resourceName, accountID),
 			},
 		},
 	})
@@ -489,6 +487,19 @@ func testAccCheckCloudflareQueueConsumerDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCloudflareQueueConsumerImportStateIDFunc(resourceName, accountID string) func(*terraform.State) (string, error) {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("queue consumer resource not found: %s", resourceName)
+		}
+
+		queueID := rs.Primary.Attributes["queue_id"]
+		consumerID := rs.Primary.Attributes["consumer_id"]
+		return fmt.Sprintf("%s/%s/%s", accountID, queueID, consumerID), nil
+	}
 }
 
 func testAccCheckCloudflareQueueConsumerWorker(rnd, accountID, queueName string) string {

--- a/internal/services/queue_consumer/resource_test.go
+++ b/internal/services/queue_consumer/resource_test.go
@@ -279,9 +279,10 @@ func TestAccCloudflareQueueConsumer_Worker(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "consumer_id",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					rs, ok := s.RootModule().Resources[resourceName]
 					if !ok {

--- a/internal/services/queue_consumer/resource_test.go
+++ b/internal/services/queue_consumer/resource_test.go
@@ -278,6 +278,21 @@ func TestAccCloudflareQueueConsumer_Worker(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("created_on"), knownvalue.NotNull()),
 				},
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("queue consumer resource not found: %s", resourceName)
+					}
+
+					queueID := rs.Primary.Attributes["queue_id"]
+					consumerID := rs.Primary.Attributes["consumer_id"]
+					return fmt.Sprintf("%s/%s/%s", accountID, queueID, consumerID), nil
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Add import support for `cloudflare_queue_consumer`.
- Use `<account_id>/<queue_id>/<consumer_id>` as the import identifier.
- Fetch and normalize the queue consumer before writing imported state.
- Preserve a configured `dead_letter_queue` during import.
- Add acceptance coverage and update the import example and generated documentation.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

Set `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`. Then run:

```shell
TF_ACC=1 go test -v \
  ./internal/services/queue_consumer \
  -run '^TestAccCloudflareQueueConsumer_Worker$' \
  -count=1 \
  -timeout=30m

TF_ACC=1 go test -v \
  ./internal/services/queue_consumer \
  -run '^TestAccCloudflareQueueConsumer_Worker_UpdateDeadLetterQueue$' \
  -count=1 \
  -timeout=30m
```

### Test output
<!-- Please paste the output of your acceptance test run below -->

```text
=== RUN   TestAccCloudflareQueueConsumer_Worker
=== PAUSE TestAccCloudflareQueueConsumer_Worker
=== CONT  TestAccCloudflareQueueConsumer_Worker
--- PASS: TestAccCloudflareQueueConsumer_Worker (5.22s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/queue_consumer	6.800s

=== RUN   TestAccCloudflareQueueConsumer_Worker_UpdateDeadLetterQueue
=== PAUSE TestAccCloudflareQueueConsumer_Worker_UpdateDeadLetterQueue
=== CONT  TestAccCloudflareQueueConsumer_Worker_UpdateDeadLetterQueue
--- PASS: TestAccCloudflareQueueConsumer_Worker_UpdateDeadLetterQueue (9.88s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal/services/queue_consumer	11.534s
```

## Additional context & links
