### PR TITLE
fix(turnstile_widget): preserve domains order to prevent perpetual drift

### DIFF
--- a/internal/services/turnstile_widget/custom.go
+++ b/internal/services/turnstile_widget/custom.go
@@ -1,0 +1,122 @@
+// This file is not generated. It is maintained by hand.
+
+package turnstile_widget
+
+import (
+	"sort"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// The Turnstile API returns a widget's domains sorted alphabetically,
+// regardless of the order they were submitted in. The Terraform resource
+// models `domains` as an ordered ListAttribute (not a SetAttribute), so
+// order matters for diff detection.
+//
+// As a result, a config that lists domains in any order other than ascending
+// alphabetical produces a perpetual diff on every plan/apply (the planned
+// order never matches the server's alphabetical order). See GitHub #7028.
+//
+// UnmarshalCustom / UnmarshalComputedCustom wrap the standard apijson
+// unmarshal and reorder the domains returned by the API back into the order
+// the user planned (captured from the envelope before unmarshal). When there
+// is no prior order to align to (e.g. import), domains fall back to a
+// canonical alphabetical sort, which matches the server's own ordering and
+// is therefore stable.
+
+// UnmarshalCustom unmarshals an API response into env, then reorders domains
+// to match the order already present in env.Result.Domains (the prior
+// state/plan).
+func UnmarshalCustom(data []byte, env *TurnstileWidgetResultEnvelope) error {
+	snap := snapshotDomainOrder(env.Result.Domains)
+	if err := apijson.Unmarshal(data, env); err != nil {
+		return err
+	}
+	reorderDomainsFromSnapshot(env.Result.Domains, snap)
+	return nil
+}
+
+// UnmarshalComputedCustom is like UnmarshalCustom but uses
+// apijson.UnmarshalComputed, for the create/update paths where computed
+// fields are populated from the response.
+func UnmarshalComputedCustom(data []byte, env *TurnstileWidgetResultEnvelope) error {
+	snap := snapshotDomainOrder(env.Result.Domains)
+	if err := apijson.UnmarshalComputed(data, env); err != nil {
+		return err
+	}
+	reorderDomainsFromSnapshot(env.Result.Domains, snap)
+	return nil
+}
+
+// domainOrderSnapshot captures the prior ordering of domains as plain strings.
+type domainOrderSnapshot struct {
+	values []string
+}
+
+// snapshotDomainOrder records the current domain order. Returns nil when
+// there are no prior domains to align to.
+func snapshotDomainOrder(domains *[]types.String) *domainOrderSnapshot {
+	if domains == nil || len(*domains) == 0 {
+		return nil
+	}
+	snap := &domainOrderSnapshot{
+		values: make([]string, len(*domains)),
+	}
+	for i, d := range *domains {
+		snap.values[i] = d.ValueString()
+	}
+	return snap
+}
+
+// reorderDomainsFromSnapshot reorders domains to match the prior snapshot.
+// When snap is nil (no prior order), it applies a canonical alphabetical
+// sort matching the server's own ordering so the result is deterministic.
+func reorderDomainsFromSnapshot(domains *[]types.String, snap *domainOrderSnapshot) {
+	if domains == nil || len(*domains) == 0 {
+		return
+	}
+
+	if snap == nil {
+		sortDomainsAlphabetically(domains)
+		return
+	}
+
+	// domain string -> desired position from prior order
+	priorIndex := make(map[string]int, len(snap.values))
+	for i, v := range snap.values {
+		// First occurrence wins; duplicate domains are unexpected.
+		if _, ok := priorIndex[v]; !ok {
+			priorIndex[v] = i
+		}
+	}
+
+	ds := *domains
+	sort.SliceStable(ds, func(i, j int) bool {
+		vi := ds[i].ValueString()
+		vj := ds[j].ValueString()
+		posI, okI := priorIndex[vi]
+		posJ, okJ := priorIndex[vj]
+
+		switch {
+		case okI && okJ:
+			return posI < posJ
+		case okI:
+			return true // matched (known) domains before unmatched
+		case okJ:
+			return false
+		default:
+			// Both unmatched: canonical alphabetical order.
+			return vi < vj
+		}
+	})
+}
+
+// sortDomainsAlphabetically applies a canonical, deterministic alphabetical
+// sort matching the server's own ordering.
+func sortDomainsAlphabetically(domains *[]types.String) {
+	ds := *domains
+	sort.SliceStable(ds, func(i, j int) bool {
+		return ds[i].ValueString() < ds[j].ValueString()
+	})
+}

--- a/internal/services/turnstile_widget/custom_test.go
+++ b/internal/services/turnstile_widget/custom_test.go
@@ -1,0 +1,162 @@
+package turnstile_widget
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func domain(s string) types.String {
+	return types.StringValue(s)
+}
+
+func domainSlice(ss ...string) *[]types.String {
+	ds := make([]types.String, len(ss))
+	for i, s := range ss {
+		ds[i] = types.StringValue(s)
+	}
+	return &ds
+}
+
+func domainStrings(domains *[]types.String) []string {
+	out := make([]string, 0, len(*domains))
+	for _, d := range *domains {
+		out = append(out, d.ValueString())
+	}
+	return out
+}
+
+func stringsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestReorderDomainsMatchesPlannedOrder is the core regression test: the API
+// returns domains sorted alphabetically, but they must be reordered back to
+// the order the user planned so Terraform sees no diff.
+func TestReorderDomainsMatchesPlannedOrder(t *testing.T) {
+	// User planned non-alphabetical order.
+	planned := domainSlice("zebra.example.com", "alpha.example.com", "middle.example.com")
+	snap := snapshotDomainOrder(planned)
+
+	// API returns alphabetical order.
+	apiResp := domainSlice("alpha.example.com", "middle.example.com", "zebra.example.com")
+	reorderDomainsFromSnapshot(apiResp, snap)
+
+	want := []string{"zebra.example.com", "alpha.example.com", "middle.example.com"}
+	if got := domainStrings(apiResp); !stringsEqual(got, want) {
+		t.Fatalf("reordered domains = %v, want %v", got, want)
+	}
+}
+
+// TestReorderDomainsNoSnapshotCanonicalSort verifies that with no prior order
+// (e.g. import), domains fall back to a deterministic alphabetical sort.
+func TestReorderDomainsNoSnapshotCanonicalSort(t *testing.T) {
+	apiResp := domainSlice("zebra.example.com", "alpha.example.com", "middle.example.com")
+	reorderDomainsFromSnapshot(apiResp, nil)
+
+	want := []string{"alpha.example.com", "middle.example.com", "zebra.example.com"}
+	if got := domainStrings(apiResp); !stringsEqual(got, want) {
+		t.Fatalf("canonical sort = %v, want %v", got, want)
+	}
+}
+
+// TestReorderDomainsAddedDomainSortsAfterMatched verifies that a domain
+// present in the API response but absent from the prior plan is placed after
+// the matched domains, in alphabetical order.
+func TestReorderDomainsAddedDomainSortsAfterMatched(t *testing.T) {
+	planned := domainSlice("zebra.example.com", "alpha.example.com")
+	snap := snapshotDomainOrder(planned)
+
+	apiResp := domainSlice("alpha.example.com", "new.example.com", "zebra.example.com")
+	reorderDomainsFromSnapshot(apiResp, snap)
+
+	want := []string{"zebra.example.com", "alpha.example.com", "new.example.com"}
+	if got := domainStrings(apiResp); !stringsEqual(got, want) {
+		t.Fatalf("reordered domains = %v, want %v", got, want)
+	}
+}
+
+// TestReorderDomainsRemovedDomainHandled verifies that a domain present in
+// the prior plan but absent from the API response does not cause issues.
+func TestReorderDomainsRemovedDomainHandled(t *testing.T) {
+	planned := domainSlice("zebra.example.com", "alpha.example.com", "removed.example.com")
+	snap := snapshotDomainOrder(planned)
+
+	apiResp := domainSlice("alpha.example.com", "zebra.example.com")
+	reorderDomainsFromSnapshot(apiResp, snap)
+
+	want := []string{"zebra.example.com", "alpha.example.com"}
+	if got := domainStrings(apiResp); !stringsEqual(got, want) {
+		t.Fatalf("reordered domains = %v, want %v", got, want)
+	}
+}
+
+// TestReorderDomainsEmptySlice verifies that nil and empty slices are handled
+// without panics.
+func TestReorderDomainsEmptySlice(t *testing.T) {
+	// nil domains
+	reorderDomainsFromSnapshot(nil, nil)
+
+	// empty domains
+	empty := domainSlice()
+	reorderDomainsFromSnapshot(empty, nil)
+
+	if len(*empty) != 0 {
+		t.Fatalf("expected empty slice, got %v", domainStrings(empty))
+	}
+}
+
+// TestReorderDomainsSingleDomain verifies the trivial single-domain case.
+func TestReorderDomainsSingleDomain(t *testing.T) {
+	planned := domainSlice("example.com")
+	snap := snapshotDomainOrder(planned)
+
+	apiResp := domainSlice("example.com")
+	reorderDomainsFromSnapshot(apiResp, snap)
+
+	want := []string{"example.com"}
+	if got := domainStrings(apiResp); !stringsEqual(got, want) {
+		t.Fatalf("reordered domains = %v, want %v", got, want)
+	}
+}
+
+// TestReorderDomainsNumericSortIssue reproduces the exact scenario from
+// GitHub #7028: staging-10 sorts between staging-1 and staging-2
+// alphabetically, but the user wants numeric order.
+func TestReorderDomainsNumericSortIssue(t *testing.T) {
+	// User planned numeric-friendly order.
+	planned := domainSlice(
+		"staging-1.example.com",
+		"staging-2.example.com",
+		"staging-10.example.com",
+		"staging-11.example.com",
+	)
+	snap := snapshotDomainOrder(planned)
+
+	// API returns alphabetical order (10 sorts between 1 and 2).
+	apiResp := domainSlice(
+		"staging-1.example.com",
+		"staging-10.example.com",
+		"staging-11.example.com",
+		"staging-2.example.com",
+	)
+	reorderDomainsFromSnapshot(apiResp, snap)
+
+	want := []string{
+		"staging-1.example.com",
+		"staging-2.example.com",
+		"staging-10.example.com",
+		"staging-11.example.com",
+	}
+	if got := domainStrings(apiResp); !stringsEqual(got, want) {
+		t.Fatalf("reordered domains = %v, want %v", got, want)
+	}
+}

--- a/internal/services/turnstile_widget/resource.go
+++ b/internal/services/turnstile_widget/resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cloudflare/cloudflare-go/v7"
 	"github.com/cloudflare/cloudflare-go/v7/option"
 	"github.com/cloudflare/cloudflare-go/v7/turnstile"
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/importpath"
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -85,7 +84,7 @@ func (r *TurnstileWidgetResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.UnmarshalComputed(bytes, &env)
+	err = UnmarshalComputedCustom(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
@@ -135,7 +134,7 @@ func (r *TurnstileWidgetResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.UnmarshalComputed(bytes, &env)
+	err = UnmarshalComputedCustom(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
@@ -176,7 +175,7 @@ func (r *TurnstileWidgetResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	err = UnmarshalCustom(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return
@@ -248,7 +247,7 @@ func (r *TurnstileWidgetResource) ImportState(ctx context.Context, req resource.
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &env)
+	err = UnmarshalCustom(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return

--- a/internal/services/turnstile_widget/resource_test.go
+++ b/internal/services/turnstile_widget/resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestMain(m *testing.M) {
@@ -228,6 +229,52 @@ func TestAccCloudflareTurnstileWidget_NonInteractiveMode(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccCloudflareTurnstileWidget_DomainsOrderNoDrift verifies that a widget
+// whose domains are declared in a non-alphabetical order does NOT produce drift
+// on a no-op re-apply. The Turnstile API canonically returns domains sorted
+// alphabetically; without reordering the API response back to the planned
+// order, Terraform sees the reordered list as a change on every plan
+// (GitHub #7028).
+func TestAccCloudflareTurnstileWidget_DomainsOrderNoDrift(t *testing.T) {
+	t.Parallel()
+	rnd := utils.GenerateRandomResourceName()
+	name := "cloudflare_turnstile_widget." + rnd
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create a widget with domains in non-alphabetical order.
+				Config: testAccCheckCloudflareTurnstileWidgetConfigDomainsOrder(rnd, accountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "domains.#", "3"),
+					// Planned (non-alphabetical) order must be preserved in state.
+					resource.TestCheckResourceAttr(name, "domains.0", "zebra.example.com"),
+					resource.TestCheckResourceAttr(name, "domains.1", "alpha.example.com"),
+					resource.TestCheckResourceAttr(name, "domains.2", "middle.example.com"),
+				),
+			},
+			{
+				// Step 2: re-apply identical config. Must be a no-op. Without
+				// the response reordering, this would plan an in-place update
+				// because the API returns domains sorted alphabetically.
+				Config: testAccCheckCloudflareTurnstileWidgetConfigDomainsOrder(rnd, accountID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(name, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareTurnstileWidgetConfigDomainsOrder(rnd, accountID string) string {
+	return acctest.LoadTestCase("turnstilewidgetconfigdomainsorder.tf", rnd, accountID)
 }
 
 func testAccCheckCloudflareTurnstileWidgetBasic(rnd, accountID string) string {

--- a/internal/services/turnstile_widget/testdata/turnstilewidgetconfigdomainsorder.tf
+++ b/internal/services/turnstile_widget/testdata/turnstilewidgetconfigdomainsorder.tf
@@ -1,0 +1,16 @@
+
+resource "cloudflare_turnstile_widget" "%[1]s" {
+  account_id = "%[2]s"
+  name       = "my-tf-widget-order-%[1]s"
+  mode       = "managed"
+
+  # Domains deliberately listed in non-alphabetical order. The API
+  # canonically returns them sorted alphabetically, so without the
+  # response-reordering fix this config produces a perpetual diff
+  # (GitHub #7028).
+  domains = [
+    "zebra.example.com",
+    "alpha.example.com",
+    "middle.example.com",
+  ]
+}


### PR DESCRIPTION
## Summary

The Turnstile API returns a widget's `domains` array sorted alphabetically, regardless of the order submitted. The Terraform schema models `domains` as a `ListAttribute` (ordered), so any non-alphabetical declaration produces a perpetual diff on every plan/apply.

This is the same class of bug as the `load_balancer_pool` origins ordering issue fixed in aad09cc.

## Changes

- **`custom.go`** (new): `UnmarshalCustom` / `UnmarshalComputedCustom` wrappers that snapshot the planned domain order before unmarshal, then reorder the API response to match. Falls back to canonical alphabetical sort on import (no prior state).
- **`resource.go`**: Swap 4 `apijson.Unmarshal`/`apijson.UnmarshalComputed` call sites to use the custom wrappers (Create, Update, Read, ImportState).
- **`custom_test.go`** (new): 7 unit tests covering planned-order preservation, canonical fallback, added/removed domains, empty slices, single domain, and the exact numeric-sort scenario from the issue (`staging-10` between `staging-1` and `staging-2`).
- **`resource_test.go`**: Acceptance test `TestAccCloudflareTurnstileWidget_DomainsOrderNoDrift` -- creates a widget with non-alphabetical domains, then re-applies and asserts `ResourceActionNoop`.
- **`turnstilewidgetconfigdomainsorder.tf`** (new): Test fixture with deliberately non-alphabetical domain order.

## Testing

Unit tests:
```
=== RUN   TestReorderDomainsMatchesPlannedOrder        --- PASS
=== RUN   TestReorderDomainsNoSnapshotCanonicalSort    --- PASS
=== RUN   TestReorderDomainsAddedDomainSortsAfterMatched --- PASS
=== RUN   TestReorderDomainsRemovedDomainHandled       --- PASS
=== RUN   TestReorderDomainsEmptySlice                 --- PASS
=== RUN   TestReorderDomainsSingleDomain               --- PASS
=== RUN   TestReorderDomainsNumericSortIssue           --- PASS
```

Fixes #7028