### PR TITLE
fix(zero_trust_access_ai_controls_mcp_portal): remove no_refresh from server_id

### DIFF
--- a/internal/services/zero_trust_access_ai_controls_mcp_portal/model.go
+++ b/internal/services/zero_trust_access_ai_controls_mcp_portal/model.go
@@ -37,7 +37,7 @@ func (m ZeroTrustAccessAIControlsMcpPortalModel) MarshalJSONForUpdate(state Zero
 }
 
 type ZeroTrustAccessAIControlsMcpPortalServersModel struct {
-	ServerID        types.String                                                     `tfsdk:"server_id" json:"server_id,required,no_refresh"`
+	ServerID        types.String                                                     `tfsdk:"server_id" json:"server_id,required"`
 	DefaultDisabled types.Bool                                                       `tfsdk:"default_disabled" json:"default_disabled,computed_optional"`
 	OnBehalf        types.Bool                                                       `tfsdk:"on_behalf" json:"on_behalf,computed_optional"`
 	UpdatedPrompts  *[]*ZeroTrustAccessAIControlsMcpPortalServersUpdatedPromptsModel `tfsdk:"updated_prompts" json:"updated_prompts,optional"`


### PR DESCRIPTION
## Summary

Removes the `no_refresh` tag from `server_id` in `ZeroTrustAccessAIControlsMcpPortalServersModel`.

## Problem

`server_id` was tagged `no_refresh`, causing the decoder to skip it during refresh/import. With `server_id` blanked, portal members were compared only by their remaining four attributes (`default_disabled`, `on_behalf`, `updated_tools`, `updated_prompts`). Two servers with identical tool mirrors (e.g. two freshly registered servers with no per-tool overrides) produced duplicate set elements, resulting in:

```
unexpected error creating NestedObjectSet: This attribute contains duplicate values
```

## Fix

Remove `no_refresh` so `server_id` is read back from the API on every refresh, keeping members distinct.

## References

- Jira: MCP-319
- Related PR: #7226
- Related issues: #7271, #7296