### PR TITLE
fix(provider): send user_agent_operator_suffix unquoted and honor its env var

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -435,6 +435,8 @@ func (p *CloudflareProvider) Configure(ctx context.Context, req provider.Configu
 	if !data.UserAgentOperatorSuffix.IsNull() && !data.UserAgentOperatorSuffix.IsUnknown() {
 		operatorSuffix := data.UserAgentOperatorSuffix.ValueString()
 		userAgentParams.OperatorSuffix = &operatorSuffix
+	} else if o, ok := os.LookupEnv(consts.UserAgentOperatorSuffixEnvVarKey); ok {
+		userAgentParams.OperatorSuffix = &o
 	} else {
 		userAgentParams.TerraformVersion = &req.TerraformVersion
 	}

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -432,8 +432,8 @@ func (p *CloudflareProvider) Configure(ctx context.Context, req provider.Configu
 		PluginVersion:   pluginVersion,
 	}
 
-	if !data.UserAgentOperatorSuffix.IsNull() {
-		operatorSuffix := data.UserAgentOperatorSuffix.String()
+	if !data.UserAgentOperatorSuffix.IsNull() && !data.UserAgentOperatorSuffix.IsUnknown() {
+		operatorSuffix := data.UserAgentOperatorSuffix.ValueString()
 		userAgentParams.OperatorSuffix = &operatorSuffix
 	} else {
 		userAgentParams.TerraformVersion = &req.TerraformVersion

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -1,0 +1,138 @@
+package internal_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v7"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/consts"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+const testProviderVersion = "1.0"
+const testTerraformVersion = "1.9.0"
+
+// providerConfig builds a `tfsdk.Config` from the provider schema, with every
+// attribute null unless overridden in `attrs`.
+func providerConfig(t *testing.T, ctx context.Context, attrs map[string]tftypes.Value) tfsdk.Config {
+	t.Helper()
+
+	schema := internal.ProviderSchema(ctx)
+	objType, ok := schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatalf("provider schema type is %T, expected tftypes.Object", schema.Type().TerraformType(ctx))
+	}
+
+	values := map[string]tftypes.Value{}
+	for name, attrType := range objType.AttributeTypes {
+		if v, ok := attrs[name]; ok {
+			values[name] = v
+			continue
+		}
+		values[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	for name := range attrs {
+		if _, ok := objType.AttributeTypes[name]; !ok {
+			t.Fatalf("provider schema has no attribute %q", name)
+		}
+	}
+
+	return tfsdk.Config{Schema: schema, Raw: tftypes.NewValue(objType, values)}
+}
+
+// configureAndCaptureUserAgent configures the provider against a local test
+// server and returns the User-Agent header the resulting client sends.
+func configureAndCaptureUserAgent(t *testing.T, attrs map[string]tftypes.Value) string {
+	t.Helper()
+	ctx := context.Background()
+
+	var userAgent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"success":true,"errors":[],"messages":[],"result":[]}`))
+	}))
+	defer srv.Close()
+
+	if _, ok := attrs[consts.BaseURLSchemaKey]; !ok {
+		if attrs == nil {
+			attrs = map[string]tftypes.Value{}
+		}
+		attrs[consts.BaseURLSchemaKey] = tftypes.NewValue(tftypes.String, srv.URL)
+	}
+
+	resp := provider.ConfigureResponse{}
+	internal.NewProvider(testProviderVersion)().Configure(ctx, provider.ConfigureRequest{
+		TerraformVersion: testTerraformVersion,
+		Config:           providerConfig(t, ctx, attrs),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Configure failed: %v", resp.Diagnostics)
+	}
+
+	client, ok := resp.ResourceData.(*cloudflare.Client)
+	if !ok {
+		t.Fatalf("ResourceData is %T, expected *cloudflare.Client", resp.ResourceData)
+	}
+
+	// The response body is irrelevant; we only care about what went out on the
+	// wire, so any decoding error is ignored.
+	var out interface{}
+	_ = client.Get(ctx, "zones", nil, &out)
+
+	if userAgent == "" {
+		t.Fatal("no request reached the test server")
+	}
+	return userAgent
+}
+
+func TestProviderUserAgentOperatorSuffix(t *testing.T) {
+	suffixKey := consts.UserAgentOperatorSuffixSchemaKey
+
+	// The plugin framework version is resolved at runtime, so assert on the
+	// suffix rather than the full user agent.
+	tests := []struct {
+		name       string
+		attrs      map[string]tftypes.Value
+		expectTail string
+	}{
+		{
+			// Regression test: the suffix used to be formatted with
+			// `StringValue.String()`, which quotes the value.
+			name:       "configured suffix is sent verbatim",
+			attrs:      map[string]tftypes.Value{suffixKey: tftypes.NewValue(tftypes.String, "mycorp/1.0")},
+			expectTail: " mycorp/1.0",
+		},
+		{
+			// Regression test: `IsNull()` alone let unknown values through as
+			// the literal string `<unknown>`.
+			name:       "unknown suffix falls back to the Terraform version",
+			attrs:      map[string]tftypes.Value{suffixKey: tftypes.NewValue(tftypes.String, tftypes.UnknownValue)},
+			expectTail: " terraform/" + testTerraformVersion,
+		},
+		{
+			name:       "no suffix falls back to the Terraform version",
+			expectTail: " terraform/" + testTerraformVersion,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := configureAndCaptureUserAgent(t, tc.attrs)
+
+			if !strings.HasPrefix(got, "terraform-provider-cloudflare/"+testProviderVersion+" terraform-plugin-framework") {
+				t.Errorf("unexpected user agent prefix: %q", got)
+			}
+			if !strings.HasSuffix(got, tc.expectTail) {
+				t.Errorf("expected user agent %q to end with %q", got, tc.expectTail)
+			}
+		})
+	}
+}

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -93,6 +94,16 @@ func configureAndCaptureUserAgent(t *testing.T, attrs map[string]tftypes.Value) 
 	return userAgent
 }
 
+// unsetEnv removes a variable for the duration of the test. `t.Setenv` can only
+// set, and the caller's environment may already export CLOUDFLARE_* values.
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	if original, ok := os.LookupEnv(key); ok {
+		t.Cleanup(func() { os.Setenv(key, original) })
+		os.Unsetenv(key)
+	}
+}
+
 func TestProviderUserAgentOperatorSuffix(t *testing.T) {
 	suffixKey := consts.UserAgentOperatorSuffixSchemaKey
 
@@ -101,6 +112,7 @@ func TestProviderUserAgentOperatorSuffix(t *testing.T) {
 	tests := []struct {
 		name       string
 		attrs      map[string]tftypes.Value
+		env        *string
 		expectTail string
 	}{
 		{
@@ -118,6 +130,17 @@ func TestProviderUserAgentOperatorSuffix(t *testing.T) {
 			expectTail: " terraform/" + testTerraformVersion,
 		},
 		{
+			name:       "suffix can come from the environment",
+			env:        stringPtr("mycorp/1.0"),
+			expectTail: " mycorp/1.0",
+		},
+		{
+			name:       "configuration takes precedence over the environment",
+			attrs:      map[string]tftypes.Value{suffixKey: tftypes.NewValue(tftypes.String, "config/1.0")},
+			env:        stringPtr("env/1.0"),
+			expectTail: " config/1.0",
+		},
+		{
 			name:       "no suffix falls back to the Terraform version",
 			expectTail: " terraform/" + testTerraformVersion,
 		},
@@ -125,6 +148,12 @@ func TestProviderUserAgentOperatorSuffix(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.env != nil {
+				t.Setenv(consts.UserAgentOperatorSuffixEnvVarKey, *tc.env)
+			} else {
+				unsetEnv(t, consts.UserAgentOperatorSuffixEnvVarKey)
+			}
+
 			got := configureAndCaptureUserAgent(t, tc.attrs)
 
 			if !strings.HasPrefix(got, "terraform-provider-cloudflare/"+testProviderVersion+" terraform-plugin-framework") {
@@ -135,4 +164,8 @@ func TestProviderUserAgentOperatorSuffix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func stringPtr(s string) *string {
+	return &s
 }


### PR DESCRIPTION
Fixes #7323.

- [x] I understand that this repository is auto-generated and my pull request may not be merged

Filed as one PR with two distinct commits per @mgirouard's direction on the issue. Happy to move any of this into codegen upstream instead — the intent here is to make the expected output concrete.

## Changes being requested

**1. `fix(provider): send user_agent_operator_suffix unquoted`**

`Configure` formatted the suffix with `basetypes.StringValue.String()`, which is the human-readable debug representation, not the value. A configured suffix of `mycorp/1.0` reached the wire as `"mycorp/1.0"`, quotes included:

```
User-Agent: terraform-provider-cloudflare/5.23.0 terraform-plugin-framework/1.19.0 "mycorp/1.0"
```

The token therefore no longer matched what the operator configured, defeating the point of the feature added in #2831.

The same branch only guarded on `IsNull()`, which is false for an unknown value, so an unknown suffix was sent as the literal text `<unknown>`. Both are fixed by guarding on `IsUnknown()` as well and using `ValueString()` — the shape every other option in `Configure` already uses.

**2. `fix(provider): read user_agent_operator_suffix from the environment`**

The schema description promises the setting "can be configured using the `CLOUDFLARE_USER_AGENT_OPERATOR_SUFFIX` environment variable", but `Configure` never read it. Every other provider setting has an `os.LookupEnv` fallback; this adds the missing one in the same shape, so explicit configuration still wins over the environment.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes

No acceptance test — this is provider `Configure` behaviour, not a resource, so it is covered by a plain unit test instead. `internal/provider_test.go` is new (the repo has no provider-level test today): it builds a `tfsdk.Config` from the provider schema, points `base_url` at an `httptest` server, and asserts the exact `User-Agent` that reaches the wire. No credentials, no `TF_ACC`, no network — it runs in the normal sharded unit test job.

### Steps to run acceptance tests

```sh
go test ./internal/ -run TestProviderUserAgentOperatorSuffix -v
```

### Test output

```
=== RUN   TestProviderUserAgentOperatorSuffix
=== RUN   TestProviderUserAgentOperatorSuffix/configured_suffix_is_sent_verbatim
=== RUN   TestProviderUserAgentOperatorSuffix/unknown_suffix_falls_back_to_the_Terraform_version
=== RUN   TestProviderUserAgentOperatorSuffix/suffix_can_come_from_the_environment
=== RUN   TestProviderUserAgentOperatorSuffix/configuration_takes_precedence_over_the_environment
=== RUN   TestProviderUserAgentOperatorSuffix/no_suffix_falls_back_to_the_Terraform_version
--- PASS: TestProviderUserAgentOperatorSuffix (0.00s)
    --- PASS: TestProviderUserAgentOperatorSuffix/configured_suffix_is_sent_verbatim (0.00s)
    --- PASS: TestProviderUserAgentOperatorSuffix/unknown_suffix_falls_back_to_the_Terraform_version (0.00s)
    --- PASS: TestProviderUserAgentOperatorSuffix/suffix_can_come_from_the_environment (0.00s)
    --- PASS: TestProviderUserAgentOperatorSuffix/configuration_takes_precedence_over_the_environment (0.00s)
    --- PASS: TestProviderUserAgentOperatorSuffix/no_suffix_falls_back_to_the_Terraform_version (0.00s)
PASS
ok  	github.com/cloudflare/terraform-provider-cloudflare/internal	0.936s
```

The first three cases pass on commit 1 alone; the two environment cases arrive with commit 2. Each commit is green on its own.

## Additional context & links

- Issue: #7323
- Feature this restores: #2831

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184GUxExLR6iaL6wqdwdsQB
