### PR TITLE
fix(zero_trust_organization): rename `mfa_ssh_piv_key_requirements`

### DIFF
--- a/docs/data-sources/zero_trust_organization.md
+++ b/docs/data-sources/zero_trust_organization.md
@@ -42,8 +42,8 @@ data "cloudflare_zero_trust_organization" "example_zero_trust_organization" {
 - `is_ui_read_only` (Boolean) Lock all settings as Read-Only in the Dashboard, regardless of user permission. Updates may only be made via the API or Terraform for this account when enabled.
 - `login_design` (Attributes) (see [below for nested schema](#nestedatt--login_design))
 - `mfa_config` (Attributes) Configures multi-factor authentication (MFA) settings for an organization. (see [below for nested schema](#nestedatt--mfa_config))
+- `mfa_piv_key_requirements` (Attributes) Configures PIV key requirements for MFA using hardware security keys. (see [below for nested schema](#nestedatt--mfa_piv_key_requirements))
 - `mfa_required_for_all_apps` (Boolean) Determines whether global MFA settings apply to applications by default. The organization must have MFA enabled with at least one authentication method and a session duration configured. Note: 'allowed_authenticators' cannot contain only the infrastructure SSH authenticators ('piv_key' and 'ssh_fido2_key') if the organization has any non-infrastructure applications.
-- `mfa_ssh_piv_key_requirements` (Attributes) Configures SSH PIV key requirements for MFA using hardware security keys. (see [below for nested schema](#nestedatt--mfa_ssh_piv_key_requirements))
 - `name` (String) The name of your Zero Trust organization.
 - `session_duration` (String) The amount of time that tokens issued for applications will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h.
 - `ui_read_only_toggle_reason` (String) A description of the reason why the UI read only field is being toggled.
@@ -83,14 +83,14 @@ Read-Only:
 - `session_duration` (String) Defines the duration of an MFA session. Must be in minutes (m) or hours (h). Minimum: 0m. Maximum: 720h (30 days). Examples:`5m` or `24h`.
 
 
-<a id="nestedatt--mfa_ssh_piv_key_requirements"></a>
-### Nested Schema for `mfa_ssh_piv_key_requirements`
+<a id="nestedatt--mfa_piv_key_requirements"></a>
+### Nested Schema for `mfa_piv_key_requirements`
 
 Read-Only:
 
 - `pin_policy` (String) Defines when a PIN is required to use the SSH key. Valid values: `never` (no PIN required), `once` (PIN required once per session), `always` (PIN required for each use).
 Available values: "never", "once", "always".
-- `require_fips_device` (Boolean) Requires the SSH PIV key to be stored on a FIPS 140-2 Level 1 or higher validated device.
+- `require_fips_device` (Boolean) Requires the PIV key to be stored on a FIPS 140-2 Level 1 or higher validated device.
 - `ssh_key_size` (List of Number) Specifies the allowed SSH key sizes in bits. Valid sizes depend on key type. Ed25519 has a fixed key size and does not accept this parameter.
 - `ssh_key_type` (List of String) Specifies the allowed SSH key types. Valid values are `ecdsa`, `ed25519`, and `rsa`.
 - `touch_policy` (String) Defines when physical touch is required to use the SSH key. Valid values: `never` (no touch required), `always` (touch required for each use), `cached` (touch cached for 15 seconds).

--- a/docs/resources/zero_trust_organization.md
+++ b/docs/resources/zero_trust_organization.md
@@ -42,14 +42,14 @@ resource "cloudflare_zero_trust_organization" "example_zero_trust_organization" 
     required_aaguids = "2fc0579f-8113-47ea-b116-bb5a8db9202a"
     session_duration = "24h"
   }
-  mfa_required_for_all_apps = false
-  mfa_ssh_piv_key_requirements = {
+  mfa_piv_key_requirements = {
     pin_policy = "always"
     require_fips_device = true
     ssh_key_size = [256, 2048]
     ssh_key_type = ["ecdsa", "rsa"]
     touch_policy = "always"
   }
+  mfa_required_for_all_apps = false
   name = "Widget Corps Internal Applications"
   session_duration = "24h"
   ui_read_only_toggle_reason = "Temporarily turn off the UI read only lock to make a change via the UI"
@@ -75,8 +75,8 @@ resource "cloudflare_zero_trust_organization" "example_zero_trust_organization" 
 - `login_design` (Attributes) (see [below for nested schema](#nestedatt--login_design))
 - `mfa_config` (Attributes) Configures multi-factor authentication (MFA) settings for an organization. (see [below for nested schema](#nestedatt--mfa_config))
 - `mfa_configuration_allowed` (Boolean) Indicates if this organization can enforce multi-factor authentication (MFA) requirements at the application and policy level.
+- `mfa_piv_key_requirements` (Attributes) Configures PIV key requirements for MFA using hardware security keys. (see [below for nested schema](#nestedatt--mfa_piv_key_requirements))
 - `mfa_required_for_all_apps` (Boolean) Determines whether global MFA settings apply to applications by default. The organization must have MFA enabled with at least one authentication method and a session duration configured. Note: 'allowed_authenticators' cannot contain only the infrastructure SSH authenticators ('piv_key' and 'ssh_fido2_key') if the organization has any non-infrastructure applications.
-- `mfa_ssh_piv_key_requirements` (Attributes) Configures SSH PIV key requirements for MFA using hardware security keys. (see [below for nested schema](#nestedatt--mfa_ssh_piv_key_requirements))
 - `name` (String) The name of your Zero Trust organization.
 - `session_duration` (String) The amount of time that tokens issued for applications will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h.
 - `ui_read_only_toggle_reason` (String) A description of the reason why the UI read only field is being toggled.
@@ -117,14 +117,14 @@ Optional:
 - `session_duration` (String) Defines the duration of an MFA session. Must be in minutes (m) or hours (h). Minimum: 0m. Maximum: 720h (30 days). Examples:`5m` or `24h`.
 
 
-<a id="nestedatt--mfa_ssh_piv_key_requirements"></a>
-### Nested Schema for `mfa_ssh_piv_key_requirements`
+<a id="nestedatt--mfa_piv_key_requirements"></a>
+### Nested Schema for `mfa_piv_key_requirements`
 
 Optional:
 
 - `pin_policy` (String) Defines when a PIN is required to use the SSH key. Valid values: `never` (no PIN required), `once` (PIN required once per session), `always` (PIN required for each use).
 Available values: "never", "once", "always".
-- `require_fips_device` (Boolean) Requires the SSH PIV key to be stored on a FIPS 140-2 Level 1 or higher validated device.
+- `require_fips_device` (Boolean) Requires the PIV key to be stored on a FIPS 140-2 Level 1 or higher validated device.
 - `ssh_key_size` (List of Number) Specifies the allowed SSH key sizes in bits. Valid sizes depend on key type. Ed25519 has a fixed key size and does not accept this parameter.
 - `ssh_key_type` (List of String) Specifies the allowed SSH key types. Valid values are `ecdsa`, `ed25519`, and `rsa`.
 - `touch_policy` (String) Defines when physical touch is required to use the SSH key. Valid values: `never` (no touch required), `always` (touch required for each use), `cached` (touch cached for 15 seconds).

--- a/examples/resources/cloudflare_zero_trust_organization/resource.tf
+++ b/examples/resources/cloudflare_zero_trust_organization/resource.tf
@@ -23,14 +23,14 @@ resource "cloudflare_zero_trust_organization" "example_zero_trust_organization" 
     required_aaguids = "2fc0579f-8113-47ea-b116-bb5a8db9202a"
     session_duration = "24h"
   }
-  mfa_required_for_all_apps = false
-  mfa_ssh_piv_key_requirements = {
+  mfa_piv_key_requirements = {
     pin_policy = "always"
     require_fips_device = true
     ssh_key_size = [256, 2048]
     ssh_key_type = ["ecdsa", "rsa"]
     touch_policy = "always"
   }
+  mfa_required_for_all_apps = false
   name = "Widget Corps Internal Applications"
   session_duration = "24h"
   ui_read_only_toggle_reason = "Temporarily turn off the UI read only lock to make a change via the UI"

--- a/internal/services/zero_trust_organization/data_source_model.go
+++ b/internal/services/zero_trust_organization/data_source_model.go
@@ -17,25 +17,25 @@ type ZeroTrustOrganizationResultDataSourceEnvelope struct {
 }
 
 type ZeroTrustOrganizationDataSourceModel struct {
-	AccountID                              types.String                                                                           `tfsdk:"account_id" path:"account_id,optional"`
-	ZoneID                                 types.String                                                                           `tfsdk:"zone_id" path:"zone_id,optional"`
-	AllowAuthenticateViaWARP               types.Bool                                                                             `tfsdk:"allow_authenticate_via_warp" json:"allow_authenticate_via_warp,computed"`
-	AuthDomain                             types.String                                                                           `tfsdk:"auth_domain" json:"auth_domain,computed"`
-	AutoRedirectToIdentity                 types.Bool                                                                             `tfsdk:"auto_redirect_to_identity" json:"auto_redirect_to_identity,computed"`
-	DenyUnmatchedRequests                  types.Bool                                                                             `tfsdk:"deny_unmatched_requests" json:"deny_unmatched_requests,computed"`
-	IsUIReadOnly                           types.Bool                                                                             `tfsdk:"is_ui_read_only" json:"is_ui_read_only,computed"`
-	MfaRequiredForAllApps                  types.Bool                                                                             `tfsdk:"mfa_required_for_all_apps" json:"mfa_required_for_all_apps,computed"`
-	Name                                   types.String                                                                           `tfsdk:"name" json:"name,computed"`
-	SessionDuration                        types.String                                                                           `tfsdk:"session_duration" json:"session_duration,computed"`
-	UIReadOnlyToggleReason                 types.String                                                                           `tfsdk:"ui_read_only_toggle_reason" json:"ui_read_only_toggle_reason,computed"`
-	UserSeatExpirationInactiveTime         types.String                                                                           `tfsdk:"user_seat_expiration_inactive_time" json:"user_seat_expiration_inactive_time,computed"`
-	WARPAuthSessionDuration                types.String                                                                           `tfsdk:"warp_auth_session_duration" json:"warp_auth_session_duration,computed"`
-	DenyUnmatchedRequestsExemptedZoneNames customfield.List[types.String]                                                         `tfsdk:"deny_unmatched_requests_exempted_zone_names" json:"deny_unmatched_requests_exempted_zone_names,computed"`
-	CustomPages                            customfield.NestedObject[ZeroTrustOrganizationCustomPagesDataSourceModel]              `tfsdk:"custom_pages" json:"custom_pages,computed"`
-	LoginDesign                            customfield.NestedObject[ZeroTrustOrganizationLoginDesignDataSourceModel]              `tfsdk:"login_design" json:"login_design,computed"`
-	MfaConfig                              customfield.NestedObject[ZeroTrustOrganizationMfaConfigDataSourceModel]                `tfsdk:"mfa_config" json:"mfa_config,computed"`
-	MfaSSHPivKeyRequirements               customfield.NestedObject[ZeroTrustOrganizationMfaSSHPivKeyRequirementsDataSourceModel] `tfsdk:"mfa_ssh_piv_key_requirements" json:"mfa_ssh_piv_key_requirements,computed"`
-	WarpAuthNonBrowser401                  types.Bool                                                                             `tfsdk:"warp_auth_non_browser_401" json:"warp_auth_non_browser_401,computed"`
+	AccountID                              types.String                                                                        `tfsdk:"account_id" path:"account_id,optional"`
+	ZoneID                                 types.String                                                                        `tfsdk:"zone_id" path:"zone_id,optional"`
+	AllowAuthenticateViaWARP               types.Bool                                                                          `tfsdk:"allow_authenticate_via_warp" json:"allow_authenticate_via_warp,computed"`
+	AuthDomain                             types.String                                                                        `tfsdk:"auth_domain" json:"auth_domain,computed"`
+	AutoRedirectToIdentity                 types.Bool                                                                          `tfsdk:"auto_redirect_to_identity" json:"auto_redirect_to_identity,computed"`
+	DenyUnmatchedRequests                  types.Bool                                                                          `tfsdk:"deny_unmatched_requests" json:"deny_unmatched_requests,computed"`
+	IsUIReadOnly                           types.Bool                                                                          `tfsdk:"is_ui_read_only" json:"is_ui_read_only,computed"`
+	MfaRequiredForAllApps                  types.Bool                                                                          `tfsdk:"mfa_required_for_all_apps" json:"mfa_required_for_all_apps,computed"`
+	Name                                   types.String                                                                        `tfsdk:"name" json:"name,computed"`
+	SessionDuration                        types.String                                                                        `tfsdk:"session_duration" json:"session_duration,computed"`
+	UIReadOnlyToggleReason                 types.String                                                                        `tfsdk:"ui_read_only_toggle_reason" json:"ui_read_only_toggle_reason,computed"`
+	UserSeatExpirationInactiveTime         types.String                                                                        `tfsdk:"user_seat_expiration_inactive_time" json:"user_seat_expiration_inactive_time,computed"`
+	WARPAuthSessionDuration                types.String                                                                        `tfsdk:"warp_auth_session_duration" json:"warp_auth_session_duration,computed"`
+	DenyUnmatchedRequestsExemptedZoneNames customfield.List[types.String]                                                      `tfsdk:"deny_unmatched_requests_exempted_zone_names" json:"deny_unmatched_requests_exempted_zone_names,computed"`
+	CustomPages                            customfield.NestedObject[ZeroTrustOrganizationCustomPagesDataSourceModel]           `tfsdk:"custom_pages" json:"custom_pages,computed"`
+	LoginDesign                            customfield.NestedObject[ZeroTrustOrganizationLoginDesignDataSourceModel]           `tfsdk:"login_design" json:"login_design,computed"`
+	MfaConfig                              customfield.NestedObject[ZeroTrustOrganizationMfaConfigDataSourceModel]             `tfsdk:"mfa_config" json:"mfa_config,computed"`
+	MfaPivKeyRequirements                  customfield.NestedObject[ZeroTrustOrganizationMfaPivKeyRequirementsDataSourceModel] `tfsdk:"mfa_piv_key_requirements" json:"mfa_piv_key_requirements,computed"`
+	WarpAuthNonBrowser401                  types.Bool                                                                          `tfsdk:"warp_auth_non_browser_401" json:"warp_auth_non_browser_401,computed"`
 }
 
 func (m *ZeroTrustOrganizationDataSourceModel) toReadParams(_ context.Context) (params zero_trust.OrganizationListParams, diags diag.Diagnostics) {
@@ -70,7 +70,7 @@ type ZeroTrustOrganizationMfaConfigDataSourceModel struct {
 	SessionDuration            types.String                   `tfsdk:"session_duration" json:"session_duration,computed"`
 }
 
-type ZeroTrustOrganizationMfaSSHPivKeyRequirementsDataSourceModel struct {
+type ZeroTrustOrganizationMfaPivKeyRequirementsDataSourceModel struct {
 	PinPolicy         types.String                   `tfsdk:"pin_policy" json:"pin_policy,computed"`
 	RequireFipsDevice types.Bool                     `tfsdk:"require_fips_device" json:"require_fips_device,computed"`
 	SSHKeySize        customfield.List[types.Int64]  `tfsdk:"ssh_key_size" json:"ssh_key_size,computed"`

--- a/internal/services/zero_trust_organization/data_source_schema.go
+++ b/internal/services/zero_trust_organization/data_source_schema.go
@@ -168,10 +168,10 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 			},
-			"mfa_ssh_piv_key_requirements": schema.SingleNestedAttribute{
-				Description: "Configures SSH PIV key requirements for MFA using hardware security keys.",
+			"mfa_piv_key_requirements": schema.SingleNestedAttribute{
+				Description: "Configures PIV key requirements for MFA using hardware security keys.",
 				Computed:    true,
-				CustomType:  customfield.NewNestedObjectType[ZeroTrustOrganizationMfaSSHPivKeyRequirementsDataSourceModel](ctx),
+				CustomType:  customfield.NewNestedObjectType[ZeroTrustOrganizationMfaPivKeyRequirementsDataSourceModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"pin_policy": schema.StringAttribute{
 						Description: "Defines when a PIN is required to use the SSH key. Valid values: `never` (no PIN required), `once` (PIN required once per session), `always` (PIN required for each use).\nAvailable values: \"never\", \"once\", \"always\".",
@@ -185,7 +185,7 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 						},
 					},
 					"require_fips_device": schema.BoolAttribute{
-						Description: "Requires the SSH PIV key to be stored on a FIPS 140-2 Level 1 or higher validated device.",
+						Description: "Requires the PIV key to be stored on a FIPS 140-2 Level 1 or higher validated device.",
 						Computed:    true,
 					},
 					"ssh_key_size": schema.ListAttribute{

--- a/internal/services/zero_trust_organization/migration/v500/model.go
+++ b/internal/services/zero_trust_organization/migration/v500/model.go
@@ -51,26 +51,26 @@ type SourceCustomPagesModel struct {
 // This corresponds to schema_version=500 in the current provider.
 // Must match zero_trust_organization.ZeroTrustOrganizationModel structure for core fields.
 type TargetZeroTrustOrganizationModel struct {
-	AccountID                              types.String            `tfsdk:"account_id"`
-	ZoneID                                 types.String            `tfsdk:"zone_id"`
-	AuthDomain                             types.String            `tfsdk:"auth_domain"`
-	DenyUnmatchedRequests                  types.Bool              `tfsdk:"deny_unmatched_requests"`
-	Name                                   types.String            `tfsdk:"name"`
-	SessionDuration                        types.String            `tfsdk:"session_duration"`
-	UserSeatExpirationInactiveTime         types.String            `tfsdk:"user_seat_expiration_inactive_time"`
-	WARPAuthSessionDuration                types.String            `tfsdk:"warp_auth_session_duration"`
-	DenyUnmatchedRequestsExemptedZoneNames *[]types.String         `tfsdk:"deny_unmatched_requests_exempted_zone_names"`
-	CustomPages                            *TargetCustomPagesModel `tfsdk:"custom_pages"`
-	LoginDesign                            *TargetLoginDesignModel `tfsdk:"login_design"`
-	MfaConfig                              *TargetMfaConfigModel                `tfsdk:"mfa_config"`
-	MfaSSHPivKeyRequirements               *TargetMfaSSHPivKeyRequirementsModel `tfsdk:"mfa_ssh_piv_key_requirements"`
-	AllowAuthenticateViaWARP               types.Bool              `tfsdk:"allow_authenticate_via_warp"`
-	AutoRedirectToIdentity                 types.Bool              `tfsdk:"auto_redirect_to_identity"`
-	IsUIReadOnly                           types.Bool              `tfsdk:"is_ui_read_only"`
-	MfaConfigurationAllowed                types.Bool              `tfsdk:"mfa_configuration_allowed"`
-	MfaRequiredForAllApps                  types.Bool              `tfsdk:"mfa_required_for_all_apps"`
-	UIReadOnlyToggleReason                 types.String            `tfsdk:"ui_read_only_toggle_reason"`
-	WarpAuthNonBrowser401                  types.Bool              `tfsdk:"warp_auth_non_browser_401"`
+	AccountID                              types.String                      `tfsdk:"account_id"`
+	ZoneID                                 types.String                      `tfsdk:"zone_id"`
+	AuthDomain                             types.String                      `tfsdk:"auth_domain"`
+	DenyUnmatchedRequests                  types.Bool                        `tfsdk:"deny_unmatched_requests"`
+	Name                                   types.String                      `tfsdk:"name"`
+	SessionDuration                        types.String                      `tfsdk:"session_duration"`
+	UserSeatExpirationInactiveTime         types.String                      `tfsdk:"user_seat_expiration_inactive_time"`
+	WARPAuthSessionDuration                types.String                      `tfsdk:"warp_auth_session_duration"`
+	DenyUnmatchedRequestsExemptedZoneNames *[]types.String                   `tfsdk:"deny_unmatched_requests_exempted_zone_names"`
+	CustomPages                            *TargetCustomPagesModel           `tfsdk:"custom_pages"`
+	LoginDesign                            *TargetLoginDesignModel           `tfsdk:"login_design"`
+	MfaConfig                              *TargetMfaConfigModel             `tfsdk:"mfa_config"`
+	MfaPivKeyRequirements                  *TargetMfaPivKeyRequirementsModel `tfsdk:"mfa_piv_key_requirements"`
+	AllowAuthenticateViaWARP               types.Bool                        `tfsdk:"allow_authenticate_via_warp"`
+	AutoRedirectToIdentity                 types.Bool                        `tfsdk:"auto_redirect_to_identity"`
+	IsUIReadOnly                           types.Bool                        `tfsdk:"is_ui_read_only"`
+	MfaConfigurationAllowed                types.Bool                        `tfsdk:"mfa_configuration_allowed"`
+	MfaRequiredForAllApps                  types.Bool                        `tfsdk:"mfa_required_for_all_apps"`
+	UIReadOnlyToggleReason                 types.String                      `tfsdk:"ui_read_only_toggle_reason"`
+	WarpAuthNonBrowser401                  types.Bool                        `tfsdk:"warp_auth_non_browser_401"`
 }
 
 // TargetCustomPagesModel represents the custom_pages nested structure in v5.
@@ -99,8 +99,8 @@ type TargetMfaConfigModel struct {
 	SessionDuration            types.String    `tfsdk:"session_duration"`
 }
 
-// TargetMfaSSHPivKeyRequirementsModel represents the mfa_ssh_piv_key_requirements nested structure in v5.
-type TargetMfaSSHPivKeyRequirementsModel struct {
+// TargetMfaPivKeyRequirementsModel represents the mfa_piv_key_requirements nested structure in v5.
+type TargetMfaPivKeyRequirementsModel struct {
 	PinPolicy         types.String    `tfsdk:"pin_policy"`
 	RequireFipsDevice types.Bool      `tfsdk:"require_fips_device"`
 	SSHKeySize        *[]types.Int64  `tfsdk:"ssh_key_size"`

--- a/internal/services/zero_trust_organization/model.go
+++ b/internal/services/zero_trust_organization/model.go
@@ -12,26 +12,26 @@ type ZeroTrustOrganizationResultEnvelope struct {
 }
 
 type ZeroTrustOrganizationModel struct {
-	AccountID                              types.String                                        `tfsdk:"account_id" path:"account_id,optional"`
-	ZoneID                                 types.String                                        `tfsdk:"zone_id" path:"zone_id,optional"`
-	AuthDomain                             types.String                                        `tfsdk:"auth_domain" json:"auth_domain,optional"`
-	DenyUnmatchedRequests                  types.Bool                                          `tfsdk:"deny_unmatched_requests" json:"deny_unmatched_requests,optional"`
-	Name                                   types.String                                        `tfsdk:"name" json:"name,optional"`
-	SessionDuration                        types.String                                        `tfsdk:"session_duration" json:"session_duration,optional"`
-	UserSeatExpirationInactiveTime         types.String                                        `tfsdk:"user_seat_expiration_inactive_time" json:"user_seat_expiration_inactive_time,optional"`
-	WARPAuthSessionDuration                types.String                                        `tfsdk:"warp_auth_session_duration" json:"warp_auth_session_duration,optional"`
-	DenyUnmatchedRequestsExemptedZoneNames *[]types.String                                     `tfsdk:"deny_unmatched_requests_exempted_zone_names" json:"deny_unmatched_requests_exempted_zone_names,optional"`
-	CustomPages                            *ZeroTrustOrganizationCustomPagesModel              `tfsdk:"custom_pages" json:"custom_pages,optional"`
-	LoginDesign                            *ZeroTrustOrganizationLoginDesignModel              `tfsdk:"login_design" json:"login_design,optional"`
-	MfaConfig                              *ZeroTrustOrganizationMfaConfigModel                `tfsdk:"mfa_config" json:"mfa_config,optional"`
-	MfaSSHPivKeyRequirements               *ZeroTrustOrganizationMfaSSHPivKeyRequirementsModel `tfsdk:"mfa_ssh_piv_key_requirements" json:"mfa_ssh_piv_key_requirements,optional"`
-	AllowAuthenticateViaWARP               types.Bool                                          `tfsdk:"allow_authenticate_via_warp" json:"allow_authenticate_via_warp,computed_optional"`
-	AutoRedirectToIdentity                 types.Bool                                          `tfsdk:"auto_redirect_to_identity" json:"auto_redirect_to_identity,computed_optional"`
-	IsUIReadOnly                           types.Bool                                          `tfsdk:"is_ui_read_only" json:"is_ui_read_only,computed_optional"`
-	MfaConfigurationAllowed                types.Bool                                          `tfsdk:"mfa_configuration_allowed" json:"mfa_configuration_allowed,computed_optional"`
-	MfaRequiredForAllApps                  types.Bool                                          `tfsdk:"mfa_required_for_all_apps" json:"mfa_required_for_all_apps,computed_optional"`
-	UIReadOnlyToggleReason                 types.String                                        `tfsdk:"ui_read_only_toggle_reason" json:"ui_read_only_toggle_reason,computed_optional"`
-	WarpAuthNonBrowser401                  types.Bool                                          `tfsdk:"warp_auth_non_browser_401" json:"warp_auth_non_browser_401,computed_optional"`
+	AccountID                              types.String                                     `tfsdk:"account_id" path:"account_id,optional"`
+	ZoneID                                 types.String                                     `tfsdk:"zone_id" path:"zone_id,optional"`
+	AuthDomain                             types.String                                     `tfsdk:"auth_domain" json:"auth_domain,optional"`
+	DenyUnmatchedRequests                  types.Bool                                       `tfsdk:"deny_unmatched_requests" json:"deny_unmatched_requests,optional"`
+	Name                                   types.String                                     `tfsdk:"name" json:"name,optional"`
+	SessionDuration                        types.String                                     `tfsdk:"session_duration" json:"session_duration,optional"`
+	UserSeatExpirationInactiveTime         types.String                                     `tfsdk:"user_seat_expiration_inactive_time" json:"user_seat_expiration_inactive_time,optional"`
+	WARPAuthSessionDuration                types.String                                     `tfsdk:"warp_auth_session_duration" json:"warp_auth_session_duration,optional"`
+	DenyUnmatchedRequestsExemptedZoneNames *[]types.String                                  `tfsdk:"deny_unmatched_requests_exempted_zone_names" json:"deny_unmatched_requests_exempted_zone_names,optional"`
+	CustomPages                            *ZeroTrustOrganizationCustomPagesModel           `tfsdk:"custom_pages" json:"custom_pages,optional"`
+	LoginDesign                            *ZeroTrustOrganizationLoginDesignModel           `tfsdk:"login_design" json:"login_design,optional"`
+	MfaConfig                              *ZeroTrustOrganizationMfaConfigModel             `tfsdk:"mfa_config" json:"mfa_config,optional"`
+	MfaPivKeyRequirements                  *ZeroTrustOrganizationMfaPivKeyRequirementsModel `tfsdk:"mfa_piv_key_requirements" json:"mfa_piv_key_requirements,optional"`
+	AllowAuthenticateViaWARP               types.Bool                                       `tfsdk:"allow_authenticate_via_warp" json:"allow_authenticate_via_warp,computed_optional"`
+	AutoRedirectToIdentity                 types.Bool                                       `tfsdk:"auto_redirect_to_identity" json:"auto_redirect_to_identity,computed_optional"`
+	IsUIReadOnly                           types.Bool                                       `tfsdk:"is_ui_read_only" json:"is_ui_read_only,computed_optional"`
+	MfaConfigurationAllowed                types.Bool                                       `tfsdk:"mfa_configuration_allowed" json:"mfa_configuration_allowed,computed_optional"`
+	MfaRequiredForAllApps                  types.Bool                                       `tfsdk:"mfa_required_for_all_apps" json:"mfa_required_for_all_apps,computed_optional"`
+	UIReadOnlyToggleReason                 types.String                                     `tfsdk:"ui_read_only_toggle_reason" json:"ui_read_only_toggle_reason,computed_optional"`
+	WarpAuthNonBrowser401                  types.Bool                                       `tfsdk:"warp_auth_non_browser_401" json:"warp_auth_non_browser_401,computed_optional"`
 }
 
 func (m ZeroTrustOrganizationModel) MarshalJSON() (data []byte, err error) {
@@ -62,7 +62,7 @@ type ZeroTrustOrganizationMfaConfigModel struct {
 	SessionDuration            types.String    `tfsdk:"session_duration" json:"session_duration,optional"`
 }
 
-type ZeroTrustOrganizationMfaSSHPivKeyRequirementsModel struct {
+type ZeroTrustOrganizationMfaPivKeyRequirementsModel struct {
 	PinPolicy         types.String    `tfsdk:"pin_policy" json:"pin_policy,optional"`
 	RequireFipsDevice types.Bool      `tfsdk:"require_fips_device" json:"require_fips_device,optional"`
 	SSHKeySize        *[]types.Int64  `tfsdk:"ssh_key_size" json:"ssh_key_size,optional"`

--- a/internal/services/zero_trust_organization/model_test.go
+++ b/internal/services/zero_trust_organization/model_test.go
@@ -1,0 +1,121 @@
+package zero_trust_organization_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/apijson"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/zero_trust_organization"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	apiFieldName   = "mfa_piv_key_requirements"
+	staleFieldName = "mfa_ssh_piv_key_requirements"
+)
+
+func pivRequirements() *zero_trust_organization.ZeroTrustOrganizationMfaPivKeyRequirementsModel {
+	keyTypes := []types.String{types.StringValue("ecdsa")}
+	keySizes := []types.Int64{types.Int64Value(256)}
+	return &zero_trust_organization.ZeroTrustOrganizationMfaPivKeyRequirementsModel{
+		PinPolicy:         types.StringValue("once"),
+		RequireFipsDevice: types.BoolValue(true),
+		SSHKeySize:        &keySizes,
+		SSHKeyType:        &keyTypes,
+		TouchPolicy:       types.StringValue("always"),
+	}
+}
+
+func assertPivKey(t *testing.T, raw []byte) {
+	t.Helper()
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("body is not valid JSON: %v\nbody: %s", err, raw)
+	}
+	if _, ok := body[staleFieldName]; ok {
+		t.Errorf("body contains stale field %q, which the API ignores", staleFieldName)
+	}
+	if _, ok := body[apiFieldName]; !ok {
+		t.Errorf("body is missing %q; the endpoint is a full-replace PUT, so omitting it clears the live value", apiFieldName)
+	}
+}
+
+// Create path.
+func TestMarshalJSONSendsPivKeyRequirements(t *testing.T) {
+	t.Parallel()
+
+	model := zero_trust_organization.ZeroTrustOrganizationModel{
+		Name:                  types.StringValue("Example"),
+		AuthDomain:            types.StringValue("example.cloudflareaccess.com"),
+		MfaPivKeyRequirements: pivRequirements(),
+	}
+
+	raw, err := model.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	assertPivKey(t, raw)
+}
+
+// Update path: changing an unrelated field must still send the PIV block.
+func TestMarshalJSONForUpdateSendsPivKeyRequirements(t *testing.T) {
+	t.Parallel()
+
+	state := zero_trust_organization.ZeroTrustOrganizationModel{
+		Name:                  types.StringValue("Example"),
+		AuthDomain:            types.StringValue("example.cloudflareaccess.com"),
+		MfaPivKeyRequirements: pivRequirements(),
+	}
+	plan := state
+	plan.Name = types.StringValue("Example Renamed")
+
+	raw, err := plan.MarshalJSONForUpdate(state)
+	if err != nil {
+		t.Fatalf("MarshalJSONForUpdate: %v", err)
+	}
+	assertPivKey(t, raw)
+}
+
+// Read path: a wrong tag leaves the attribute null and every plan shows a diff.
+func TestUnmarshalPopulatesPivKeyRequirements(t *testing.T) {
+	t.Parallel()
+
+	const apiResponse = `{
+	  "result": {
+	    "name": "Example",
+	    "auth_domain": "example.cloudflareaccess.com",
+	    "mfa_piv_key_requirements": {
+	      "pin_policy": "once",
+	      "require_fips_device": true,
+	      "ssh_key_size": [256],
+	      "ssh_key_type": ["ecdsa"],
+	      "touch_policy": "always"
+	    }
+	  }
+	}`
+
+	var env zero_trust_organization.ZeroTrustOrganizationResultEnvelope
+	if err := apijson.Unmarshal([]byte(apiResponse), &env); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	got := env.Result.MfaPivKeyRequirements
+	if got == nil {
+		t.Fatalf("%s was not decoded from the API response", apiFieldName)
+	}
+	if got.PinPolicy.ValueString() != "once" {
+		t.Errorf("pin_policy = %q, want %q", got.PinPolicy.ValueString(), "once")
+	}
+	if got.TouchPolicy.ValueString() != "always" {
+		t.Errorf("touch_policy = %q, want %q", got.TouchPolicy.ValueString(), "always")
+	}
+	if !got.RequireFipsDevice.ValueBool() {
+		t.Error("require_fips_device = false, want true")
+	}
+	if got.SSHKeyType == nil || len(*got.SSHKeyType) != 1 || (*got.SSHKeyType)[0].ValueString() != "ecdsa" {
+		t.Errorf("ssh_key_type = %v, want [ecdsa]", got.SSHKeyType)
+	}
+	if got.SSHKeySize == nil || len(*got.SSHKeySize) != 1 || (*got.SSHKeySize)[0].ValueInt64() != 256 {
+		t.Errorf("ssh_key_size = %v, want [256]", got.SSHKeySize)
+	}
+}

--- a/internal/services/zero_trust_organization/normalizations.go
+++ b/internal/services/zero_trust_organization/normalizations.go
@@ -31,7 +31,10 @@ func normalizeFalseAndNullBool(data *basetypes.BoolValue, stateData basetypes.Bo
 	*data = stateData
 }
 
-func normalizeEmptyAndNullList(data **[]types.String, stateData *[]types.String) {
+// normalizeEmptyAndNullList laxes the equality between a null list and an empty
+// list. It is generic over the element type so it can be used for both
+// []types.String and []types.Int64 attributes.
+func normalizeEmptyAndNullList[T any](data **[]T, stateData *[]T) {
 	if (data != nil && *data != nil && len(**data) > 0) || (stateData != nil && len(*stateData) > 0) {
 		return
 	}
@@ -66,6 +69,14 @@ func normalizeReadZeroTrustOrganizationAPIData(_ context.Context, data, sourceDa
 	normalizeEmptyAndNullObject(&data.LoginDesign, sourceData.LoginDesign)
 	normalizeEmptyAndNullList(&data.DenyUnmatchedRequestsExemptedZoneNames, sourceData.DenyUnmatchedRequestsExemptedZoneNames)
 	normalizeEmptyAndNullString(&data.UIReadOnlyToggleReason, sourceData.UIReadOnlyToggleReason)
+
+	// The API serializes mfa_piv_key_requirements.ssh_key_type and .ssh_key_size with
+	// `omitempty`, so an explicitly configured empty list round-trips as an absent field
+	// and decodes back as null. Lax that equality to avoid a perpetual diff.
+	if data.MfaPivKeyRequirements != nil && sourceData.MfaPivKeyRequirements != nil {
+		normalizeEmptyAndNullList(&data.MfaPivKeyRequirements.SSHKeyType, sourceData.MfaPivKeyRequirements.SSHKeyType)
+		normalizeEmptyAndNullList(&data.MfaPivKeyRequirements.SSHKeySize, sourceData.MfaPivKeyRequirements.SSHKeySize)
+	}
 
 	return diags
 }

--- a/internal/services/zero_trust_organization/schema.go
+++ b/internal/services/zero_trust_organization/schema.go
@@ -142,8 +142,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 			},
-			"mfa_ssh_piv_key_requirements": schema.SingleNestedAttribute{
-				Description: "Configures SSH PIV key requirements for MFA using hardware security keys.",
+			"mfa_piv_key_requirements": schema.SingleNestedAttribute{
+				Description: "Configures PIV key requirements for MFA using hardware security keys.",
 				Optional:    true,
 				Attributes: map[string]schema.Attribute{
 					"pin_policy": schema.StringAttribute{
@@ -158,7 +158,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 					},
 					"require_fips_device": schema.BoolAttribute{
-						Description: "Requires the SSH PIV key to be stored on a FIPS 140-2 Level 1 or higher validated device.",
+						Description: "Requires the PIV key to be stored on a FIPS 140-2 Level 1 or higher validated device.",
 						Optional:    true,
 					},
 					"ssh_key_size": schema.ListAttribute{


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes broken read/write of PIV requirements on `cloudflare_zero_trust_organization`.

### Problem

The provider serialized the attribute as `mfa_ssh_piv_key_requirements`. But the API field is `mfa_piv_key_requirements` (recently renamed).

This caused a phantom diff, so `Read` never populated state. And caused a silent wipe, effectively making `zero_trust_organization` resource unmanageable from Terraform. This is because the real key was never sent, live PIV requirements were cleared on *any* apply touching the org.

### Root cause

Not spec lag. Stainless generated the correct name in https://github.com/cloudflare/terraform-provider-cloudflare/commits/bf0f9274f. 

But https://github.com/cloudflare/terraform-provider-cloudflare/commits/09a916f5b reverted it while restoring unrelated hand-written code in the same files.

### Changes

- Renamed the attribute, Go fields, and types to `mfa_piv_key_requirements` in `model.go`, `schema.go`, `data_source_model.go`, `data_source_schema.go`.
- Renamed the target model in `migration/v500/model.go` (not generated; required or the parity test fails and `MoveState` panics).
- `normalizations.go`: made `normalizeEmptyAndNullList` generic and applied it to `ssh_key_type` / `ssh_key_size`. The API serializes both with `omitempty`, so a configured empty list round-trips as absent and decodes to null.
- Added `model_test.go` (unit tests) pinning the wire format on the Create, Update, and Read paths.
- Updated docs and the example.

### Note on existing behavior

If PIV requirements are set out-of-band and *not* declared in config, the full-replace `PUT` still clears them. That is standard `Optional` semantics and matches `mfa_config` and `login_design` in this resource. Declare the block to manage the value.

## Acceptance test run results

- [X] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
<!-- Please describe the steps you took to run the acceptance tests -->

### Test output
<!-- Please paste the output of your acceptance test run below --> 

## Additional context & links
