### PR TITLE
add UseStateForUnknown to policy_id in zero_trust_device_default_profile

### DIFF
--- a/internal/services/zero_trust_device_default_profile/resource_test.go
+++ b/internal/services/zero_trust_device_default_profile/resource_test.go
@@ -421,3 +421,42 @@ func testAccCloudflareZeroTrustDeviceDefaultProfileWithOptionals(accountID, rnd 
 func testAccCloudflareZeroTrustDeviceDefaultProfileWithoutOptionals(accountID, rnd string) string {
 	return acctest.LoadTestCase("devicedefaultprofilewithoutoptionals.tf", rnd, accountID)
 }
+
+func TestAccCloudflareZeroTrustDeviceDefaultProfile_PolicyIdStability(t *testing.T) {
+	rnd := utils.GenerateRandomResourceName()
+	resourceName := fmt.Sprintf("cloudflare_zero_trust_device_default_profile.%s", rnd)
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck_AccountID(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and verify policy_id is computed
+			{
+				Config: testAccCloudflareZeroTrustDeviceDefaultProfileBasic(accountID, rnd),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policy_id"), knownvalue.NotNull()),
+				},
+			},
+			// Update and verify policy_id remains stable (UseStateForUnknown behavior)
+			{
+				Config: testAccCloudflareZeroTrustDeviceDefaultProfileUpdated(accountID, rnd),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						// Verify policy_id is known in the plan (not "known after apply")
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("policy_id"), knownvalue.NotNull()),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policy_id"), knownvalue.NotNull()),
+				},
+			},
+			// Verify no plan changes after apply
+			{
+				Config:   testAccCloudflareZeroTrustDeviceDefaultProfileUpdated(accountID, rnd),
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/internal/services/zero_trust_device_default_profile/schema.go
+++ b/internal/services/zero_trust_device_default_profile/schema.go
@@ -6,9 +6,9 @@ import (
 	"context"
 
 	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/schemata"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/cloudflare/terraform-provider-cloudflare/internal/schemata"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -239,7 +239,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"policy_id": schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"fallback_domains": schema.ListNestedAttribute{
 				Computed:      true,


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
add UseStateForUnknown to policy_id in zero_trust_device_default_profile

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests
TF_ACC=1 go test -v -run TestAccCloudflareZeroTrustDeviceDefaultProfile_PolicyIdStability ./internal/services/zero_trust_device_default_profile/

