### PR TITLE
feat: export the provider constructor for in-process embedding

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,0 +1,29 @@
+// Package provider exposes the Cloudflare Terraform provider implementation so
+// that it can be embedded in other Go programs.
+//
+// The implementation itself lives under internal/, which Go's import rules make
+// unreachable from outside this module. Tools that host the provider in-process
+// rather than running it as a plugin binary -- code generators, test harnesses,
+// and Crossplane providers built with upjet -- therefore have no way to obtain
+// it. This package is a thin, dependency-free re-export that closes that gap
+// without moving any of the implementation out of internal/.
+package provider
+
+import (
+	fwprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal"
+)
+
+// New returns a factory for the Cloudflare Terraform provider, in the shape
+// expected by providerserver.Serve. The version is reported to Terraform as the
+// provider version.
+func New(version string) func() fwprovider.Provider {
+	return internal.NewProvider(version)
+}
+
+// NewProvider returns the Cloudflare Terraform provider directly, for callers
+// that need the provider itself rather than a factory.
+func NewProvider(version string) fwprovider.Provider {
+	return internal.NewProvider(version)()
+}


### PR DESCRIPTION
## What

Adds `provider/provider.go`, a thin re-export of the constructor that `internal` already provides. No implementation moves out of `internal/`, and no existing file is touched.

## Why

The provider implementation lives entirely under `internal/`, which Go's import rules make unreachable from outside this module. Programs that host the provider in-process, rather than running it as a plugin binary, have no way to obtain it and today must either fork this repository or give up.

That affects code generators, test harnesses, and Crossplane providers built with [upjet](https://github.com/crossplane/upjet), which embed a provider's schema and plugin-framework server directly instead of shelling out to Terraform.

This is specific to v5+. The v4 provider exposed `cloudflare.Provider()` from an importable package, so embedding worked. Moving the implementation under `internal/` closed that off, and there is currently no supported alternative.

## API

```go
// factory, in the shape providerserver.Serve expects
func New(version string) func() fwprovider.Provider

// the provider directly, for callers that want it without the closure
func NewProvider(version string) fwprovider.Provider
```

Both delegate straight to `internal.NewProvider`.

## Tested

Builds and vets against `main`. Also verified against v5.15.0 and v5.24.0 to confirm it does not depend on any particular release's internals.

Beyond compiling, it is in production use. I used it to build a Crossplane provider that manages several domains and dozens of DNS records through GitOps, covering create, update, adopt and delete against the live Cloudflare API. The zone definitions and the Crossplane composition that consumes them are public:

https://github.com/activescott/home-infra-k8s-flux/tree/main/infrastructure/prod/dns

## Compatibility

Additive only. New package, no signature changes, nothing removed. The exported surface is two functions wrapping an existing internal one.
