### PR TITLE
feat(ruleset): add origin_range_requests to set_cache_settings action

### DIFF
--- a/docs/data-sources/ruleset.md
+++ b/docs/data-sources/ruleset.md
@@ -107,6 +107,7 @@ Available values: "set", "add", "remove".
 - `origin` (Attributes) An origin to route to. (see [below for nested schema](#nestedatt--rules--action_parameters--origin))
 - `origin_cache_control` (Boolean) Whether Cloudflare will aim to strictly adhere to RFC 7234.
 - `origin_error_page_passthru` (Boolean) Whether to generate Cloudflare error pages for issues from the origin server.
+- `origin_range_requests` (Attributes) Controls whether Cloudflare fetches a large asset from the origin as a series of range requests instead of one whole-body request. (see [below for nested schema](#nestedatt--rules--action_parameters--origin_range_requests))
 - `overrides` (Attributes) A set of overrides to apply to the target ruleset. (see [below for nested schema](#nestedatt--rules--action_parameters--overrides))
 - `phases` (List of String) A list of phases to skip the execution of. This option is incompatible with the rulesets option.
 Available values: "ddos_l4", "ddos_l7", "http_config_settings", "http_custom_errors", "http_log_custom_fields", "http_ratelimit", "http_request_cache_settings", "http_request_dynamic_redirect", "http_request_firewall_custom", "http_request_firewall_managed", "http_request_late_transform", "http_request_origin", "http_request_redirect", "http_request_sanitize", "http_request_sbfm", "http_request_transform", "http_response_cache_settings", "http_response_compression", "http_response_firewall_managed", "http_response_headers_transform", "magic_transit", "magic_transit_ids_managed", "magic_transit_managed", "magic_transit_ratelimit".
@@ -442,6 +443,15 @@ Read-Only:
 
 - `host` (String) A resolved host to route to.
 - `port` (Number) A destination port to route to.
+
+
+<a id="nestedatt--rules--action_parameters--origin_range_requests"></a>
+### Nested Schema for `rules.action_parameters.origin_range_requests`
+
+Read-Only:
+
+- `mode` (String) Whether to use range requests. `default` is the behaviour the zone gets without this rule.
+Available values: "on", "off", "default".
 
 
 <a id="nestedatt--rules--action_parameters--overrides"></a>

--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -125,6 +125,7 @@ Available values: "set", "add", "remove".
 - `origin` (Attributes) An origin to route to. (see [below for nested schema](#nestedatt--rules--action_parameters--origin))
 - `origin_cache_control` (Boolean) Whether Cloudflare will aim to strictly adhere to RFC 7234.
 - `origin_error_page_passthru` (Boolean) Whether to generate Cloudflare error pages for issues from the origin server.
+- `origin_range_requests` (Attributes) Controls whether Cloudflare fetches a large asset from the origin as a series of range requests instead of one whole-body request. (see [below for nested schema](#nestedatt--rules--action_parameters--origin_range_requests))
 - `overrides` (Attributes) A set of overrides to apply to the target ruleset. (see [below for nested schema](#nestedatt--rules--action_parameters--overrides))
 - `phases` (List of String) A list of phases to skip the execution of. This option is incompatible with the rulesets option.
 Available values: "ddos_l4", "ddos_l7", "http_config_settings", "http_custom_errors", "http_log_custom_fields", "http_ratelimit", "http_request_cache_settings", "http_request_dynamic_redirect", "http_request_firewall_custom", "http_request_firewall_managed", "http_request_late_transform", "http_request_origin", "http_request_redirect", "http_request_sanitize", "http_request_sbfm", "http_request_transform", "http_response_cache_settings", "http_response_compression", "http_response_firewall_managed", "http_response_headers_transform", "magic_transit", "magic_transit_ids_managed", "magic_transit_managed", "magic_transit_ratelimit".
@@ -499,6 +500,15 @@ Optional:
 
 - `host` (String) A resolved host to route to.
 - `port` (Number) A destination port to route to.
+
+
+<a id="nestedatt--rules--action_parameters--origin_range_requests"></a>
+### Nested Schema for `rules.action_parameters.origin_range_requests`
+
+Required:
+
+- `mode` (String) Whether to use range requests. `default` is the behaviour the zone gets without this rule.
+Available values: "on", "off", "default".
 
 
 <a id="nestedatt--rules--action_parameters--overrides"></a>

--- a/internal/services/ruleset/data_source_model.go
+++ b/internal/services/ruleset/data_source_model.go
@@ -113,6 +113,7 @@ type RulesetRulesActionParametersDataSourceModel struct {
 	ReadTimeout              types.Int64                                                                                       `tfsdk:"read_timeout" json:"read_timeout,computed"`
 	RespectStrongEtags       types.Bool                                                                                        `tfsdk:"respect_strong_etags" json:"respect_strong_etags,computed"`
 	ServeStale               customfield.NestedObject[RulesetRulesActionParametersServeStaleDataSourceModel]                   `tfsdk:"serve_stale" json:"serve_stale,computed"`
+	OriginRangeRequests      customfield.NestedObject[RulesetRulesActionParametersOriginRangeRequestsDataSourceModel]          `tfsdk:"origin_range_requests" json:"origin_range_requests,computed"`
 	StripETags               types.Bool                                                                                        `tfsdk:"strip_etags" json:"strip_etags,computed"`
 	StripLastModified        types.Bool                                                                                        `tfsdk:"strip_last_modified" json:"strip_last_modified,computed"`
 	StripSetCookie           types.Bool                                                                                        `tfsdk:"strip_set_cookie" json:"strip_set_cookie,computed"`
@@ -310,6 +311,10 @@ type RulesetRulesActionParametersEdgeTTLStatusCodeTTLStatusCodeRangeDataSourceMo
 
 type RulesetRulesActionParametersServeStaleDataSourceModel struct {
 	DisableStaleWhileUpdating types.Bool `tfsdk:"disable_stale_while_updating" json:"disable_stale_while_updating,computed"`
+}
+
+type RulesetRulesActionParametersOriginRangeRequestsDataSourceModel struct {
+	Mode types.String `tfsdk:"mode" json:"mode,computed"`
 }
 
 type RulesetRulesActionParametersCookieFieldsDataSourceModel struct {

--- a/internal/services/ruleset/data_source_schema.go
+++ b/internal/services/ruleset/data_source_schema.go
@@ -1531,6 +1531,26 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 										},
 									},
 								},
+								"origin_range_requests": schema.SingleNestedAttribute{
+									Description: "Controls whether Cloudflare fetches a large asset from the origin as a series of range requests instead of one whole-body request.",
+									Computed:    true,
+									Validators: []validator.Object{
+										customvalidator.RequiresOtherStringAttributeToBe(
+											path.MatchRelative().AtParent().AtParent().AtName("action"),
+											"set_cache_settings",
+										),
+									},
+									CustomType: customfield.NewNestedObjectType[RulesetRulesActionParametersOriginRangeRequestsDataSourceModel](ctx),
+									Attributes: map[string]schema.Attribute{
+										"mode": schema.StringAttribute{
+											Description: "Whether to use range requests. `default` is the behaviour the zone gets without this rule.\nAvailable values: \"on\", \"off\", \"default\".",
+											Computed:    true,
+											Validators: []validator.String{
+												stringvalidator.OneOf("on", "off", "default"),
+											},
+										},
+									},
+								},
 								"strip_etags": schema.BoolAttribute{
 									Description: "Whether to strip the ETag header from the response.",
 									Computed:    true,

--- a/internal/services/ruleset/migration/v500/model.go
+++ b/internal/services/ruleset/migration/v500/model.go
@@ -321,20 +321,21 @@ type TargetV5RuleModel struct {
 //   - map[string][]types.String for customfield.Map[customfield.List[types.String]] (MapAttribute)
 type TargetV5ActionParametersModel struct {
 	// Nested objects (MaxItems:1 blocks → SingleNestedAttribute)
-	Response     *TargetV5ResponseModel     `tfsdk:"response"`
-	Autominify   *TargetV5AutoMinifyModel   `tfsdk:"autominify"`
-	BrowserTTL   *TargetV5BrowserTTLModel   `tfsdk:"browser_ttl"`
-	CacheKey     *TargetV5CacheKeyModel     `tfsdk:"cache_key"`
-	CacheReserve *TargetV5CacheReserveModel `tfsdk:"cache_reserve"`
-	EdgeTTL      *TargetV5EdgeTTLModel      `tfsdk:"edge_ttl"`
-	FromList     *TargetV5FromListModel     `tfsdk:"from_list"`
-	FromValue    *TargetV5FromValueModel    `tfsdk:"from_value"`
-	MatchedData  *TargetV5MatchedDataModel  `tfsdk:"matched_data"`
-	Overrides    *TargetV5OverridesModel    `tfsdk:"overrides"`
-	Origin       *TargetV5OriginModel       `tfsdk:"origin"`
-	SNI          *TargetV5SNIModel          `tfsdk:"sni"`
-	ServeStale   *TargetV5ServeStaleModel   `tfsdk:"serve_stale"`
-	URI          *TargetV5URIModel          `tfsdk:"uri"`
+	Response            *TargetV5ResponseModel            `tfsdk:"response"`
+	Autominify          *TargetV5AutoMinifyModel          `tfsdk:"autominify"`
+	BrowserTTL          *TargetV5BrowserTTLModel          `tfsdk:"browser_ttl"`
+	CacheKey            *TargetV5CacheKeyModel            `tfsdk:"cache_key"`
+	CacheReserve        *TargetV5CacheReserveModel        `tfsdk:"cache_reserve"`
+	EdgeTTL             *TargetV5EdgeTTLModel             `tfsdk:"edge_ttl"`
+	FromList            *TargetV5FromListModel            `tfsdk:"from_list"`
+	FromValue           *TargetV5FromValueModel           `tfsdk:"from_value"`
+	MatchedData         *TargetV5MatchedDataModel         `tfsdk:"matched_data"`
+	Overrides           *TargetV5OverridesModel           `tfsdk:"overrides"`
+	Origin              *TargetV5OriginModel              `tfsdk:"origin"`
+	SNI                 *TargetV5SNIModel                 `tfsdk:"sni"`
+	ServeStale          *TargetV5ServeStaleModel          `tfsdk:"serve_stale"`
+	OriginRangeRequests *TargetV5OriginRangeRequestsModel `tfsdk:"origin_range_requests"`
+	URI                 *TargetV5URIModel                 `tfsdk:"uri"`
 
 	// Nested object lists
 	Algorithms               []*TargetV5AlgorithmModel        `tfsdk:"algorithms"`
@@ -585,6 +586,10 @@ type TargetV5TargetURLModel struct {
 
 type TargetV5ServeStaleModel struct {
 	DisableStaleWhileUpdating types.Bool `tfsdk:"disable_stale_while_updating"`
+}
+
+type TargetV5OriginRangeRequestsModel struct {
+	Mode types.String `tfsdk:"mode"`
 }
 
 // Cache control directive models for set_cache_settings action

--- a/internal/services/ruleset/model.go
+++ b/internal/services/ruleset/model.go
@@ -103,6 +103,7 @@ type RulesetRulesActionParametersModel struct {
 	ReadTimeout              types.Int64                                                                             `tfsdk:"read_timeout" json:"read_timeout,optional"`
 	RespectStrongEtags       types.Bool                                                                              `tfsdk:"respect_strong_etags" json:"respect_strong_etags,optional"`
 	ServeStale               customfield.NestedObject[RulesetRulesActionParametersServeStaleModel]                   `tfsdk:"serve_stale" json:"serve_stale,optional"`
+	OriginRangeRequests      customfield.NestedObject[RulesetRulesActionParametersOriginRangeRequestsModel]          `tfsdk:"origin_range_requests" json:"origin_range_requests,optional"`
 	StripETags               types.Bool                                                                              `tfsdk:"strip_etags" json:"strip_etags,optional"`
 	StripLastModified        types.Bool                                                                              `tfsdk:"strip_last_modified" json:"strip_last_modified,optional"`
 	StripSetCookie           types.Bool                                                                              `tfsdk:"strip_set_cookie" json:"strip_set_cookie,optional"`
@@ -299,6 +300,10 @@ type RulesetRulesActionParametersEdgeTTLStatusCodeTTLStatusCodeRangeModel struct
 
 type RulesetRulesActionParametersServeStaleModel struct {
 	DisableStaleWhileUpdating types.Bool `tfsdk:"disable_stale_while_updating" json:"disable_stale_while_updating,optional"`
+}
+
+type RulesetRulesActionParametersOriginRangeRequestsModel struct {
+	Mode types.String `tfsdk:"mode" json:"mode,required"`
 }
 
 type RulesetRulesActionParametersCookieFieldsModel struct {

--- a/internal/services/ruleset/ruleset_test.go
+++ b/internal/services/ruleset/ruleset_test.go
@@ -5505,6 +5505,9 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 										"serve_stale": knownvalue.ObjectExact(map[string]knownvalue.Check{
 											"disable_stale_while_updating": knownvalue.Bool(false),
 										}),
+										"origin_range_requests": knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"mode": knownvalue.StringExact("on"),
+										}),
 									}),
 								}),
 							}),
@@ -5583,6 +5586,9 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 									"serve_stale": knownvalue.ObjectExact(map[string]knownvalue.Check{
 										"disable_stale_while_updating": knownvalue.Bool(false),
 									}),
+									"origin_range_requests": knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"mode": knownvalue.StringExact("on"),
+									}),
 								}),
 							}),
 						}),
@@ -5657,6 +5663,9 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 									"respect_strong_etags":       knownvalue.Bool(true),
 									"serve_stale": knownvalue.ObjectExact(map[string]knownvalue.Check{
 										"disable_stale_while_updating": knownvalue.Bool(false),
+									}),
+									"origin_range_requests": knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"mode": knownvalue.StringExact("on"),
 									}),
 								}),
 							}),
@@ -5721,6 +5730,7 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 										"serve_stale": knownvalue.ObjectExact(map[string]knownvalue.Check{
 											"disable_stale_while_updating": knownvalue.Bool(true),
 										}),
+										"origin_range_requests": knownvalue.Null(),
 									}),
 								}),
 							}),
@@ -5776,6 +5786,7 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 									"serve_stale": knownvalue.ObjectExact(map[string]knownvalue.Check{
 										"disable_stale_while_updating": knownvalue.Bool(true),
 									}),
+									"origin_range_requests": knownvalue.Null(),
 								}),
 							}),
 						}),
@@ -5828,6 +5839,7 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 									"serve_stale": knownvalue.ObjectExact(map[string]knownvalue.Check{
 										"disable_stale_while_updating": knownvalue.Bool(true),
 									}),
+									"origin_range_requests": knownvalue.Null(),
 								}),
 							}),
 						}),
@@ -5910,6 +5922,13 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 								}),
 							}),
 						),
+						plancheck.ExpectKnownValue(
+							"cloudflare_ruleset.my_ruleset",
+							tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("action_parameters").AtMapKey("origin_range_requests"),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"mode": knownvalue.StringExact("default"),
+							}),
+						),
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -6045,6 +6064,20 @@ func TestAccCloudflareRuleset_SetCacheSettingsRules(t *testing.T) {
 									"serve_stale":                knownvalue.Null(),
 								}),
 							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"cloudflare_ruleset.my_ruleset",
+						tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("action_parameters").AtMapKey("origin_range_requests"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"mode": knownvalue.StringExact("default"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cloudflare_ruleset.my_ruleset",
+						tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("action_parameters").AtMapKey("origin_range_requests"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"mode": knownvalue.StringExact("default"),
 						}),
 					),
 				},

--- a/internal/services/ruleset/schema.go
+++ b/internal/services/ruleset/schema.go
@@ -1542,6 +1542,26 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										},
 									},
 								},
+								"origin_range_requests": schema.SingleNestedAttribute{
+									Description: "Controls whether Cloudflare fetches a large asset from the origin as a series of range requests instead of one whole-body request.",
+									Optional:    true,
+									Validators: []validator.Object{
+										customvalidator.RequiresOtherStringAttributeToBe(
+											path.MatchRelative().AtParent().AtParent().AtName("action"),
+											"set_cache_settings",
+										),
+									},
+									CustomType: customfield.NewNestedObjectType[RulesetRulesActionParametersOriginRangeRequestsModel](ctx),
+									Attributes: map[string]schema.Attribute{
+										"mode": schema.StringAttribute{
+											Description: "Whether to use range requests. `default` is the behaviour the zone gets without this rule.\nAvailable values: \"on\", \"off\", \"default\".",
+											Required:    true,
+											Validators: []validator.String{
+												stringvalidator.OneOf("on", "off", "default"),
+											},
+										},
+									},
+								},
 								"strip_etags": schema.BoolAttribute{
 									Description: "Whether to strip the ETag header from the response.",
 									Optional:    true,

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_SetCacheSettingsRules/3.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_SetCacheSettingsRules/3.tf
@@ -59,6 +59,9 @@ resource "cloudflare_ruleset" "my_ruleset" {
         serve_stale = {
           disable_stale_while_updating = false
         }
+        origin_range_requests = {
+          mode = "on"
+        }
       }
     }
   ]

--- a/internal/services/ruleset/testdata/TestAccCloudflareRuleset_SetCacheSettingsRules/5.tf
+++ b/internal/services/ruleset/testdata/TestAccCloudflareRuleset_SetCacheSettingsRules/5.tf
@@ -39,6 +39,9 @@ resource "cloudflare_ruleset" "my_ruleset" {
             }
           }
         }
+        origin_range_requests = {
+          mode = "default"
+        }
       }
     }
   ]


### PR DESCRIPTION
Add Terraform support for `set_cache_settings.origin_range_requests` in Ruleset resources and data sources. The nested `mode` accepts the API's case-sensitive `on`, `off`, and `default` values, and explicit `default` remains present in state.

Includes acceptance coverage for create, remove, and re-add flows. The re-add step checks `default` in both resource and data source state.

<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Expose `origin_range_requests` under Ruleset `set_cache_settings` action parameters, including the resource and data source schemas, v5 migration model, generated docs, and acceptance coverage. This follows the pattern used for `vary` in #7194.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [x] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

I built the provider from this branch and used a disposable Terraform state to import an existing zone `http_request_cache_settings` entrypoint. The initial configuration matched the live rule with `mode = "off"`.

1. Import the entrypoint and run a plan with `mode = "off"`.
2. Change only `mode` to `default`, apply, and read the result through both the resource and data source.
3. Confirm the API returns explicit `default` and run another plan.
4. Change `mode` back to `off`, apply, and run a final plan.

The stock Go acceptance case was not used for the live run because it creates and deletes a zone entrypoint. The test zone already had an entrypoint, so importing it avoided deleting existing configuration.

### Test output

```text
import existing entrypoint: pass
baseline plan with mode=off: no changes

planned resource change: mode off -> default
apply: pass
API mode: default
resource state mode: default
data source state mode: default
post-apply plan: no changes

planned resource change: mode default -> off
restore apply: pass
API mode: off
resource state mode: off
data source state mode: off
final plan: no changes
```

The test restored the entrypoint's original `off` value.

## Additional context & links

Local checks passed:

```text
go test -mod=mod ./internal/services/ruleset/...
ok  github.com/cloudflare/terraform-provider-cloudflare/internal/services/ruleset
ok  github.com/cloudflare/terraform-provider-cloudflare/internal/services/ruleset/migration/v500

GOFLAGS=-mod=mod ./scripts/lint
exit 0

terraform fmt -check internal/services/ruleset/testdata/TestAccCloudflareRuleset_SetCacheSettingsRules/3.tf internal/services/ruleset/testdata/TestAccCloudflareRuleset_SetCacheSettingsRules/5.tf
exit 0
```

The current `next` branch needs `-mod=mod` for local builds because its checked-in `go.sum` does not include the existing `cloudflare-go/v6` dependency checksums. No dependency files are changed in this PR.
