### PR TITLE
resource/cloudflare_ruleset: add content_converter to action_parameters

### DIFF
--- a/.changelog/content-converter.txt
+++ b/.changelog/content-converter.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudflare_ruleset: add `content_converter` to `action_parameters` for `http_config_settings` `set_config` rules
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.3
 
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/cloudflare/cloudflare-go v0.117.0
+	github.com/cloudflare/cloudflare-go v0.118.0
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/internal/framework/service/rulesets/model.go
+++ b/internal/framework/service/rulesets/model.go
@@ -37,6 +37,7 @@ type ActionParametersModel struct {
 	CacheKey                 []*ActionParameterCacheKeyModel              `tfsdk:"cache_key"`
 	CacheReserve             []*ActionParameterCacheReserveModel          `tfsdk:"cache_reserve"`
 	Content                  types.String                                 `tfsdk:"content"`
+	ContentConverter         types.Bool                                   `tfsdk:"content_converter"`
 	ContentType              types.String                                 `tfsdk:"content_type"`
 	CookieFields             types.Set                                    `tfsdk:"cookie_fields"`
 	DisableApps              types.Bool                                   `tfsdk:"disable_apps"`

--- a/internal/framework/service/rulesets/resource.go
+++ b/internal/framework/service/rulesets/resource.go
@@ -322,6 +322,7 @@ func toRulesetResourceModel(ctx context.Context, zoneID, accountID basetypes.Str
 				BIC:                     flatteners.Bool(ruleResponse.ActionParameters.BrowserIntegrityCheck),
 				Cache:                   flatteners.Bool(ruleResponse.ActionParameters.Cache),
 				Content:                 flatteners.String(ruleResponse.ActionParameters.Content),
+				ContentConverter:        flatteners.Bool(ruleResponse.ActionParameters.ContentConverter),
 				ContentType:             flatteners.String(ruleResponse.ActionParameters.ContentType),
 				DisableApps:             flatteners.Bool(ruleResponse.ActionParameters.DisableApps),
 				DisableRailgun:          flatteners.Bool(ruleResponse.ActionParameters.DisableRailgun),
@@ -830,6 +831,10 @@ func (r *RulesModel) toRulesetRule(ctx context.Context) cfv1.RulesetRule {
 
 		if !ap.Content.IsNull() {
 			rr.ActionParameters.Content = ap.Content.ValueString()
+		}
+
+		if !ap.ContentConverter.IsNull() {
+			rr.ActionParameters.ContentConverter = cfv1.BoolPtr(ap.ContentConverter.ValueBool())
 		}
 
 		if !ap.ContentType.IsNull() {

--- a/internal/framework/service/rulesets/resource_test.go
+++ b/internal/framework/service/rulesets/resource_test.go
@@ -2022,6 +2022,7 @@ func TestAccCloudflareRuleset_Config(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.autominify.0.css", "true"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.autominify.0.js", "true"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.bic", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.content_converter", "false"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.disable_apps", "true"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.disable_zaraz", "true"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.action_parameters.0.disable_railgun", "true"),
@@ -4268,6 +4269,7 @@ func testAccCloudflareRulesetConfigAllEnabled(rnd, accountID, zoneID string) str
 			js = true
 		}
 		bic = true
+		content_converter = false
 		disable_apps = true
 		disable_zaraz = true
 		disable_rum = true

--- a/internal/framework/service/rulesets/schema.go
+++ b/internal/framework/service/rulesets/schema.go
@@ -170,6 +170,10 @@ func (r *RulesetResource) Schema(ctx context.Context, req resource.SchemaRequest
 										Optional:            true,
 										MarkdownDescription: "Content of the custom error response.",
 									},
+									"content_converter": schema.BoolAttribute{
+										Optional:            true,
+										MarkdownDescription: "Whether to enable content conversion (e.g., HTML to Markdown).",
+									},
 									"content_type": schema.StringAttribute{
 										Optional:            true,
 										MarkdownDescription: "Content-Type of the custom error response.",


### PR DESCRIPTION
## Summary
- expose `content_converter` in the v4 Rulesets schema and model
- preserve the boolean through API flatten and expand paths
- bump legacy `cloudflare-go` to the expected v0.118.0 release

## Dependency
- cloudflare/cloudflare-go#4359 must release as v0.118.0 first

## Tests
- Rulesets package compiles against the local SDK change
- acceptance coverage added; not run without account credentials