### PR TITLE
fix(worker_version): reconcile response binding order

### DIFF
--- a/internal/services/worker_version/binding_test.go
+++ b/internal/services/worker_version/binding_test.go
@@ -288,3 +288,83 @@ func TestJsonBindingBackwardsCompatibility(t *testing.T) {
 
 	t.Logf("Successfully marshaled binding: %s", output)
 }
+
+func TestReorderResponseBindingsToMatchPlan(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	planBindings, diags := customfield.NewObjectList(ctx, []worker_version.WorkerVersionBindingsModel{
+		{
+			Name:        types.StringValue("KV_PRIMARY"),
+			Type:        types.StringValue("kv_namespace"),
+			NamespaceID: types.StringUnknown(),
+		},
+		{
+			Name:       types.StringValue("claudeflare_users"),
+			Type:       types.StringValue("d1"),
+			ID:         types.StringValue("d1-id"),
+			DatabaseID: types.StringUnknown(),
+		},
+		{
+			Name:        types.StringValue("KV_ARCHIVE"),
+			Type:        types.StringValue("kv_namespace"),
+			NamespaceID: types.StringUnknown(),
+		},
+	})
+	if diags.HasError() {
+		t.Fatalf("create plan bindings: %v", diags)
+	}
+
+	sortedPlanBindings, diags := worker_version.SortBindingsByName(ctx, planBindings)
+	if diags.HasError() {
+		t.Fatalf("sort plan bindings: %v", diags)
+	}
+
+	env := worker_version.WorkerVersionResultEnvelope{Result: worker_version.WorkerVersionModel{Bindings: sortedPlanBindings}}
+	response := []byte(`{
+		"result": {
+			"bindings": [
+				{"name":"claudeflare_users","type":"d1","id":"d1-id","database_id":"database-id"},
+				{"name":"KV_PRIMARY","type":"kv_namespace","namespace_id":"primary-namespace-id"},
+				{"name":"KV_ARCHIVE","type":"kv_namespace","namespace_id":"archive-namespace-id"}
+			]
+		}
+	}`)
+
+	if err := apijson.UnmarshalComputed(worker_version.ReorderResponseBindingsToMatchPlan(response, sortedPlanBindings), &env); err != nil {
+		t.Fatalf("unmarshal computed response: %v", err)
+	}
+
+	bindings, diags := env.Result.Bindings.AsStructSliceT(ctx)
+	if diags.HasError() {
+		t.Fatalf("read reconciled bindings: %v", diags)
+	}
+	computedByName := map[string]worker_version.WorkerVersionBindingsModel{}
+	for _, binding := range bindings {
+		computedByName[binding.Name.ValueString()] = binding
+	}
+
+	if got := computedByName["claudeflare_users"].DatabaseID.ValueString(); got != "database-id" {
+		t.Errorf("D1 database_id = %q, want %q", got, "database-id")
+	}
+	if got := computedByName["KV_PRIMARY"].NamespaceID.ValueString(); got != "primary-namespace-id" {
+		t.Errorf("KV_PRIMARY namespace_id = %q, want %q", got, "primary-namespace-id")
+	}
+	if got := computedByName["KV_ARCHIVE"].NamespaceID.ValueString(); got != "archive-namespace-id" {
+		t.Errorf("KV_ARCHIVE namespace_id = %q, want %q", got, "archive-namespace-id")
+	}
+
+	orderedBindings, diags := worker_version.SortRefreshedBindingsToMatchPrevious(ctx, env.Result.Bindings, planBindings)
+	if diags.HasError() {
+		t.Fatalf("restore plan order: %v", diags)
+	}
+	bindings, diags = orderedBindings.AsStructSliceT(ctx)
+	if diags.HasError() {
+		t.Fatalf("read ordered bindings: %v", diags)
+	}
+	for i, want := range []string{"KV_PRIMARY", "claudeflare_users", "KV_ARCHIVE"} {
+		if got := bindings[i].Name.ValueString(); got != want {
+			t.Errorf("binding %d name = %q, want %q", i, got, want)
+		}
+	}
+}

--- a/internal/services/worker_version/custom.go
+++ b/internal/services/worker_version/custom.go
@@ -21,7 +21,87 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
+
+func sortByName[T any](values []T, name func(T) string) bool {
+	compare := func(a, b T) int {
+		return strings.Compare(name(a), name(b))
+	}
+	reordered := !slices.IsSortedFunc(values, compare)
+	slices.SortFunc(values, compare)
+	return reordered
+}
+
+func bindingName(binding attr.Value, diags *diag.Diagnostics) (types.String, bool) {
+	obj, ok := binding.(basetypes.ObjectValue)
+	if !ok {
+		if diags != nil {
+			diags.AddError("Invalid element type", "Expected element type to be basetypes.ObjectType.")
+		}
+		return types.StringNull(), false
+	}
+	nameAttr, ok := obj.Attributes()["name"]
+	if !ok {
+		if diags != nil {
+			diags.AddError("Invalid element", "Missing 'name' attribute")
+		}
+		return types.StringNull(), false
+	}
+	name, ok := nameAttr.(types.String)
+	if !ok {
+		if diags != nil {
+			diags.AddError("Invalid element", "'name' attribute must be a string")
+		}
+		return types.StringNull(), false
+	}
+	return name, true
+}
+
+// ReorderResponseBindingsToMatchPlan returns the response unchanged unless its
+// bindings have the same unique names as the planned bindings. In that case,
+// it places response bindings in plan order so UnmarshalComputed merges each
+// binding's computed fields with the matching planned binding.
+func ReorderResponseBindingsToMatchPlan(response []byte, planBindings customfield.NestedObjectList[WorkerVersionBindingsModel]) []byte {
+	if planBindings.IsNull() || planBindings.IsUnknown() {
+		return response
+	}
+
+	responseBindings := gjson.GetBytes(response, "result.bindings")
+	bindings := responseBindings.Array()
+	plan := planBindings.Elements()
+	if !responseBindings.IsArray() || len(bindings) == 0 || len(bindings) != len(plan) {
+		return response
+	}
+
+	reordered := sortByName(bindings, func(binding gjson.Result) string {
+		return binding.Get("name").String()
+	})
+
+	reorderedBindings := make([]string, len(bindings))
+	for i, binding := range bindings {
+		planName, ok := bindingName(plan[i], nil)
+		responseName := binding.Get("name")
+		if !ok || planName.IsNull() || planName.IsUnknown() ||
+			!responseName.Exists() || responseName.Type != gjson.String ||
+			planName.ValueString() != responseName.String() ||
+			(i > 0 && responseName.String() == bindings[i-1].Get("name").String()) {
+			return response
+		}
+		reorderedBindings[i] = binding.Raw
+	}
+	if !reordered {
+		return response
+	}
+
+	reorderedResponse, err := sjson.SetRawBytes(response, "result.bindings", []byte("["+strings.Join(reorderedBindings, ",")+"]"))
+	if err != nil {
+		return response
+	}
+
+	return reorderedResponse
+}
 
 func readFile(path string) (string, error) {
 	if strings.HasPrefix(path, "~/") {
@@ -235,25 +315,11 @@ func SortRefreshedBindingsToMatchPrevious[T any](
 	// Mapping of binding name to refreshed binding value.
 	refreshedBindingsByName := make(map[string]attr.Value, len(refreshedBindingElements))
 	for _, val := range refreshedBindingElements {
-		refreshedObj, ok := val.(basetypes.ObjectValue)
+		name, ok := bindingName(val, &diags)
 		if !ok {
-			diags.AddError("Invalid element type", "Expected element type to be basetypes.ObjectType.")
 			return refreshedBindings, diags
 		}
-
-		refreshedAttrs := refreshedObj.Attributes()
-		nameAttr, ok := refreshedAttrs["name"]
-		if !ok {
-			diags.AddError("Invalid element", "Missing 'name' attribute")
-			return refreshedBindings, diags
-		}
-
-		nameString, ok := nameAttr.(types.String)
-		if !ok {
-			diags.AddError("Invalid element", "'name' attribute must be a string")
-			return refreshedBindings, diags
-		}
-		refreshedBindingsByName[nameString.ValueString()] = refreshedObj
+		refreshedBindingsByName[name.ValueString()] = val
 	}
 
 	// Refreshed bindings sorted to match the order they appear in state (or
@@ -261,32 +327,18 @@ func SortRefreshedBindingsToMatchPrevious[T any](
 	// ordered last.
 	sortedBindings := make([]attr.Value, 0, len(refreshedBindingElements))
 	for _, val := range previousBindings.Elements() {
-		stateObj, ok := val.(basetypes.ObjectValue)
+		name, ok := bindingName(val, &diags)
 		if !ok {
-			diags.AddError("Invalid element type", "Expected element type to be basetypes.ObjectType.")
-			return refreshedBindings, diags
-		}
-
-		stateAttrs := stateObj.Attributes()
-		nameAttr, ok := stateAttrs["name"]
-		if !ok {
-			diags.AddError("Invalid element", "Missing 'name' attribute")
-			return refreshedBindings, diags
-		}
-
-		nameString, ok := nameAttr.(types.String)
-		if !ok {
-			diags.AddError("Invalid element", "'name' attribute must be a string")
 			return refreshedBindings, diags
 		}
 
 		// Reorder refreshed bindings that exist in state (or planned state) to
 		// match the order they appear in state.
-		if refreshedBinding, ok := refreshedBindingsByName[nameString.ValueString()]; ok {
+		if refreshedBinding, ok := refreshedBindingsByName[name.ValueString()]; ok {
 			sortedBindings = append(sortedBindings, refreshedBinding)
 			// Binding names must be unique, the API will never return multiple
 			// bindings with the same name.
-			delete(refreshedBindingsByName, nameString.ValueString())
+			delete(refreshedBindingsByName, name.ValueString())
 		}
 	}
 
@@ -303,8 +355,8 @@ func SortRefreshedBindingsToMatchPrevious[T any](
 	}, diags
 }
 
-// Sorts the given list of bindings in ascending order by name. This matches the
-// order that the Workers API returns bindings.
+// Sorts the given list of bindings in ascending order by name for deterministic
+// request serialization.
 func SortBindingsByName[T any](
 	ctx context.Context,
 	bindings customfield.NestedObjectList[T],
@@ -315,41 +367,12 @@ func SortBindingsByName[T any](
 	}
 
 	sortedBindings := bindings.Elements()
-	slices.SortFunc(sortedBindings, func(a, b attr.Value) int {
-		aObj, ok := a.(basetypes.ObjectValue)
+	sortByName(sortedBindings, func(binding attr.Value) string {
+		name, ok := bindingName(binding, &diags)
 		if !ok {
-			diags.AddError("Invalid element type", "Expected element type to be basetypes.ObjectType.")
-			return 0
+			return ""
 		}
-		aAttrs := aObj.Attributes()
-		aNameAttr, ok := aAttrs["name"]
-		if !ok {
-			diags.AddError("Invalid element", "Missing 'name' attribute")
-			return 0
-		}
-		aNameString, ok := aNameAttr.(types.String)
-		if !ok {
-			diags.AddError("Invalid element", "'name' attribute must be a string")
-			return 0
-		}
-
-		bObj, ok := b.(basetypes.ObjectValue)
-		if !ok {
-			diags.AddError("Invalid element type", "Expected element type to be basetypes.ObjectType.")
-			return 0
-		}
-		bAttrs := bObj.Attributes()
-		bNameAttr, ok := bAttrs["name"]
-		if !ok {
-			diags.AddError("Invalid element", "Missing 'name' attribute")
-			return 0
-		}
-		bNameString, ok := bNameAttr.(types.String)
-		if !ok {
-			diags.AddError("Invalid element", "'name' attribute must be a string")
-			return 0
-		}
-		return strings.Compare(aNameString.ValueString(), bNameString.ValueString())
+		return name.ValueString()
 	})
 
 	value, d := types.ListValue(bindings.ElementType(ctx), sortedBindings)

--- a/internal/services/worker_version/resource.go
+++ b/internal/services/worker_version/resource.go
@@ -117,11 +117,8 @@ func (r *WorkerVersionResource) Create(ctx context.Context, req resource.CreateR
 	planBindings := data.Bindings
 
 	var diags diag.Diagnostics
-	// Reorder plan bindings to be sorted in ascending order by name, which
-	// matches the order that the API returns them. This is important for
-	// apijson.UnmarshalComputed to work correctly. If the unmarshal target
-	// doesn't match the order that the API returns the bindings, the unmarshal
-	// operation will assign computed properties to the wrong bindings.
+	// Keep request serialization deterministic. API response bindings are matched
+	// to these planned bindings by name before computed fields are unmarshaled.
 	data.Bindings, diags = SortBindingsByName(ctx, planBindings)
 	resp.Diagnostics.Append(diags...)
 
@@ -151,6 +148,7 @@ func (r *WorkerVersionResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
+	bytes = ReorderResponseBindingsToMatchPlan(bytes, data.Bindings)
 	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Reorder `result.bindings` to the sorted planned binding names before `apijson.UnmarshalComputed` merges computed fields by index. This prevents D1 and KV computed fields from attaching to the wrong binding when EWC returns bindings in a different order.

Matching is exact and case-sensitive. Responses with null, missing, additional, or duplicate names retain the existing behavior. Request serialization and final Terraform state ordering remain unchanged.

The request and response paths now share binding-name extraction and sorting logic. Binding tests have also been consolidated in `binding_test.go`.

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

A focused unit regression was added. Credentialed acceptance tests were not run.

### Steps to run acceptance tests

```sh
go test ./internal/services/worker_version -run TestReorderResponseBindingsToMatchPlan -count=1
go test ./internal/services/worker_version -count=1
```

### Test output

```text
ok  github.com/cloudflare/terraform-provider-cloudflare/internal/services/worker_version  2.093s
ok  github.com/cloudflare/terraform-provider-cloudflare/internal/services/worker_version  1.980s
```

## Additional context & links

- WC-5923