### PR TITLE
docs(changelog): add entries for v4.52.7, v4.52.8, and v4.52.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 4.52.9 (September 1st, 2026)
+
+ENHANCEMENTS:
+
+* resource/cloudflare_ruleset: add `content_converter` to `action_parameters` for `http_config_settings` `set_config` rules ([#7348](https://github.com/cloudflare/terraform-provider-cloudflare/pull/7348))
+
+DEPENDENCIES:
+
+* provider: bump `github.com/cloudflare/cloudflare-go` from v0.117.0 to v0.118.0 ([#7349](https://github.com/cloudflare/terraform-provider-cloudflare/pull/7349))
+
+## 4.52.8 (June 23rd, 2026)
+
+ENHANCEMENTS:
+
+* resource/cloudflare_ruleset: add `asset_name` to `action_parameters` for `http_custom_errors` `serve_error` rules ([#7141](https://github.com/cloudflare/terraform-provider-cloudflare/pull/7141))
+
+BUG FIXES:
+
+* resource/cloudflare_ruleset: allow `edge_ttl.default` of `0` for `override_origin` mode (no edge caching / always revalidate), which the Cloudflare API accepts ([#7210](https://github.com/cloudflare/terraform-provider-cloudflare/pull/7210))
+
+## 4.52.7 (March 24th, 2026)
+
+BUG FIXES:
+
+* provider: mark credential fields as sensitive and update validation for new key formats ([#6958](https://github.com/cloudflare/terraform-provider-cloudflare/pull/6958))
+
 ## 4.52.6 (March 19th, 2026)
 
 BUG FIXES:


### PR DESCRIPTION
Backfills three missing CHANGELOG entries -- the bot has not been running on the `v4` branch.

- **4.52.7** (March 24th, 2026): provider credential fields sensitive (#6958)
- **4.52.8** (June 23rd, 2026): ruleset `asset_name` enhancement (#7141) + `edge_ttl.default=0` bug fix (#7210)
- **4.52.9** (September 1st, 2026): ruleset `content_converter` enhancement (#7348) + cloudflare-go v0.118.0 dep bump (#7349)