### PR TITLE
docs(zero_trust_organization): document import

### DIFF
--- a/docs/resources/zero_trust_organization.md
+++ b/docs/resources/zero_trust_organization.md
@@ -130,5 +130,8 @@ Available values: "never", "always", "cached".
 
 ## Import
 
+Import is supported using the following syntax:
 
-~> This resource does not currently support `terraform import`.
+```shell
+$ terraform import cloudflare_zero_trust_organization.example '<account_id>'
+```

--- a/examples/resources/cloudflare_zero_trust_organization/import.sh
+++ b/examples/resources/cloudflare_zero_trust_organization/import.sh
@@ -1,0 +1,1 @@
+$ terraform import cloudflare_zero_trust_organization.example '<account_id>'

--- a/scripts/generate-docs
+++ b/scripts/generate-docs
@@ -9,6 +9,11 @@ cat << EOT > examples/resources/cloudflare_list_item/import.sh
 $ terraform import cloudflare_list_item.example '<account_id>/<list_id>/<item_id>'
 EOT
 
+# update Zero Trust organization docs to account for custom import behavior
+cat << EOT > examples/resources/cloudflare_zero_trust_organization/import.sh
+$ terraform import cloudflare_zero_trust_organization.example '<account_id>'
+EOT
+
 echo "==> Generating zone setting IDs from OpenAPI spec"
 python3 "$(dirname "$0")/generate-zone-setting-ids"
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

The `cloudflare_zero_trust_organization` documentation currently states that Terraform import is unsupported, although the resource implements `ResourceWithImportState` and accepts `{account_id}` as its import ID.

This change:

- adds the missing `import.sh` example;
- preserves the custom import example in `scripts/generate-docs`;
- updates the generated resource documentation with the supported import command.

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

Not run because this is a documentation-only change. Existing acceptance coverage in `resource_test.go` already exercises imports using the account ID.

The import was also validated manually with provider v5.24.0 against an existing Zero Trust organization. The import succeeded, and a follow-up targeted plan reported no changes.

### Test output

Targeted documentation checks passed:

```text
bash -n scripts/generate-docs
bash -n examples/resources/cloudflare_zero_trust_organization/import.sh
shellcheck scripts/generate-docs
shellcheck --shell=sh examples/resources/cloudflare_zero_trust_organization/import.sh
git diff --check
```

The full provider build and test suite were not run locally.

## Additional context & links

`ZeroTrustOrganizationResource.ImportState` parses the import ID using the `{account_id}` format. The documentation incorrectly reports that import is unsupported because the resource did not have an `examples/resources/cloudflare_zero_trust_organization/import.sh` file.
