### PR TITLE
extend US jurisdiction support for R2

### DIFF
--- a/docs/data-sources/r2_bucket.md
+++ b/docs/data-sources/r2_bucket.md
@@ -28,13 +28,13 @@ data "cloudflare_r2_bucket" "example_r2_bucket" {
 ### Optional
 
 - `account_id` (String) Account ID.
+- `jurisdiction` (String) Jurisdiction where objects in this bucket are guaranteed to be stored.
+Available values: "default", "eu", "fedramp", "us".
 
 ### Read-Only
 
 - `creation_date` (String) Creation timestamp.
 - `id` (String) Name of the bucket.
-- `jurisdiction` (String) Jurisdiction where objects in this bucket are guaranteed to be stored.
-Available values: "default", "eu", "fedramp", "us".
 - `location` (String) Location of the bucket.
 Available values: "apac", "eeur", "enam", "weur", "wnam", "oc".
 - `name` (String) Name of the bucket.

--- a/docs/data-sources/r2_bucket_cors.md
+++ b/docs/data-sources/r2_bucket_cors.md
@@ -26,6 +26,11 @@ data "cloudflare_r2_bucket_cors" "example_r2_bucket_cors" {
 - `account_id` (String) Account ID.
 - `bucket_name` (String) Name of the bucket.
 
+### Optional
+
+- `jurisdiction` (String) Jurisdiction of the bucket.
+Available values: "default", "eu", "fedramp", "us".
+
 ### Read-Only
 
 - `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))

--- a/docs/data-sources/r2_bucket_event_notification.md
+++ b/docs/data-sources/r2_bucket_event_notification.md
@@ -32,6 +32,11 @@ data "cloudflare_r2_bucket_event_notification" "example_r2_bucket_event_notifica
 - `bucket_name` (String) Name of the bucket.
 - `queue_id` (String) Queue ID.
 
+### Optional
+
+- `jurisdiction` (String) Jurisdiction of the bucket.
+Available values: "default", "eu", "fedramp", "us".
+
 ### Read-Only
 
 - `queue_name` (String) Name of the queue.

--- a/docs/data-sources/r2_bucket_lifecycle.md
+++ b/docs/data-sources/r2_bucket_lifecycle.md
@@ -26,6 +26,11 @@ data "cloudflare_r2_bucket_lifecycle" "example_r2_bucket_lifecycle" {
 - `account_id` (String) Account ID.
 - `bucket_name` (String) Name of the bucket.
 
+### Optional
+
+- `jurisdiction` (String) Jurisdiction of the bucket.
+Available values: "default", "eu", "fedramp", "us".
+
 ### Read-Only
 
 - `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))

--- a/docs/data-sources/r2_bucket_lock.md
+++ b/docs/data-sources/r2_bucket_lock.md
@@ -26,6 +26,11 @@ data "cloudflare_r2_bucket_lock" "example_r2_bucket_lock" {
 - `account_id` (String) Account ID.
 - `bucket_name` (String) Name of the bucket.
 
+### Optional
+
+- `jurisdiction` (String) Jurisdiction of the bucket.
+Available values: "default", "eu", "fedramp", "us".
+
 ### Read-Only
 
 - `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))

--- a/docs/data-sources/r2_bucket_sippy.md
+++ b/docs/data-sources/r2_bucket_sippy.md
@@ -26,6 +26,11 @@ data "cloudflare_r2_bucket_sippy" "example_r2_bucket_sippy" {
 - `account_id` (String) Account ID.
 - `bucket_name` (String) Name of the bucket.
 
+### Optional
+
+- `jurisdiction` (String) Jurisdiction of the bucket.
+Available values: "default", "eu", "fedramp", "us".
+
 ### Read-Only
 
 - `destination` (Attributes) Details about the configured destination bucket. (see [below for nested schema](#nestedatt--destination))

--- a/docs/data-sources/r2_custom_domain.md
+++ b/docs/data-sources/r2_custom_domain.md
@@ -32,6 +32,11 @@ data "cloudflare_r2_custom_domain" "example_r2_custom_domain" {
 - `bucket_name` (String) Name of the bucket.
 - `domain` (String) Name of the custom domain.
 
+### Optional
+
+- `jurisdiction` (String) Jurisdiction of the bucket.
+Available values: "default", "eu", "fedramp", "us".
+
 ### Read-Only
 
 - `ciphers` (List of String) An allowlist of ciphers for TLS termination. These ciphers must be in the BoringSSL format.

--- a/docs/data-sources/worker_version.md
+++ b/docs/data-sources/worker_version.md
@@ -140,7 +140,7 @@ Available values: "raw", "pkcs8", "spki", "jwk".
 - `instance_name` (String) The user-chosen instance name. Must exist at deploy time. The worker can search, chat, update, and manage items/jobs on this instance.
 - `json` (String) JSON data to use.
 - `jurisdiction` (String) The [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) of the R2 bucket.
-Available values: "eu", "fedramp", "fedramp-high".
+Available values: "eu", "fedramp", "fedramp-high", "us".
 - `key_base64` (String, Sensitive) Base64-encoded key data. Required if `format` is "raw", "pkcs8", or "spki".
 - `key_jwk` (String, Sensitive) Key data in [JSON Web Key](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#json_web_key) format. Required if `format` is "jwk".
 - `name` (String) A JavaScript variable name for the binding.

--- a/docs/data-sources/worker_versions.md
+++ b/docs/data-sources/worker_versions.md
@@ -143,7 +143,7 @@ Available values: "raw", "pkcs8", "spki", "jwk".
 - `instance_name` (String) The user-chosen instance name. Must exist at deploy time. The worker can search, chat, update, and manage items/jobs on this instance.
 - `json` (String) JSON data to use.
 - `jurisdiction` (String) The [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) of the R2 bucket.
-Available values: "eu", "fedramp", "fedramp-high".
+Available values: "eu", "fedramp", "fedramp-high", "us".
 - `key_base64` (String, Sensitive) Base64-encoded key data. Required if `format` is "raw", "pkcs8", or "spki".
 - `key_jwk` (String, Sensitive) Key data in [JSON Web Key](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#json_web_key) format. Required if `format` is "jwk".
 - `name` (String) A JavaScript variable name for the binding.

--- a/docs/resources/worker_version.md
+++ b/docs/resources/worker_version.md
@@ -233,7 +233,7 @@ Available values: "raw", "pkcs8", "spki", "jwk".
 - `instance_name` (String) The user-chosen instance name. Must exist at deploy time. The worker can search, chat, update, and manage items/jobs on this instance.
 - `json` (String) JSON data to use.
 - `jurisdiction` (String) The [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) of the R2 bucket.
-Available values: "eu", "fedramp", "fedramp-high".
+Available values: "eu", "fedramp", "fedramp-high", "us".
 - `key_base64` (String, Sensitive) Base64-encoded key data. Required if `format` is "raw", "pkcs8", or "spki".
 - `key_jwk` (String, Sensitive) Key data in [JSON Web Key](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#json_web_key) format. Required if `format` is "jwk".
 - `namespace` (String) The namespace the instance belongs to. Defaults to "default" if omitted. Customers who don't use namespaces can simply omit this field.

--- a/docs/resources/workers_script.md
+++ b/docs/resources/workers_script.md
@@ -266,7 +266,7 @@ Available values: "raw", "pkcs8", "spki", "jwk".
 - `instance_name` (String) The user-chosen instance name. Must exist at deploy time. The worker can search, chat, update, and manage items/jobs on this instance.
 - `json` (String) JSON data to use.
 - `jurisdiction` (String) The [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) of the R2 bucket.
-Available values: "eu", "fedramp", "fedramp-high".
+Available values: "eu", "fedramp", "fedramp-high", "us".
 - `key_base64` (String, Sensitive) Base64-encoded key data. Required if `format` is "raw", "pkcs8", or "spki".
 - `key_jwk` (String, Sensitive) Key data in [JSON Web Key](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#json_web_key) format. Required if `format` is "jwk".
 - `namespace` (String) The namespace the instance belongs to. Defaults to "default" if omitted. Customers who don't use namespaces can simply omit this field.

--- a/internal/services/r2_bucket/data_source_model.go
+++ b/internal/services/r2_bucket/data_source_model.go
@@ -20,7 +20,7 @@ type R2BucketDataSourceModel struct {
 	BucketName   types.String `tfsdk:"bucket_name" path:"bucket_name,required"`
 	AccountID    types.String `tfsdk:"account_id" path:"account_id,optional"`
 	CreationDate types.String `tfsdk:"creation_date" json:"creation_date,computed"`
-	Jurisdiction types.String `tfsdk:"jurisdiction" json:"jurisdiction,computed,no_refresh"`
+	Jurisdiction types.String `tfsdk:"jurisdiction" json:"jurisdiction,computed_optional,no_refresh"`
 	Location     types.String `tfsdk:"location" json:"location,computed"`
 	Name         types.String `tfsdk:"name" json:"name,computed"`
 	StorageClass types.String `tfsdk:"storage_class" json:"storage_class,computed"`
@@ -29,6 +29,9 @@ type R2BucketDataSourceModel struct {
 func (m *R2BucketDataSourceModel) toReadParams(_ context.Context) (params r2.BucketGetParams, diags diag.Diagnostics) {
 	params = r2.BucketGetParams{
 		AccountID: cloudflare.F(m.AccountID.ValueString()),
+	}
+	if !m.Jurisdiction.IsNull() {
+		params.Jurisdiction = cloudflare.F(r2.BucketGetParamsCfR2Jurisdiction(m.Jurisdiction.ValueString()))
 	}
 
 	return

--- a/internal/services/r2_bucket/data_source_model_test.go
+++ b/internal/services/r2_bucket/data_source_model_test.go
@@ -1,0 +1,28 @@
+package r2_bucket
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestR2BucketDataSourceToReadParamsJurisdiction(t *testing.T) {
+	t.Parallel()
+
+	params, diags := (&R2BucketDataSourceModel{Jurisdiction: types.StringValue("us")}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if !params.Jurisdiction.Present || string(params.Jurisdiction.Value) != "us" {
+		t.Fatalf("expected us jurisdiction, got %#v", params.Jurisdiction)
+	}
+
+	params, diags = (&R2BucketDataSourceModel{Jurisdiction: types.StringNull()}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if params.Jurisdiction.Present {
+		t.Fatalf("expected omitted jurisdiction, got %#v", params.Jurisdiction)
+	}
+}

--- a/internal/services/r2_bucket/data_source_schema.go
+++ b/internal/services/r2_bucket/data_source_schema.go
@@ -34,6 +34,7 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 			},
 			"jurisdiction": schema.StringAttribute{
 				Description: "Jurisdiction where objects in this bucket are guaranteed to be stored.\nAvailable values: \"default\", \"eu\", \"fedramp\", \"us\".",
+				Optional:    true,
 				Computed:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive(

--- a/internal/services/r2_bucket/jurisdiction_test.go
+++ b/internal/services/r2_bucket/jurisdiction_test.go
@@ -1,0 +1,90 @@
+package r2_bucket_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_bucket"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_bucket_cors"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_bucket_event_notification"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_bucket_lifecycle"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_bucket_lock"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_bucket_sippy"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_custom_domain"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_managed_domain"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestR2USJurisdictionValidation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	resourceSchemas := []struct {
+		name   string
+		schema func(context.Context) resourceschema.Schema
+	}{
+		{"bucket", r2_bucket.ResourceSchema},
+		{"bucket CORS", r2_bucket_cors.ResourceSchema},
+		{"bucket event notification", r2_bucket_event_notification.ResourceSchema},
+		{"bucket lifecycle", r2_bucket_lifecycle.ResourceSchema},
+		{"bucket lock", r2_bucket_lock.ResourceSchema},
+		{"bucket Sippy", r2_bucket_sippy.ResourceSchema},
+		{"custom domain", r2_custom_domain.ResourceSchema},
+		{"managed domain", r2_managed_domain.ResourceSchema},
+	}
+	for _, test := range resourceSchemas {
+		t.Run("resource "+test.name, func(t *testing.T) {
+			attribute := test.schema(ctx).Attributes["jurisdiction"].(resourceschema.StringAttribute)
+			assertUSJurisdictionValidation(t, ctx, attribute.Validators)
+		})
+	}
+
+	dataSourceSchemas := []struct {
+		name   string
+		schema func(context.Context) datasourceschema.Schema
+	}{
+		{"bucket", r2_bucket.DataSourceSchema},
+		{"bucket CORS", r2_bucket_cors.DataSourceSchema},
+		{"bucket event notification", r2_bucket_event_notification.DataSourceSchema},
+		{"bucket lifecycle", r2_bucket_lifecycle.DataSourceSchema},
+		{"bucket lock", r2_bucket_lock.DataSourceSchema},
+		{"bucket Sippy", r2_bucket_sippy.DataSourceSchema},
+		{"custom domain", r2_custom_domain.DataSourceSchema},
+	}
+	for _, test := range dataSourceSchemas {
+		t.Run("data source "+test.name, func(t *testing.T) {
+			attribute := test.schema(ctx).Attributes["jurisdiction"].(datasourceschema.StringAttribute)
+			if !attribute.Optional {
+				t.Fatal("expected jurisdiction to be optional")
+			}
+			assertUSJurisdictionValidation(t, ctx, attribute.Validators)
+		})
+	}
+}
+
+func assertUSJurisdictionValidation(t *testing.T, ctx context.Context, validators []validator.String) {
+	t.Helper()
+	if len(validators) == 0 {
+		t.Fatal("expected jurisdiction validator")
+	}
+
+	for _, test := range []struct {
+		value     string
+		wantError bool
+	}{
+		{value: "us"},
+		{value: "invalid", wantError: true},
+	} {
+		response := &validator.StringResponse{}
+		request := validator.StringRequest{ConfigValue: types.StringValue(test.value)}
+		for _, jurisdictionValidator := range validators {
+			jurisdictionValidator.ValidateString(ctx, request, response)
+		}
+		if got := response.Diagnostics.HasError(); got != test.wantError {
+			t.Fatalf("validation error for %q: got %t, want %t", test.value, got, test.wantError)
+		}
+	}
+}

--- a/internal/services/r2_bucket_cors/data_source_model.go
+++ b/internal/services/r2_bucket_cors/data_source_model.go
@@ -17,14 +17,18 @@ type R2BucketCORSResultDataSourceEnvelope struct {
 }
 
 type R2BucketCORSDataSourceModel struct {
-	AccountID  types.String                                                   `tfsdk:"account_id" path:"account_id,required"`
-	BucketName types.String                                                   `tfsdk:"bucket_name" path:"bucket_name,required"`
-	Rules      customfield.NestedObjectList[R2BucketCORSRulesDataSourceModel] `tfsdk:"rules" json:"rules,computed"`
+	AccountID    types.String                                                   `tfsdk:"account_id" path:"account_id,required"`
+	BucketName   types.String                                                   `tfsdk:"bucket_name" path:"bucket_name,required"`
+	Jurisdiction types.String                                                   `tfsdk:"jurisdiction" json:"-,optional,no_refresh"`
+	Rules        customfield.NestedObjectList[R2BucketCORSRulesDataSourceModel] `tfsdk:"rules" json:"rules,computed"`
 }
 
 func (m *R2BucketCORSDataSourceModel) toReadParams(_ context.Context) (params r2.BucketCORSGetParams, diags diag.Diagnostics) {
 	params = r2.BucketCORSGetParams{
 		AccountID: cloudflare.F(m.AccountID.ValueString()),
+	}
+	if !m.Jurisdiction.IsNull() {
+		params.Jurisdiction = cloudflare.F(r2.BucketCORSGetParamsCfR2Jurisdiction(m.Jurisdiction.ValueString()))
 	}
 
 	return

--- a/internal/services/r2_bucket_cors/data_source_model_test.go
+++ b/internal/services/r2_bucket_cors/data_source_model_test.go
@@ -1,0 +1,28 @@
+package r2_bucket_cors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestR2BucketCORSDataSourceToReadParamsJurisdiction(t *testing.T) {
+	t.Parallel()
+
+	params, diags := (&R2BucketCORSDataSourceModel{Jurisdiction: types.StringValue("us")}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if !params.Jurisdiction.Present || string(params.Jurisdiction.Value) != "us" {
+		t.Fatalf("expected us jurisdiction, got %#v", params.Jurisdiction)
+	}
+
+	params, diags = (&R2BucketCORSDataSourceModel{Jurisdiction: types.StringNull()}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if params.Jurisdiction.Present {
+		t.Fatalf("expected omitted jurisdiction, got %#v", params.Jurisdiction)
+	}
+}

--- a/internal/services/r2_bucket_cors/data_source_schema.go
+++ b/internal/services/r2_bucket_cors/data_source_schema.go
@@ -27,6 +27,18 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				Description: "Name of the bucket.",
 				Required:    true,
 			},
+			"jurisdiction": schema.StringAttribute{
+				Description: "Jurisdiction of the bucket.\nAvailable values: \"default\", \"eu\", \"fedramp\", \"us\".",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOfCaseInsensitive(
+						"default",
+						"eu",
+						"fedramp",
+						"us",
+					),
+				},
+			},
 			"rules": schema.ListNestedAttribute{
 				Computed:   true,
 				CustomType: customfield.NewNestedObjectListType[R2BucketCORSRulesDataSourceModel](ctx),

--- a/internal/services/r2_bucket_cors/schema.go
+++ b/internal/services/r2_bucket_cors/schema.go
@@ -42,6 +42,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"default",
 						"eu",
 						"fedramp",
+						"us",
 					),
 				},
 			},

--- a/internal/services/r2_bucket_event_notification/data_source_model.go
+++ b/internal/services/r2_bucket_event_notification/data_source_model.go
@@ -17,16 +17,20 @@ type R2BucketEventNotificationResultDataSourceEnvelope struct {
 }
 
 type R2BucketEventNotificationDataSourceModel struct {
-	AccountID  types.String                                                                `tfsdk:"account_id" path:"account_id,required"`
-	BucketName types.String                                                                `tfsdk:"bucket_name" path:"bucket_name,required"`
-	QueueID    types.String                                                                `tfsdk:"queue_id" path:"queue_id,required"`
-	QueueName  types.String                                                                `tfsdk:"queue_name" json:"queueName,computed"`
-	Rules      customfield.NestedObjectList[R2BucketEventNotificationRulesDataSourceModel] `tfsdk:"rules" json:"rules,computed"`
+	AccountID    types.String                                                                `tfsdk:"account_id" path:"account_id,required"`
+	BucketName   types.String                                                                `tfsdk:"bucket_name" path:"bucket_name,required"`
+	Jurisdiction types.String                                                                `tfsdk:"jurisdiction" json:"-,optional,no_refresh"`
+	QueueID      types.String                                                                `tfsdk:"queue_id" path:"queue_id,required"`
+	QueueName    types.String                                                                `tfsdk:"queue_name" json:"queueName,computed"`
+	Rules        customfield.NestedObjectList[R2BucketEventNotificationRulesDataSourceModel] `tfsdk:"rules" json:"rules,computed"`
 }
 
 func (m *R2BucketEventNotificationDataSourceModel) toReadParams(_ context.Context) (params r2.BucketEventNotificationGetParams, diags diag.Diagnostics) {
 	params = r2.BucketEventNotificationGetParams{
 		AccountID: cloudflare.F(m.AccountID.ValueString()),
+	}
+	if !m.Jurisdiction.IsNull() {
+		params.Jurisdiction = cloudflare.F(r2.BucketEventNotificationGetParamsCfR2Jurisdiction(m.Jurisdiction.ValueString()))
 	}
 
 	return

--- a/internal/services/r2_bucket_event_notification/data_source_model_test.go
+++ b/internal/services/r2_bucket_event_notification/data_source_model_test.go
@@ -1,0 +1,28 @@
+package r2_bucket_event_notification
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestR2BucketEventNotificationDataSourceToReadParamsJurisdiction(t *testing.T) {
+	t.Parallel()
+
+	params, diags := (&R2BucketEventNotificationDataSourceModel{Jurisdiction: types.StringValue("us")}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if !params.Jurisdiction.Present || string(params.Jurisdiction.Value) != "us" {
+		t.Fatalf("expected us jurisdiction, got %#v", params.Jurisdiction)
+	}
+
+	params, diags = (&R2BucketEventNotificationDataSourceModel{Jurisdiction: types.StringNull()}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if params.Jurisdiction.Present {
+		t.Fatalf("expected omitted jurisdiction, got %#v", params.Jurisdiction)
+	}
+}

--- a/internal/services/r2_bucket_event_notification/data_source_schema.go
+++ b/internal/services/r2_bucket_event_notification/data_source_schema.go
@@ -34,6 +34,18 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				Description: "Name of the bucket.",
 				Required:    true,
 			},
+			"jurisdiction": schema.StringAttribute{
+				Description: "Jurisdiction of the bucket.\nAvailable values: \"default\", \"eu\", \"fedramp\", \"us\".",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOfCaseInsensitive(
+						"default",
+						"eu",
+						"fedramp",
+						"us",
+					),
+				},
+			},
 			"queue_id": schema.StringAttribute{
 				Description: "Queue ID.",
 				Required:    true,

--- a/internal/services/r2_bucket_event_notification/schema.go
+++ b/internal/services/r2_bucket_event_notification/schema.go
@@ -49,6 +49,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"default",
 						"eu",
 						"fedramp",
+						"us",
 					),
 				},
 			},

--- a/internal/services/r2_bucket_lifecycle/data_source_model.go
+++ b/internal/services/r2_bucket_lifecycle/data_source_model.go
@@ -18,14 +18,18 @@ type R2BucketLifecycleResultDataSourceEnvelope struct {
 }
 
 type R2BucketLifecycleDataSourceModel struct {
-	AccountID  types.String                                                        `tfsdk:"account_id" path:"account_id,required"`
-	BucketName types.String                                                        `tfsdk:"bucket_name" path:"bucket_name,required"`
-	Rules      customfield.NestedObjectList[R2BucketLifecycleRulesDataSourceModel] `tfsdk:"rules" json:"rules,computed"`
+	AccountID    types.String                                                        `tfsdk:"account_id" path:"account_id,required"`
+	BucketName   types.String                                                        `tfsdk:"bucket_name" path:"bucket_name,required"`
+	Jurisdiction types.String                                                        `tfsdk:"jurisdiction" json:"-,optional,no_refresh"`
+	Rules        customfield.NestedObjectList[R2BucketLifecycleRulesDataSourceModel] `tfsdk:"rules" json:"rules,computed"`
 }
 
 func (m *R2BucketLifecycleDataSourceModel) toReadParams(_ context.Context) (params r2.BucketLifecycleGetParams, diags diag.Diagnostics) {
 	params = r2.BucketLifecycleGetParams{
 		AccountID: cloudflare.F(m.AccountID.ValueString()),
+	}
+	if !m.Jurisdiction.IsNull() {
+		params.Jurisdiction = cloudflare.F(r2.BucketLifecycleGetParamsCfR2Jurisdiction(m.Jurisdiction.ValueString()))
 	}
 
 	return

--- a/internal/services/r2_bucket_lifecycle/data_source_model_test.go
+++ b/internal/services/r2_bucket_lifecycle/data_source_model_test.go
@@ -1,0 +1,28 @@
+package r2_bucket_lifecycle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestR2BucketLifecycleDataSourceToReadParamsJurisdiction(t *testing.T) {
+	t.Parallel()
+
+	params, diags := (&R2BucketLifecycleDataSourceModel{Jurisdiction: types.StringValue("us")}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if !params.Jurisdiction.Present || string(params.Jurisdiction.Value) != "us" {
+		t.Fatalf("expected us jurisdiction, got %#v", params.Jurisdiction)
+	}
+
+	params, diags = (&R2BucketLifecycleDataSourceModel{Jurisdiction: types.StringNull()}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if params.Jurisdiction.Present {
+		t.Fatalf("expected omitted jurisdiction, got %#v", params.Jurisdiction)
+	}
+}

--- a/internal/services/r2_bucket_lifecycle/data_source_schema.go
+++ b/internal/services/r2_bucket_lifecycle/data_source_schema.go
@@ -26,6 +26,18 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				Description: "Name of the bucket.",
 				Required:    true,
 			},
+			"jurisdiction": schema.StringAttribute{
+				Description: "Jurisdiction of the bucket.\nAvailable values: \"default\", \"eu\", \"fedramp\", \"us\".",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOfCaseInsensitive(
+						"default",
+						"eu",
+						"fedramp",
+						"us",
+					),
+				},
+			},
 			"rules": schema.ListNestedAttribute{
 				Computed:   true,
 				CustomType: customfield.NewNestedObjectListType[R2BucketLifecycleRulesDataSourceModel](ctx),

--- a/internal/services/r2_bucket_lifecycle/schema.go
+++ b/internal/services/r2_bucket_lifecycle/schema.go
@@ -41,6 +41,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"default",
 						"eu",
 						"fedramp",
+						"us",
 					),
 				},
 			},

--- a/internal/services/r2_bucket_lock/data_source_model.go
+++ b/internal/services/r2_bucket_lock/data_source_model.go
@@ -18,14 +18,18 @@ type R2BucketLockResultDataSourceEnvelope struct {
 }
 
 type R2BucketLockDataSourceModel struct {
-	AccountID  types.String                                                   `tfsdk:"account_id" path:"account_id,required"`
-	BucketName types.String                                                   `tfsdk:"bucket_name" path:"bucket_name,required"`
-	Rules      customfield.NestedObjectList[R2BucketLockRulesDataSourceModel] `tfsdk:"rules" json:"rules,computed"`
+	AccountID    types.String                                                   `tfsdk:"account_id" path:"account_id,required"`
+	BucketName   types.String                                                   `tfsdk:"bucket_name" path:"bucket_name,required"`
+	Jurisdiction types.String                                                   `tfsdk:"jurisdiction" json:"-,optional,no_refresh"`
+	Rules        customfield.NestedObjectList[R2BucketLockRulesDataSourceModel] `tfsdk:"rules" json:"rules,computed"`
 }
 
 func (m *R2BucketLockDataSourceModel) toReadParams(_ context.Context) (params r2.BucketLockGetParams, diags diag.Diagnostics) {
 	params = r2.BucketLockGetParams{
 		AccountID: cloudflare.F(m.AccountID.ValueString()),
+	}
+	if !m.Jurisdiction.IsNull() {
+		params.Jurisdiction = cloudflare.F(r2.BucketLockGetParamsCfR2Jurisdiction(m.Jurisdiction.ValueString()))
 	}
 
 	return

--- a/internal/services/r2_bucket_lock/data_source_model_test.go
+++ b/internal/services/r2_bucket_lock/data_source_model_test.go
@@ -1,0 +1,28 @@
+package r2_bucket_lock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestR2BucketLockDataSourceToReadParamsJurisdiction(t *testing.T) {
+	t.Parallel()
+
+	params, diags := (&R2BucketLockDataSourceModel{Jurisdiction: types.StringValue("us")}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if !params.Jurisdiction.Present || string(params.Jurisdiction.Value) != "us" {
+		t.Fatalf("expected us jurisdiction, got %#v", params.Jurisdiction)
+	}
+
+	params, diags = (&R2BucketLockDataSourceModel{Jurisdiction: types.StringNull()}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if params.Jurisdiction.Present {
+		t.Fatalf("expected omitted jurisdiction, got %#v", params.Jurisdiction)
+	}
+}

--- a/internal/services/r2_bucket_lock/data_source_schema.go
+++ b/internal/services/r2_bucket_lock/data_source_schema.go
@@ -26,6 +26,18 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				Description: "Name of the bucket.",
 				Required:    true,
 			},
+			"jurisdiction": schema.StringAttribute{
+				Description: "Jurisdiction of the bucket.\nAvailable values: \"default\", \"eu\", \"fedramp\", \"us\".",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOfCaseInsensitive(
+						"default",
+						"eu",
+						"fedramp",
+						"us",
+					),
+				},
+			},
 			"rules": schema.ListNestedAttribute{
 				Computed:   true,
 				CustomType: customfield.NewNestedObjectListType[R2BucketLockRulesDataSourceModel](ctx),

--- a/internal/services/r2_bucket_lock/schema.go
+++ b/internal/services/r2_bucket_lock/schema.go
@@ -41,6 +41,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"default",
 						"eu",
 						"fedramp",
+						"us",
 					),
 				},
 			},

--- a/internal/services/r2_bucket_sippy/data_source_model.go
+++ b/internal/services/r2_bucket_sippy/data_source_model.go
@@ -17,16 +17,20 @@ type R2BucketSippyResultDataSourceEnvelope struct {
 }
 
 type R2BucketSippyDataSourceModel struct {
-	AccountID   types.String                                                      `tfsdk:"account_id" path:"account_id,required"`
-	BucketName  types.String                                                      `tfsdk:"bucket_name" path:"bucket_name,required"`
-	Enabled     types.Bool                                                        `tfsdk:"enabled" json:"enabled,computed"`
-	Destination customfield.NestedObject[R2BucketSippyDestinationDataSourceModel] `tfsdk:"destination" json:"destination,computed"`
-	Source      customfield.NestedObject[R2BucketSippySourceDataSourceModel]      `tfsdk:"source" json:"source,computed"`
+	AccountID    types.String                                                      `tfsdk:"account_id" path:"account_id,required"`
+	BucketName   types.String                                                      `tfsdk:"bucket_name" path:"bucket_name,required"`
+	Jurisdiction types.String                                                      `tfsdk:"jurisdiction" json:"-,optional,no_refresh"`
+	Enabled      types.Bool                                                        `tfsdk:"enabled" json:"enabled,computed"`
+	Destination  customfield.NestedObject[R2BucketSippyDestinationDataSourceModel] `tfsdk:"destination" json:"destination,computed"`
+	Source       customfield.NestedObject[R2BucketSippySourceDataSourceModel]      `tfsdk:"source" json:"source,computed"`
 }
 
 func (m *R2BucketSippyDataSourceModel) toReadParams(_ context.Context) (params r2.BucketSippyGetParams, diags diag.Diagnostics) {
 	params = r2.BucketSippyGetParams{
 		AccountID: cloudflare.F(m.AccountID.ValueString()),
+	}
+	if !m.Jurisdiction.IsNull() {
+		params.Jurisdiction = cloudflare.F(r2.BucketSippyGetParamsCfR2Jurisdiction(m.Jurisdiction.ValueString()))
 	}
 
 	return

--- a/internal/services/r2_bucket_sippy/data_source_model_test.go
+++ b/internal/services/r2_bucket_sippy/data_source_model_test.go
@@ -1,0 +1,28 @@
+package r2_bucket_sippy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestR2BucketSippyDataSourceToReadParamsJurisdiction(t *testing.T) {
+	t.Parallel()
+
+	params, diags := (&R2BucketSippyDataSourceModel{Jurisdiction: types.StringValue("us")}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if !params.Jurisdiction.Present || string(params.Jurisdiction.Value) != "us" {
+		t.Fatalf("expected us jurisdiction, got %#v", params.Jurisdiction)
+	}
+
+	params, diags = (&R2BucketSippyDataSourceModel{Jurisdiction: types.StringNull()}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if params.Jurisdiction.Present {
+		t.Fatalf("expected omitted jurisdiction, got %#v", params.Jurisdiction)
+	}
+}

--- a/internal/services/r2_bucket_sippy/data_source_schema.go
+++ b/internal/services/r2_bucket_sippy/data_source_schema.go
@@ -25,6 +25,18 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				Description: "Name of the bucket.",
 				Required:    true,
 			},
+			"jurisdiction": schema.StringAttribute{
+				Description: "Jurisdiction of the bucket.\nAvailable values: \"default\", \"eu\", \"fedramp\", \"us\".",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOfCaseInsensitive(
+						"default",
+						"eu",
+						"fedramp",
+						"us",
+					),
+				},
+			},
 			"enabled": schema.BoolAttribute{
 				Description: "State of Sippy for this bucket.",
 				Computed:    true,

--- a/internal/services/r2_bucket_sippy/schema.go
+++ b/internal/services/r2_bucket_sippy/schema.go
@@ -46,6 +46,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"default",
 						"eu",
 						"fedramp",
+						"us",
 					),
 				},
 			},

--- a/internal/services/r2_custom_domain/data_source_model.go
+++ b/internal/services/r2_custom_domain/data_source_model.go
@@ -17,20 +17,24 @@ type R2CustomDomainResultDataSourceEnvelope struct {
 }
 
 type R2CustomDomainDataSourceModel struct {
-	AccountID  types.String                                                  `tfsdk:"account_id" path:"account_id,required"`
-	BucketName types.String                                                  `tfsdk:"bucket_name" path:"bucket_name,required"`
-	Domain     types.String                                                  `tfsdk:"domain" path:"domain,required"`
-	Enabled    types.Bool                                                    `tfsdk:"enabled" json:"enabled,computed"`
-	MinTLS     types.String                                                  `tfsdk:"min_tls" json:"minTLS,computed"`
-	ZoneID     types.String                                                  `tfsdk:"zone_id" json:"zoneId,computed"`
-	ZoneName   types.String                                                  `tfsdk:"zone_name" json:"zoneName,computed"`
-	Ciphers    customfield.List[types.String]                                `tfsdk:"ciphers" json:"ciphers,computed"`
-	Status     customfield.NestedObject[R2CustomDomainStatusDataSourceModel] `tfsdk:"status" json:"status,computed"`
+	AccountID    types.String                                                  `tfsdk:"account_id" path:"account_id,required"`
+	BucketName   types.String                                                  `tfsdk:"bucket_name" path:"bucket_name,required"`
+	Jurisdiction types.String                                                  `tfsdk:"jurisdiction" json:"-,optional,no_refresh"`
+	Domain       types.String                                                  `tfsdk:"domain" path:"domain,required"`
+	Enabled      types.Bool                                                    `tfsdk:"enabled" json:"enabled,computed"`
+	MinTLS       types.String                                                  `tfsdk:"min_tls" json:"minTLS,computed"`
+	ZoneID       types.String                                                  `tfsdk:"zone_id" json:"zoneId,computed"`
+	ZoneName     types.String                                                  `tfsdk:"zone_name" json:"zoneName,computed"`
+	Ciphers      customfield.List[types.String]                                `tfsdk:"ciphers" json:"ciphers,computed"`
+	Status       customfield.NestedObject[R2CustomDomainStatusDataSourceModel] `tfsdk:"status" json:"status,computed"`
 }
 
 func (m *R2CustomDomainDataSourceModel) toReadParams(_ context.Context) (params r2.BucketDomainCustomGetParams, diags diag.Diagnostics) {
 	params = r2.BucketDomainCustomGetParams{
 		AccountID: cloudflare.F(m.AccountID.ValueString()),
+	}
+	if !m.Jurisdiction.IsNull() {
+		params.Jurisdiction = cloudflare.F(r2.BucketDomainCustomGetParamsCfR2Jurisdiction(m.Jurisdiction.ValueString()))
 	}
 
 	return

--- a/internal/services/r2_custom_domain/data_source_model_test.go
+++ b/internal/services/r2_custom_domain/data_source_model_test.go
@@ -1,0 +1,28 @@
+package r2_custom_domain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestR2CustomDomainDataSourceToReadParamsJurisdiction(t *testing.T) {
+	t.Parallel()
+
+	params, diags := (&R2CustomDomainDataSourceModel{Jurisdiction: types.StringValue("us")}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if !params.Jurisdiction.Present || string(params.Jurisdiction.Value) != "us" {
+		t.Fatalf("expected us jurisdiction, got %#v", params.Jurisdiction)
+	}
+
+	params, diags = (&R2CustomDomainDataSourceModel{Jurisdiction: types.StringNull()}).toReadParams(context.Background())
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	if params.Jurisdiction.Present {
+		t.Fatalf("expected omitted jurisdiction, got %#v", params.Jurisdiction)
+	}
+}

--- a/internal/services/r2_custom_domain/data_source_schema.go
+++ b/internal/services/r2_custom_domain/data_source_schema.go
@@ -33,6 +33,18 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				Description: "Name of the bucket.",
 				Required:    true,
 			},
+			"jurisdiction": schema.StringAttribute{
+				Description: "Jurisdiction of the bucket.\nAvailable values: \"default\", \"eu\", \"fedramp\", \"us\".",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOfCaseInsensitive(
+						"default",
+						"eu",
+						"fedramp",
+						"us",
+					),
+				},
+			},
 			"domain": schema.StringAttribute{
 				Description: "Name of the custom domain.",
 				Required:    true,

--- a/internal/services/r2_custom_domain/schema.go
+++ b/internal/services/r2_custom_domain/schema.go
@@ -49,6 +49,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"default",
 						"eu",
 						"fedramp",
+						"us",
 					),
 				},
 			},

--- a/internal/services/r2_managed_domain/schema.go
+++ b/internal/services/r2_managed_domain/schema.go
@@ -40,6 +40,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"default",
 						"eu",
 						"fedramp",
+						"us",
 					),
 				},
 			},

--- a/internal/services/worker_version/data_source_schema.go
+++ b/internal/services/worker_version/data_source_schema.go
@@ -366,13 +366,14 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 							Computed:    true,
 						},
 						"jurisdiction": schema.StringAttribute{
-							Description: "The [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) of the R2 bucket.\nAvailable values: \"eu\", \"fedramp\", \"fedramp-high\".",
+							Description: "The [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) of the R2 bucket.\nAvailable values: \"eu\", \"fedramp\", \"fedramp-high\", \"us\".",
 							Computed:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOfCaseInsensitive(
 									"eu",
 									"fedramp",
 									"fedramp-high",
+									"us",
 								),
 							},
 						},

--- a/internal/services/worker_version/list_data_source_schema.go
+++ b/internal/services/worker_version/list_data_source_schema.go
@@ -327,13 +327,14 @@ func ListDataSourceSchema(ctx context.Context) schema.Schema {
 										Computed:    true,
 									},
 									"jurisdiction": schema.StringAttribute{
-										Description: "The [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) of the R2 bucket.\nAvailable values: \"eu\", \"fedramp\", \"fedramp-high\".",
+										Description: "The [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) of the R2 bucket.\nAvailable values: \"eu\", \"fedramp\", \"fedramp-high\", \"us\".",
 										Computed:    true,
 										Validators: []validator.String{
 											stringvalidator.OneOfCaseInsensitive(
 												"eu",
 												"fedramp",
 												"fedramp-high",
+												"us",
 											),
 										},
 									},

--- a/internal/services/worker_version/schema.go
+++ b/internal/services/worker_version/schema.go
@@ -671,13 +671,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Optional:    true,
 						},
 						"jurisdiction": schema.StringAttribute{
-							Description: "The [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) of the R2 bucket.\nAvailable values: \"eu\", \"fedramp\", \"fedramp-high\".",
+							Description: "The [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) of the R2 bucket.\nAvailable values: \"eu\", \"fedramp\", \"fedramp-high\", \"us\".",
 							Optional:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOfCaseInsensitive(
 									"eu",
 									"fedramp",
 									"fedramp-high",
+									"us",
 								),
 							},
 						},

--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -420,13 +420,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Optional:    true,
 						},
 						"jurisdiction": schema.StringAttribute{
-							Description: "The [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) of the R2 bucket.\nAvailable values: \"eu\", \"fedramp\", \"fedramp-high\".",
+							Description: "The [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) of the R2 bucket.\nAvailable values: \"eu\", \"fedramp\", \"fedramp-high\", \"us\".",
 							Optional:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOfCaseInsensitive(
 									"eu",
 									"fedramp",
 									"fedramp-high",
+									"us",
 								),
 							},
 						},


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- Please note that most the code in this repository is auto-generated. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Add support for the R2 `us` jurisdiction.

- Accept `us` in R2 resource and Workers binding validators.
- Allow R2 data sources to send the `cf-r2-jurisdiction` header when configured.
- Preserve existing behavior when jurisdiction is omitted.
- Add focused unit tests and regenerate provider documentation.

## Acceptance test run results

- [ ] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

### Steps to run acceptance tests

Acceptance tests were not run because they require `TF_ACC=1` and suitable Cloudflare account credentials.

### Test output

```text
PASS  Targeted tests for all affected service packages
PASS  ./scripts/check-schema-versions
PASS  ./scripts/lint (34 pre-existing sweeper warnings)
PASS  git diff --check
```