### PR TITLE
add fedramp-high R2 jurisdiction support

### DIFF
--- a/docs/data-sources/r2_bucket.md
+++ b/docs/data-sources/r2_bucket.md
@@ -34,7 +34,7 @@ data "cloudflare_r2_bucket" "example_r2_bucket" {
 - `creation_date` (String) Creation timestamp.
 - `id` (String) Name of the bucket.
 - `jurisdiction` (String) Jurisdiction where objects in this bucket are guaranteed to be stored.
-Available values: "default", "eu", "fedramp", "us".
+Available values: "default", "eu", "fedramp", "fedramp-high", "us".
 - `location` (String) Location of the bucket.
 Available values: "apac", "eeur", "enam", "weur", "wnam", "oc".
 - `name` (String) Name of the bucket.

--- a/docs/resources/r2_bucket.md
+++ b/docs/resources/r2_bucket.md
@@ -34,7 +34,7 @@ resource "cloudflare_r2_bucket" "example_r2_bucket" {
 ### Optional
 
 - `jurisdiction` (String) Jurisdiction where objects in this bucket are guaranteed to be stored.
-Available values: "default", "eu", "fedramp", "us".
+Available values: "default", "eu", "fedramp", "fedramp-high", "us".
 - `location` (String) Location of the bucket.
 Available values: "apac", "eeur", "enam", "weur", "wnam", "oc".  Note: `location` is only honored the first time a bucket with a given name is created. If you delete and recreate a bucket with the same name, the original bucket location will be used. It is also a best-effort, not a guarantee, of bucket location.
 - `storage_class` (String) Storage class for newly uploaded objects, unless specified otherwise.

--- a/internal/services/r2_bucket/data_source_schema.go
+++ b/internal/services/r2_bucket/data_source_schema.go
@@ -33,13 +33,14 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 				Computed:    true,
 			},
 			"jurisdiction": schema.StringAttribute{
-				Description: "Jurisdiction where objects in this bucket are guaranteed to be stored.\nAvailable values: \"default\", \"eu\", \"fedramp\", \"us\".",
+				Description: "Jurisdiction where objects in this bucket are guaranteed to be stored.\nAvailable values: \"default\", \"eu\", \"fedramp\", \"fedramp-high\", \"us\".",
 				Computed:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive(
 						"default",
 						"eu",
 						"fedramp",
+						"fedramp-high",
 						"us",
 					),
 				},

--- a/internal/services/r2_bucket/jurisdiction_test.go
+++ b/internal/services/r2_bucket/jurisdiction_test.go
@@ -1,0 +1,28 @@
+package r2_bucket_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_bucket"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestR2BucketFedRAMPHighJurisdictionValidation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	jurisdiction := r2_bucket.ResourceSchema(ctx).Attributes["jurisdiction"].(resourceschema.StringAttribute)
+	request := validator.StringRequest{ConfigValue: types.StringValue("fedramp-high")}
+	response := &validator.StringResponse{}
+
+	for _, jurisdictionValidator := range jurisdiction.Validators {
+		jurisdictionValidator.ValidateString(ctx, request, response)
+	}
+
+	if response.Diagnostics.HasError() {
+		t.Fatalf("expected fedramp-high to be a valid jurisdiction: %v", response.Diagnostics)
+	}
+}

--- a/internal/services/r2_bucket/resource_test.go
+++ b/internal/services/r2_bucket/resource_test.go
@@ -266,6 +266,36 @@ func TestAccCloudflareR2Bucket_AllJurisdictions(t *testing.T) {
 	}
 }
 
+func TestAccCloudflareR2Bucket_FedRAMPHighJurisdiction(t *testing.T) {
+	if !strings.Contains(os.Getenv("CLOUDFLARE_BASE_URL"), "api.fed.cloudflare.com") {
+		t.Skip("skipping: fedramp-high requires the FedRAMP API endpoint and account credentials")
+	}
+
+	rnd := utils.GenerateRandomResourceName()
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	resourceName := "cloudflare_r2_bucket." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheck_AccountID(t)
+		},
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudflareR2BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareR2BucketJurisdictionSpecific(rnd, accountID, "fedramp-high"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rnd)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("jurisdiction"), knownvalue.StringExact("fedramp-high")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_id"), knownvalue.StringExact(accountID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("storage_class"), knownvalue.StringExact("Standard")),
+				},
+			},
+		},
+	})
+}
+
 func TestAccCloudflareR2Bucket_ComprehensiveConfiguration(t *testing.T) {
 	rnd := utils.GenerateRandomResourceName()
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")

--- a/internal/services/r2_bucket/schema.go
+++ b/internal/services/r2_bucket/schema.go
@@ -91,7 +91,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"jurisdiction": schema.StringAttribute{
-				Description: "Jurisdiction where objects in this bucket are guaranteed to be stored.\nAvailable values: \"default\", \"eu\", \"fedramp\", \"us\".",
+				Description: "Jurisdiction where objects in this bucket are guaranteed to be stored.\nAvailable values: \"default\", \"eu\", \"fedramp\", \"fedramp-high\", \"us\".",
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString("default"),
@@ -100,6 +100,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"default",
 						"eu",
 						"fedramp",
+						"fedramp-high",
 						"us",
 					),
 				},


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

FedRAMP High accounts require the `fedramp-high` R2 jurisdiction, but the provider currently rejects it during configuration validation.

- Allow `fedramp-high` in the R2 bucket resource and data source schemas.
- Update the generated documentation.
- Add validation coverage and a FedRAMP-specific acceptance test.

## Acceptance test run results

- [x] I have added or updated acceptance tests for my changes
- [ ] I have run acceptance tests for my changes and included the results below

The live acceptance test requires FedRAMP API credentials, which were unavailable locally.

### Steps to run acceptance tests

```shell
CLOUDFLARE_BASE_URL="https://api.fed.cloudflare.com/client/v4" \
CLOUDFLARE_ACCOUNT_ID="<fedramp-account-id>" \
CLOUDFLARE_API_TOKEN="<fedramp-api-token>" \
TF_ACC=1 \
go test -v ./internal/services/r2_bucket \
  -run '^TestAccCloudflareR2Bucket_FedRAMPHighJurisdiction$'
```

Test output
```
$ go test ./internal/services/r2_bucket
ok github.com/cloudflare/terraform-provider-cloudflare/internal/services/r2_bucket
```

Additional context & links
- https://github.com/cloudflare/terraform-provider-cloudflare/pull/7270