### PR TITLE
fix(ai_gateway_dynamic_routing): normalize version graph responses

### DIFF
--- a/internal/services/ai_gateway_dynamic_routing/custom.go
+++ b/internal/services/ai_gateway_dynamic_routing/custom.go
@@ -25,8 +25,13 @@ func normalizeDynamicRoutingResponse(raw []byte) ([]byte, error) {
 	elementsRaw, hasElements := result["elements"]
 	if hasElements {
 		elementsRaw = bytes.TrimSpace(elementsRaw)
-		if bytes.Equal(elementsRaw, []byte("null")) || bytes.Equal(elementsRaw, []byte("[]")) {
+		if bytes.Equal(elementsRaw, []byte("null")) {
 			hasElements = false
+		} else {
+			var elements []json.RawMessage
+			if err := json.Unmarshal(elementsRaw, &elements); err == nil && elements != nil && len(elements) == 0 {
+				hasElements = false
+			}
 		}
 	}
 

--- a/internal/services/ai_gateway_dynamic_routing/custom.go
+++ b/internal/services/ai_gateway_dynamic_routing/custom.go
@@ -29,8 +29,13 @@ func normalizeDynamicRoutingResponse(raw []byte) ([]byte, error) {
 			hasElements = false
 		} else {
 			var elements []json.RawMessage
-			if err := json.Unmarshal(elementsRaw, &elements); err == nil && elements != nil && len(elements) == 0 {
+			if err := json.Unmarshal(elementsRaw, &elements); err != nil || elements == nil {
+				return raw, nil
+			}
+			if len(elements) == 0 {
 				hasElements = false
+			} else if !isDynamicRoutingGraph(elements) {
+				return raw, nil
 			}
 		}
 	}

--- a/internal/services/ai_gateway_dynamic_routing/custom.go
+++ b/internal/services/ai_gateway_dynamic_routing/custom.go
@@ -1,0 +1,107 @@
+package ai_gateway_dynamic_routing
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// normalizeDynamicRoutingResponse adapts the alternate API response shape to the
+// provider model while preserving populated documented elements responses.
+func normalizeDynamicRoutingResponse(raw []byte) ([]byte, error) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return raw, nil
+	}
+
+	resultRaw, ok := envelope["result"]
+	if !ok {
+		return raw, nil
+	}
+
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(resultRaw, &result); err != nil {
+		return raw, nil
+	}
+	elementsRaw, hasElements := result["elements"]
+	if hasElements {
+		elementsRaw = bytes.TrimSpace(elementsRaw)
+		if bytes.Equal(elementsRaw, []byte("null")) || bytes.Equal(elementsRaw, []byte("[]")) {
+			hasElements = false
+		}
+	}
+
+	versionRaw, ok := result["version"]
+	if !ok {
+		return raw, nil
+	}
+
+	var version map[string]json.RawMessage
+	if err := json.Unmarshal(versionRaw, &version); err != nil {
+		return raw, nil
+	}
+
+	dataRaw, ok := version["data"]
+	if !ok {
+		return raw, nil
+	}
+
+	var graph []json.RawMessage
+	if err := json.Unmarshal(dataRaw, &graph); err != nil || graph == nil {
+		return raw, nil
+	}
+	if !isDynamicRoutingGraph(graph) {
+		return raw, nil
+	}
+
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, dataRaw); err != nil {
+		return raw, nil
+	}
+
+	if !hasElements {
+		result["elements"] = json.RawMessage(append([]byte(nil), compact.Bytes()...))
+	}
+	// The generated model exposes version.data as a string, while this API
+	// variant returns the graph as an array.
+	versionData, err := json.Marshal(compact.String())
+	if err != nil {
+		return nil, err
+	}
+	version["data"] = versionData
+
+	versionRaw, err = json.Marshal(version)
+	if err != nil {
+		return nil, err
+	}
+	result["version"] = versionRaw
+	resultRaw, err = json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+	envelope["result"] = resultRaw
+
+	return json.Marshal(envelope)
+}
+
+func isDynamicRoutingGraph(graph []json.RawMessage) bool {
+	for _, elementRaw := range graph {
+		var element map[string]json.RawMessage
+		if err := json.Unmarshal(elementRaw, &element); err != nil || element == nil {
+			return false
+		}
+
+		var id, elementType string
+		if err := json.Unmarshal(element["id"], &id); err != nil || id == "" {
+			return false
+		}
+		if err := json.Unmarshal(element["type"], &elementType); err != nil || elementType == "" {
+			return false
+		}
+		var outputs map[string]json.RawMessage
+		if err := json.Unmarshal(element["outputs"], &outputs); err != nil || outputs == nil {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/services/ai_gateway_dynamic_routing/custom_test.go
+++ b/internal/services/ai_gateway_dynamic_routing/custom_test.go
@@ -243,6 +243,8 @@ func TestNormalizeDynamicRoutingResponse_PreservesUnsupportedPayloads(t *testing
 		`{"result":{"version":{"data":[1]}},"success":true}`,
 		`{"result":{"version":{"data":[{}]}},"success":true}`,
 		`{"result":{"elements":[],"version":{"data":[{}]}},"success":true}`,
+		`{"result":{"elements":{},"version":{"data":[{"id":"start","outputs":{},"type":"end"}]}},"success":true}`,
+		`{"result":{"elements":[null],"version":{"data":[{"id":"start","outputs":{},"type":"end"}]}},"success":true}`,
 		`{"result":`,
 	}
 

--- a/internal/services/ai_gateway_dynamic_routing/custom_test.go
+++ b/internal/services/ai_gateway_dynamic_routing/custom_test.go
@@ -1,0 +1,377 @@
+package ai_gateway_dynamic_routing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v7"
+	"github.com/cloudflare/cloudflare-go/v7/option"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/customfield"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func newTestResource(t *testing.T, baseURL string) *AIGatewayDynamicRoutingResource {
+	t.Helper()
+
+	r := NewResource().(*AIGatewayDynamicRoutingResource)
+	client := cloudflare.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIToken("test-token"),
+	)
+	resp := &resource.ConfigureResponse{}
+	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: client}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Configure failed: %v", resp.Diagnostics)
+	}
+	return r
+}
+
+func newTestDataSource(t *testing.T, baseURL string) *AIGatewayDynamicRoutingDataSource {
+	t.Helper()
+
+	d := NewAIGatewayDynamicRoutingDataSource().(*AIGatewayDynamicRoutingDataSource)
+	client := cloudflare.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIToken("test-token"),
+	)
+	resp := &datasource.ConfigureResponse{}
+	d.Configure(context.Background(), datasource.ConfigureRequest{ProviderData: client}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Configure failed: %v", resp.Diagnostics)
+	}
+	return d
+}
+
+func newTestState(t *testing.T, ctx context.Context, elements []*AIGatewayDynamicRoutingElementsModel) tfsdk.State {
+	t.Helper()
+
+	model := AIGatewayDynamicRoutingModel{
+		ID:         types.StringValue("route-1"),
+		AccountID:  types.StringValue("account-1"),
+		GatewayID:  types.StringValue("gateway-1"),
+		Elements:   &elements,
+		Name:       types.StringValue("route"),
+		CreatedAt:  newNullTime(),
+		ModifiedAt: newNullTime(),
+		Success:    types.BoolNull(),
+		Deployment: customfield.NullObject[AIGatewayDynamicRoutingDeploymentModel](ctx),
+		Route:      customfield.NullObject[AIGatewayDynamicRoutingRouteModel](ctx),
+		Version:    customfield.NullObject[AIGatewayDynamicRoutingVersionModel](ctx),
+	}
+
+	state := tfsdk.State{Schema: ResourceSchema(ctx)}
+	if diags := state.Set(ctx, &model); diags.HasError() {
+		t.Fatalf("failed to create test state: %v", diags)
+	}
+	return state
+}
+
+func newTestDataSourceConfig(t *testing.T, ctx context.Context) tfsdk.Config {
+	t.Helper()
+
+	model := AIGatewayDynamicRoutingDataSourceModel{
+		AccountID:  types.StringValue("account-1"),
+		GatewayID:  types.StringValue("gateway-1"),
+		ID:         types.StringValue("route-1"),
+		CreatedAt:  newNullTime(),
+		ModifiedAt: newNullTime(),
+		Name:       types.StringNull(),
+		Deployment: customfield.NullObject[AIGatewayDynamicRoutingDeploymentDataSourceModel](ctx),
+		Elements:   customfield.NullObjectList[AIGatewayDynamicRoutingElementsDataSourceModel](ctx),
+		Version:    customfield.NullObject[AIGatewayDynamicRoutingVersionDataSourceModel](ctx),
+	}
+
+	state := tfsdk.State{Schema: DataSourceSchema(ctx)}
+	if diags := state.Set(ctx, &model); diags.HasError() {
+		t.Fatalf("failed to create test data source config: %v", diags)
+	}
+	return tfsdk.Config{Schema: state.Schema, Raw: state.Raw}
+}
+
+func newNullTime() timetypes.RFC3339 {
+	return timetypes.NewRFC3339Null()
+}
+
+func testElements(next string) []*AIGatewayDynamicRoutingElementsModel {
+	return []*AIGatewayDynamicRoutingElementsModel{
+		{
+			ID:   types.StringValue("start"),
+			Type: types.StringValue("start"),
+			Outputs: &AIGatewayDynamicRoutingElementsOutputsModel{
+				Next: &AIGatewayDynamicRoutingElementsOutputsNextModel{
+					ElementID: types.StringValue(next),
+				},
+			},
+		},
+	}
+}
+
+func testResponse(graph, versionData string, documented bool) string {
+	elements := ""
+	if documented {
+		elements = fmt.Sprintf(",\"elements\":%s", graph)
+	}
+
+	data := graph
+	if documented {
+		data = fmt.Sprintf("%q", versionData)
+	}
+
+	return fmt.Sprintf(`{"result":{"id":"route-1","name":"route","gateway_id":"gateway-1"%s,"version":{"active":"true","data":%s,"version_id":"version-1"}},"success":true}`, elements, data)
+}
+
+func testServer(t *testing.T, response *string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/accounts/account-1/ai-gateway/gateways/gateway-1/routes/route-1" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(*response))
+	}))
+}
+
+func readState(t *testing.T, ctx context.Context, resp *resource.ReadResponse) AIGatewayDynamicRoutingModel {
+	t.Helper()
+
+	var model AIGatewayDynamicRoutingModel
+	if diags := resp.State.Get(ctx, &model); diags.HasError() {
+		t.Fatalf("failed to read response state: %v", diags)
+	}
+	return model
+}
+
+func TestNormalizeDynamicRoutingResponse(t *testing.T) {
+	graph := `[{"id":"start","outputs":{"next":{"elementId":"end"}},"type":"start"}]`
+
+	tests := map[string]struct {
+		input            string
+		wantElementCount int
+		wantElementID    string
+		wantVersionData  string
+		wantUnchanged    bool
+	}{
+		"array version data": {
+			input:            testResponse(graph, "", false),
+			wantElementCount: 1,
+			wantElementID:    "start",
+			wantVersionData:  graph,
+		},
+		"documented response": {
+			input:            testResponse(graph, "documented", true),
+			wantElementCount: 1,
+			wantElementID:    "start",
+			wantVersionData:  "documented",
+			wantUnchanged:    true,
+		},
+		"documented elements with array version data": {
+			input:            fmt.Sprintf(`{"result":{"elements":[{"id":"canonical","outputs":{},"type":"end"}],"version":{"data":%s}},"success":true}`, graph),
+			wantElementCount: 1,
+			wantElementID:    "canonical",
+			wantVersionData:  graph,
+		},
+		"null elements with array version data": {
+			input:            fmt.Sprintf(`{"result":{"elements":null,"version":{"data":%s}},"success":true}`, graph),
+			wantElementCount: 1,
+			wantElementID:    "start",
+			wantVersionData:  graph,
+		},
+		"empty elements with array version data": {
+			input:            fmt.Sprintf(`{"result":{"elements":[],"version":{"data":%s}},"success":true}`, graph),
+			wantElementCount: 1,
+			wantElementID:    "start",
+			wantVersionData:  graph,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := normalizeDynamicRoutingResponse([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("normalizeDynamicRoutingResponse returned error: %v", err)
+			}
+			if tt.wantUnchanged && string(got) != tt.input {
+				t.Fatalf("documented response was changed: %s", got)
+			}
+
+			var envelope struct {
+				Result struct {
+					Elements []map[string]any `json:"elements"`
+					Version  struct {
+						Data string `json:"data"`
+					} `json:"version"`
+				} `json:"result"`
+			}
+			if err := json.Unmarshal(got, &envelope); err != nil {
+				t.Fatalf("normalized response is invalid JSON: %v", err)
+			}
+			if len(envelope.Result.Elements) != tt.wantElementCount {
+				t.Fatalf("unexpected elements: %#v", envelope.Result.Elements)
+			}
+			if tt.wantElementID != "" && envelope.Result.Elements[0]["id"] != tt.wantElementID {
+				t.Errorf("element id = %v, want %q", envelope.Result.Elements[0]["id"], tt.wantElementID)
+			}
+			if envelope.Result.Version.Data != tt.wantVersionData {
+				t.Errorf("version.data = %q, want %q", envelope.Result.Version.Data, tt.wantVersionData)
+			}
+		})
+	}
+}
+
+func TestNormalizeDynamicRoutingResponse_PreservesUnsupportedPayloads(t *testing.T) {
+	tests := []string{
+		`{"result":{"version":{"data":{"not":"an array"}}},"success":true}`,
+		`{"result":{"version":{"data":"already a string"}},"success":true}`,
+		`{"result":{"version":{"data":[null]}},"success":true}`,
+		`{"result":{"version":{"data":[1]}},"success":true}`,
+		`{"result":{"version":{"data":[{}]}},"success":true}`,
+		`{"result":{"elements":[],"version":{"data":[{}]}},"success":true}`,
+		`{"result":`,
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			got, err := normalizeDynamicRoutingResponse([]byte(input))
+			if err != nil {
+				t.Fatalf("normalizeDynamicRoutingResponse returned error: %v", err)
+			}
+			if string(got) != input {
+				t.Fatalf("unsupported response changed: %s", got)
+			}
+		})
+	}
+}
+
+func TestRead_ArrayVersionDataPreservesAndUpdatesElements(t *testing.T) {
+	ctx := context.Background()
+	response := testResponse(`[{"id":"start","outputs":{"next":{"elementId":"end"}},"type":"start"}]`, "", false)
+	ts := testServer(t, &response)
+	defer ts.Close()
+
+	r := newTestResource(t, ts.URL)
+	state := newTestState(t, ctx, testElements("end"))
+	readResp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, readResp)
+	if readResp.Diagnostics.HasError() {
+		t.Fatalf("Read returned diagnostics: %v", readResp.Diagnostics)
+	}
+
+	model := readState(t, ctx, readResp)
+	if model.Elements == nil || len(*model.Elements) != 1 || (*model.Elements)[0].ID.ValueString() != "start" {
+		t.Fatalf("array-valued version.data did not populate elements: %#v", model.Elements)
+	}
+
+	response = testResponse(`[{"id":"changed","outputs":{"next":{"elementId":"other"}},"type":"start"}]`, "", false)
+	changedResp := &resource.ReadResponse{State: readResp.State}
+	r.Read(ctx, resource.ReadRequest{State: readResp.State}, changedResp)
+	if changedResp.Diagnostics.HasError() {
+		t.Fatalf("Read with changed graph returned diagnostics: %v", changedResp.Diagnostics)
+	}
+
+	changed := readState(t, ctx, changedResp)
+	if changed.Elements == nil || len(*changed.Elements) != 1 || (*changed.Elements)[0].ID.ValueString() != "changed" {
+		t.Fatalf("remote graph change was not reflected in state: %#v", changed.Elements)
+	}
+	if (*changed.Elements)[0].Outputs == nil || (*changed.Elements)[0].Outputs.Next == nil || (*changed.Elements)[0].Outputs.Next.ElementID.ValueString() != "other" {
+		t.Fatalf("remote graph edge change was not reflected in state: %#v", (*changed.Elements)[0].Outputs)
+	}
+}
+
+func TestRead_DocumentedResponsePreservesElements(t *testing.T) {
+	ctx := context.Background()
+	graph := `[{"id":"start","outputs":{"next":{"elementId":"end"}},"type":"start"}]`
+	response := testResponse(graph, "documented", true)
+	ts := testServer(t, &response)
+	defer ts.Close()
+
+	r := newTestResource(t, ts.URL)
+	state := newTestState(t, ctx, testElements("end"))
+	resp := &resource.ReadResponse{State: state}
+	r.Read(ctx, resource.ReadRequest{State: state}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	model := readState(t, ctx, resp)
+	if model.Elements == nil || len(*model.Elements) != 1 || (*model.Elements)[0].ID.ValueString() != "start" {
+		t.Fatalf("documented elements response was not preserved: %#v", model.Elements)
+	}
+}
+
+func TestDataSourceRead_ArrayVersionDataPopulatesElements(t *testing.T) {
+	ctx := context.Background()
+	response := testResponse(`[{"id":"start","outputs":{"next":{"elementId":"end"}},"type":"start"}]`, "", false)
+	ts := testServer(t, &response)
+	defer ts.Close()
+
+	d := newTestDataSource(t, ts.URL)
+	config := newTestDataSourceConfig(t, ctx)
+	resp := &datasource.ReadResponse{State: tfsdk.State{Schema: DataSourceSchema(ctx)}}
+	d.Read(ctx, datasource.ReadRequest{Config: config}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	var model AIGatewayDynamicRoutingDataSourceModel
+	if diags := resp.State.Get(ctx, &model); diags.HasError() {
+		t.Fatalf("failed to read data source state: %v", diags)
+	}
+	elements, diags := model.Elements.AsStructSliceT(ctx)
+	if diags.HasError() {
+		t.Fatalf("failed to read data source elements: %v", diags)
+	}
+	if len(elements) != 1 || elements[0].ID.ValueString() != "start" {
+		t.Fatalf("array-valued version.data did not populate data source elements: %#v", model.Elements)
+	}
+	if model.AccountID.ValueString() != "account-1" || model.GatewayID.ValueString() != "gateway-1" || model.ID.ValueString() != "route-1" {
+		t.Fatalf("data source identity changed: account=%q gateway=%q id=%q", model.AccountID.ValueString(), model.GatewayID.ValueString(), model.ID.ValueString())
+	}
+	version, diags := model.Version.Value(ctx)
+	if diags.HasError() {
+		t.Fatalf("failed to read data source version: %v", diags)
+	}
+	if version == nil || version.Data.ValueString() != `[{"id":"start","outputs":{"next":{"elementId":"end"}},"type":"start"}]` {
+		t.Fatalf("data source version.data was not normalized: %#v", version)
+	}
+}
+
+func TestImportState_ArrayVersionDataPopulatesElements(t *testing.T) {
+	ctx := context.Background()
+	graph := `[{"id":"start","outputs":{"next":{"elementId":"end"}},"type":"start"}]`
+	response := testResponse(graph, "", false)
+	ts := testServer(t, &response)
+	defer ts.Close()
+
+	r := newTestResource(t, ts.URL)
+	resp := &resource.ImportStateResponse{State: tfsdk.State{Schema: ResourceSchema(ctx)}}
+	r.ImportState(ctx, resource.ImportStateRequest{ID: "account-1/gateway-1/route-1"}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("ImportState returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	model := readState(t, ctx, &resource.ReadResponse{State: resp.State})
+	if model.Elements == nil || len(*model.Elements) != 1 || (*model.Elements)[0].ID.ValueString() != "start" {
+		t.Fatalf("array-valued version.data did not populate imported elements: %#v", model.Elements)
+	}
+	if model.AccountID.ValueString() != "account-1" || model.GatewayID.ValueString() != "gateway-1" || model.ID.ValueString() != "route-1" {
+		t.Fatalf("imported identity changed: account=%q gateway=%q id=%q", model.AccountID.ValueString(), model.GatewayID.ValueString(), model.ID.ValueString())
+	}
+	version, diags := model.Version.Value(ctx)
+	if diags.HasError() {
+		t.Fatalf("failed to read imported version: %v", diags)
+	}
+	if version == nil || version.Data.ValueString() != graph {
+		t.Fatalf("imported version.data was not normalized: %#v", version)
+	}
+}

--- a/internal/services/ai_gateway_dynamic_routing/custom_test.go
+++ b/internal/services/ai_gateway_dynamic_routing/custom_test.go
@@ -193,6 +193,12 @@ func TestNormalizeDynamicRoutingResponse(t *testing.T) {
 			wantElementID:    "start",
 			wantVersionData:  graph,
 		},
+		"whitespace empty elements with array version data": {
+			input:            fmt.Sprintf(`{"result":{"elements":[  ],"version":{"data":%s}},"success":true}`, graph),
+			wantElementCount: 1,
+			wantElementID:    "start",
+			wantVersionData:  graph,
+		},
 	}
 
 	for name, tt := range tests {

--- a/internal/services/ai_gateway_dynamic_routing/data_source.go
+++ b/internal/services/ai_gateway_dynamic_routing/data_source.go
@@ -78,6 +78,11 @@ func (d *AIGatewayDynamicRoutingDataSource) Read(ctx context.Context, req dataso
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
+	bytes, err = normalizeDynamicRoutingResponse(bytes)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to normalize http response", err.Error())
+		return
+	}
 	err = apijson.UnmarshalComputed(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())

--- a/internal/services/ai_gateway_dynamic_routing/resource.go
+++ b/internal/services/ai_gateway_dynamic_routing/resource.go
@@ -175,6 +175,11 @@ func (r *AIGatewayDynamicRoutingResource) Read(ctx context.Context, req resource
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
+	bytes, err = normalizeDynamicRoutingResponse(bytes)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to normalize http response", err.Error())
+		return
+	}
 	err = apijson.Unmarshal(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
@@ -250,6 +255,11 @@ func (r *AIGatewayDynamicRoutingResource) ImportState(ctx context.Context, req r
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
+	bytes, err = normalizeDynamicRoutingResponse(bytes)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to normalize http response", err.Error())
+		return
+	}
 	err = apijson.Unmarshal(bytes, &env)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())

--- a/internal/services/ai_gateway_dynamic_routing/resource_test.go
+++ b/internal/services/ai_gateway_dynamic_routing/resource_test.go
@@ -1,0 +1,271 @@
+package ai_gateway_dynamic_routing_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go/v7"
+	"github.com/cloudflare/cloudflare-go/v7/option"
+	"github.com/cloudflare/terraform-provider-cloudflare/internal/services/ai_gateway_dynamic_routing"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	frameworkresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+type dynamicRoutingTestProvider struct{}
+
+type dynamicRoutingTestProviderModel struct {
+	BaseURL types.String `tfsdk:"base_url"`
+}
+
+func (dynamicRoutingTestProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "cloudflare"
+	resp.Version = "test"
+}
+
+func (dynamicRoutingTestProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+	resp.Schema = providerschema.Schema{
+		Attributes: map[string]providerschema.Attribute{
+			"base_url": providerschema.StringAttribute{Optional: true},
+		},
+	}
+}
+
+func (dynamicRoutingTestProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	var data dynamicRoutingTestProviderModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := cloudflare.NewClient(option.WithBaseURL(data.BaseURL.ValueString()))
+	resp.ResourceData = client
+	resp.DataSourceData = client
+}
+
+func (dynamicRoutingTestProvider) Resources(context.Context) []func() frameworkresource.Resource {
+	return []func() frameworkresource.Resource{ai_gateway_dynamic_routing.NewResource}
+}
+
+func (dynamicRoutingTestProvider) DataSources(context.Context) []func() datasource.DataSource {
+	return nil
+}
+
+type dynamicRoutingFakeServer struct {
+	mu      sync.RWMutex
+	graph   string
+	exists  bool
+	deletes int
+}
+
+func (s *dynamicRoutingFakeServer) setGraph(graph string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.graph = graph
+}
+
+func (s *dynamicRoutingFakeServer) graphJSON() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.graph
+}
+
+func (s *dynamicRoutingFakeServer) restoreGraph(graph string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.graph = graph
+	s.exists = true
+}
+
+func (s *dynamicRoutingFakeServer) wasDeleted() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.deletes > 0 && !s.exists
+}
+
+func (s *dynamicRoutingFakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	routePath := "/accounts/account-1/ai-gateway/gateways/gateway-1/routes"
+	itemPath := routePath + "/route-1"
+	if r.URL.Path != routePath && r.URL.Path != itemPath {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		if r.URL.Path != routePath {
+			http.NotFound(w, r)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		var request map[string]json.RawMessage
+		if err := json.Unmarshal(body, &request); err != nil || request["elements"] == nil {
+			http.Error(w, "invalid create request", http.StatusBadRequest)
+			return
+		}
+		var elements []json.RawMessage
+		if err := json.Unmarshal(request["elements"], &elements); err != nil || len(elements) != 2 {
+			http.Error(w, "unexpected graph", http.StatusBadRequest)
+			return
+		}
+		s.mu.Lock()
+		s.graph = string(request["elements"])
+		s.exists = true
+		s.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"result":{"id":"route-1","name":"route","gateway_id":"gateway-1","elements":%s,"version":{"active":"true","data":"documented","version_id":"version-1"}},"success":true}`, s.graphJSON())
+	case http.MethodGet:
+		if r.URL.Path != itemPath {
+			http.NotFound(w, r)
+			return
+		}
+		s.mu.RLock()
+		exists := s.exists
+		s.mu.RUnlock()
+		if !exists {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"result":{"id":"route-1","name":"route","gateway_id":"gateway-1","version":{"active":"true","data":%s,"version_id":"version-1"}},"success":true}`, s.graphJSON())
+	case http.MethodDelete:
+		if r.URL.Path != itemPath {
+			http.NotFound(w, r)
+			return
+		}
+		s.mu.Lock()
+		s.exists = false
+		s.deletes++
+		s.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":{"id":"route-1"},"success":true}`))
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func TestAIGatewayDynamicRoutingProtocol(t *testing.T) {
+	graphA := `[{"id":"start","outputs":{"next":{"elementId":"end"}},"type":"start"},{"id":"end","outputs":{},"type":"end"}]`
+	graphB := `[{"id":"changed","outputs":{"next":{"elementId":"other"}},"type":"start"},{"id":"other","outputs":{},"type":"end"}]`
+
+	fake := &dynamicRoutingFakeServer{graph: graphA}
+	server := httptest.NewServer(fake)
+	defer server.Close()
+
+	config := func(startID, nextID, endID string) string {
+		return fmt.Sprintf(`provider "cloudflare" {
+  base_url = %q
+}
+
+resource "cloudflare_ai_gateway_dynamic_routing" "test" {
+  account_id = "account-1"
+  gateway_id = "gateway-1"
+  name       = "route"
+
+  elements = [
+    {
+      id   = %q
+      type = "start"
+      outputs = {
+        next = { element_id = %q }
+      }
+    },
+    {
+      id      = %q
+      type    = "end"
+      outputs = {}
+    },
+  ]
+}
+`, server.URL, startID, nextID, endID)
+	}
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"cloudflare": func() (tfprotov6.ProviderServer, error) {
+				return providerserver.NewProtocol6(dynamicRoutingTestProvider{})(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: config("start", "end", "end"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				PreConfig: func() {
+					fake.setGraph(graphB)
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("cloudflare_ai_gateway_dynamic_routing.test", plancheck.ResourceActionReplace),
+					},
+				},
+			},
+			{
+				Config:  config("changed", "other", "other"),
+				Destroy: true,
+			},
+			{
+				PreConfig: func() {
+					fake.restoreGraph(graphB)
+				},
+				Config:             config("changed", "other", "other"),
+				ResourceName:       "cloudflare_ai_gateway_dynamic_routing.test",
+				ImportState:        true,
+				ImportStateId:      "account-1/gateway-1/route-1",
+				ImportStatePersist: true,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected one imported resource, got %d", len(states))
+					}
+					attributes := states[0].Attributes
+					for path, expected := range map[string]string{
+						"id":                                 "route-1",
+						"elements.#":                         "2",
+						"elements.0.id":                      "changed",
+						"elements.0.outputs.next.element_id": "other",
+						"elements.1.id":                      "other",
+						"version.data":                       graphB,
+					} {
+						if got := attributes[path]; got != expected {
+							return fmt.Errorf("%s = %q, want %q", path, got, expected)
+						}
+					}
+					return nil
+				},
+			},
+			{
+				Config:             config("changed", "other", "other"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+
+	if !fake.wasDeleted() {
+		t.Error("expected the test lifecycle to delete the fake route")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes perpetual replacement plans for `cloudflare_ai_gateway_dynamic_routing` when the API returns the route graph under `result.version.data` instead of top-level `result.elements`.

The provider now:

- Promotes a valid array-valued `version.data` graph to `elements` when `elements` is absent or `null`.
- Normalizes array-valued `version.data` to the string representation expected by the generated model.
- Applies the normalization to resource refresh, import, and data-source reads.
- Preserves documented responses, explicit empty `elements`, and malformed or unsupported payloads.

## Problem

A dynamic route can apply successfully and remain active, but some API responses return its graph in this shape:

```json
{
  "result": {
    "version": {
      "data": [...]
    }
  }
}
```

The Terraform schema tracks the graph in top-level `elements`. During refresh, the missing field clears `elements` from state. Because `elements` requires replacement, the next plan proposes recreating an otherwise unchanged route.

Users currently have to suppress the drift with:

```
lifecycle {
  ignore_changes = [elements]
}
```

## Approach
This adds a service-local response normalizer rather than changing the shared JSON decoder or Terraform schema.

The compatibility path is used only when version.data contains a supported graph array. Documented responses with top-level elements retain their existing behavior, and unsupported payloads are left for the existing decoder to handle.

## Testing
- `go test ./...`
- `go vet ./internal/services/ai_gateway_dynamic_routing`
- `gofmt`
- `git diff --check`
- Schema-version validation

Fixes #7300.