### PR TITLE
fix(page_rule): allow one-year edge cache TTL

### DIFF
--- a/internal/services/page_rule/resource_test.go
+++ b/internal/services/page_rule/resource_test.go
@@ -3175,14 +3175,14 @@ func TestAccCloudflarePageRule_EdgeCacheTTLNotClobbered(t *testing.T) {
 				Config: testAccCheckCloudflarePageRuleConfigWithEdgeCacheTtl(zoneID, target, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists(resourceName, &before),
-					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "10"),
+					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "31536000"),
 				),
 			},
 			{
 				Config: testAccCheckCloudflarePageRuleConfigWithEdgeCacheTtl(zoneID, target, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists(resourceName, &before),
-					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "10"),
+					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "31536000"),
 				),
 				PlanOnly: true,
 			},
@@ -3202,14 +3202,14 @@ func TestAccCloudflarePageRule_EdgeCacheTTLNotClobbered(t *testing.T) {
 				Config: testAccCheckCloudflarePageRuleConfigWithEdgeCacheTtlAndAlwaysOnline(zoneID, target, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists(resourceName, &after),
-					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "10"),
+					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "31536000"),
 				),
 			},
 			{
 				Config: testAccCheckCloudflarePageRuleConfigWithEdgeCacheTtlAndAlwaysOnline(zoneID, target, rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudflarePageRuleExists(resourceName, &after),
-					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "10"),
+					resource.TestCheckResourceAttr(resourceName, "actions.edge_cache_ttl", "31536000"),
 				),
 				PlanOnly: true,
 			},

--- a/internal/services/page_rule/schema.go
+++ b/internal/services/page_rule/schema.go
@@ -272,7 +272,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Optional: true,
 						Validators: []validator.Int64{
 							int64validator.AtLeast(0),
-							int64validator.AtMost(2419200),
+							int64validator.AtMost(31536000),
 						},
 					},
 					"email_obfuscation": schema.StringAttribute{

--- a/internal/services/page_rule/testdata/pageruleconfigwithedgecachettl.tf
+++ b/internal/services/page_rule/testdata/pageruleconfigwithedgecachettl.tf
@@ -4,6 +4,6 @@ resource "cloudflare_page_rule" "%[3]s"{
   target  = "%[2]s"
   actions = {
     ssl            = "flexible"
-    edge_cache_ttl = 10
+    edge_cache_ttl = 31536000
   }
 }

--- a/internal/services/page_rule/testdata/pageruleconfigwithedgecachettlandalwaysonline.tf
+++ b/internal/services/page_rule/testdata/pageruleconfigwithedgecachettlandalwaysonline.tf
@@ -3,6 +3,6 @@ resource "cloudflare_page_rule" "%[3]s" {
   zone_id = "%[1]s"
   target  = "%[2]s"
   actions = {
-    edge_cache_ttl = 10
+    edge_cache_ttl = 31536000
   }
 }


### PR DESCRIPTION
Summary: Correct the v5 cloudflare_page_rule actions.edge_cache_ttl validator to accept the API maximum of 31,536,000 seconds (365 days). This restores the v4 limit and exercises the upper boundary through the existing create, plan-only, import, and update acceptance flow.\n\nGeneration note: internal/services/page_rule/schema.go is generated by Stainless. The durable fix must also correct or confirm the Page Rules OpenAPI input or generator override that feeds Terraform. Published API documentation already shows the correct maximum, so the provider generation input currently diverges from that contract.\n\nValidation: git diff --check passed. The focused Go test/build did not finish in this environment command window; CI should run the provider test suite.