### PR TITLE
ci: notify GChat space on release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -133,3 +133,27 @@ jobs:
         run: ./scripts/trigger-terraform-registry-sync
         env:
           TERRAFORM_REGISTRY_COOKIE: ${{ secrets.TERRAFORM_REGISTRY_COOKIE }}
+      - name: Notify GChat
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GCHAT_WEBHOOK: ${{ secrets.GCHAT_RELEASE_WEBHOOK }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          RELEASE=$(gh api repos/${{ github.repository }}/releases/tags/$TAG)
+          URL=$(echo "$RELEASE" | jq -r '.html_url')
+          AUTHOR=$(echo "$RELEASE" | jq -r '.author.login')
+          BODY=$(echo "$RELEASE" | jq -r '.body' \
+            | sed 's/\r//' \
+            | sed 's/^## \(.*\)$/\*\1\*/' \
+            | sed 's/^### \(.*\)$/\*\1\*/' \
+            | sed 's/^\* /• /' \
+            | sed 's/^- /• /')
+          TEXT="🚀 *A new release was published:*
+          *${{ github.repository }}* ${TAG} — ${URL}
+          ${BODY}
+          Released by @${AUTHOR}"
+          jq -n --arg text "$TEXT" '{"text": $text}' \
+            | curl -s -X POST "$GCHAT_WEBHOOK" \
+              -H 'Content-Type: application/json' \
+              -d @-

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -144,16 +144,17 @@ jobs:
           URL=$(echo "$RELEASE" | jq -r '.html_url')
           AUTHOR=$(echo "$RELEASE" | jq -r '.author.login')
           BODY=$(echo "$RELEASE" | jq -r '.body' \
-            | sed 's/\r//' \
+            | tr -d '\r' \
             | sed 's/^## \(.*\)$/\*\1\*/' \
             | sed 's/^### \(.*\)$/\*\1\*/' \
+            | sed 's/\*\*\([^*]*\)\*\*/\*\1\*/' \
             | sed 's/^\* /• /' \
             | sed 's/^- /• /')
-          TEXT="🚀 *A new release was published:*
-          *${{ github.repository }}* ${TAG} — ${URL}
-          ${BODY}
-          Released by @${AUTHOR}"
-          jq -n --arg text "$TEXT" '{"text": $text}' \
+          printf '%s' "🚀 *A new release was published:*
+*${{ github.repository }}* ${TAG} — ${URL}
+${BODY}
+Released by @${AUTHOR}" \
+            | jq -Rs '{"text": .}' \
             | curl -s -X POST "$GCHAT_WEBHOOK" \
               -H 'Content-Type: application/json' \
               -d @-


### PR DESCRIPTION
Adds a `Notify GChat` step at the end of the release workflow that posts a formatted message to the Terraform Provider & cf-terraforming space when a new release is published.

Replaces the existing repo-level webhook to `thefrenchy.workers.dev` (a personal Cloudflare account we don't own). Once this merges and the workflow is confirmed working, that webhook will be removed.

**Message format:**
```
🚀 *A new release was published:*
*cloudflare/terraform-provider-cloudflare* v5.26.0 — https://github.com/...
*What's Changed*
• feat: ...
• fix: ...
Released by @author
```

The GChat webhook URL is stored as the `GCHAT_RELEASE_WEBHOOK` repository secret.